### PR TITLE
Handle window close request and show confirmation dialog if files are open

### DIFF
--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -15,8 +15,11 @@
 #include "stb-image/stb_image.h"
 #include <utility>
 
-std::vector<std::string> g_DroppedFilePaths;
-bool g_FileWasDropped = false;
+// globals shared with callbacks
+static std::vector<std::string> g_dropped_file_paths;
+static bool g_file_was_dropped = false;
+static rocprofvis_view_render_options_t g_render_options =
+    rocprofvis_view_render_options_t::kRocProfVisViewRenderOption_None;
 
 std::pair<GLFWimage, unsigned char*>
 glfw_create_icon()
@@ -44,12 +47,13 @@ glfw_create_icon()
 static void
 drop_callback(GLFWwindow* window, int count, const char* paths[])
 {
-    g_DroppedFilePaths.clear();
+    (void) window; // Unused parameter
+    g_dropped_file_paths.clear();
     for(int i = 0; i < count; i++)
     {
-        g_DroppedFilePaths.push_back(paths[i]);
+        g_dropped_file_paths.push_back(paths[i]);
     }
-    g_FileWasDropped = true;
+    g_file_was_dropped = true;
 }
 
 static void
@@ -59,6 +63,22 @@ content_scale_callback(GLFWwindow* window, float xscale, float yscale)
     (void) window;
     (void) yscale;
     rocprofvis_view_set_dpi(xscale);
+}
+
+static void
+close_callback(GLFWwindow* window)
+{
+    g_render_options = rocprofvis_view_render_options_t::kRocProfVisViewRenderOption_RequestExit;
+    glfwSetWindowShouldClose(window, GLFW_FALSE);
+}
+
+static void
+app_notification_callback(GLFWwindow* window, int notification)
+{
+    if(notification == static_cast<int>(rocprofvis_view_notification_t::kRocProfVisViewNotification_Exit_App))
+    {
+        glfwSetWindowShouldClose(window, GLFW_TRUE);
+    }
 }
 
 static void
@@ -96,6 +116,8 @@ main(int, char**)
             glfwGetWindowContentScale(window, &xs, &ys);
             content_scale_callback(window, xs, ys);
         }
+        // Window close callback
+        glfwSetWindowCloseCallback(window, close_callback);
 
         if(window && rocprofvis_imgui_backend_setup(&backend, window))
         {
@@ -110,7 +132,9 @@ main(int, char**)
 
                 ImGui::StyleColorsLight();
 
-                rocprofvis_view_init();
+                rocprofvis_view_init([window](int notification) -> void {
+                    app_notification_callback(window, notification);
+                });
 
                 backend.m_config(&backend, window);
 
@@ -130,10 +154,10 @@ main(int, char**)
                 while(!glfwWindowShouldClose(window))
                 {
                     // handle dropped file signal flag from callback
-                    if (g_FileWasDropped)
+                    if (g_file_was_dropped)
                     {
-                        rocprofvis_view_open_files(g_DroppedFilePaths);
-                        g_FileWasDropped = false;
+                        rocprofvis_view_open_files(g_dropped_file_paths);
+                        g_file_was_dropped = false;
                     }                    
 
                     glfwPollEvents();
@@ -152,7 +176,9 @@ main(int, char**)
                     backend.m_new_frame(&backend);
                     ImGui::NewFrame();
 
-                    rocprofvis_view_render();
+                    rocprofvis_view_render(g_render_options);
+                    g_render_options = rocprofvis_view_render_options_t::
+                        kRocProfVisViewRenderOption_None;
 
                     ImGui::Render();
                     ImDrawData* draw_data    = ImGui::GetDrawData();

--- a/src/view/inc/rocprofvis_view_module.h
+++ b/src/view/inc/rocprofvis_view_module.h
@@ -2,12 +2,32 @@
 
 #pragma once
 
-#include <vector>
+#include <functional>
 #include <string>
+#include <vector>
 
-bool rocprofvis_view_init();
-void rocprofvis_view_render();
-void rocprofvis_view_destroy();
-void rocprofvis_view_set_dpi(float dpi);
-void rocprofvis_view_open_files(const std::vector<std::string>& file_paths);
+typedef enum rocprofvis_view_render_options_t
+{
+    kRocProfVisViewRenderOption_None        = 0,
+    kRocProfVisViewRenderOption_RequestExit = 1,
+} rocprofvis_view_render_options_t;
 
+typedef enum rocprofvis_view_notification_t
+{
+    kRocProfVisViewNotification_Exit_App = 1,
+} rocprofvis_view_notification_t;
+
+bool
+rocprofvis_view_init(std::function<void(int)> notification_callback);
+
+void
+rocprofvis_view_render(const rocprofvis_view_render_options_t& render_options);
+
+void
+rocprofvis_view_destroy();
+
+void
+rocprofvis_view_set_dpi(float dpi);
+
+void
+rocprofvis_view_open_files(const std::vector<std::string>& file_paths);

--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -25,6 +25,8 @@ public:
     static void       DestroyInstance();
 
     bool Init();
+    void SetNotificationCallback(std::function<void(int)> callback);
+
     void Render() override;
     void Update() override;
 
@@ -39,6 +41,8 @@ public:
     Project* GetCurrentProject();
 
     void OpenFile(std::string file_path);
+    
+    void ShowCloseConfirm();
 
 private:
     AppWindow();
@@ -54,7 +58,7 @@ private:
 
     void HandleTabClosed(std::shared_ptr<RocEvent> e);
     void HandleTabSelectionChanged(std::shared_ptr<RocEvent> e);
-
+    
     static AppWindow* s_instance;
 
     std::shared_ptr<VFixedContainer> m_main_view;
@@ -84,6 +88,7 @@ private:
     std::unique_ptr<SettingsPanel>      m_settings_panel;
 
     size_t m_tool_bar_index;
+    std::function<void(int)> m_notification_callback;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_view_module.cpp
+++ b/src/view/src/rocprofvis_view_module.cpp
@@ -9,19 +9,30 @@
 using namespace RocProfVis::View;
 
 bool
-rocprofvis_view_init()
+rocprofvis_view_init(std::function<void(int)> notification_callback)
 {
-    bool result = AppWindow::GetInstance()->Init();
+    auto app = AppWindow::GetInstance();
+    bool result = app->Init();
     if(!result)
     {
         spdlog::error("Failed initializing the Application Window");
     }
+    else 
+    {
+        app->SetNotificationCallback(notification_callback);
+    }
     return result;
+
 }
 
 void
-rocprofvis_view_render()
+rocprofvis_view_render(const rocprofvis_view_render_options_t& render_options)
 {
+    if(render_options ==
+       rocprofvis_view_render_options_t::kRocProfVisViewRenderOption_RequestExit)
+    {
+        AppWindow::GetInstance()->ShowCloseConfirm();
+    }
     AppWindow::GetInstance()->Render();
 }
 


### PR DESCRIPTION

Added callback to detect glfw window close requests.
Created callback interface so that application (AppWindow) can notify main render loop.
Show confirmation dialog on exit if there are open tabs.
Added file -> exitt menu option.
Cleaned up formatting.

