### PR TITLE
Do not decrement index during reorder.

### DIFF
--- a/src/controller/src/rocprofvis_controller_timeline.cpp
+++ b/src/controller/src/rocprofvis_controller_timeline.cpp
@@ -367,10 +367,6 @@ rocprofvis_result_t Timeline::SetObject(rocprofvis_property_t property, uint64_t
                         {
                             m_graphs.erase(m_graphs.begin() + i);
                             is_replace = true;
-                            if (i < index)
-                            {
-                                index--;
-                            }
                             break;
                         }
                     }


### PR DESCRIPTION
[Problem]
- New position is always 1 less than the position specified by passed in index. Ex starting with {0, 1, 2}, if 0 is moved to index 2, the array will become {1, 0, 2} when the expected result is {1, 2, 0}. This also means it is not possible to move a graph downwards by 1 position as doing so results in the graph being put back into its original spot.

[Fix]
-Do not decrement index during reorder.