### PR TITLE
Fetch data for tracks that are not unloaded but not in view 

### DIFF
--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1035,7 +1035,7 @@ TimelineView::RenderGraphView()
 
             track_item.chart->SetInViewVertical(is_visible);
 
-            if(is_visible)
+            if(is_visible || track_item.chart->GetDistanceToView() <= m_unload_track_distance) 
             {
                 // Request data for the chart if it doesn't have data.
                 if((!track_item.chart->HasData() && track_item.chart->GetRequestState() ==
@@ -1051,6 +1051,10 @@ TimelineView::RenderGraphView()
                         (m_view_time_offset_ns + m_v_width + buffer_distance) + m_min_x,
                         m_graph_size.x * 3);
                 }
+            }
+
+            if(is_visible)
+            {
                 ImU32 selection_color = m_settings.GetColor(Colors::kTransparent);
                 if(track_item.selected)
                 {


### PR DESCRIPTION
## Motivation

When scrolling vertically some tracks may have data missing because they were not notified to request new data when the zoom level or panning offset changed.

## Technical Details

Fetch data for tracks that are not unloaded but not in view too when new LOD need to be retrieved.
