### PR TITLE
NavigationManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(VIEW_FILES
 	src/view/src/rocprofvis_compute_data_provider.cpp
 	src/view/src/rocprofvis_compute_metric.cpp
 	src/view/src/rocprofvis_compute_roofline.cpp
+	src/view/src/rocprofvis_navigation_manager.cpp
     src/view/src/widgets/rocprofvis_widget.cpp
     src/view/src/widgets/rocprofvis_debug_window.cpp
 )

--- a/src/view/src/rocprofvis_compute_block.cpp
+++ b/src/view/src/rocprofvis_compute_block.cpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "rocprofvis_compute_block.h"
+#include "rocprofvis_navigation_manager.h"
+#include "rocprofvis_navigation_url.h"
 
 namespace RocProfVis
 {
@@ -99,10 +101,11 @@ const std::array LINK_DEFINITIONS {
 constexpr int WINDOW_PADDING_DEFAULT = 8;
 constexpr int LEVEL_HISTORY_LIMIT = 5;
 
-ComputeBlockDetails::ComputeBlockDetails(std::shared_ptr<ComputeDataProvider> data_provider)
+ComputeBlockDetails::ComputeBlockDetails(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider)
 : m_block_navigation_event_token(-1)
 , m_navigation_changed(true)
 , m_current_location(block_diagram_navigation_location_t{kBlockDiagramLevelGPU, kBlockDiagramBlockNone})
+, m_owner_id(owner_id)
 {
     for (const block_diagram_block_info_t& block : BLOCK_DEFINITIONS)
     {
@@ -543,13 +546,14 @@ ComputeBlockDiagramNavHelper* ComputeBlockDiagram::Navigation()
     return navigation;
 }
 
-ComputeBlockView::ComputeBlockView(std::shared_ptr<ComputeDataProvider> data_provider)
+ComputeBlockView::ComputeBlockView(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider)
 : m_block_diagram(nullptr)
 , m_details_panel(nullptr)
 , m_container(nullptr)
+, m_owner_id(owner_id)
 {
     m_block_diagram = std::make_shared<ComputeBlockDiagram>(data_provider);
-    m_details_panel = std::make_shared<ComputeBlockDetails>(data_provider);
+    m_details_panel = std::make_shared<ComputeBlockDetails>(m_owner_id, data_provider);
 
     LayoutItem left;
     left.m_item = m_block_diagram;

--- a/src/view/src/rocprofvis_compute_block.h
+++ b/src/view/src/rocprofvis_compute_block.h
@@ -129,7 +129,7 @@ class ComputeBlockDetails : public RocWidget
 public:
     void Render();
     void Update();
-    ComputeBlockDetails(std::shared_ptr<ComputeDataProvider> data_provider);
+    ComputeBlockDetails(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider);
     ~ComputeBlockDetails();
 
 private:
@@ -139,6 +139,7 @@ private:
     EventManager::SubscriptionToken m_block_navigation_event_token;
     block_diagram_navigation_location_t m_current_location;
     bool m_navigation_changed;
+    std::string m_owner_id;
 };
 
 class ComputeBlockDiagramNavHelper
@@ -193,7 +194,7 @@ class ComputeBlockView : public RocWidget
 public:
     void Render();
     void Update();
-    ComputeBlockView(std::shared_ptr<ComputeDataProvider> data_provider);
+    ComputeBlockView(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider);
     ~ComputeBlockView();
 
 private:
@@ -202,6 +203,7 @@ private:
     std::shared_ptr<ComputeBlockDiagram> m_block_diagram;
     std::shared_ptr<ComputeBlockDetails> m_details_panel;
     std::shared_ptr<HSplitContainer> m_container;
+    std::string m_owner_id;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/rocprofvis_compute_roofline.cpp
@@ -7,8 +7,9 @@ namespace RocProfVis
 namespace View
 {
 
-ComputeRooflineView::ComputeRooflineView(std::shared_ptr<ComputeDataProvider> data_provider) 
+ComputeRooflineView::ComputeRooflineView(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider) 
 : m_roofline(nullptr)
+, m_owner_id(owner_id)
 {
     m_roofline = std::make_unique<ComputeMetricRoofline>(data_provider, kRooflineGroupByKernel);
 }

--- a/src/view/src/rocprofvis_compute_roofline.h
+++ b/src/view/src/rocprofvis_compute_roofline.h
@@ -15,13 +15,14 @@ class ComputeRooflineView : public RocWidget
 public:
     void Render();
     void Update();
-    ComputeRooflineView(std::shared_ptr<ComputeDataProvider> data_provider);
+    ComputeRooflineView(std::string root_id, std::shared_ptr<ComputeDataProvider> data_provider);
     ~ComputeRooflineView();
 
 private:
     void RenderMenuBar();
 
     std::unique_ptr<ComputeMetricRoofline> m_roofline;
+    std::string m_owner_id;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_compute_root.cpp
+++ b/src/view/src/rocprofvis_compute_root.cpp
@@ -1,26 +1,33 @@
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "rocprofvis_compute_root.h"
+#include "rocprofvis_navigation_manager.h"
+#include "rocprofvis_navigation_url.h"
 
 namespace RocProfVis
 {
 namespace View
 {
 
-ComputeRoot::ComputeRoot()
+ComputeRoot::ComputeRoot(std::string owner_id)
 : m_compute_data_provider(nullptr)
 , m_tab_container(nullptr)
+, m_owner_id(owner_id)
 {
     m_compute_data_provider = std::make_shared<ComputeDataProvider>();
 
     m_tab_container = std::make_shared<TabContainer>();
-    m_tab_container->AddTab(TabItem{"Summary View", "compute_summary_view", std::make_shared<ComputeSummaryView>(m_compute_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Roofline View", "compute_roofline_view", std::make_shared<ComputeRooflineView>(m_compute_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Block View", "compute_block_view", std::make_shared<ComputeBlockView>(m_compute_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Table View", "compute_table_view", std::make_shared<ComputeTableView>(m_compute_data_provider), false});
+    m_tab_container->AddTab(TabItem{"Summary View", COMPUTE_SUMMARY_VIEW_URL, std::make_shared<ComputeSummaryView>(m_owner_id, m_compute_data_provider), false});
+    m_tab_container->AddTab(TabItem{"Roofline View", COMPUTE_ROOFLINE_VIEW_URL, std::make_shared<ComputeRooflineView>(m_owner_id, m_compute_data_provider), false});
+    m_tab_container->AddTab(TabItem{"Block View", COMPUTE_BLOCK_VIEW_URL, std::make_shared<ComputeBlockView>(m_owner_id, m_compute_data_provider), false});
+    m_tab_container->AddTab(TabItem{"Table View", COMPUTE_TABLE_VIEW_URL, std::make_shared<ComputeTableView>(m_owner_id, m_compute_data_provider), false});
+
+    NavigationManager::GetInstance()->RegisterContainer(m_tab_container, m_owner_id, m_owner_id);
 }
 
-ComputeRoot::~ComputeRoot() {}
+ComputeRoot::~ComputeRoot() {
+    NavigationManager::GetInstance()->UnregisterContainer(m_tab_container, m_owner_id, m_owner_id);
+}
 
 void ComputeRoot::Update()
 {

--- a/src/view/src/rocprofvis_compute_root.h
+++ b/src/view/src/rocprofvis_compute_root.h
@@ -20,12 +20,13 @@ public:
     void Update() override;
     void SetProfilePath(std::filesystem::path path);
     bool ProfileLoaded();
-    ComputeRoot();
+    ComputeRoot(std::string owner_id);
     ~ComputeRoot();
 
 private:
     std::shared_ptr<TabContainer> m_tab_container;
     std::shared_ptr<ComputeDataProvider> m_compute_data_provider;
+    std::string m_owner_id;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_compute_summary.cpp
+++ b/src/view/src/rocprofvis_compute_summary.cpp
@@ -71,10 +71,11 @@ ComputeSummaryRight::ComputeSummaryRight(std::shared_ptr<ComputeDataProvider> da
 
 ComputeSummaryRight::~ComputeSummaryRight() {}
 
-ComputeSummaryView::ComputeSummaryView(std::shared_ptr<ComputeDataProvider> data_provider)
+ComputeSummaryView::ComputeSummaryView(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider)
 : m_container(nullptr)
 , m_left_view(nullptr)
 , m_right_view(nullptr)
+, m_owner_id(owner_id)
 {
     m_left_view = std::make_shared<ComputeSummaryLeft>(data_provider);
     m_right_view = std::make_shared<ComputeSummaryRight>(data_provider);

--- a/src/view/src/rocprofvis_compute_summary.h
+++ b/src/view/src/rocprofvis_compute_summary.h
@@ -40,7 +40,7 @@ class ComputeSummaryView : public RocWidget
 public:
     void Render();
     void Update();
-    ComputeSummaryView(std::shared_ptr<ComputeDataProvider> data_provider);
+    ComputeSummaryView(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider);
     ~ComputeSummaryView(); 
 
 private:
@@ -49,6 +49,7 @@ private:
     std::shared_ptr<HSplitContainer> m_container;
     std::shared_ptr<ComputeSummaryLeft> m_left_view;
     std::shared_ptr<ComputeSummaryRight> m_right_view;
+    std::string m_owner_id;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_compute_table.cpp
+++ b/src/view/src/rocprofvis_compute_table.cpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "rocprofvis_compute_table.h"
+#include "rocprofvis_navigation_manager.h"
+#include "rocprofvis_navigation_url.h"
 
 namespace RocProfVis
 {
@@ -94,19 +96,24 @@ void ComputeTableCategory::Update()
     }
 }
 
-ComputeTableView::ComputeTableView(std::shared_ptr<ComputeDataProvider> data_provider) 
+ComputeTableView::ComputeTableView(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider) 
 : m_tab_container(nullptr)
 , m_search_term("")
 , m_search_edited(false)
+, m_owner_id(owner_id)
 {
     m_tab_container = std::make_shared<TabContainer>();
     for (const table_view_category_info_t& category : TAB_DEFINITIONS)
     {
         m_tab_container->AddTab(TabItem{category.m_name, "compute_table_tab_" + category.m_name, std::make_shared<ComputeTableCategory>(data_provider, category.m_category), false});
     }
+
+    NavigationManager::GetInstance()->RegisterContainer(m_tab_container, COMPUTE_TABLE_VIEW_URL, m_owner_id);
 }
 
-ComputeTableView::~ComputeTableView() {}
+ComputeTableView::~ComputeTableView() {
+    NavigationManager::GetInstance()->UnregisterContainer(m_tab_container, COMPUTE_TABLE_VIEW_URL, m_owner_id);
+}
 
 void ComputeTableView::Update()
 {

--- a/src/view/src/rocprofvis_compute_table.h
+++ b/src/view/src/rocprofvis_compute_table.h
@@ -61,7 +61,7 @@ class ComputeTableView : public RocWidget
 public:
     void Render();
     void Update();
-    ComputeTableView(std::shared_ptr<ComputeDataProvider> data_provider);
+    ComputeTableView(std::string owner_id, std::shared_ptr<ComputeDataProvider> data_provider);
     ~ComputeTableView();
 
 private:
@@ -70,6 +70,7 @@ private:
     bool m_search_edited;
     char m_search_term[32];
     std::shared_ptr<TabContainer> m_tab_container;
+    std::string m_owner_id;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_navigation_manager.cpp
+++ b/src/view/src/rocprofvis_navigation_manager.cpp
@@ -1,0 +1,133 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "rocprofvis_navigation_manager.h"
+#include <sstream>
+#include "spdlog/spdlog.h"
+
+namespace RocProfVis
+{
+namespace View
+{
+
+NavigationManager* NavigationManager::s_instance = nullptr;
+
+NavigationManager* NavigationManager::GetInstance()
+{
+    if (!s_instance)
+    {
+        s_instance = new NavigationManager();
+    }
+    return s_instance;
+}
+
+void NavigationManager::DestroyInstance()
+{
+    if (s_instance)
+    {
+        delete s_instance;
+        s_instance = nullptr;
+    }
+}
+
+void NavigationManager::Go(const std::string& url)
+{
+    navigation_node_t* node = m_root_node.get();
+    std::stringstream stream(url);
+    std::string chunk;
+    while (std::getline(stream, chunk, '/')) 
+    {
+        if (node && node->m_children.count(chunk) > 0)
+        {
+            node->m_children[chunk]->m_container->SetActiveTab(chunk);
+            node = node->m_children[chunk];
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+void NavigationManager::RegisterRootContainer(std::shared_ptr<TabContainer> container)
+{
+    m_root_node->m_container = container;
+}
+
+void NavigationManager::RegisterContainer(std::shared_ptr<TabContainer> container, const std::string& parent_id, const std::string& owner_id)
+{
+    m_containers.push_back(container_entry_t{container, parent_id, owner_id});
+}
+
+void NavigationManager::UnregisterContainer(std::shared_ptr<TabContainer> container, const std::string& parent_id, const std::string& owner_id)
+{
+    for (auto it = m_containers.begin(); it != m_containers.end(); it ++)
+    {
+        if (it->m_container == container && it->m_parent_id == parent_id && it->m_owner_id == owner_id)
+        {
+            m_containers.erase(it);
+            break;
+        }
+    }
+}
+
+void NavigationManager::RefreshNavigationTree()
+{
+    m_node_map.clear();
+    m_root_node->m_children.clear();
+
+    for (auto entry : m_containers)
+    {        
+        if (m_node_map[entry.m_owner_id].count(entry.m_parent_id) == 0)
+        {
+            // Child created before parent. Create parent node but leave container and children empty to be filled later.
+            std::unique_ptr<navigation_node_t> parent_node = std::make_unique<navigation_node_t>();
+            parent_node->m_id = entry.m_parent_id;
+            parent_node->m_container = nullptr;
+            m_node_map[entry.m_owner_id][entry.m_parent_id] = std::move(parent_node);
+        }
+        for (const TabItem* tab : entry.m_container->GetTabs())
+        {           
+            if (m_node_map[entry.m_owner_id].count(tab->m_id) == 0)
+            {
+                // New node. Create it and add it to the parent's children.
+                std::unique_ptr<navigation_node_t> node = std::make_unique<navigation_node_t>();
+                node->m_id = tab->m_id;
+                node->m_container = entry.m_container;
+                node->m_children = {};
+                m_node_map[entry.m_owner_id][entry.m_parent_id]->m_children[tab->m_id] = node.get();
+                m_node_map[entry.m_owner_id][tab->m_id] = std::move(node);
+            }
+            else if (!m_node_map[entry.m_owner_id][tab->m_id]->m_container)
+            {
+                // Existing node with unpopulated container and children from first case. Populate container and add it to parent's children.
+                m_node_map[entry.m_owner_id][tab->m_id]->m_container = entry.m_container;
+                m_node_map[entry.m_owner_id][entry.m_parent_id]->m_children[tab->m_id] = m_node_map[entry.m_owner_id][tab->m_id].get();
+            }
+            else
+            {
+                spdlog::error("NavigationManager::RefreshNavigationTree - Duplicate tab id {} found for {}.", tab->m_id, entry.m_owner_id);
+            }
+        }
+    }
+
+    for (auto& it : m_node_map)
+    {
+        // Update the root node's children. These are the first level nodes that can be identfied by their owner_id being same as their parent_id;
+        const std::string& owner_id = it.first;
+        it.second[owner_id]->m_container = m_root_node->m_container;
+        m_root_node->m_children[owner_id] = it.second[owner_id].get();
+    }
+}
+
+NavigationManager::NavigationManager()
+: m_root_node(nullptr)
+{
+    m_root_node = std::make_unique<navigation_node_t>();
+    m_root_node->m_id = "root";
+}
+
+NavigationManager::~NavigationManager()
+{}
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/rocprofvis_navigation_manager.h
+++ b/src/view/src/rocprofvis_navigation_manager.h
@@ -1,0 +1,73 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "widgets/rocprofvis_widget.h"
+
+namespace RocProfVis
+{
+namespace View
+{
+
+typedef struct navigation_node_t
+{
+    std::string m_id;
+    std::shared_ptr<TabContainer> m_container;
+    std::unordered_map<std::string, navigation_node_t*> m_children;
+} navigation_node_t;
+
+typedef struct container_entry_t
+{
+    std::shared_ptr<TabContainer> m_container;
+    std::string m_parent_id;
+    std::string m_owner_id;
+} container_entry_t;
+
+class NavigationManager
+{
+public:
+    static NavigationManager* GetInstance();
+    static void DestroyInstance();
+
+    /*
+    * Navigates to the specified location.
+    * @param url Path of TabItem IDs to specified location seperated by '/'. Must begin with the root tab but does not have to include a leaf tab.
+    */
+    void Go(const std::string& url);
+    /*
+    * Registers the specified container as the root container.
+    * @param container The container which is always present and is parent of all other containers while not having a parent of its own.
+    */
+    void RegisterRootContainer(std::shared_ptr<TabContainer> container);
+    /*
+    * Registers the specified container. 
+    * @param container The container to register.
+    * @param parent_id The id of the tab that the container belongs to.
+    * @param owner_id The id of the root tab that the container belongs to.
+    */
+    void RegisterContainer(std::shared_ptr<TabContainer> container, const std::string& parent_id, const std::string& owner_id);
+    /*
+    * Unregisters the specified container.
+    * @param container The container to register.
+    * @param parent_id The id of the tab that the container belongs to.
+    * @param owner_id The id of the root tab that the container belongs to.
+    */
+    void UnregisterContainer(std::shared_ptr<TabContainer> container, const std::string& parent_id, const std::string& owner_id);
+    /*
+     * Builds the navigation tree from the registered containers. Should be called if containers have been registered/unregistered.
+    */
+    void RefreshNavigationTree();
+
+private:
+    NavigationManager();
+    ~NavigationManager();
+
+    static NavigationManager* s_instance;
+
+    std::vector<container_entry_t> m_containers;
+    std::unordered_map<std::string, std::unordered_map<std::string, std::unique_ptr<navigation_node_t>>> m_node_map;
+    std::unique_ptr<navigation_node_t> m_root_node;
+};
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/rocprofvis_navigation_url.h
+++ b/src/view/src/rocprofvis_navigation_url.h
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+namespace RocProfVis
+{
+namespace View
+{
+	constexpr char* COMPUTE_SUMMARY_VIEW_URL = "summary";
+	constexpr char* COMPUTE_ROOFLINE_VIEW_URL = "roofline";
+	constexpr char* COMPUTE_BLOCK_VIEW_URL = "block";
+	constexpr char* COMPUTE_TABLE_VIEW_URL = "table";
+	constexpr char* COMPUTE_TABLE_SPEED_OF_LIGHT_URL = "speed_of_light";
+	constexpr char* COMPUTE_TABLE_COMMAND_PROCESSOR_URL = "command_processor";
+	constexpr char* COMPUTE_TABLE_WORKGROUP_MANAGER_URL = "workgroup_manager";
+	constexpr char* COMPUTE_TABLE_WAVEFRONT_URL = "wavefront";
+	constexpr char* COMPUTE_TABLE_INSTRUCTION_MIX_URL = "instruction_mix";	
+	constexpr char* COMPUTE_TABLE_COMPUTE_PIPELINE_URL = "compute_pipeline";
+	constexpr char* COMPUTE_TABLE_LOCAL_DATA_STORE_URL = "local_data_store";
+	constexpr char* COMPUTE_TABLE_INSTRUCTION_CACHE_URL = "instruction_cache";
+	constexpr char* COMPUTE_TABLE_SCALAR_CACHE_URL = "scaler_cache";
+	constexpr char* COMPUTE_TABLE_ADDRESS_PROCESSING_UNIT_URL = "address_processing_unit";
+	constexpr char* COMPUTE_TABLE_VECTOR_CACHE_URL = "vector_cache";
+	constexpr char* COMPUTE_TABLE_L2_CACHE_URL = "l2_cache";
+	constexpr char* COMPUTE_TABLE_L2_CACHE_PER_CHANNEL_URL = "l2_cache_per_channel";
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -526,3 +526,16 @@ TabContainer::SetActiveTab(const std::string& id)
         m_set_active_tab_index = std::distance(m_tabs.begin(), it);
     }
 }
+
+// Gets a read only list of tabs.
+const std::vector<const TabItem*>
+TabContainer::GetTabs()
+{
+    std::vector<const TabItem*> tabs;
+    for (TabItem& tab : m_tabs)
+    {
+        const TabItem* t = &tab;
+        tabs.push_back(t);
+    }
+    return tabs;
+}

--- a/src/view/src/widgets/rocprofvis_widget.h
+++ b/src/view/src/widgets/rocprofvis_widget.h
@@ -157,7 +157,7 @@ public:
     void SetActiveTab(int index);
     void SetActiveTab(const std::string& id);
 
-
+    const std::vector<const TabItem*> GetTabs();
 private:
     std::vector<TabItem> m_tabs;
     int                  m_active_tab_index; // index of the currently active tab


### PR DESCRIPTION
1. Add singleton NavigationManager to help handle jumping between TabItems in nested TabContainers:

    Usage:
    -Add TabContainers using RegisterRootContainer() and RegisterContainer(). Remove TabContainers using UnRegisterContainer(). 
    -Build the nav tree using RefreshNavigationTree() after register or unregister.
    -Use Go(URL) to navigate, where URL is a sequence of TabItem IDs beginning from root container separated by '/'
    Ex: Go ("{compute_tab_id}/table/instruction_cache")

    Limitations:
    -All children of a root tab must have unique IDs. (Can't have "{compute_tab_id}/table/table"). Children of different root tabs can share IDs.
    -All root tabs must have unique IDs. Root tab being a tab inside the AppWindow TabContainer. (Can't open the same file twice).

2. Define TabItem IDs in a separate header for referencing during navigation.
