### PR TITLE
Fix table desync when tracks are unselected quickly.

### DIFF
--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -30,6 +30,8 @@ enum class RequestType
     kFetchGraph,
     kFetchTrackEventTable,
     kFetchTrackSampleTable,
+    kClearTrackEventTable,
+    kClearTrackSampleTable,
     kFetchEventExtendedData,
     kFetchEventFlowDetails,
     kFetchEventCallStack
@@ -255,6 +257,7 @@ typedef struct data_req_info_t
     rocprofvis_controller_arguments_t* request_args;        // arguments for the request
     ProviderState                      loading_state;       // state of the request
     RequestType                        request_type;        // type of request
+    bool                               internal_request;    // true if request is handled by view (and not controller)
     std::shared_ptr<RequestParamsBase> custom_params;       // custom request parameters
 } data_req_info_t;
 
@@ -397,6 +400,8 @@ public:
 
     bool FetchMultiTrackTable(const TableRequestParams& table_params);
 
+    bool QueueClearTrackTableRequest(rocprofvis_controller_table_type_t table_type);
+
     bool IsRequestPending(uint64_t request_id);
 
     /*
@@ -465,7 +470,6 @@ public:
     const std::vector<std::vector<std::string>>& GetTableData(TableType type);
     std::shared_ptr<TableRequestParams>          GetTableParams(TableType type);
     uint64_t                                     GetTableTotalRowCount(TableType type);
-    void                                         ClearTable(TableType type);
 
     void SetTrackDataReadyCallback(
         const std::function<void(uint64_t, const std::string&)>& callback);
@@ -496,6 +500,11 @@ private:
 
     bool SetupCommonTableArguments(rocprofvis_controller_arguments_t* args,
                                    const TableRequestParams&          table_params);
+    /*
+    Clears data for a given table type.
+    This should not be called directly, instead use QueueClearTrackTableRequest().
+    */
+    void ClearTable(TableType type);
 
 
     void CreateRawEventData(const TrackRequestParams &params, rocprofvis_controller_array_t* track_data);                           

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -60,13 +60,11 @@ InfiniteScrollTable::HandleTrackSelectionChanged(
             }
         }
 
+        bool result = false;
         // if no tracks match the table type, clear the table
         if(filtered_tracks.empty())
         {
-            m_data_provider.ClearTable(m_table_type);
-            // Todo: Clear any pending requests for this table type?
-            // clear any pending track selection event
-            m_track_selection_event_to_handle = nullptr;
+            result = m_data_provider.QueueClearTrackTableRequest(m_req_table_type);
         }
         else
         {
@@ -77,20 +75,21 @@ InfiniteScrollTable::HandleTrackSelectionChanged(
                                                   m_group_columns.size() ? m_group_columns.data() : "",
                                                   0, m_fetch_chunk_size);
 
-            bool result = m_data_provider.FetchMultiTrackTable(event_table_params);
-            if(!result)
-            {
-                spdlog::error("Failed to fetch table data for tracks: {}",
-                              filtered_tracks.size());
-                // save this selection event to reprocess it later (it's ok to replace the
-                // previous one as the new one reflects the current selection)
-                m_track_selection_event_to_handle = selection_changed_event;
-            }
-            else
-            {
-                // clear any pending track selection event
-                m_track_selection_event_to_handle = nullptr;
-            }
+            result = m_data_provider.FetchMultiTrackTable(event_table_params);
+        }
+
+        if(!result)
+        {
+            spdlog::error("Failed to queue table request for tracks: {}",
+                            filtered_tracks.size());
+            // save this selection event to reprocess it later (it's ok to replace the
+            // previous one as the new one reflects the current selection)
+            m_track_selection_event_to_handle = selection_changed_event;
+        }
+        else
+        {
+            // clear any pending track selection event
+            m_track_selection_event_to_handle = nullptr;
         }
         // Update the selected tracks for this table type
         m_selected_tracks = std::move(filtered_tracks);


### PR DESCRIPTION
[Problem]
-Clearing of a table is essentially instantaneous while fetching new table data takes some time. With current implementation it is possible for a clear request issued after a fetch request to be handled before the fetch request. This causes the cleared table to be overwritten by the fetched data, even though the last action taken by the user should result in a cleared table.

[Fix]
-Add interal requests types kClearTrackEventTable, kClearTrackSampleTable. These requests are not sent to controller. When they are handled, they clear their respective m_table_infos. This ensures that a clear request issued after a fetch request will be handled after the fetch request.
