### PR TITLE
Improve UI Performance by avoiding temporary allocations

### DIFF
--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -94,7 +94,7 @@ FlameTrackItem::ExtractPointsFromData()
 
 void
 FlameTrackItem::DrawBox(ImVec2 start_position, int color_index,
-                        rocprofvis_trace_event_t flame, float duration,
+                        rocprofvis_trace_event_t const& flame, float duration,
                         ImDrawList* draw_list)
 {
     ImVec2 cursor_position = ImGui::GetCursorScreenPos();

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -21,7 +21,7 @@ public:
                    float movement, double min_x, double max_x, float scale_x);
     void SetRandomColorFlag(bool set_color);
     void DrawBox(ImVec2 start_position, int boxplot_box_id,
-                 rocprofvis_trace_event_t flame, float duration, ImDrawList* draw_list);
+                 rocprofvis_trace_event_t const& flame, float duration, ImDrawList* draw_list);
 
     bool                       HandleTrackDataChanged() override;
     bool                       ExtractPointsFromData();


### PR DESCRIPTION
Use a const& to rocprofvis_trace_event_t in FlameTrackItem::DrawBox to avoid a performance problem reallocating strings unnecessarily.