### PR TITLE
Decouple InfiniteScrollTable from track selection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(VIEW_FILES
     src/view/src/rocprofvis_track_topology.cpp
     src/view/src/rocprofvis_track_details.cpp
     src/view/src/rocprofvis_project.cpp
+	src/view/src/rocprofvis_multi_track_table.cpp
     src/view/src/widgets/rocprofvis_widget.cpp	
     src/view/src/widgets/rocprofvis_debug_window.cpp
     src/view/src/widgets/rocprofvis_gui_helpers.cpp

--- a/src/view/src/rocprofvis_analysis_view.cpp
+++ b/src/view/src/rocprofvis_analysis_view.cpp
@@ -6,10 +6,10 @@
 #include "rocprofvis_controller_enums.h"
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_events_view.h"
+#include "rocprofvis_multi_track_table.h"
 #include "rocprofvis_track_details.h"
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_debug_window.h"
-#include "widgets/rocprofvis_infinite_scroll_table.h"
 
 namespace RocProfVis
 {
@@ -20,10 +20,10 @@ AnalysisView::AnalysisView(DataProvider& dp, std::shared_ptr<TrackTopology> topo
                            std::shared_ptr<TimelineSelection>  timeline_selection,
                            std::shared_ptr<AnnotationsManager> annotation_manager)
 : m_data_provider(dp)
-, m_event_table(std::make_shared<InfiniteScrollTable>(dp, timeline_selection,
-                                                      TableType::kEventTable))
-, m_sample_table(std::make_shared<InfiniteScrollTable>(dp, timeline_selection,
-                                                       TableType::kSampleTable))
+, m_event_table(
+      std::make_shared<MultiTrackTable>(dp, timeline_selection, TableType::kEventTable))
+, m_sample_table(
+      std::make_shared<MultiTrackTable>(dp, timeline_selection, TableType::kSampleTable))
 , m_events_view(std::make_shared<EventsView>(dp, timeline_selection))
 
 , m_annotation_view(std::make_shared<AnnotationView>(annotation_manager))

--- a/src/view/src/rocprofvis_analysis_view.h
+++ b/src/view/src/rocprofvis_analysis_view.h
@@ -5,7 +5,7 @@
 #include "rocprofvis_annotations.h"
 #include "rocprofvis_event_manager.h"
 #include "widgets/rocprofvis_widget.h"
- 
+
 namespace RocProfVis
 {
 namespace View
@@ -13,7 +13,7 @@ namespace View
 
 class DataProvider;
 class EventsView;
-class InfiniteScrollTable;
+class MultiTrackTable;
 class TrackTopology;
 class TrackDetails;
 class TimelineSelection;
@@ -22,7 +22,7 @@ class AnalysisView : public RocWidget
 {
 public:
     AnalysisView(DataProvider& dp, std::shared_ptr<TrackTopology> topology,
-                 std::shared_ptr<TimelineSelection> timeline_selection,
+                 std::shared_ptr<TimelineSelection>  timeline_selection,
                  std::shared_ptr<AnnotationsManager> annotation_manager);
     ~AnalysisView();
     void Render() override;
@@ -34,8 +34,8 @@ private:
 
     DataProvider& m_data_provider;
 
-    std::shared_ptr<InfiniteScrollTable> m_event_table;
-    std::shared_ptr<InfiniteScrollTable> m_sample_table;
+    std::shared_ptr<MultiTrackTable> m_event_table;
+    std::shared_ptr<MultiTrackTable> m_sample_table;
 
     std::shared_ptr<TabContainer>   m_tab_container;
     std::shared_ptr<EventsView>     m_events_view;

--- a/src/view/src/rocprofvis_multi_track_table.cpp
+++ b/src/view/src/rocprofvis_multi_track_table.cpp
@@ -1,0 +1,336 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "rocprofvis_multi_track_table.h"
+#include "icons/rocprovfis_icon_defines.h"
+#include "rocprofvis_event_manager.h"
+#include "rocprofvis_settings_manager.h"
+#include "rocprofvis_timeline_selection.h"
+#include "rocprofvis_utils.h"
+#include "spdlog/spdlog.h"
+#include "widgets/rocprofvis_notification_manager.h"
+#include <sstream>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+constexpr uint64_t INVALID_UINT64_INDEX = std::numeric_limits<uint64_t>::max();
+
+const std::string TRACK_ID_COLUMN_NAME  = "__trackId";
+const std::string STREAM_ID_COLUMN_NAME = "__streamTrackId";
+const std::string ID_COLUMN_NAME        = "id";
+const std::string NAME_COLUMN_NAME      = "name";
+const std::string START_TS_COLUMN_NAME  = "startTs";
+const std::string END_TS_COLUMN_NAME    = "endTs";
+const std::string DURATION_COLUMN_NAME  = "duration";
+
+MultiTrackTable::MultiTrackTable(DataProvider&                      dp,
+                                 std::shared_ptr<TimelineSelection> timeline_selection,
+                                 TableType                          table_type)
+: InfiniteScrollTable(dp, table_type)
+, m_important_column_idxs(std::vector<size_t>(kNumImportantColumns, INVALID_UINT64_INDEX))
+, m_timeline_selection(timeline_selection)
+, m_defer_track_selection_changed(false)
+{
+    m_widget_name = (table_type == TableType::kEventTable)
+                        ? GenUniqueName("Event Table")
+                        : GenUniqueName("Sample Table");
+}
+
+void
+MultiTrackTable::HandleTrackSelectionChanged()
+{
+    std::vector<uint64_t> tracks;
+    double                start_ns;
+    double                end_ns;
+    m_timeline_selection->GetSelectedTracks(tracks);
+
+    // If no valid time range is provided, use the full trace range
+    if(m_timeline_selection->HasValidTimeRangeSelection())
+    {
+        m_timeline_selection->GetSelectedTimeRange(start_ns, end_ns);
+    }
+    else
+    {
+        start_ns = m_data_provider.GetStartTime();
+        end_ns   = m_data_provider.GetEndTime();
+    }
+
+    // loop trough tracks and filter out ones that don't match the table type
+    std::vector<uint64_t> filtered_tracks;
+    for(uint64_t track_id : tracks)
+    {
+        const track_info_t* track_info = m_data_provider.GetTrackInfo(track_id);
+        if(track_info)
+        {
+            if((track_info->track_type == kRPVControllerTrackTypeSamples &&
+                m_table_type == TableType::kSampleTable) ||
+               (track_info->track_type == kRPVControllerTrackTypeEvents &&
+                m_table_type == TableType::kEventTable))
+            {
+                filtered_tracks.push_back(track_id);
+            }
+        }
+    }
+
+    bool fetch_result = false;
+
+    uint64_t request_id = (m_table_type == TableType::kEventTable)
+                              ? DataProvider::EVENT_TABLE_REQUEST_ID
+                              : DataProvider::SAMPLE_TABLE_REQUEST_ID;
+    // Cancel pending requests.
+    if(m_data_provider.IsRequestPending(request_id))
+    {
+        m_data_provider.CancelRequest(request_id);
+    }
+    // if no tracks match the table type, clear the table
+    if(filtered_tracks.empty())
+    {
+        m_data_provider.ClearTable(m_table_type);
+        fetch_result = true;
+    }
+    else
+    {
+        // Fetch table data for the selected tracks
+        TableRequestParams event_table_params(
+            m_req_table_type, filtered_tracks, start_ns, end_ns, m_filter_options.filter,
+            (m_filter_options.column_index == 0)
+                ? ""
+                : m_column_names_ptr[m_filter_options.column_index],
+            m_filter_options.group_columns, 0, m_fetch_chunk_size);
+
+        fetch_result = m_data_provider.FetchMultiTrackTable(event_table_params);
+    }
+
+    if(!fetch_result)
+    {
+        spdlog::error("Failed to queue table request for tracks: {}",
+                      filtered_tracks.size());
+        // save this selection event to reprocess it later (it's ok to replace the
+        // previous one as the new one reflects the current selection)
+        m_defer_track_selection_changed = true;
+    }
+    else
+    {
+        // clear any pending track selection event
+        m_defer_track_selection_changed = false;
+    }
+    // Update the selected tracks for this table type
+    m_selected_tracks = std::move(filtered_tracks);
+}
+
+void
+MultiTrackTable::Update()
+{
+    // Handle track selection changed event
+    if(m_defer_track_selection_changed)
+    {
+        if(!m_data_provider.IsRequestPending(m_table_type == TableType::kEventTable
+                                                 ? DataProvider::EVENT_TABLE_REQUEST_ID
+                                                 : DataProvider::SAMPLE_TABLE_REQUEST_ID))
+        {
+            // try to repocess the deferred track selection event
+            spdlog::debug(
+                "Reprocessing deferred track selection changed event for table type: {}",
+                m_table_type == TableType::kEventTable ? "Event Table" : "Sample Table");
+            HandleTrackSelectionChanged();
+        }
+    }
+    if(m_data_changed)
+    {
+        const std::vector<std::string>& column_names =
+            m_data_provider.GetTableHeader(m_table_type);
+
+        // remember column index positions
+        m_important_column_idxs =
+            std::vector<size_t>(kNumImportantColumns, INVALID_UINT64_INDEX);
+        for(size_t i = 0; i < column_names.size(); i++)
+        {
+            const auto& col = column_names[i];
+            if(!col.empty())
+            {
+                if(col == TRACK_ID_COLUMN_NAME)
+                {
+                    m_important_column_idxs[kTrackId] = i;
+                }
+                else if(col == STREAM_ID_COLUMN_NAME)
+                {
+                    m_important_column_idxs[kStreamId] = i;
+                }
+                else if(col == ID_COLUMN_NAME)
+                {
+                    m_important_column_idxs[kId] = i;
+                }
+                else if(col == NAME_COLUMN_NAME)
+                {
+                    m_important_column_idxs[kName] = i;
+                }
+                else if(col == START_TS_COLUMN_NAME)
+                {
+                    m_important_column_idxs[kTimeStartNs] = i;
+                }
+                else if(col == END_TS_COLUMN_NAME)
+                {
+                    m_important_column_idxs[kTimeEndNs] = i;
+                }
+                else if(col == DURATION_COLUMN_NAME)
+                {
+                    m_important_column_idxs[kDurationNs] = i;
+                }
+            }
+        }
+    }
+    InfiniteScrollTable::Update();
+}
+
+uint64_t
+MultiTrackTable::GetTrackIdHelper(
+    const std::vector<std::vector<std::string>>& table_data) const
+{
+    uint64_t track_id  = INVALID_UINT64_INDEX;
+    uint64_t stream_id = INVALID_UINT64_INDEX;
+
+    // get track id or stream id
+    if(m_important_column_idxs[kTrackId] != INVALID_UINT64_INDEX &&
+       m_important_column_idxs[kTrackId] < table_data[m_selected_row].size())
+    {
+        track_id =
+            std::stoull(table_data[m_selected_row][m_important_column_idxs[kTrackId]]);
+    }
+    else if(m_important_column_idxs[kStreamId] != INVALID_UINT64_INDEX &&
+            m_important_column_idxs[kStreamId] < table_data[m_selected_row].size())
+    {
+        stream_id =
+            std::stoull(table_data[m_selected_row][m_important_column_idxs[kStreamId]]);
+    }
+
+    uint64_t target_track_id = INVALID_UINT64_INDEX;
+    if(track_id != INVALID_UINT64_INDEX)
+    {
+        target_track_id = track_id;
+    }
+    else if(stream_id != INVALID_UINT64_INDEX)
+    {
+        target_track_id = stream_id;
+    }
+
+    return target_track_id;
+}
+
+void
+MultiTrackTable::FetchData(const TableRequestParams& params) const
+{
+    m_data_provider.FetchMultiTrackTable(params);
+}
+
+void
+MultiTrackTable::RenderContextMenu() const
+{
+    auto style = m_settings.GetDefaultStyle();
+
+    // Render context menu for row actions
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+    if(ImGui::BeginPopup(ROWCONTEXTMENU_POPUP_NAME))
+    {
+        const std::vector<std::vector<std::string>>& table_data =
+            m_data_provider.GetTableData(m_table_type);
+        uint32_t target_track_id = GetTrackIdHelper(table_data);
+
+        if(ImGui::MenuItem("Copy Row Data", nullptr, false))
+        {
+            if(m_selected_row < 0 || m_selected_row >= (int) table_data.size())
+            {
+                spdlog::warn("Selected row index out of bounds: {}", m_selected_row);
+            }
+            else
+            {
+                // Build and copy the data from the selected row
+                std::ostringstream str_collector;
+                for(size_t i = 0; i < table_data[m_selected_row].size(); ++i)
+                {
+                    if(i > 0) str_collector << ",";
+                    str_collector << table_data[m_selected_row][i];
+                }
+                std::string row_data = str_collector.str();
+                // Copy the row data to the clipboard
+                ImGui::SetClipboardText(row_data.c_str());
+                // Show notification that data was copied
+                NotificationManager::GetInstance().Show("Row data copied to clipboard",
+                                                        NotificationLevel::Info, 1.0);
+            }
+        }
+        else if(ImGui::MenuItem("Go to event", nullptr, false,
+                                target_track_id != INVALID_UINT64_INDEX))
+        {
+            if(m_selected_row < 0 || m_selected_row >= (int) table_data.size())
+            {
+                spdlog::warn("Selected row index out of bounds: {}", m_selected_row);
+            }
+            else
+            {
+                // Handle navigation
+                if(target_track_id != INVALID_UINT64_INDEX)
+                {
+                    spdlog::info("Navigating to track ID: {} from row: {}",
+                                 target_track_id, m_selected_row);
+                    EventManager::GetInstance()->AddEvent(
+                        std::make_shared<ScrollToTrackEvent>(
+                            static_cast<int>(RocEvents::kHandleUserGraphNavigationEvent),
+                            target_track_id, m_data_provider.GetTraceFilePath()));
+                    // get start time and duration
+                    uint64_t start_time = 0;
+                    uint64_t duration   = 0;
+                    if(m_important_column_idxs[kTimeStartNs] != INVALID_UINT64_INDEX &&
+                       m_important_column_idxs[kTimeStartNs] <
+                           table_data[m_selected_row].size())
+                    {
+                        start_time = std::stoull(
+                            table_data[m_selected_row]
+                                      [m_important_column_idxs[kTimeStartNs]]);
+                    }
+
+                    if(m_important_column_idxs[kDurationNs] != INVALID_UINT64_INDEX &&
+                       m_important_column_idxs[kDurationNs] <
+                           table_data[m_selected_row].size())
+                    {
+                        duration =
+                            std::stoull(table_data[m_selected_row]
+                                                  [m_important_column_idxs[kDurationNs]]);
+                    }
+
+                    ViewRangeNS view_range = calculate_adaptive_view_range(
+                        static_cast<double>(start_time), static_cast<double>(duration));
+                    EventManager::GetInstance()->AddEvent(std::make_shared<RangeEvent>(
+                        static_cast<int>(RocEvents::kSetViewRange), view_range.start_ns,
+                        view_range.end_ns, m_data_provider.GetTraceFilePath()));
+                }
+                else
+                {
+                    spdlog::warn("No valid track or stream ID found for row: {}",
+                                 m_selected_row);
+                }
+            }
+        }
+        // TODO handle event selection
+        // else if(ImGui::MenuItem("Select event", nullptr, false))
+        // {
+        //     uint64_t event_id = INVALID_UINT64_INDEX;
+
+        //     if(m_important_columns[kId] != INVALID_COLUMN_INDEX &&
+        //        m_important_columns[kId] < table_data[m_selected_row].size())
+        //     {
+        //         event_id =
+        //             std::stoull(table_data[m_selected_row][m_important_columns[kId]]);
+        //     }
+        // }
+
+        ImGui::EndPopup();
+    }
+    // Pop the style vars for window padding and item spacing
+    ImGui::PopStyleVar(2);
+}
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/rocprofvis_multi_track_table.h
+++ b/src/view/src/rocprofvis_multi_track_table.h
@@ -1,0 +1,59 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "imgui.h"
+#include "rocprofvis_data_provider.h"
+#include "widgets/rocprofvis_infinite_scroll_table.h"
+#include <string>
+#include <vector>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+class TimelineSelection;
+
+class MultiTrackTable : public InfiniteScrollTable
+{
+public:
+    MultiTrackTable(DataProvider&                      dp,
+                    std::shared_ptr<TimelineSelection> timeline_selection,
+                    TableType table_type = TableType::kEventTable);
+
+    void Update() override;
+
+    void HandleTrackSelectionChanged();
+
+private:
+    // Important columns in the table
+    enum ImportantColumns
+    {
+        kId,
+        kName,
+        kTimeStartNs,
+        kTimeEndNs,
+        kDurationNs,
+        kTrackId,
+        kStreamId,
+        kNumImportantColumns
+    };
+
+    void FetchData(const TableRequestParams& params) const override;
+    void RenderContextMenu() const override;
+
+    uint64_t GetTrackIdHelper(
+        const std::vector<std::vector<std::string>>& table_data) const;
+
+    std::shared_ptr<TimelineSelection> m_timeline_selection;
+    bool                               m_defer_track_selection_changed;
+
+    // Keep track of currently selected tracks for this table type
+    std::vector<uint64_t> m_selected_tracks;
+
+    std::vector<size_t> m_important_column_idxs;
+};
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -5,32 +5,18 @@
 #include "rocprofvis_event_manager.h"
 #include "rocprofvis_font_manager.h"
 #include "rocprofvis_settings_manager.h"
-#include "rocprofvis_timeline_selection.h"
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_gui_helpers.h"
-#include "widgets/rocprofvis_notification_manager.h"
-#include <sstream>
 
 namespace RocProfVis
 {
 namespace View
 {
 
-constexpr const char* ROWCONTEXTMENU_POPUP_NAME = "RowContextMenu";
 constexpr uint64_t INVALID_UINT64_INDEX = std::numeric_limits<uint64_t>::max();
 
-const std::string TRACK_ID_COLUMN_NAME = "__trackId";
-const std::string STREAM_ID_COLUMN_NAME = "__streamTrackId";
-const std::string ID_COLUMN_NAME        = "id";
-const std::string NAME_COLUMN_NAME      = "name";
-const std::string START_TS_COLUMN_NAME  = "startTs";
-const std::string END_TS_COLUMN_NAME    = "endTs";
-const std::string DURATION_COLUMN_NAME  = "duration";
-
-InfiniteScrollTable::InfiniteScrollTable(
-    DataProvider& dp, std::shared_ptr<TimelineSelection> timeline_selection,
-    TableType table_type)
+InfiniteScrollTable::InfiniteScrollTable(DataProvider& dp, TableType table_type)
 : m_data_provider(dp)
 , m_skip_data_fetch(false)
 , m_table_type(table_type)
@@ -39,171 +25,21 @@ InfiniteScrollTable::InfiniteScrollTable(
 , m_fetch_pad_items(30)        // Number of items to pad the fetch range
 , m_fetch_threshold_items(10)  // Number of items from the edge to trigger a fetch
 , m_last_table_size(0, 0)
-, m_defer_track_selection_changed(false)
 , m_settings(SettingsManager::GetInstance())
 , m_req_table_type(table_type == TableType::kEventTable ? kRPVControllerTableTypeEvents
                                                         : kRPVControllerTableTypeSamples)
 , m_filter_options({ 0, "", "" })
 , m_pending_filter_options({ 0, "", "" })
 , m_data_changed(true)
-, m_important_column_idxs(std::vector<size_t>(kNumImportantColumns, INVALID_UINT64_INDEX))
-, m_timeline_selection(timeline_selection)
-{
-    m_widget_name = (table_type == TableType::kEventTable)
-                        ? GenUniqueName("Event Table")
-                        : GenUniqueName("Sample Table");
-}
-
-void
-InfiniteScrollTable::HandleTrackSelectionChanged()
-{
-    std::vector<uint64_t> tracks;
-    double                start_ns;
-    double                end_ns;
-    m_timeline_selection->GetSelectedTracks(tracks);
-
-    // If no valid time range is provided, use the full trace range
-    if(m_timeline_selection->HasValidTimeRangeSelection())
-    {
-        m_timeline_selection->GetSelectedTimeRange(start_ns, end_ns);
-    }
-    else
-    {
-        start_ns = m_data_provider.GetStartTime();
-        end_ns   = m_data_provider.GetEndTime();
-    }
-
-    // loop trough tracks and filter out ones that don't match the table type
-    std::vector<uint64_t> filtered_tracks;
-    for(uint64_t track_id : tracks)
-    {
-        const track_info_t* track_info = m_data_provider.GetTrackInfo(track_id);
-        if(track_info)
-        {
-            if((track_info->track_type == kRPVControllerTrackTypeSamples &&
-                m_table_type == TableType::kSampleTable) ||
-               (track_info->track_type == kRPVControllerTrackTypeEvents &&
-                m_table_type == TableType::kEventTable))
-            {
-                filtered_tracks.push_back(track_id);
-            }
-        }
-    }
-
-    bool fetch_result = false;
-
-    uint64_t request_id = (m_table_type == TableType::kEventTable)
-                              ? DataProvider::EVENT_TABLE_REQUEST_ID
-                              : DataProvider::SAMPLE_TABLE_REQUEST_ID;
-    // Cancel pending requests.
-    if(m_data_provider.IsRequestPending(request_id))
-    {
-        m_data_provider.CancelRequest(request_id);
-    }
-    // if no tracks match the table type, clear the table
-    if(filtered_tracks.empty())
-    {
-        m_data_provider.ClearTable(m_table_type);
-        fetch_result = true;
-    }
-    else
-    {
-        // Fetch table data for the selected tracks
-        TableRequestParams event_table_params(
-            m_req_table_type, filtered_tracks, start_ns, end_ns, m_filter_options.filter,
-            (m_filter_options.column_index == 0)
-                ? ""
-                : m_column_names_ptr[m_filter_options.column_index],
-            m_filter_options.group_columns, 0, m_fetch_chunk_size);
-
-        fetch_result = m_data_provider.FetchMultiTrackTable(event_table_params);
-    }
-
-    if(!fetch_result)
-    {
-        spdlog::error("Failed to queue table request for tracks: {}",
-                      filtered_tracks.size());
-        // save this selection event to reprocess it later (it's ok to replace the
-        // previous one as the new one reflects the current selection)
-        m_defer_track_selection_changed = true;
-    }
-    else
-    {
-        // clear any pending track selection event
-        m_defer_track_selection_changed = false;
-    }
-    // Update the selected tracks for this table type
-    m_selected_tracks = std::move(filtered_tracks);
-}
-
-void
-InfiniteScrollTable::HandleNewTableData(std::shared_ptr<TableDataEvent> e)
-{
-    if(e && e->GetSourceId() == m_data_provider.GetTraceFilePath())
-    {
-        m_data_changed = true;
-    }
-}
+{}
 
 void
 InfiniteScrollTable::Update()
 {
-    // Handle track selection changed event
-    if(m_defer_track_selection_changed)
-    {
-        if(!m_data_provider.IsRequestPending(m_table_type == TableType::kEventTable
-                                                 ? DataProvider::EVENT_TABLE_REQUEST_ID
-                                                 : DataProvider::SAMPLE_TABLE_REQUEST_ID))
-        {
-            // try to repocess the deferred track selection event
-            spdlog::debug(
-                "Reprocessing deferred track selection changed event for table type: {}",
-                m_table_type == TableType::kEventTable ? "Event Table" : "Sample Table");
-            HandleTrackSelectionChanged();
-        }
-    }
     if(m_data_changed)
     {
         const std::vector<std::string>& column_names =
             m_data_provider.GetTableHeader(m_table_type);
-
-        //remember column index positions
-        m_important_column_idxs = std::vector<size_t>(kNumImportantColumns, INVALID_UINT64_INDEX);
-        for(size_t i = 0; i < column_names.size(); i++)
-        {
-            const auto& col = column_names[i];
-            if(!col.empty()) 
-            {
-                if(col == TRACK_ID_COLUMN_NAME)
-                {
-                    m_important_column_idxs[kTrackId] = i;
-                }
-                else if(col == STREAM_ID_COLUMN_NAME)
-                {
-                    m_important_column_idxs[kStreamId] = i;
-                }
-                else if(col == ID_COLUMN_NAME)
-                {
-                    m_important_column_idxs[kId] = i;
-                }
-                else if(col == NAME_COLUMN_NAME)
-                {
-                    m_important_column_idxs[kName] = i;
-                }
-                else if(col == START_TS_COLUMN_NAME)
-                {
-                    m_important_column_idxs[kTimeStartNs] = i;
-                }
-                else if(col == END_TS_COLUMN_NAME)
-                {
-                    m_important_column_idxs[kTimeEndNs] = i;
-                }
-                else if(col == DURATION_COLUMN_NAME)
-                {
-                    m_important_column_idxs[kDurationNs] = i;
-                }
-            }
-        }
 
         if(m_table_type == TableType::kEventTable)
         {
@@ -219,7 +55,7 @@ InfiniteScrollTable::Update()
                 for(size_t i = 0; i < column_names.size(); i++)
                 {
                     const auto& col = column_names[i];
-                    if(col.empty() || col[0] == '_') 
+                    if(col.empty() || col[0] == '_')
                     {
                         continue;  // Skip empty or internal columns
                     }
@@ -243,6 +79,15 @@ InfiniteScrollTable::Update()
         }
 
         m_data_changed = false;
+    }
+}
+
+void
+InfiniteScrollTable::HandleNewTableData(std::shared_ptr<TableDataEvent> e)
+{
+    if(e && e->GetSourceId() == m_data_provider.GetTraceFilePath())
+    {
+        m_data_changed = true;
     }
 }
 
@@ -398,8 +243,8 @@ InfiniteScrollTable::Render()
         ImVec2 outer_size = ImVec2(0.0f, ImGui::GetContentRegionAvail().y);
         if(outer_size.y != m_last_table_size.y)
         {
-            // If the outer size has changed, we need to recalulate the number of items to
-            // fetch
+            // If the outer size has changed, we need to recalulate the number of
+            // items to fetch
             int visible_rows   = outer_size.y / row_height;
             m_fetch_chunk_size = std::max(visible_rows * 4, 100);
             m_fetch_pad_items  = clamp(visible_rows / 2, 10, 30);
@@ -552,7 +397,7 @@ InfiniteScrollTable::Render()
                                       new_start_pos, frame_count, m_fetch_chunk_size,
                                       scroll_y);
 
-                        m_data_provider.FetchMultiTrackTable(TableRequestParams(
+                        FetchData(TableRequestParams(
                             m_req_table_type, event_table_params->m_track_ids,
                             event_table_params->m_start_ts, event_table_params->m_end_ts,
                             event_table_params->m_filter.c_str(),
@@ -569,8 +414,9 @@ InfiniteScrollTable::Render()
                         uint64_t new_start_pos = (scroll_y) / row_height;
 
                         // Ensure start position does not go below zero
-                        // (this can happen if the start_row is close to the beginning of
-                        // the table if a previous fetch did not return enough rows)
+                        // (this can happen if the start_row is close to the beginning
+                        // of the table if a previous fetch did not return enough
+                        // rows)
                         if(m_fetch_pad_items > new_start_pos)
                         {
                             new_start_pos = 0;
@@ -585,7 +431,7 @@ InfiniteScrollTable::Render()
                                       new_start_pos, frame_count, m_fetch_chunk_size,
                                       scroll_y);
 
-                        m_data_provider.FetchMultiTrackTable(TableRequestParams(
+                        FetchData(TableRequestParams(
                             m_req_table_type, event_table_params->m_track_ids,
                             event_table_params->m_start_ts, event_table_params->m_end_ts,
                             event_table_params->m_filter.c_str(),
@@ -600,8 +446,6 @@ InfiniteScrollTable::Render()
             // Render context menu for row actions
             RenderContextMenu();
 
-            // Pop the style vars for window padding and item spacing
-            ImGui::PopStyleVar(2);
             ImGui::EndTable();  // End BeginTable
         }
         else
@@ -652,7 +496,7 @@ InfiniteScrollTable::Render()
 
                 // if filtering changed reset the start row as current row
                 // may be beyond result length causing an assertion in controller
-                if(filter_requested) 
+                if(filter_requested)
                 {
                     event_table_params->m_start_row = 0;
                 }
@@ -660,7 +504,7 @@ InfiniteScrollTable::Render()
                 spdlog::debug("Fetching data for sort, frame count: {}", frame_count);
 
                 // Fetch the event table with the updated params
-                m_data_provider.FetchMultiTrackTable(TableRequestParams(
+                FetchData(TableRequestParams(
                     m_req_table_type, event_table_params->m_track_ids,
                     event_table_params->m_start_ts, event_table_params->m_end_ts,
                     event_table_params->m_filter.c_str(),
@@ -683,136 +527,9 @@ InfiniteScrollTable::Render()
     m_skip_data_fetch = false;  // Reset the skip data fetch flag after rendering
 }
 
-uint64_t
-InfiniteScrollTable::GetTrackIdHelper(
-    const std::vector<std::vector<std::string>>& table_data) const
-{
-    uint64_t track_id  = INVALID_UINT64_INDEX;
-    uint64_t stream_id = INVALID_UINT64_INDEX;
-    
-    // get track id or stream id
-    if(m_important_column_idxs[kTrackId] != INVALID_UINT64_INDEX &&
-       m_important_column_idxs[kTrackId] < table_data[m_selected_row].size())
-    {
-        track_id = std::stoull(table_data[m_selected_row][m_important_column_idxs[kTrackId]]);
-    }
-    else if(m_important_column_idxs[kStreamId] != INVALID_UINT64_INDEX &&
-            m_important_column_idxs[kStreamId] < table_data[m_selected_row].size())
-    {
-        stream_id =
-            std::stoull(table_data[m_selected_row][m_important_column_idxs[kStreamId]]);
-    }
-
-    uint64_t target_track_id = INVALID_UINT64_INDEX;
-    if(track_id != INVALID_UINT64_INDEX)
-    {
-        target_track_id = track_id;
-    }
-    else if(stream_id != INVALID_UINT64_INDEX)
-    {
-        target_track_id = stream_id;
-    }
-
-    return target_track_id;
-}
-
-void 
+void
 InfiniteScrollTable::RenderContextMenu() const
-{
-    auto style =  m_settings.GetDefaultStyle();
-    
-    // Render context menu for row actions
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-    if(ImGui::BeginPopup(ROWCONTEXTMENU_POPUP_NAME))
-    {
-        const std::vector<std::vector<std::string>>& table_data =
-            m_data_provider.GetTableData(m_table_type);
-        uint32_t target_track_id = GetTrackIdHelper(table_data);
-                
-        if(ImGui::MenuItem("Copy Row Data", nullptr, false))
-        {
-            if(m_selected_row < 0 || m_selected_row >= (int) table_data.size())
-            {
-                spdlog::warn("Selected row index out of bounds: {}",
-                                m_selected_row);
-            }
-            else
-            {
-                // Build and copy the data from the selected row
-                std::ostringstream str_collector;
-                for(size_t i = 0; i < table_data[m_selected_row].size(); ++i)
-                {
-                    if(i > 0) str_collector << ",";
-                    str_collector << table_data[m_selected_row][i];
-                }
-                std::string row_data = str_collector.str();
-                // Copy the row data to the clipboard
-                ImGui::SetClipboardText(row_data.c_str());
-                // Show notification that data was copied
-                NotificationManager::GetInstance().Show(
-                    "Row data copied to clipboard", NotificationLevel::Info, 1.0);
-            }
-        }
-        else if(ImGui::MenuItem("Go to event", nullptr, false, target_track_id != INVALID_UINT64_INDEX)) 
-        {
-            if(m_selected_row < 0 || m_selected_row >= (int) table_data.size())
-            {
-                spdlog::warn("Selected row index out of bounds: {}",
-                                m_selected_row);
-            }
-            else
-            {
-                // Handle navigation
-                if(target_track_id != INVALID_UINT64_INDEX) 
-                {
-                    spdlog::info("Navigating to track ID: {} from row: {}", target_track_id, m_selected_row);
-                    EventManager::GetInstance()->AddEvent(std::make_shared<ScrollToTrackEvent>(
-                        static_cast<int>(RocEvents::kHandleUserGraphNavigationEvent),
-                        target_track_id, m_data_provider.GetTraceFilePath()));
-                    //get start time and duration
-                    uint64_t start_time = 0;
-                    uint64_t duration = 0;
-                    if(m_important_column_idxs[kTimeStartNs] != INVALID_UINT64_INDEX &&
-                       m_important_column_idxs[kTimeStartNs] < table_data[m_selected_row].size())
-                    {
-                        start_time = std::stoull(table_data[m_selected_row][m_important_column_idxs[kTimeStartNs]]);
-                    }
-
-                    if(m_important_column_idxs[kDurationNs] != INVALID_UINT64_INDEX &&
-                       m_important_column_idxs[kDurationNs] < table_data[m_selected_row].size())
-                    {
-                        duration = std::stoull(table_data[m_selected_row][m_important_column_idxs[kDurationNs]]);
-                    }
-
-                    ViewRangeNS view_range = calculate_adaptive_view_range(static_cast<double>(start_time),  static_cast<double>(duration));
-                    EventManager::GetInstance()->AddEvent(std::make_shared<RangeEvent>(
-                        static_cast<int>(RocEvents::kSetViewRange), view_range.start_ns,
-                        view_range.end_ns, m_data_provider.GetTraceFilePath()));
-                }
-                else
-                {
-                    spdlog::warn("No valid track or stream ID found for row: {}",
-                                  m_selected_row);
-                }
-            }
-        }
-        // TODO handle event selection
-        // else if(ImGui::MenuItem("Select event", nullptr, false)) 
-        // {
-        //     uint64_t event_id = INVALID_UINT64_INDEX;
-
-        //     if(m_important_columns[kId] != INVALID_COLUMN_INDEX &&
-        //        m_important_columns[kId] < table_data[m_selected_row].size())
-        //     {
-        //         event_id =
-        //             std::stoull(table_data[m_selected_row][m_important_columns[kId]]);
-        //     }
-        // }
-
-        ImGui::EndPopup();
-    }
-}
+{}
 
 void
 InfiniteScrollTable::RenderLoadingIndicator() const

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -4,7 +4,6 @@
 
 #include "imgui.h"
 #include "rocprofvis_data_provider.h"
-#include "rocprofvis_events.h"
 #include "widgets/rocprofvis_widget.h"
 #include <string>
 #include <vector>
@@ -14,49 +13,31 @@ namespace RocProfVis
 namespace View
 {
 
+constexpr const char* ROWCONTEXTMENU_POPUP_NAME = "RowContextMenu";
+
 class SettingsManager;
-class TimelineSelection;
+class TableDataEvent;
 
 class InfiniteScrollTable : public RocWidget
 {
 public:
-    InfiniteScrollTable(DataProvider&                      dp,
-                        std::shared_ptr<TimelineSelection> timeline_selection,
-                        TableType table_type = TableType::kEventTable);
-
+    InfiniteScrollTable(DataProvider& dp, TableType table_type = TableType::kEventTable);
     void Update() override;
     void Render() override;
     void SetTableType(TableType type) { m_table_type = type; }
 
-    void HandleTrackSelectionChanged();
     void HandleNewTableData(std::shared_ptr<TableDataEvent> e);
 
-private:
-    // Important columns in the table
-    enum ImportantColumns
-    {
-        kId,
-        kName,
-        kTimeStartNs,
-        kTimeEndNs,
-        kDurationNs,
-        kTrackId,
-        kStreamId,
-        kNumImportantColumns
-    };
-
+protected:
     struct FilterOptions
     {
         int  column_index;
         char group_columns[256];
         char filter[256];
     };
-    void RenderContextMenu() const;
-    void RenderLoadingIndicator() const;
-    bool XButton(const char* id) const;
 
-    uint64_t GetTrackIdHelper(
-        const std::vector<std::vector<std::string>>& table_data) const;
+    virtual void FetchData(const TableRequestParams& params) const = 0;
+    virtual void RenderContextMenu() const;
 
     std::vector<std::string> m_column_names;
     std::vector<const char*> m_column_names_ptr;
@@ -66,28 +47,27 @@ private:
     TableType m_table_type;  // Type of table (e.g., EventTable, SampleTable)
     rocprofvis_controller_table_type_t m_req_table_type;
 
-    DataProvider&                      m_data_provider;
-    SettingsManager&                   m_settings;
-    std::shared_ptr<TimelineSelection> m_timeline_selection;
+    DataProvider&    m_data_provider;
+    SettingsManager& m_settings;
 
     int m_fetch_chunk_size;
+
+    bool m_data_changed;
+
+    // Track the selected row for context menu actions
+    int m_selected_row = -1;
+
+private:
+    void RenderLoadingIndicator() const;
+    bool XButton(const char* id) const;
+
     int m_fetch_pad_items;
     int m_fetch_threshold_items;
 
     // Internal state flags below
     bool     m_skip_data_fetch;
     uint64_t m_last_total_row_count;
-    bool     m_data_changed;
-    bool     m_defer_track_selection_changed;
-
-    // Track the selected row for context menu actions
-    int    m_selected_row = -1;
-    ImVec2 m_last_table_size;
-
-    // Keep track of currently selected tracks for this table type
-    std::vector<uint64_t> m_selected_tracks;
-
-    std::vector<size_t> m_important_column_idxs;
+    ImVec2   m_last_table_size;
 };
 
 }  // namespace View


### PR DESCRIPTION
[Motivation]
As we are making the controller table API more general, I think it will be useful to have a widget that takes care of clipping, chunking, and rendering a large table that is not tied to a selection of tracks. Implementing a op_type table or event search table with existing InfiniteScrollTable as is would require circumvention of timeline selection-based checks that are scattered throughout.

[Change]
Break up InfiniteScrollTable into abstract widget InfiniteScrollTable and MultiTrackTable. 

- InfinteScrollTable is responsible for:

1. Rendering the filter section based on table type, the loading indicator, and the rendering table itself. 
2. Requesting new data from derived when table is scrolled and when filters/sorting are applied. 
3. Notifying derives when new data comes in from DP via m_data_changed flag, 
4. Updating filtering options when new data comes in from DP. 

- MultiTrackTable is responsible for:

1. Rendering the context menu.
2. Fetching any data requested by InfiniteScrollTable from DP. (This is the only hard requirement for any concrete implementation)
3. Fetching new data from DP when track selection changes.
4. Updating the important columns when InfinteScrollTable notifies of new data.

