### PR TITLE
Add initial experimental thread-safety code to the SegmentTimeline

### DIFF
--- a/src/controller/inc/rocprofvis_controller_enums.h
+++ b/src/controller/inc/rocprofvis_controller_enums.h
@@ -33,6 +33,8 @@ typedef enum rocprofvis_result_t
     kRocProfVisResultCancelled = 11,
     // Operation is pending
     kRocProfVisResultPending = 12,
+    // Operation failed as a value is duplicated
+    kRocProfVisResultDuplicate = 13,
 } rocprofvis_result_t;
 
 /*


### PR DESCRIPTION
The contents of these objects cannot be modified without acquiring a mutex if we mean to support parallel operations in the UI.