### PR TITLE
FIx linux build

### DIFF
--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -61,7 +61,7 @@ ProfileDatabase::CallbackGetTrackRecordsCount(void* data, int argc, sqlite3_stmt
 {
     ROCPROFVIS_ASSERT_MSG_RETURN(argc == 3, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void *func = &CallbackGetTrackRecordsCount;
+    void *func = (void*)&CallbackGetTrackRecordsCount;
     rocprofvis_db_sqlite_callback_parameters* callback_params =
         (rocprofvis_db_sqlite_callback_parameters*) data;
     ProfileDatabase* db = (ProfileDatabase*) callback_params->db;
@@ -79,7 +79,7 @@ ProfileDatabase::CallbackTrimTableQuery(void* data, int argc, sqlite3_stmt* stmt
                                                 char** azColName)
 {
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void *func = &CallbackTrimTableQuery;
+    void *func = (void*)&CallbackTrimTableQuery;
     rocprofvis_db_sqlite_callback_parameters* callback_params =
         (rocprofvis_db_sqlite_callback_parameters*) data;
     rocprofvis_db_sqlite_trim_parameters* params =
@@ -100,7 +100,7 @@ int ProfileDatabase::CallbackGetTrackProperties(void* data, int argc, sqlite3_st
 {
     ROCPROFVIS_ASSERT_MSG_RETURN(argc == 5, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void *func = &CallbackGetTrackProperties;
+    void *func = (void*)&CallbackGetTrackProperties;
     rocprofvis_db_sqlite_callback_parameters* callback_params =
         (rocprofvis_db_sqlite_callback_parameters*) data;
     ProfileDatabase*            db = (ProfileDatabase*) callback_params->db;
@@ -122,7 +122,7 @@ int ProfileDatabase::CallbackAddAnyRecord(void* data, int argc, sqlite3_stmt* st
     ROCPROFVIS_ASSERT_MSG_RETURN(argc == rocprofvis_db_sqlite_slice_query_format::NUM_PARAMS,
                                  ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void *func = &CallbackAddAnyRecord;
+    void *func = (void*)&CallbackAddAnyRecord;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     ProfileDatabase* db = (ProfileDatabase*)callback_params->db;
     if(callback_params->future->Interrupted()) return SQLITE_ABORT;
@@ -169,7 +169,7 @@ int ProfileDatabase::CallbackAddFlowTrace(void *data, int argc, sqlite3_stmt* st
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(argc == rocprofvis_db_sqlite_dataflow_query_format::NUM_PARAMS,
                                  ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
-    void*  func = &CallbackAddFlowTrace;
+    void*  func = (void*)&CallbackAddFlowTrace;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     ProfileDatabase* db = (ProfileDatabase*)callback_params->db;
     if(callback_params->future->Interrupted()) return SQLITE_ABORT;
@@ -193,7 +193,7 @@ int ProfileDatabase::CallbackAddFlowTrace(void *data, int argc, sqlite3_stmt* st
 
 int ProfileDatabase::CallbackAddExtInfo(void* data, int argc, sqlite3_stmt* stmt, char** azColName) {
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void*  func = &CallbackAddExtInfo;
+    void*  func = (void*)&CallbackAddExtInfo;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     ProfileDatabase* db = (ProfileDatabase*)callback_params->db;
     rocprofvis_db_ext_data_t record;
@@ -217,7 +217,7 @@ int ProfileDatabase::CallbackAddEssentialInfo(void* data, int argc, sqlite3_stmt
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(argc == rocprofvis_db_sqlite_essential_data_query_format::NUM_PARAMS,
                                  ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
-    void*  func = &CallbackAddEssentialInfo;
+    void*  func = (void*)&CallbackAddEssentialInfo;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     ProfileDatabase* db = (ProfileDatabase*)callback_params->db;
     rocprofvis_db_ext_data_t record;
@@ -665,7 +665,7 @@ int ProfileDatabase::CalculateEventLevels(void* data, int argc, sqlite3_stmt* st
 {
     ROCPROFVIS_ASSERT_MSG_RETURN(argc == 9 , ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void* func = &CalculateEventLevels;
+    void* func = (void*)&CalculateEventLevels;
     rocprofvis_db_sqlite_callback_parameters* callback_params =
         (rocprofvis_db_sqlite_callback_parameters*) data;
     ProfileDatabase* db = (ProfileDatabase*) callback_params->db;

--- a/src/model/src/database/rocprofvis_db_rocpd.cpp
+++ b/src/model/src/database/rocprofvis_db_rocpd.cpp
@@ -92,7 +92,7 @@ rocprofvis_dm_size_t RocpdDatabase::GetMemoryFootprint()
 int RocpdDatabase::CallBackAddTrack(void *data, int argc, sqlite3_stmt* stmt, char **azColName){
     ROCPROFVIS_ASSERT_MSG_RETURN(argc== NUMBER_OF_TRACK_IDENTIFICATION_PARAMETERS + 1, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void* func = &CallBackAddTrack;
+    void* func = (void*)&CallBackAddTrack;
     rocprofvis_dm_track_params_t track_params = {0};
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     RocpdDatabase* db = (RocpdDatabase*)callback_params->db;
@@ -157,7 +157,7 @@ int RocpdDatabase::CallBackAddTrack(void *data, int argc, sqlite3_stmt* stmt, ch
 int RocpdDatabase::CallBackAddString(void *data, int argc, sqlite3_stmt* stmt, char **azColName){
     ROCPROFVIS_ASSERT_MSG_RETURN(argc==2, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void* func = &CallBackAddString;
+    void* func = (void*)&CallBackAddString;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     RocpdDatabase* db = (RocpdDatabase*)callback_params->db;
     if(callback_params->future->Interrupted()) return SQLITE_ABORT;
@@ -177,7 +177,7 @@ int RocpdDatabase::CallBackAddString(void *data, int argc, sqlite3_stmt* stmt, c
 int RocpdDatabase::CallbackAddStackTrace(void *data, int argc, sqlite3_stmt* stmt, char **azColName){
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(argc==4, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
-    void* func = &CallbackAddStackTrace;
+    void* func = (void*)&CallbackAddStackTrace;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     RocpdDatabase* db = (RocpdDatabase*)callback_params->db;
     rocprofvis_db_stack_data_t record;

--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -68,7 +68,7 @@ rocprofvis_dm_result_t RocprofDatabase::RemapStringIds(rocprofvis_db_flow_data_t
 int RocprofDatabase::CallBackAddTrack(void *data, int argc, sqlite3_stmt* stmt, char **azColName){
     ROCPROFVIS_ASSERT_MSG_RETURN(argc==NUMBER_OF_TRACK_IDENTIFICATION_PARAMETERS+1, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void* func = &CallBackAddTrack;
+    void* func = (void*)&CallBackAddTrack;
     rocprofvis_dm_track_params_t track_params = {0};
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     RocprofDatabase* db = (RocprofDatabase*)callback_params->db;
@@ -165,7 +165,7 @@ int RocprofDatabase::CallBackAddTrack(void *data, int argc, sqlite3_stmt* stmt, 
 int RocprofDatabase::CallBackAddString(void *data, int argc, sqlite3_stmt* stmt, char **azColName){
     ROCPROFVIS_ASSERT_MSG_RETURN(argc==1, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void*  func = &CallBackAddString;
+    void*  func = (void*)&CallBackAddString;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     RocprofDatabase* db = (RocprofDatabase*)callback_params->db;
     if(callback_params->future->Interrupted()) return SQLITE_ABORT;
@@ -177,7 +177,7 @@ int RocprofDatabase::CallBackAddString(void *data, int argc, sqlite3_stmt* stmt,
 
 int RocprofDatabase::CallbackCacheTable(void *data, int argc, sqlite3_stmt* stmt, char **azColName){
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void* func = &CallbackCacheTable;
+    void* func = (void*)&CallbackCacheTable;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     RocprofDatabase* db = (RocprofDatabase*)callback_params->db;
     DatabaseCache * ref_tables = (DatabaseCache *)callback_params->handle;
@@ -196,7 +196,7 @@ RocprofDatabase::CallbackNodeEnumeration(void* data, int argc, sqlite3_stmt* stm
                                          char** azColName)
 {
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void*  func = &CallbackNodeEnumeration;
+    void*  func = (void*)&CallbackNodeEnumeration;
     rocprofvis_db_sqlite_callback_parameters* callback_params =
         (rocprofvis_db_sqlite_callback_parameters*) data;
     RocprofDatabase* db = (RocprofDatabase*) callback_params->db;
@@ -218,7 +218,7 @@ RocprofDatabase::CallbackAddStackTrace(void* data, int argc, sqlite3_stmt* stmt,
 {
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(argc == 2, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
-    void*  func = &CallbackAddStackTrace;
+    void*  func = (void*)&CallbackAddStackTrace;
     rocprofvis_db_sqlite_callback_parameters* callback_params =
         (rocprofvis_db_sqlite_callback_parameters*) data;
     RocprofDatabase*           db = (RocprofDatabase*) callback_params->db;

--- a/src/model/src/database/rocprofvis_db_rocprof.h
+++ b/src/model/src/database/rocprofvis_db_rocprof.h
@@ -204,7 +204,7 @@ private:
 
         inline static const rocprofvis_null_data_exceptions_skip
             s_null_data_exceptions_skip = { 
-                { &CallBackAddTrack,
+                { (void*)&CallBackAddTrack,
                   { 
                         Builder::AGENT_ID_SERVICE_NAME, 
                         Builder::QUEUE_ID_SERVICE_NAME 
@@ -221,7 +221,7 @@ private:
         inline static const rocprofvis_null_data_exceptions_string
             s_null_data_exceptions_string = { 
             { 
-                &CallbackCacheTable, 
+                (void*)&CallbackCacheTable, 
                 { 
                     { "name", "N/A" }, 
                     { "start", "0" }, 
@@ -229,7 +229,7 @@ private:
                 },
             },
             {
-                &CallbackRunQuery,
+                (void*)&CallbackRunQuery,
                 { 
                     { "name", "N/A" },  
                     { "start", "0" }, 

--- a/src/model/src/database/rocprofvis_db_sqlite.cpp
+++ b/src/model/src/database/rocprofvis_db_sqlite.cpp
@@ -30,7 +30,7 @@ namespace DataModel
 int SqliteDatabase::CallbackGetValue(void* data, int argc, sqlite3_stmt* stmt, char** azColName){
     ROCPROFVIS_ASSERT_MSG_RETURN(argc==1, ERROR_DATABASE_QUERY_PARAMETERS_MISMATCH, 1);
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
-    void*  func = &CallbackGetValue;
+    void*  func = (void*)&CallbackGetValue;
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     SqliteDatabase* db = (SqliteDatabase*) callback_params->db;
     std::string * string_ptr = (rocprofvis_dm_string_t*)callback_params->handle;
@@ -230,7 +230,7 @@ SqliteDatabase::CollectTrackServiceData(
     sqlite3_stmt* stmt, int column_index, char** azColName,
                         rocprofvis_db_sqlite_track_service_data_t& service_data)
 {
-    void* func = &CollectTrackServiceData;
+    void* func = (void*)&CollectTrackServiceData;
     std::string column_name = azColName[column_index];
     if(column_name == Builder::OPERATION_SERVICE_NAME)
     {
@@ -296,7 +296,7 @@ int SqliteDatabase::CallbackRunQuery(void *data, int argc, sqlite3_stmt* stmt, c
     ROCPROFVIS_ASSERT_MSG_RETURN(data, ERROR_SQL_QUERY_PARAMETERS_CANNOT_BE_NULL, 1);
     rocprofvis_db_sqlite_callback_parameters* callback_params = (rocprofvis_db_sqlite_callback_parameters*)data;
     SqliteDatabase* db = (SqliteDatabase*)callback_params->db;
-    void* func = &CallbackRunQuery;
+    void* func = (void*)&CallbackRunQuery;
     if (callback_params->future->Interrupted()) return 1;
     rocprofvis_db_sqlite_track_service_data_t service_data{};
     bool  is_query_for_table_view = false;
@@ -772,7 +772,7 @@ int SqliteDatabase::Sqlite3Exec(sqlite3* db, const char* query,
             {
                 if(sqlite3_column_type(stmt, i) == SQLITE_NULL)
                 {
-                    skip_this_row = NullExceptionSkip(callback, col_names[i]);
+                    skip_this_row = NullExceptionSkip((void*)callback, col_names[i]);
                     if(skip_this_row)
                     {
                         break;


### PR DESCRIPTION
-Cast callbacks:

```
error: invalid conversion from ‘int (*)(void*, int, sqlite3_stmt*, char**)’ to ‘void*’ [-fpermissive]
[build]   668 |     void* func = &CalculateEventLevels;
[build]       |                  ^~~~~~~~~~~~~~~~~~~~~
[build]       |                  |
[build]       |                  int (*)(void*, int, sqlite3_stmt*, char**)
```