### PR TITLE
Fix misaligned flows when interacting with event track expand/contract button

### DIFF
--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -51,13 +51,16 @@ FlameTrackItem::FlameTrackItem(DataProvider&                      dp,
 }
 
 void
-FlameTrackItem::RenderMetaDataAreaExpand()
+FlameTrackItem::RenderMetaAreaExpand()
 {
-    ImVec2 window_size = ImGui::GetWindowSize();
-    ImVec2 button_size = ImVec2(28.0f, 28.0f);
-    ImVec2 pos = ImVec2(window_size.x - button_size.x, window_size.y - button_size.y);
-
-    ImGui::SetCursorPos(pos);
+    ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                          m_settings.GetColor(Colors::kTransparent));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,
+                          m_settings.GetColor(Colors::kTransparent));
+    ImGui::SetCursorPos(
+        ImVec2(ImGui::GetContentRegionMax() - m_metadata_padding -
+               ImVec2(ImGui::GetTextLineHeight(), ImGui::GetTextLineHeight())));
 
     int visible_levels = static_cast<int>(std::ceil(m_track_height / m_level_height));
 
@@ -66,6 +69,7 @@ FlameTrackItem::RenderMetaDataAreaExpand()
         if(ImGui::ArrowButton("##expand", ImGuiDir_Down))
         {
             m_track_height = m_max_level * m_level_height + m_level_height + 2.0f;
+            m_track_height_changed = true;
         }
         if(ImGui::IsItemHovered()) ImGui::SetTooltip("Expand track to see all events");
     }
@@ -76,9 +80,11 @@ FlameTrackItem::RenderMetaDataAreaExpand()
         {
             m_track_height =
                 m_track_default_height;  // Default track height defined in parent class.
+            m_track_height_changed = true;
         }
         if(ImGui::IsItemHovered()) ImGui::SetTooltip("Contract track to default height");
     }
+    ImGui::PopStyleColor(3);
 }
 FlameTrackItem::~FlameTrackItem()
 {

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -50,12 +50,12 @@ public:
     ~FlameTrackItem();
 
     bool ReleaseData() override;
-    void RenderMetaDataAreaExpand() override;
 
 protected:
     void RenderChart(float graph_width) override;
     void RenderMetaAreaScale() override;
     void RenderMetaAreaOptions() override;
+    void RenderMetaAreaExpand() override;
 
 private:
     // Local cache of selection state packed with event data for each event.

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1024,7 +1024,7 @@ TimelineView::RenderGraphView()
                                                      m_min_x, m_max_x, m_pixels_per_ns,
                                                      m_scroll_position_y);
 
-                    m_resize_activity |= track_item.chart->GetResizeStatus();
+                    m_resize_activity |= track_item.chart->TrackHeightChanged();
 
                     if(is_reordering)
                     {

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -31,7 +31,7 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id, std::string name, float zoom
 , m_metadata_padding(ImVec2(4.0f, 4.0f))
 , m_resize_grip_thickness(4.0f)
 , m_request_state(TrackDataRequestState::kIdle)
-, m_is_resize(false)
+, m_track_height_changed(false)
 , m_meta_area_clicked(false)
 , m_meta_area_scale_width(0.0f)
 , m_settings(SettingsManager::GetInstance())
@@ -49,9 +49,11 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id, std::string name, float zoom
 }
 
 bool
-TrackItem::GetResizeStatus()
+TrackItem::TrackHeightChanged()
 {
-    return m_is_resize;
+    bool height_changed    = m_track_height_changed;
+    m_track_height_changed = false;
+    return height_changed;
 }
 float
 TrackItem::GetTrackHeight()
@@ -167,7 +169,7 @@ TrackItem::GetReorderGripWidth()
 }
 
 void
-TrackItem::RenderMetaDataAreaExpand()
+TrackItem::RenderMetaAreaExpand()
 {
     // no-op
 }
@@ -299,7 +301,7 @@ TrackItem::RenderMetaArea()
         }
         ImGui::PopStyleVar();
         RenderMetaAreaScale();
-        RenderMetaDataAreaExpand();
+        RenderMetaAreaExpand();
     }
     ImGui::EndChild();  // end metadata area
     ImGui::PopStyleColor();
@@ -317,8 +319,6 @@ TrackItem::RenderMetaArea()
 void
 TrackItem::RenderResizeBar(const ImVec2& parent_size)
 {
-    m_is_resize = false;
-
     ImGui::SetCursorPos(ImVec2(0, parent_size.y - m_resize_grip_thickness));
     ImGui::PushStyleColor(ImGuiCol_ChildBg, m_settings.GetColor(Colors::kTransparent));
     ImGui::BeginChild("Resize Bar", ImVec2(parent_size.x, m_resize_grip_thickness),
@@ -343,7 +343,7 @@ TrackItem::RenderResizeBar(const ImVec2& parent_size)
 
         ImGui::ResetMouseDragDelta();
         ImGui::EndDragDropSource();
-        m_is_resize = true;
+        m_track_height_changed = true;
     }
     if(ImGui::BeginDragDropTarget())
     {

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -49,7 +49,6 @@ public:
     virtual void       Render(float width);
     virtual void       Update();
     const std::string& GetName();
-    virtual void       RenderMetaDataAreaExpand();
     virtual void       UpdateMovement(float zoom, double time_offset_ns, double& min_x,
                                       double& max_x, double scale_x, float m_scroll_position);
 
@@ -64,7 +63,7 @@ public:
 
     virtual std::tuple<double, double> GetMinMax();
 
-    bool        GetResizeStatus();
+    bool        TrackHeightChanged();
     static void SetSidebarSize(int sidebar_size);
 
     virtual bool HasData();
@@ -83,28 +82,29 @@ protected:
     virtual void RenderMetaArea();
     virtual void RenderMetaAreaScale()          = 0;
     virtual void RenderMetaAreaOptions()        = 0;
+    virtual void RenderMetaAreaExpand();
     virtual void RenderChart(float graph_width) = 0;
     virtual void RenderResizeBar(const ImVec2& parent_size);
     virtual bool ExtractPointsFromData() = 0;
 
     void FetchHelper();
 
-    float    m_zoom;
-    double   m_time_offset_ns;
-    double   m_min_x;
-    double   m_max_x;
-    double   m_scale_x;
-    uint64_t m_id;
-    float    m_track_height;
-    float    m_track_content_height;
-    float    m_track_default_height;
+    float                 m_zoom;
+    double                m_time_offset_ns;
+    double                m_min_x;
+    double                m_max_x;
+    double                m_scale_x;
+    uint64_t              m_id;
+    float                 m_track_height;
+    float                 m_track_content_height;
+    float                 m_track_default_height;
     float                 m_min_track_height;
+    bool                  m_track_height_changed;
     bool                  m_is_in_view_vertical;
     float                 m_distance_to_view_y;
     std::string           m_name;
     ImVec2                m_metadata_padding;
     float                 m_resize_grip_thickness;
-    bool                  m_is_resize;
     DataProvider&         m_data_provider;
     TrackDataRequestState m_request_state;
     SettingsManager&      m_settings;


### PR DESCRIPTION
-Have expand button set resize_status.
-Only reset resize_status once it has been read, instead of once per frame.
-Renamed resize_status to track_height_changed.
-Renamed RenderMetaDataAreaExpand() to RenderMetaAreaExpand() for consistency. Moved to protected from public. 
-Fix expand button positioning at very small/large font sizes, use frameless style for consistency.
