### PR TITLE
Simple copy to clipboard functionality for table view.

### DIFF
--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -49,7 +49,8 @@ private:
     uint64_t m_last_total_row_count;
     int m_current_group_selection_idx;
 
-
+    // Track the selected row for context menu actions    
+    int m_selected_row = -1;
     ImVec2 m_last_table_size;
     std::shared_ptr<TrackSelectionChangedEvent> m_track_selection_event_to_handle;
     


### PR DESCRIPTION
Added context menu option to copy row data to clipboard.

Right click on a table row to get a context menu that allows you to copy the data to the clipboard.