### PR TITLE
Fix TabContainer::SetActiveTab

### DIFF
--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -421,8 +421,7 @@ TabContainer::Render()
                 {
                     p_open = nullptr;
                 }
-                if(ImGui::BeginTabItem(tab.m_label.c_str(), p_open,
-                                       ImGuiTabBarFlags_None))
+                if(ImGui::BeginTabItem(tab.m_label.c_str(), p_open, flags))
                 {
                     // show tooltip for the active tab if header is hovered
                     if(ImGui::IsItemHovered())


### PR DESCRIPTION
-TabContainer::SetActiveTab() does not function because the flag variable it updates is never passed to BeginTabItem in TabContainer::Render(). 