### PR TITLE
Allow event to be de-selected

### DIFF
--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -26,7 +26,14 @@ void
 EventsView::Render()
 {
     ImGui::BeginChild("EventsView", ImVec2(0, 0), true);
-    ImGui::Text(std::to_string(m_data_provider.GetSelectedEvent()).c_str());
+    if(m_data_provider.GetSelectedEvent() == std::numeric_limits<uint64_t>::max())
+    {
+        ImGui::Text("No event selected.");
+    }
+    else
+    {
+        ImGui::Text("Event ID: %llu", m_data_provider.GetSelectedEvent());
+    }   
     ImGui::EndChild();
 }
 

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -139,8 +139,16 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index,
         // Select on click
         if(ImGui::IsMouseClicked(ImGuiMouseButton_Left))
         {
-            m_selected_event_id = flame.m_id;
-            m_dp.SetSelectedEvent(m_selected_event_id);
+            if(m_selected_event_id != flame.m_id ||  m_dp.GetSelectedEvent() != flame.m_id)
+            {
+                m_dp.SetSelectedEvent(flame.m_id);
+                m_selected_event_id = flame.m_id;
+            }
+            else
+            {
+                m_dp.SetSelectedEvent(std::numeric_limits<uint64_t>::max());
+                m_selected_event_id = std::numeric_limits<uint64_t>::max();
+            }            
         }
 
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, m_text_padding);


### PR DESCRIPTION
Tiny PR to allow events on the track view to be deselected as well as selected.