### PR TITLE
Clean up of event notification code

### DIFF
--- a/src/view/src/rocprofvis_analysis_view.cpp
+++ b/src/view/src/rocprofvis_analysis_view.cpp
@@ -109,7 +109,7 @@ AnalysisView::HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e)
         {
             std::shared_ptr<TrackSelectionChangedEvent> selection_changed_event =
                 std::static_pointer_cast<TrackSelectionChangedEvent>(e);
-            if(selection_changed_event && selection_changed_event->GetTracePath() ==
+            if(selection_changed_event && selection_changed_event->GetSourceId() ==
                                               m_data_provider.GetTraceFilePath())
             {
                 if(m_event_table)
@@ -130,7 +130,7 @@ AnalysisView::HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e)
         {
             std::shared_ptr<EventSelectionChangedEvent> selection_changed_event =
                 std::static_pointer_cast<EventSelectionChangedEvent>(e);
-            if(selection_changed_event && selection_changed_event->GetTracePath() ==
+            if(selection_changed_event && selection_changed_event->GetSourceId() ==
                                               m_data_provider.GetTraceFilePath())
             {
                 if(m_events_view)
@@ -151,7 +151,7 @@ AnalysisView::HandleNewTableData(std::shared_ptr<RocEvent> e)
         std::shared_ptr<TableDataEvent> table_data_event =
             std::static_pointer_cast<TableDataEvent>(e);
         if(table_data_event &&
-           table_data_event->GetTracePath() == m_data_provider.GetTraceFilePath())
+           table_data_event->GetSourceId() == m_data_provider.GetTraceFilePath())
         {
             const uint64_t& request_id = table_data_event->GetRequestID();
             if(request_id == DataProvider::EVENT_TABLE_REQUEST_ID && m_event_table)

--- a/src/view/src/rocprofvis_annotations.cpp
+++ b/src/view/src/rocprofvis_annotations.cpp
@@ -98,6 +98,7 @@ AnnotationsViewProjectSettings::Valid() const
 
 AnnotationsView::AnnotationsView(const std::string& project_id)
 : m_project_settings(project_id, *this)
+, m_project_id(project_id)
 {
     if(m_project_settings.Valid())
     {
@@ -105,11 +106,11 @@ AnnotationsView::AnnotationsView(const std::string& project_id)
     }
 
     auto sticky_note_handler = [this](std::shared_ptr<RocEvent> e) {
-        m_show_sticky_edit_popup = true;
-        auto evt                 = std::dynamic_pointer_cast<StickyNoteEvent>(e);
-        if(evt)
+        auto evt = std::dynamic_pointer_cast<StickyNoteEvent>(e);
+        if(evt && evt->GetSourceId() == m_project_id)
         {
-            m_edit_sticky_id = evt->GetID();
+            m_show_sticky_edit_popup = true;
+            m_edit_sticky_id         = evt->GetNoteId();
 
             for(int i = 0; i < m_sticky_notes.size(); i++)
             {
@@ -147,7 +148,7 @@ void
 AnnotationsView::AddSticky(double time_ns, float y_offset, const ImVec2& size,
                            const std::string& text, const std::string& title)
 {
-    m_sticky_notes.emplace_back(time_ns, y_offset, size, text, title);
+    m_sticky_notes.emplace_back(time_ns, y_offset, size, text, title, m_project_id);
 }
 
 bool

--- a/src/view/src/rocprofvis_annotations.h
+++ b/src/view/src/rocprofvis_annotations.h
@@ -62,6 +62,7 @@ private:
     int                             m_edit_sticky_id         = -1;
     EventManager::SubscriptionToken m_edit_token;
 
+    std::string                    m_project_id;
     AnnotationsViewProjectSettings m_project_settings;
 };
 

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -508,7 +508,7 @@ AppWindow::HandleTabSelectionChanged(std::shared_ptr<RocEvent> e)
     if(tab_selected_event)
     {
         // Only handle the event if the tab source is the main tab source
-        if(tab_selected_event->GetTabSource() == GetMainTabSourceName())
+        if(tab_selected_event->GetSourceId() == GetMainTabSourceName())
         {
             m_main_view->GetMutableAt(m_tool_bar_index)->m_item = nullptr;  
 

--- a/src/view/src/rocprofvis_events.h
+++ b/src/view/src/rocprofvis_events.h
@@ -52,19 +52,65 @@ class RocEvent
 public:
     RocEvent();
     RocEvent(int event_id);
+    RocEvent(int event_id, const std::string& src_id);
     virtual ~RocEvent();
 
-    virtual int          GetId();
-    virtual void         SetId(int id);
-    virtual RocEventType GetType();
-    virtual void         SetType(RocEventType type);
-    virtual void         SetAllowPropagate(bool allow);
-    void                 StopPropagation();
-    bool                 CanPropagate() const;
+    /**
+     * @brief Get the event ID, see the RocEvents enum for standard event IDs.
+     * @return int Event ID
+     */
+    int GetId() const;
+
+    /**
+     * @brief Set the event ID
+     * @param id Event ID
+     */
+    void SetId(int id);
+
+    /**
+     * @brief Get the event type, see the RocEventType enum for standard event types.
+     *        Use this to determine the actual derived type of the event object.
+     * @return RocEventType Event Type
+     */
+    RocEventType GetType() const;
+
+    /**
+     * @brief Set whether the event can propagate to other listeners.
+     *        If set to false, the event will not be propagated further.
+     * @param allow True to allow propagation, false to stop propagation.
+     */
+    void SetAllowPropagate(bool allow);
+
+    /**
+     * @brief Stop the propagation of the event to other listeners.
+     */
+    void StopPropagation();
+
+    /**
+     * @brief Check if the event can propagate to other listeners.
+     * @return true if the event can propagate, false otherwise.
+     */
+    bool CanPropagate() const;
+
+    /**
+     * @brief Set the source ID of the event.
+     *        Set this so that event listeners can filter events based on source.
+     * @param source_id Source ID
+     */
+    void SetSourceId(const std::string& source_id);
+
+    /**
+     * @brief Get the source ID of the event.
+     * @return std::string Source ID
+     */
+    const std::string GetSourceId() const;
 
 protected:
+    void SetType(RocEventType type);
+
     int          m_event_id;
     RocEventType m_event_type;
+    std::string  m_source_id;
 
 private:
     bool m_allow_propagate;
@@ -73,16 +119,14 @@ private:
 class TrackDataEvent : public RocEvent
 {
 public:
-    TrackDataEvent(int event_id, uint64_t track_id, const std::string& trace_path,
+    TrackDataEvent(int event_id, uint64_t track_id, const std::string& source_id,
                    uint64_t request_id, uint64_t response_code);
     uint64_t           GetTrackID() const;
-    const std::string& GetTracePath() const;
     uint64_t           GetRequestID() const;
     uint64_t           GetResponseCode() const;
 
 private:
     uint64_t    m_track_id;
-    std::string m_trace_path;
     uint64_t    m_request_id;
     uint64_t    m_response_code;
 };
@@ -90,20 +134,18 @@ private:
 class TableDataEvent : public RocEvent
 {
 public:
-    TableDataEvent(const std::string& trace_path, uint64_t request_id);
-    const std::string& GetTracePath() const;
+    TableDataEvent(const std::string& source_id, uint64_t request_id);
     uint64_t           GetRequestID() const;
 
 private:
-    std::string m_trace_path;
     uint64_t    m_request_id;
 };
 
 class StickyNoteEvent : public RocEvent
 {
 public:
-    StickyNoteEvent(int id);
-    const int GetID();
+    StickyNoteEvent(int id, const std::string& source_id);
+    const int GetNoteId() const;
 
 private:
     int m_id;
@@ -113,17 +155,14 @@ class ScrollToTrackEvent : public RocEvent
 {
 public:
     ScrollToTrackEvent(int event_id, const uint64_t& track_id,
-                       const std::string& trace_path);
+                       const std::string& source_id);
     const uint64_t     GetTrackID() const;
-    const std::string& GetTracePath() const;
 
 private:
     uint64_t    m_track_id;
-    std::string m_trace_path;
 };
 
 #ifdef COMPUTE_UI_SUPPORT
-
 class ComputeTableSearchEvent : public RocEvent
 {
 public:
@@ -134,44 +173,40 @@ private:
     std::string m_search_term;
 };
 #endif
+
 class TabEvent : public RocEvent
 {
 public:
-    TabEvent(int event_id, const std::string& tab_id, const std::string& tab_source);
+    TabEvent(int event_id, const std::string& tab_id, const std::string& source_id);
     const std::string& GetTabId() const;
-    const std::string& GetTabSource() const;
 
 private:
     std::string m_tab_id;
-    std::string m_tab_source;
 };
 
 class TrackSelectionChangedEvent : public RocEvent
 {
 public:
     TrackSelectionChangedEvent(std::vector<uint64_t> selected_tracks, double start_ns,
-                               double end_ns, const std::string& trace_path);
+                               double end_ns, const std::string& source_id);
     const std::vector<uint64_t>& GetSelectedTracks() const;
     double                       GetStartNs() const;
     double                       GetEndNs() const;
-    const std::string&           GetTracePath() const;
 
 private:
     std::vector<uint64_t> m_selected_tracks;  // IDs of selected tracks
     double                m_start_ns;         // start time in nanoseconds
     double                m_end_ns;           // end time in nanoseconds
-    std::string           m_trace_path;
 };
 
 class EventSelectionChangedEvent : public RocEvent
 {
 public:
     EventSelectionChangedEvent(uint64_t event_id, uint64_t track_id, bool selected,
-                               const std::string& trace_path, bool batch = false);
+                               const std::string& source_id, bool batch = false);
     uint64_t           GetEventID() const;
     uint64_t           GetEventTrackID() const;
     bool               EventSelected() const;
-    const std::string& GetTracePath() const;
     bool               IsBatch() const;
     
 private:
@@ -179,22 +214,19 @@ private:
     uint16_t    m_event_track_id;
     bool        m_selected;
     bool        m_is_batch;
-    std::string m_trace_path;
 };
 
 class RangeEvent : public RocEvent
 {
 public:
     RangeEvent(int event_id, double start_ns, double end_ns,
-                      const std::string& trace_path);
+                      const std::string& source_id);
     double             GetStartNs() const;
     double             GetEndNs() const;
-    const std::string& GetTracePath() const;
 
 private:
     double      m_start_ns;
     double      m_end_ns;
-    std::string m_trace_path;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -152,7 +152,7 @@ FlameTrackItem::HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e)
     std::shared_ptr<EventSelectionChangedEvent> selection_changed_event =
         std::static_pointer_cast<EventSelectionChangedEvent>(e);
     if(selection_changed_event &&
-       selection_changed_event->GetTracePath() == m_data_provider.GetTraceFilePath())
+       selection_changed_event->GetSourceId() == m_data_provider.GetTraceFilePath())
     {
         // Update selection state cache.
         for(ChartItem& item : m_chart_items)

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -10,12 +10,14 @@ namespace View
 
 static int s_unique_id_counter = 0;
 StickyNote::StickyNote(double time_ns, float y_offset, const ImVec2& size,
-                       const std::string& text, const std::string& title)
+                       const std::string& text, const std::string& title,
+                       const std::string& project_id)
 : m_time_ns(time_ns)
 , m_y_offset(y_offset)
 , m_size(size)
 , m_text(text)
 , m_title(title)
+, m_project_id(project_id)
 , m_id(s_unique_id_counter)
 {
     s_unique_id_counter = s_unique_id_counter + 1;
@@ -138,7 +140,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position, double 
            ("EditSticky##" + std::to_string(reinterpret_cast<uintptr_t>(this))).c_str(),
            ImVec2(edit_btn_size, edit_btn_size)))
     {
-        EventManager::GetInstance()->AddEvent(std::make_shared<StickyNoteEvent>(m_id));
+        EventManager::GetInstance()->AddEvent(std::make_shared<StickyNoteEvent>(m_id, m_project_id));
     }
 
     // Draw edit button graphics over the button

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -11,7 +11,7 @@ class StickyNote
 {
 public:
     StickyNote(double time_ns, float y_offset, const ImVec2& size,
-               const std::string& text, const std::string& title);
+               const std::string& text, const std::string& title, const std::string &project_id);
 
     void Render(ImDrawList* draw_list, const ImVec2& window_position, double v_min_x,
                 double pixels_per_ns);
@@ -40,6 +40,7 @@ private:
     ImVec2      m_size;
     std::string m_text;
     std::string m_title;
+    std::string m_project_id;
     bool        m_dragging      = false;
     ImVec2      m_drag_offset   = ImVec2(0, 0);
     ImVec2      m_resize_offset = ImVec2(0, 0);

--- a/src/view/src/rocprofvis_timeline_arrow.cpp
+++ b/src/view/src/rocprofvis_timeline_arrow.cpp
@@ -170,7 +170,7 @@ TimelineArrow::HandleEventSelectionChanged(std::shared_ptr<RocEvent> e)
     std::shared_ptr<EventSelectionChangedEvent> selection_changed_event =
         std::static_pointer_cast<EventSelectionChangedEvent>(e);
     if(selection_changed_event &&
-       selection_changed_event->GetTracePath() == m_data_provider.GetTraceFilePath())
+       selection_changed_event->GetSourceId() == m_data_provider.GetTraceFilePath())
     {
         m_selected_event_data.clear();
         std::vector<uint64_t> selected_event_ids;

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -84,7 +84,7 @@ TimelineView::TimelineView(DataProvider&                      dp,
         auto evt = std::dynamic_pointer_cast<ScrollToTrackEvent>(e);
         if(evt)
         {
-            if(evt->GetTracePath() == m_data_provider.GetTraceFilePath())
+            if(evt->GetSourceId() == m_data_provider.GetTraceFilePath())
             {
                 this->ScrollToTrack(evt->GetTrackID());
             }
@@ -98,7 +98,7 @@ TimelineView::TimelineView(DataProvider&                      dp,
         auto evt = std::dynamic_pointer_cast<RangeEvent>(e);
         if(evt)
         {
-            if(evt->GetTracePath() == m_data_provider.GetTraceFilePath())
+            if(evt->GetSourceId() == m_data_provider.GetTraceFilePath())
             {
                 this->SetViewableRangeNS(evt->GetStartNs(), evt->GetEndNs());
             }
@@ -332,7 +332,7 @@ TimelineView::HandleNewTrackData(std::shared_ptr<RocEvent> e)
     }
     else
     {
-        const std::string& trace_path = tde->GetTracePath();
+        const std::string& trace_path = tde->GetSourceId();
         // check if event trace path matches the current our data provider's trace path
         // since events are global for all views
         if(m_data_provider.GetTraceFilePath() != trace_path)

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -46,7 +46,7 @@ TraceView::TraceView()
         if(ets)
         {
             // Only handle the event if the tab source is the main tab source
-            if(ets->GetTabSource() == AppWindow::GetInstance()->GetMainTabSourceName())
+            if(ets->GetSourceId() == AppWindow::GetInstance()->GetMainTabSourceName())
             {
                 m_data_provider.SetSelectedState(ets->GetTabId());
             }
@@ -94,7 +94,7 @@ TraceView::TraceView()
     auto event_selection_handler = [this](std::shared_ptr<RocEvent> e) {
         std::shared_ptr<EventSelectionChangedEvent> event =
             std::dynamic_pointer_cast<EventSelectionChangedEvent>(e);
-        if(event && event->GetTracePath() == m_data_provider.GetTraceFilePath())
+        if(event && event->GetSourceId() == m_data_provider.GetTraceFilePath())
         {
             if(event->EventSelected())
             {

--- a/src/view/src/rocprofvis_track_details.cpp
+++ b/src/view/src/rocprofvis_track_details.cpp
@@ -243,7 +243,7 @@ void
 TrackDetails::HandleTrackSelectionChanged(
     std::shared_ptr<TrackSelectionChangedEvent> event)
 {
-    if(event && event->GetTracePath() == m_data_provider.GetTraceFilePath())
+    if(event && event->GetSourceId() == m_data_provider.GetTraceFilePath())
     {
         m_selected_track_ids = event->GetSelectedTracks();
         m_selection_dirty    = true;

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -55,7 +55,7 @@ void
 InfiniteScrollTable::HandleTrackSelectionChanged(
     std::shared_ptr<TrackSelectionChangedEvent> e)
 {
-    if(e && e->GetTracePath() == m_data_provider.GetTraceFilePath())
+    if(e && e->GetSourceId() == m_data_provider.GetTraceFilePath())
     {
         const std::vector<uint64_t>& tracks   = e->GetSelectedTracks();
         double                       start_ns = e->GetStartNs();
@@ -137,7 +137,7 @@ InfiniteScrollTable::HandleTrackSelectionChanged(
 void
 InfiniteScrollTable::HandleNewTableData(std::shared_ptr<TableDataEvent> e)
 {
-    if(e && e->GetTracePath() == m_data_provider.GetTraceFilePath())
+    if(e && e->GetSourceId() == m_data_provider.GetTraceFilePath())
     {
         m_data_changed = true;
     }


### PR DESCRIPTION
 - Use a common GetSourceId() method defined in base class instead of each derived class implementing it's own approach (tab source or trace path)
 - Added documentation of base class interface
 - Updated StickyNoteEvent publishers and listeners to use source id so that events from one trace do not get handled by other open traces