### PR TITLE
Include cfloat in rocprofvis_controller_graph.cpp for linux build.

### DIFF
--- a/src/controller/src/rocprofvis_controller_graph.cpp
+++ b/src/controller/src/rocprofvis_controller_graph.cpp
@@ -9,6 +9,7 @@
 #include "rocprofvis_controller_track.h"
 #include "rocprofvis_core.h"
 #include "rocprofvis_core_assert.h"
+#include <cfloat>
 
 namespace RocProfVis
 {


### PR DESCRIPTION
Fix build on linux:
_[build] /home/rocm/Dev/rocprofiler-visualizer/src/controller/src/rocprofvis_controller_graph.cpp:149:32: error: ‘DBL_MAX’ was not declared in this scope
[build]   149 |             double event_min = DBL_MAX;
[build]       |                                ^~~~~~~
[build] /home/rocm/Dev/rocprofiler-visualizer/src/controller/src/rocprofvis_controller_graph.cpp:10:1: note: ‘DBL_MAX’ is defined in header ‘<cfloat>’; did you forget to ‘#include cfloat’?_
