### PR TITLE
Fix: Do not request a table start row that is beyond the table count.

### DIFF
--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -650,6 +650,13 @@ InfiniteScrollTable::Render()
                     (filter.column_index == 0) ? "" : m_column_names[filter.column_index];
                 event_table_params->m_group_columns = filter.group_columns;
 
+                // if filtering changed reset the start row as current row
+                // may be beyond result length causing an assertion in controller
+                if(filter_requested) 
+                {
+                    event_table_params->m_start_row = 0;
+                }
+
                 spdlog::debug("Fetching data for sort, frame count: {}", frame_count);
 
                 // Fetch the event table with the updated params


### PR DESCRIPTION

Reset the row start whenever filter changes as we don't know how many rows will be returned.

Requesting an offset beyond the end of the resulting row count causes an assertion in controller.
