### PR TITLE
Fix timeline vertical splitter not working.

### DIFF
--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -161,7 +161,7 @@ TimelineView::RenderInteractiveUI(ImVec2 screen_pos)
     ImGui::SetScrollY(static_cast<float>(m_scroll_position_y));
     ImGui::BeginChild("UI Interactive Content", ImVec2(m_graph_size.x, total_height),
                       false,
-                      ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+                      window_flags | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
 
     ImDrawList* draw_list       = ImGui::GetWindowDrawList();
     ImVec2      window_position = ImGui::GetWindowPos();


### PR DESCRIPTION
-Prevent "UI Interactive Content" window from taking mouse inputs.