### PR TITLE
Fix jittery movement when zoomed in deeply on large data sets.

### DIFF
--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -18,7 +18,7 @@ class FlameTrackItem : public TrackItem
 {
 public:
     FlameTrackItem(DataProvider& dp, int chart_id, std::string name, float zoom,
-                   float movement, double min_x, double max_x, float scale_x);
+                   double time_offset_ns, double min_x, double max_x, double scale_x);
     void SetRandomColorFlag(bool set_color);
     void DrawBox(ImVec2 start_position, int boxplot_box_id,
                  rocprofvis_trace_event_t const& flame, float duration, ImDrawList* draw_list);

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -17,8 +17,8 @@ namespace View
 {
 
 LineTrackItem::LineTrackItem(DataProvider& dp, int id, std::string name, float zoom,
-                             float movement, double& min_x, double& max_x, float scale_x)
-: TrackItem(dp, id, name, zoom, movement, min_x, max_x, scale_x)
+                             double time_offset_ns, double& min_x, double& max_x, double scale_x)
+: TrackItem(dp, id, name, zoom, time_offset_ns, min_x, max_x, scale_x)
 , m_min_y(0)
 , m_max_y(0)
 , m_data({})
@@ -473,7 +473,7 @@ LineTrackItem::MapToUI(rocprofvis_data_point_t& point, ImVec2& cursor_position,
 {
     ImVec2 container_pos = ImGui::GetWindowPos();
 
-    double x = container_pos.x + (point.x_value - (m_min_x + m_movement)) * scaleX;
+    double x = container_pos.x + (point.x_value - (m_min_x + m_time_offset_ns)) * scaleX;
     double y = cursor_position.y + content_size.y - (point.y_value - m_min_y) * scaleY;
 
     return ImVec2(x, y);

--- a/src/view/src/rocprofvis_line_track_item.h
+++ b/src/view/src/rocprofvis_line_track_item.h
@@ -19,8 +19,8 @@ namespace View
 class LineTrackItem : public TrackItem
 {
 public:
-    LineTrackItem(DataProvider& dp, int id, std::string name, float zoom, float movement,
-                  double& min_x, double& max_x, float scale_x);
+    LineTrackItem(DataProvider& dp, int id, std::string name, float zoom, double time_offset_ns,
+                  double& min_x, double& max_x, double scale_x);
     ~LineTrackItem();
 
     ImVec2 MapToUI(rocprofvis_data_point_t& point, ImVec2& c_position, ImVec2& c_size,

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -9,11 +9,11 @@ using namespace RocProfVis::View;
 float TrackItem::s_metadata_width = 400.0f;
 
 TrackItem::TrackItem(DataProvider& dp, int id, std::string name, float zoom,
-                     float movement, double& min_x, double& max_x, float scale_x)
+                     double time_offset_ns, double& min_x, double& max_x, double scale_x)
 : m_data_provider(dp)
 , m_id(id)
 , m_zoom(zoom)
-, m_movement(movement)
+, m_time_offset_ns(time_offset_ns)
 , m_min_x(min_x)
 , m_max_x(max_x)
 , m_scale_x(scale_x)
@@ -111,11 +111,11 @@ TrackItem::SetSelected(bool selected)
 }
 
 void
-TrackItem::UpdateMovement(float zoom, float movement, double& min_x, double& max_x,
-                          float scale_x, float y_scroll_position)
+TrackItem::UpdateMovement(float zoom, double time_offset_ns, double& min_x, double& max_x,
+                          double scale_x, float y_scroll_position)
 {
     m_zoom     = zoom;
-    m_movement = movement;
+    m_time_offset_ns = time_offset_ns;
     m_scale_x  = scale_x;
     m_min_x    = min_x;
     m_max_x    = max_x;

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -20,8 +20,8 @@ enum class TrackDataRequestState
 class TrackItem
 {
 public:
-    TrackItem(DataProvider& dp, int id, std::string name, float zoom, float movement,
-              double& min_x, double& max_x, float scale_x);
+    TrackItem(DataProvider& dp, int id, std::string name, float zoom, double time_offset_ns,
+              double& min_x, double& max_x, double scale_x);
 
     virtual ~TrackItem() {}
     void               SetID(int id);
@@ -31,9 +31,9 @@ public:
     void               Update();
     const std::string& GetName();
 
-    virtual void UpdateMovement(float zoom, float movement, double& min_x, double& max_x,
-                                float scale_x,
-                                float m_scroll_position);  // movement should be double?
+    virtual void UpdateMovement(float zoom, double time_offset_ns, double& min_x, double& max_x,
+                                double scale_x,
+                                float m_scroll_position);
 
     virtual void SetColorByValue(rocprofvis_color_by_value_t color_by_value_digits) = 0;
     bool         IsInViewVertical();
@@ -69,7 +69,7 @@ protected:
     void FetchHelper();
 
     float                 m_zoom;
-    double                m_movement;
+    double                m_time_offset_ns;
     double                m_min_x;
     double                m_max_x;
     double                m_scale_x;


### PR DESCRIPTION
Floating point did not have enough precision for offset and scale variables.
Renamed movement to time_offset_ns for better clarity.
Added safeguards in FlameTrackItem::RenderChart() to prevent float overflow by capping large duration values to FLT_MAX.