### PR TITLE
Fix duplicate tracks and ID conflicts in sidebar.

### DIFF
--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -83,11 +83,8 @@ SideBar::Render()
                                                 {
                                                     if(queue.info)
                                                     {
-                                                        ImGui::PushID(
-                                                            queue.info->name.c_str());
                                                         RenderTrackItem(
                                                             queue.graph_index);
-                                                        ImGui::PopID();
                                                     }
                                                 }
                                                 ImGui::Unindent();
@@ -103,11 +100,8 @@ SideBar::Render()
                                                 {
                                                     if(stream.info)
                                                     {
-                                                        ImGui::PushID(
-                                                            stream.info->name.c_str());
                                                         RenderTrackItem(
                                                             stream.graph_index);
-                                                        ImGui::PopID();
                                                     }
                                                 }
                                                 ImGui::Unindent();
@@ -123,11 +117,8 @@ SideBar::Render()
                                                 {
                                                     if(thread.info)
                                                     {
-                                                        ImGui::PushID(
-                                                            thread.info->name.c_str());
                                                         RenderTrackItem(
                                                             thread.graph_index);
-                                                        ImGui::PopID();
                                                     }
                                                 }
                                                 ImGui::Unindent();
@@ -143,11 +134,8 @@ SideBar::Render()
                                                 {
                                                     if(counter.info)
                                                     {
-                                                        ImGui::PushID(
-                                                            counter.info->name.c_str());
                                                         RenderTrackItem(
                                                             counter.graph_index);
-                                                        ImGui::PopID();
                                                     }
                                                 }
                                                 ImGui::Unindent();
@@ -180,9 +168,7 @@ SideBar::Render()
                 {
                     for(const int& index : topology.uncategorized_graph_indices)
                     {
-                        ImGui::PushID((*m_graphs)[index].chart->GetID());
                         RenderTrackItem(index);
-                        ImGui::PopID();
                     }
                 }
                 if(use_header)
@@ -206,6 +192,7 @@ SideBar::RenderTrackItem(const int& index)
 {
     rocprofvis_graph_t& graph = (*m_graphs)[index];
 
+    ImGui::PushID(graph.chart->GetID());
     ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
                           m_settings.GetColor(Colors::kTransparent));
@@ -292,6 +279,7 @@ SideBar::RenderTrackItem(const int& index)
             "Not In Frame by: %f units.", graph.chart->GetDistanceToView());
     }
 #endif
+    ImGui::PopID();
 }
 
 }  // namespace View


### PR DESCRIPTION
-Do not include threads/queues/streams without track bindings when querying topology. (This is already done for counters).
-Use track id as ID for each leaf sidebar entry, instead of thread/queue/stream/counter name.