### PR TITLE
TabContainer Tooltip

### DIFF
--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -420,6 +420,12 @@ TabContainer::Render()
                 if(ImGui::BeginTabItem(tab.m_label.c_str(), p_open,
                                        ImGuiTabBarFlags_None))
                 {
+                    // show tooltip for the active tab if header is hovered
+                    if(ImGui::IsItemHovered())
+                    {
+                        ImGui::SetTooltip("%s", tab.m_id.c_str());
+                    }
+
                     new_selected_tab = i;
                     if(tab.m_widget)
                     {
@@ -427,15 +433,15 @@ TabContainer::Render()
                     }
                     ImGui::EndTabItem();
                 }
+                // show tooltip for inactive tabs if header is hovered
+                else if(ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("%s", tab.m_id.c_str());
+                }
 
                 if(p_open && !is_open)
                 {
                     index_to_remove = i;
-                }
-                // show tooltip if hovered
-                if(ImGui::IsItemHovered())
-                {
-                    ImGui::SetTooltip("%s", tab.m_id.c_str());
                 }
             }
             ImGui::EndTabBar();


### PR DESCRIPTION
[Problem]
-IsItemHovered() after  EndTabItem() means that entire tab area is checked for hover. Unless something inside tab content steals the mouse, hovering anywhere in a tab will show tooltip.

[Fix]
-Restrict hover region to the tab's header. Has to be separately for active and nonactive tabs.