### PR TITLE
Use the max. number of rows when reporting the table row count

### DIFF
--- a/src/controller/src/rocprofvis_controller_table.cpp
+++ b/src/controller/src/rocprofvis_controller_table.cpp
@@ -485,7 +485,7 @@ rocprofvis_result_t Table::GetUInt64(rocprofvis_property_t property, uint64_t in
             }
             case kRPVControllerTableNumRows:
             {
-                *value = m_rows.size();
+                *value = m_num_items;
                 result = kRocProfVisResultSuccess;
                 break;
             }


### PR DESCRIPTION
The current table gets the max. row count from the database - but it was reporting the number that have been cached, which is incorrect.