### PR TITLE
Adding CPACK Packaging Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,9 +161,9 @@ if( NOT DEFINED BUILD_ID )
   endif()
 endif()
 
-#TODO - Update Correct Maintainer Name and Email
-set(PKG_MAINTAINER_NM  "ROCPROF-Visualizer Dev Support")
-set(PKG_MAINTAINER_EMAIL  "ROCPROF-Visualizer-Support@amd.com")
+#Package Maintainer Name and Email
+set(PKG_MAINTAINER_NM  "ROCm Visualizer Support")
+set(PKG_MAINTAINER_EMAIL  "rocm-visualizer-support@amd.com")
 
 set(RUNTIME_COMP_TYPE "RV_RUNTIME")
 set(PKG_DESCRIPTION "A visualizer for the ROCm Profiler Tools")


### PR DESCRIPTION
## Motivation
To Enable CPACK Packaging for rocprof-visualizer
This pull request adds comprehensive packaging support for the `rocprof-visualizer` project in `CMakeLists.txt`. The changes introduce configuration for generating DEB, RPM, and TGZ packages using CPack, including metadata, dependency management, and install directives. This enables easier distribution and installation of the software across different platforms.


## Technical Details
**Packaging configuration and metadata:**
* Added CPack packaging directives, including package vendor, maintainer name and email, versioning, and descriptions for the generated packages.
* Configured package dependencies for Debian (e.g., `libvulkan1`, `libc6`) and placeholders for RPM dependencies, as well as homepage and extended package descriptions.

**Install and build integration:**
* Set up installation instructions for the `rocprof-visualizer` binary into the appropriate system directory during packaging.
* Integrated environment variable support for build and release identifiers to allow dynamic versioning in packages.

**Platform-specific packaging support:**
* Enabled generation of DEB, RPM, and TGZ packages and configured platform-specific variables and behaviors, such as release tagging and component installation.

## Test Plan
* Build, Package Generation
* Verification of Package Name, Parameters, Contents (Binary for now) 

## Test Result
* Package Generated Successfully - rocprof-visualizer_0.1.4.70100
* Contents Verified - bin/rocprof-visualizer


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
