### PR TITLE
Event table fetching interface implementation in the View 

### DIFF
--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -280,7 +280,8 @@ RenderProviderTest(DataProvider& provider)
 {
     ImGui::Begin("Data Provider Test Window", nullptr, ImGuiWindowFlags_None);
 
-    static char track_index_buffer[64] = "0";  // Buffer to hold the user input
+    static char track_index_buffer[64] = "0";
+    static char end_track_index_buffer[64] = "1"; // for setting table track range
 
     // Callback function to filter non-numeric characters
     auto NumericFilter = [](ImGuiInputTextCallbackData* data) -> int {
@@ -295,18 +296,15 @@ RenderProviderTest(DataProvider& provider)
         return 0;  // Allow numeric characters
     };
 
-    // InputText with numeric filtering
     ImGui::InputText("Track index", track_index_buffer, IM_ARRAYSIZE(track_index_buffer),
                      ImGuiInputTextFlags_CallbackCharFilter, NumericFilter);
 
     int index = std::atoi(track_index_buffer);
 
-
-    if(ImGui::Button("Fetch Track"))
-    {
-        provider.FetchTrack(index, provider.GetStartTime(), provider.GetEndTime(), 1000,
-                            0);
-    }
+    ImGui::Separator();
+    ImGui::Text("Table Parameters");
+    ImGui::InputText("End Track index", end_track_index_buffer, IM_ARRAYSIZE(end_track_index_buffer),
+                    ImGuiInputTextFlags_CallbackCharFilter, NumericFilter);
 
     static char row_start_buffer[64] = "-1";
     ImGui::InputText("Start Row", row_start_buffer, IM_ARRAYSIZE(row_start_buffer),
@@ -317,11 +315,34 @@ RenderProviderTest(DataProvider& provider)
     ImGui::InputText("Row Count", row_count_buffer, IM_ARRAYSIZE(row_count_buffer),
                     ImGuiInputTextFlags_CallbackCharFilter, NumericFilter);
     uint64_t row_count = std::atoi(row_count_buffer);
-        
-    if(ImGui::Button("Fetch Table"))
+
+
+    if(ImGui::Button("Fetch Single Track Table"))
     {
         provider.FetchEventTable(index, provider.GetStartTime(), provider.GetEndTime(),start_row,
                                  row_count);
+    }
+    if(ImGui::Button("Fetch Multi Track Table"))
+    {
+        int end_index = std::atoi(end_track_index_buffer);
+        std::vector<uint64_t> vect;
+        for(int i = index; i < end_index; ++i)
+        {
+            vect.push_back(i);
+        }
+        provider.FetchMultiTrackEventTable(vect, provider.GetStartTime(), provider.GetEndTime(),start_row,
+                                 row_count);
+    }
+    if(ImGui::Button("Print Event Table"))
+    {
+        provider.DumpEventTable();
+    }    
+    ImGui::Separator();
+
+    if(ImGui::Button("Fetch Track"))
+    {
+        provider.FetchTrack(index, provider.GetStartTime(), provider.GetEndTime(), 1000,
+                            0);
     }
 
     if(ImGui::Button("Fetch Whole Track"))
@@ -341,10 +362,7 @@ RenderProviderTest(DataProvider& provider)
     {
         provider.DumpMetaData();
     }
-    if(ImGui::Button("Print Event Table"))
-    {
-        provider.DumpEventTable();
-    }
+
 
     ImGui::End();
 }

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -599,7 +599,7 @@ DataProvider::FetchEventTable(uint64_t index, double start_ts, double end_ts,
             request_info.request_args       = args;
             request_info.index              = index;
             request_info.loading_state      = ProviderState::kLoading;
-            request_info.request_type       = RequestType::kFetchSingleTrackEventTable;
+            request_info.request_type       = RequestType::kFetchTrackEventTable;
             request_info.start_ts           = start_ts;
             request_info.end_ts             = end_ts;
             m_requests.emplace(request_info.index, request_info);
@@ -703,6 +703,11 @@ DataProvider::FetchMultiTrackEventTable(const std::vector<uint64_t>& track_indic
                 return false;
             }
 
+            // set the number of tracks in the request
+            result = rocprofvis_controller_set_uint64(
+                args, kRPVControllerTableArgsNumTracks, 0, num_sample_tracks);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+
             // prepare to fetch the table
             spdlog::debug("Allocating table results array");
             rocprofvis_controller_array_t* array = rocprofvis_controller_array_alloc(0);
@@ -724,7 +729,7 @@ DataProvider::FetchMultiTrackEventTable(const std::vector<uint64_t>& track_indic
             request_info.request_args       = args;
             request_info.index              = track_indices[0];
             request_info.loading_state      = ProviderState::kLoading;
-            request_info.request_type       = RequestType::kFetchSingleTrackEventTable;
+            request_info.request_type       = RequestType::kFetchTrackEventTable;
             request_info.start_ts           = start_ts;
             request_info.end_ts             = end_ts;
             m_requests.emplace(request_info.index, request_info);
@@ -974,7 +979,7 @@ DataProvider::ProcessRequest(data_req_info_t& req)
         spdlog::debug("Processing track data {}", req.index);
         ProcessTrackRequest(req);
     }
-    else if(req.request_type == RequestType::kFetchSingleTrackEventTable)
+    else if(req.request_type == RequestType::kFetchTrackEventTable)
     {
         spdlog::debug("Processing event table data {}", req.index);
         ProcessEventTableRequest(req);

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -26,7 +26,7 @@ enum class RequestType
 {
     kFetchTrack,
     kFetchGraph,
-    kFetchSingleTrackEventTable
+    kFetchTrackEventTable
 };
 
 typedef struct track_info_t


### PR DESCRIPTION
The View module's data provider interface now can fetch both single track and multi-track event table data.
The test provider debug UI interface has been updated to provide controls for setting up parameters and printing the table data.

This PR only implements the fetching interface between the view and the controller. Table data display in the bottom pane and automatic retrieval will come in a future PR.