### PR TITLE
Enable horizontal scolling and hiding columns via table flags

### DIFF
--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -184,9 +184,9 @@ InfiniteScrollTable::Render()
     rocprofvis_controller_sort_order_t sort_order = kRPVControllerSortOrderAscending;
 
     ImGuiTableFlags table_flags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_RowBg |
-                                  ImGuiTableFlags_BordersOuter |
+                                  ImGuiTableFlags_BordersOuter | ImGuiTableFlags_ScrollX |
                                   ImGuiTableFlags_BordersV | ImGuiTableFlags_Resizable |
-                                  ImGuiTableFlags_Reorderable;
+                                  ImGuiTableFlags_Reorderable | ImGuiTableFlags_Hideable;
 
     if(!m_data_provider.IsRequestPending(m_table_type == TableType::kEventTable
                                              ? DataProvider::EVENT_TABLE_REQUEST_ID


### PR DESCRIPTION
Event table now supports horizontal scrolling and enables context menu to hide / show columns.