### PR TITLE
Fix typo in queries using the table: rocpd_memory_copy

### DIFF
--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -572,14 +572,14 @@ rocprofvis_dm_result_t  RocprofDatabase::ReadFlowTraceInfo(
                         "SELECT E.id as id, 4, E.correlation_id, MC.nid, MC.dst_agent_id, coalesce(MC.queue_id,0), MC.start "
                         "FROM rocpd_region R "
                         "INNER JOIN rocpd_event E ON R.event_id = E.id "
-                        "INNER JOIN _rocpd_memory_copy MC ON MC.id = E.correlation_id "
+                        "INNER JOIN rocpd_memory_copy MC ON MC.id = E.correlation_id "
                         "WHERE R.id == ";
             query << event_id.bitfield.event_id;
                         " UNION "
                         "SELECT E.id as id, 3, E.correlation_id, MA.nid, MA.agent_id, coalesce(MA.queue_id,0), MA.start "
                         "FROM rocpd_region R "
                         "INNER JOIN rocpd_event E ON R.event_id = E.id "
-                        "INNER JOIN _rocpd_memory_copy MA ON MA.id = E.correlation_id "
+                        "INNER JOIN rocpd_memory_copy MA ON MA.id = E.correlation_id "
                         "WHERE R.id == ";
             query << event_id.bitfield.event_id;
                         query << ");";
@@ -600,7 +600,7 @@ rocprofvis_dm_result_t  RocprofDatabase::ReadFlowTraceInfo(
         if (event_id.bitfield.event_op == kRocProfVisDmOperationMemoryCopy)
         {
             query <<    "SELECT E.id as id, 1, E.correlation_id, R.nid, R.pid, R.tid, R.end "
-                        "FROM _rocpd_memory_copy MC "
+                        "FROM rocpd_memory_copy MC "
                         "INNER JOIN rocpd_event E ON MC.event_id = E.id "
                         "INNER JOIN rocpd_region R ON R.id = E.correlation_id "
                         "WHERE MC.id == ";


### PR DESCRIPTION
Memory tracks appear to be named correctly now.
Memory events now display extended data.

Fix for errors such as these in the log files:

```
[2025-08-14 09:29:36.272] [rocprofvis-log] [debug] SELECT * FROM (SELECT E.id as id, 2, E.correlation_id, KD.nid, KD.agent_id, KD.queue_id, KD.start FROM rocpd_region R INNER JOIN rocpd_event E ON R.event_id = E.id INNER JOIN rocpd_kernel_dispatch KD ON KD.id = E.correlation_id WHERE R.id == 52011 UNION SELECT E.id as id, 4, E.correlation_id, MC.nid, MC.dst_agent_id, coalesce(MC.queue_id,0), MC.start FROM rocpd_region R INNER JOIN rocpd_event E ON R.event_id = E.id INNER JOIN _rocpd_memory_copy MC ON MC.id = E.correlation_id WHERE R.id == 5201152011);
[2025-08-14 09:29:36.273] [rocprofvis-log] [debug] SQL error 
[2025-08-14 09:29:36.273] [rocprofvis-log] [debug] 1
[2025-08-14 09:29:36.273] [rocprofvis-log] [debug] :
[2025-08-14 09:29:36.273] [rocprofvis-log] [debug] no such table: _rocpd_memory_copy
```

