### PR TITLE
Modify resize grips in widget container classes so they behave like other resize grips in app.

### DIFF
--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -126,7 +126,7 @@ HSplitContainer::HSplitContainer(const LayoutItem& l, const LayoutItem& r)
 {
     m_widget_name = GenUniqueName("HSplitContainer");
     m_left_name   = GenUniqueName("LeftColumn");
-    m_handle_name = GenUniqueName("ResizeHandle");
+    m_handle_name = GenUniqueName("##ResizeHandle");
     m_right_name  = GenUniqueName("RightColumn");
 }
 
@@ -201,8 +201,8 @@ HSplitContainer::Render()
     ImGui::SameLine();
 
     // Create a resize handle between columns
-    ImGui::InvisibleButton(m_handle_name.c_str(),
-                           ImVec2(m_resize_grip_size, total_size.y));  // col_height));
+    ImGui::Selectable(m_handle_name.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick,
+                      ImVec2(m_resize_grip_size, total_size.y));
 
     // Change cursor appearance when hovering over the resize handle
     if(ImGui::IsItemHovered())
@@ -251,6 +251,9 @@ VSplitContainer::VSplitContainer(const LayoutItem& t, const LayoutItem& b)
 , m_dirty(true)
 {
     m_widget_name = GenUniqueName("VSplitContainer");
+    m_top_name    = GenUniqueName("TopRow");
+    m_handle_name = GenUniqueName("##ResizeHandle");
+    m_bottom_name = GenUniqueName("BottomRow");
 }
 
 void
@@ -309,7 +312,7 @@ VSplitContainer::Render()
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, m_top.m_window_padding);
 
     ImGui::PushStyleColor(ImGuiCol_ChildBg, m_top.m_bg_color);
-    ImGui::BeginChild("TopRow", ImVec2(col_width, m_top_row_height),
+    ImGui::BeginChild(m_top_name.c_str(), ImVec2(col_width, m_top_row_height),
                       m_top.m_child_window_flags);
     if(m_top.m_item)
     {
@@ -320,9 +323,8 @@ VSplitContainer::Render()
     ImGui::PopStyleVar(2);
 
     // Create a resize handle between columns
-    if(ImGui::InvisibleButton("ResizeHandle", ImVec2(total_size.x, m_resize_grip_size)))
-    {
-    }
+    ImGui::Selectable(m_handle_name.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick,
+                      ImVec2(total_size.x, m_resize_grip_size));
 
     // Change cursor appearance when hovering over the resize handle
     if(ImGui::IsItemHovered())
@@ -347,7 +349,8 @@ VSplitContainer::Render()
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, m_bottom.m_window_padding);
 
     ImGui::PushStyleColor(ImGuiCol_ChildBg, m_bottom.m_bg_color);
-    ImGui::BeginChild("BottomRow", ImVec2(col_width, 0), m_bottom.m_child_window_flags);
+    ImGui::BeginChild(m_bottom_name.c_str(), ImVec2(col_width, 0),
+                      m_bottom.m_child_window_flags);
     if(m_bottom.m_item)
     {
         m_bottom.m_item->Render();

--- a/src/view/src/widgets/rocprofvis_widget.h
+++ b/src/view/src/widgets/rocprofvis_widget.h
@@ -20,6 +20,7 @@ public:
     virtual void Render();
 
     std::string GenUniqueName(std::string name);
+
 protected:
     std::string m_widget_name;
 };
@@ -31,8 +32,8 @@ public:
     LayoutItem(float w, float h);
 
     std::shared_ptr<RocWidget> m_item;  // Widget that this item will render
-    float m_height;
-    float m_width;
+    float                      m_height;
+    float                      m_width;
 
     int32_t m_bg_color;
 
@@ -47,13 +48,12 @@ class RocCustomWidget : public RocWidget
 public:
     RocCustomWidget(const std::function<void()>& callback);
 
-	virtual void Render();
-    void SetCallback(const std::function<void()>& callback);
+    virtual void Render();
+    void         SetCallback(const std::function<void()>& callback);
 
 private:
-	std::function<void()> m_callback;
+    std::function<void()> m_callback;
 };
-
 
 class VFixedContainer : public RocWidget
 {
@@ -63,7 +63,7 @@ public:
     // Todo, add, insert, remove operations
     // ex: void AddItem(LayoutItem &item);
 
-    bool SetAt(int index, const LayoutItem &item);
+    bool   SetAt(int index, const LayoutItem& item);
     size_t ItemCount();
 
     virtual void Render();
@@ -99,7 +99,7 @@ private:
     std::string m_handle_name;
 
     float m_split_ratio;
-    bool m_dirty;
+    bool  m_dirty;
 };
 
 class VSplitContainer : public RocWidget
@@ -125,8 +125,12 @@ private:
     LayoutItem m_bottom;
     float      m_resize_grip_size;
 
+    std::string m_top_name;
+    std::string m_bottom_name;
+    std::string m_handle_name;
+
     float m_split_ratio;
-    bool m_dirty;
+    bool  m_dirty;
 };
 
 }  // namespace View


### PR DESCRIPTION
Fix: Use ImGui::Selectable instead of invisible button so resize grips look and feel consitent through out application.