### PR TITLE
Fix block-to-table shortcut not working on Ubuntu

### DIFF
--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -207,7 +207,7 @@ AppWindow::Render()
                 // Determine the type of view to create based on the file extension
                 if(file_path.extension().string() == ".csv")
                 {
-                    auto compute_view = std::make_shared<ComputeRoot>(file_path_str);
+                    auto compute_view = std::make_shared<ComputeRoot>();
                     compute_view->SetProfilePath(file_path.parent_path().string());
                     compute_view->OpenTrace(file_path.parent_path().string());
                     tab_item.m_widget = compute_view;

--- a/src/view/src/rocprofvis_compute_root.cpp
+++ b/src/view/src/rocprofvis_compute_root.cpp
@@ -15,24 +15,25 @@ namespace RocProfVis
 namespace View
 {
 
-ComputeRoot::ComputeRoot(std::string owner_id)
+ComputeRoot::ComputeRoot()
 : m_compute_data_provider(nullptr)
 , m_compute_data_provider2(nullptr)
 , m_tab_container(nullptr)
-, m_owner_id(owner_id)
 , m_data_dirty_event_token(-1)
 , m_data_dirty(false)
 {
+    m_id = GenUniqueName("");
+    
     m_compute_data_provider = std::make_shared<ComputeDataProvider>();
     m_compute_data_provider2 = std::make_shared<ComputeDataProvider2>();
 
     m_tab_container = std::make_shared<TabContainer>();
-    m_tab_container->AddTab(TabItem{"Summary View", COMPUTE_SUMMARY_VIEW_URL, std::make_shared<ComputeSummaryView>(m_owner_id, m_compute_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Roofline View", COMPUTE_ROOFLINE_VIEW_URL, std::make_shared<ComputeRooflineView>(m_owner_id, m_compute_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Block View", COMPUTE_BLOCK_VIEW_URL, std::make_shared<ComputeBlockView>(m_owner_id, m_compute_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Table View", COMPUTE_TABLE_VIEW_URL, std::make_shared<ComputeTableView>(m_owner_id, m_compute_data_provider2), false});
+    m_tab_container->AddTab(TabItem{"Summary View", COMPUTE_SUMMARY_VIEW_URL, std::make_shared<ComputeSummaryView>(m_id, m_compute_data_provider), false});
+    m_tab_container->AddTab(TabItem{"Roofline View", COMPUTE_ROOFLINE_VIEW_URL, std::make_shared<ComputeRooflineView>(m_id, m_compute_data_provider), false});
+    m_tab_container->AddTab(TabItem{"Block View", COMPUTE_BLOCK_VIEW_URL, std::make_shared<ComputeBlockView>(m_id, m_compute_data_provider), false});
+    m_tab_container->AddTab(TabItem{"Table View", COMPUTE_TABLE_VIEW_URL, std::make_shared<ComputeTableView>(m_id, m_compute_data_provider2), false});
 
-    NavigationManager::GetInstance()->RegisterContainer(m_tab_container, m_owner_id, m_owner_id);
+    NavigationManager::GetInstance()->RegisterContainer(m_tab_container, m_id, m_id);
 
     auto data_dirty_event_handler = [this](std::shared_ptr<RocEvent> event) 
     {
@@ -42,7 +43,7 @@ ComputeRoot::ComputeRoot(std::string owner_id)
 }
 
 ComputeRoot::~ComputeRoot() {
-    NavigationManager::GetInstance()->UnregisterContainer(m_tab_container, m_owner_id, m_owner_id);
+    NavigationManager::GetInstance()->UnregisterContainer(m_tab_container, m_id, m_id);
 }
 
 void ComputeRoot::Update()

--- a/src/view/src/rocprofvis_compute_root.h
+++ b/src/view/src/rocprofvis_compute_root.h
@@ -20,14 +20,14 @@ public:
     void OpenTrace(const std::string& path);
     void SetProfilePath(const std::string& path);
     bool ProfileLoaded();
-    ComputeRoot(std::string owner_id);
+    ComputeRoot();
     ~ComputeRoot();
 
 private:
     std::shared_ptr<TabContainer> m_tab_container;
     std::shared_ptr<ComputeDataProvider> m_compute_data_provider;
     std::shared_ptr<ComputeDataProvider2> m_compute_data_provider2;
-    std::string m_owner_id;
+    std::string m_id;
     EventManager::SubscriptionToken m_data_dirty_event_token;
     bool m_data_dirty;
 };


### PR DESCRIPTION
[Problem]
-The navigation tree uses the file path of the trace to identify the root tab.  The path separator on ubuntu is the same as the url separator expected by navigation code, so the url cannot be parsed correctly. 

[Fix]
-Use a unique generated hex string to identify the root tab instead of trace path.