### PR TITLE
For RocPD DB cast the PMC value column to REAL

### DIFF
--- a/src/model/src/database/rocprofvis_db_rocpd.cpp
+++ b/src/model/src/database/rocprofvis_db_rocpd.cpp
@@ -220,7 +220,7 @@ rocprofvis_dm_result_t  RocpdDatabase::ReadTraceMetadata(Future* future)
         if (kRocProfVisDmResultSuccess != ExecuteSQLQuery(future, 
                         "select DISTINCT 0 as const, deviceId, monitorType, 1 as category from rocpd_monitor where deviceId > 0;", 
                         "select 0 as op, start, value, start as end, 0, 0, 0, deviceId, monitorType from rocpd_monitor ",
-                        "select id, monitorType, value, start, start as end, deviceId  from rocpd_monitor ",
+                        "select id, monitorType, CAST(value AS REAL) as value, start, start as end, deviceId  from rocpd_monitor ",
                         &CallBackAddTrack)) break;
 
         ShowProgress(20, "Loading strings", kRPVDbBusy, future );


### PR DESCRIPTION
This fixes the sorting of the value column in the samples table when using a ROCPD database which stores this as a string.