### PR TITLE
Fix SQL error when table search term has 0 results.

### DIFF
--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -528,6 +528,10 @@ ProfileDatabase::BuildTableQuery(
             slice_query_map[GetEventOperationQuery((rocprofvis_dm_event_operation_t)track)] = " WHERE " + string_id_filter_map.at((rocprofvis_dm_event_operation_t)track);
         }
     }
+    if(slice_query_map.empty())
+    {
+        return kRocProfVisDmResultSuccess;
+    }
     query = "WITH all_rows AS (";
 
     if (group && strlen(group))


### PR DESCRIPTION
[Problem]
-When searching for a substring with 0 matches, BuildTableQuery returns an invalid query:
WITH all_rows AS () SELECT * FROM all_rows  LIMIT 1000;

[Fix]
-Return empty query when slice_query_map is empty.
