### PR TITLE
Search UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,8 @@ set(VIEW_FILES
     src/view/src/rocprofvis_track_topology.cpp
     src/view/src/rocprofvis_track_details.cpp
     src/view/src/rocprofvis_project.cpp
-	src/view/src/rocprofvis_multi_track_table.cpp
+    src/view/src/rocprofvis_multi_track_table.cpp
+    src/view/src/rocprofvis_event_search.cpp
     src/view/src/widgets/rocprofvis_widget.cpp	
     src/view/src/widgets/rocprofvis_debug_window.cpp
     src/view/src/widgets/rocprofvis_gui_helpers.cpp

--- a/src/view/src/rocprofvis_analysis_view.cpp
+++ b/src/view/src/rocprofvis_analysis_view.cpp
@@ -73,9 +73,6 @@ AnalysisView::AnalysisView(DataProvider& dp, std::shared_ptr<TrackTopology> topo
     auto time_line_selection_changed_handler = [this](std::shared_ptr<RocEvent> e) {
         this->HandleTimelineSelectionChanged(e);
     };
-    auto new_table_data_handler = [this](std::shared_ptr<RocEvent> e) {
-        this->HandleNewTableData(e);
-    };
 
     // Subscribe to timeline selection changed event
     m_timeline_track_selection_changed_token = EventManager::GetInstance()->Subscribe(
@@ -84,8 +81,6 @@ AnalysisView::AnalysisView(DataProvider& dp, std::shared_ptr<TrackTopology> topo
     m_timeline_event_selection_changed_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kTimelineEventSelectionChanged),
         time_line_selection_changed_handler);
-    m_new_table_data_token = EventManager::GetInstance()->Subscribe(
-        static_cast<int>(RocEvents::kNewTableData), new_table_data_handler);
 }
 
 AnalysisView::~AnalysisView()
@@ -97,8 +92,6 @@ AnalysisView::~AnalysisView()
     EventManager::GetInstance()->Unsubscribe(
         static_cast<int>(RocEvents::kTimelineEventSelectionChanged),
         m_timeline_event_selection_changed_token);
-    EventManager::GetInstance()->Unsubscribe(static_cast<int>(RocEvents::kNewTableData),
-                                             m_new_table_data_token);
 }
 
 void
@@ -153,30 +146,6 @@ AnalysisView::HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e)
                         selection_changed_event->GetEventID(),
                         selection_changed_event->EventSelected());
                 }
-            }
-        }
-    }
-}
-
-void
-AnalysisView::HandleNewTableData(std::shared_ptr<RocEvent> e)
-{
-    if(e)
-    {
-        RocEventType                    event_type = e->GetType();
-        std::shared_ptr<TableDataEvent> table_data_event =
-            std::static_pointer_cast<TableDataEvent>(e);
-        if(table_data_event &&
-           table_data_event->GetSourceId() == m_data_provider.GetTraceFilePath())
-        {
-            const uint64_t& request_id = table_data_event->GetRequestID();
-            if(request_id == DataProvider::EVENT_TABLE_REQUEST_ID && m_event_table)
-            {
-                m_event_table->HandleNewTableData(table_data_event);
-            }
-            else if(request_id == DataProvider::SAMPLE_TABLE_REQUEST_ID && m_sample_table)
-            {
-                m_sample_table->HandleNewTableData(table_data_event);
             }
         }
     }

--- a/src/view/src/rocprofvis_analysis_view.h
+++ b/src/view/src/rocprofvis_analysis_view.h
@@ -30,7 +30,6 @@ public:
 
 private:
     void HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e);
-    void HandleNewTableData(std::shared_ptr<RocEvent> e);
 
     DataProvider& m_data_provider;
 
@@ -44,7 +43,6 @@ private:
 
     EventManager::SubscriptionToken m_timeline_track_selection_changed_token;
     EventManager::SubscriptionToken m_timeline_event_selection_changed_token;
-    EventManager::SubscriptionToken m_new_table_data_token;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_annotation_view.cpp
+++ b/src/view/src/rocprofvis_annotation_view.cpp
@@ -30,7 +30,7 @@ AnnotationView::Render()
 
     if(m_annotations->GetStickyNotes().empty())
     {
-        ImGui::Text("No notes");
+        ImGui::Text("No annotations.");
     }
     else if(ImGui::BeginTable("StickyNotesTable", 4,
                               ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg))

--- a/src/view/src/rocprofvis_event_search.cpp
+++ b/src/view/src/rocprofvis_event_search.cpp
@@ -1,0 +1,335 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#include "rocprofvis_event_search.h"
+#include "icons/rocprovfis_icon_defines.h"
+#include "rocprofvis_event_manager.h"
+#include "rocprofvis_settings_manager.h"
+#include "rocprofvis_utils.h"
+#include "spdlog/spdlog.h"
+#include "widgets/rocprofvis_notification_manager.h"
+
+namespace RocProfVis
+{
+namespace View
+{
+
+constexpr uint64_t MAX_RESULTS_DISPLAYED = 5;
+
+const std::string TRACK_ID_COLUMN_NAME  = "__trackId";
+const std::string STREAM_ID_COLUMN_NAME = "__streamTrackId";
+const std::string ID_COLUMN_NAME        = "id";
+const std::string NAME_COLUMN_NAME      = "name";
+
+EventSearch::EventSearch(DataProvider& dp)
+: InfiniteScrollTable(dp, TableType::kEventSearchTable)
+, m_important_column_idxs(std::vector<size_t>(kNumImportantColumns, INVALID_UINT64_INDEX))
+, m_should_open(false)
+, m_should_close(false)
+, m_focus_text_input(false)
+, m_search_deferred(false)
+, m_searched(false)
+, m_width(1000.0f)
+, m_text_input("\0")
+{
+    m_widget_name = GenUniqueName("Event Search Table");
+}
+
+void
+EventSearch::Update()
+{
+    if(m_search_deferred && !m_data_provider.IsRequestPending(GetRequestID()))
+    {
+        Search();
+    }
+    if(m_data_changed)
+    {
+        m_hidden_column_indices.clear();
+        const std::vector<std::string>& column_names =
+            m_data_provider.GetTableHeader(m_table_type);
+        for(size_t i = 0; i < column_names.size(); i++)
+        {
+            if(i != m_important_column_idxs[kId] && i != m_important_column_idxs[kName] &&
+               i != m_time_column_indices[kTimeStartNs] &&
+               i != m_time_column_indices[kDurationNs])
+            {
+                m_hidden_column_indices.push_back(i);
+            }
+        }
+    }
+    InfiniteScrollTable::Update();
+}
+
+void
+EventSearch::Render()
+{
+    if(m_should_open)
+    {
+        ImGui::OpenPopup("event_search", ImGuiPopupFlags_NoReopen);
+        m_should_open  = false;
+        m_should_close = false;
+    }
+
+    if(Open())
+    {
+        ImGui::SetNextWindowSize(ImVec2(m_width, Height()));
+        ImGui::SetNextWindowPos(
+            ImVec2(ImGui::GetItemRectMin().x,
+                   ImGui::GetItemRectMax().y + ImGui::GetStyle().FramePadding.y));
+        if(ImGui::BeginPopup("event_search", ImGuiWindowFlags_NoFocusOnAppearing))
+        {
+            if(m_data_provider.IsRequestPending(GetRequestID()) ||
+               m_data_provider.GetTableTotalRowCount(m_table_type) > 0)
+            {
+                ImGui::SetNextWindowSize(ImGui::GetContentRegionAvail() -
+                                         ImVec2(0, ImGui::GetFrameHeightWithSpacing()));
+                InfiniteScrollTable::Render();
+            }
+            ImGui::AlignTextToFramePadding();
+#ifdef ROCPROFVIS_DEVELOPER_MODE
+            auto table_params = m_data_provider.GetTableParams(m_table_type);
+            if(table_params)
+            {
+                ImGui::Text("Showing %llu to %llu of %llu result(s)",
+                            table_params->m_start_row,
+                            table_params->m_start_row + table_params->m_req_row_count,
+                            m_data_provider.GetTableTotalRowCount(m_table_type));
+            }
+#else
+            ImGui::Text("Showing %llu result(s)",
+                        m_data_provider.GetTableTotalRowCount(m_table_type));
+#endif
+            if(m_should_close)
+            {
+                ImGui::CloseCurrentPopup();
+                m_should_close = false;
+            }
+            ImGui::EndPopup();
+        }
+    }
+}
+
+void
+EventSearch::Show()
+{
+    if(!Open())
+    {
+        m_should_open = true;
+    }
+}
+
+void
+EventSearch::Search()
+{
+    size_t input_length = strlen(m_text_input);
+    if(input_length > 0)
+    {
+        bool                     valid = false;
+        std::vector<std::string> terms;
+        if(m_text_input[0] == '"')
+        {
+            std::string term;
+            bool        open_quote = true;
+            for(int i = 1; i < input_length; i++)
+            {
+                if(m_text_input[i] == '"')
+                {
+                    if(open_quote)
+                    {
+                        if(!term.empty())
+                        {
+                            terms.emplace_back(term);
+                            term = "";
+                        }
+                        open_quote = false;
+                    }
+                    else
+                    {
+                        open_quote = true;
+                    }
+                }
+                else
+                {
+                    term += m_text_input[i];
+                }
+            }
+            valid = !terms.empty() && !open_quote;
+        }
+        else
+        {
+            terms.emplace_back(m_text_input);
+            valid = true;
+        }
+        if(valid)
+        {
+            m_data_provider.CancelRequest(GetRequestID());
+            m_search_deferred = !m_data_provider.FetchTable(TableRequestParams(
+                m_req_table_type, {},
+                { kRocProfVisDmOperationLaunch, kRocProfVisDmOperationDispatch },
+                m_data_provider.GetStartTime(), m_data_provider.GetEndTime(), "", "", "",
+                { terms }, 0, m_fetch_chunk_size));
+            m_searched        = true;
+            m_should_open     = true;
+        }
+        else
+        {
+            NotificationManager::GetInstance().Show("Invalid search term.",
+                                                    NotificationLevel::Error);
+        }
+    }
+}
+
+void
+EventSearch::Clear()
+{
+    m_data_provider.CancelRequest(GetRequestID());
+    m_data_provider.ClearTable(m_table_type);
+    m_text_input[0] = '\0';
+    m_searched      = false;
+    m_should_close  = true;
+}
+
+void
+EventSearch::SetWidth(float width)
+{
+    m_width = std::max(0.0f, width);
+}
+
+char*
+EventSearch::TextInput()
+{
+    return m_text_input;
+}
+
+size_t
+EventSearch::TextInputLimit() const
+{
+    return IM_ARRAYSIZE(m_text_input);
+}
+
+bool
+EventSearch::FocusTextInput()
+{
+    if(m_focus_text_input)
+    {
+        m_focus_text_input = false;
+        return true;
+    }
+    else
+    {
+        m_focus_text_input = Open() && !ImGui::IsItemFocused() &&
+                             ImGui::IsMouseHoveringRect(ImGui::GetItemRectMin(),
+                                                        ImGui::GetItemRectMax()) &&
+                             ImGui::IsMouseClicked(ImGuiMouseButton_Left);
+        return m_focus_text_input;
+    }
+}
+
+bool
+EventSearch::Open() const
+{
+    return ImGui::IsPopupOpen("event_search");
+}
+
+bool
+EventSearch::Searched() const
+{
+    return !m_searched;
+}
+
+float
+EventSearch::Width() const
+{
+    return m_width;
+}
+
+void
+EventSearch::FormatData()
+{
+    std::vector<formatted_column_info_t>& formatted_column_data =
+        m_data_provider.GetMutableFormattedTableData(m_table_type);
+    formatted_column_data.clear();
+    formatted_column_data.resize(m_data_provider.GetTableHeader(m_table_type).size());
+    InfiniteScrollTable::FormatTimeColumns();
+}
+
+void
+EventSearch::IndexColumns()
+{
+    const std::vector<std::string>& column_names =
+        m_data_provider.GetTableHeader(m_table_type);
+    m_important_column_idxs =
+        std::vector<size_t>(kNumImportantColumns, INVALID_UINT64_INDEX);
+    m_hidden_column_indices.clear();
+    for(size_t i = 0; i < column_names.size(); i++)
+    {
+        const auto& col = column_names[i];
+        if(!col.empty())
+        {
+            if(col == TRACK_ID_COLUMN_NAME)
+            {
+                m_important_column_idxs[kTrackId] = i;
+            }
+            else if(col == STREAM_ID_COLUMN_NAME)
+            {
+                m_important_column_idxs[kStreamId] = i;
+            }
+            else if(col == ID_COLUMN_NAME)
+            {
+                m_important_column_idxs[kId] = i;
+            }
+            else if(col == NAME_COLUMN_NAME)
+            {
+                m_important_column_idxs[kName] = i;
+            }
+        }
+    }
+    InfiniteScrollTable::IndexColumns();
+}
+
+void
+EventSearch::RowSelected(const ImGuiMouseButton mouse_button)
+{
+    if(mouse_button == ImGuiMouseButton_Left)
+    {
+        uint64_t track_id = SelectedRowToTrackID(m_important_column_idxs[kTrackId],
+                                                 m_important_column_idxs[kStreamId]);
+        std::pair<uint64_t, uint64_t> time_range = SelectedRowToTimeRange();
+        if(track_id != INVALID_UINT64_INDEX && time_range.first != INVALID_UINT64_INDEX &&
+           time_range.second != INVALID_UINT64_INDEX)
+        {
+            ViewRangeNS view_range = calculate_adaptive_view_range(
+                static_cast<double>(time_range.first),
+                static_cast<double>(time_range.second - time_range.first));
+            EventManager::GetInstance()->AddEvent(std::make_shared<ScrollToTrackEvent>(
+                static_cast<int>(RocEvents::kHandleUserGraphNavigationEvent), track_id,
+                m_data_provider.GetTraceFilePath()));
+            EventManager::GetInstance()->AddEvent(std::make_shared<RangeEvent>(
+                static_cast<int>(RocEvents::kSetViewRange), view_range.start_ns,
+                view_range.end_ns, m_data_provider.GetTraceFilePath()));
+            m_should_close = true;
+        }
+    }
+    InfiniteScrollTable::RowSelected(mouse_button);
+}
+
+float
+EventSearch::Height() const
+{
+    float    height;
+    uint64_t results = m_data_provider.GetTableTotalRowCount(m_table_type);
+    if(results > 0)
+    {
+        height = (2 + std::min(results, MAX_RESULTS_DISPLAYED)) *
+                 ImGui::GetFrameHeightWithSpacing();
+    }
+    else
+    {
+        height = m_data_provider.IsRequestPending(GetRequestID())
+                     ? 2 * ImGui::GetFrameHeightWithSpacing()
+                     : ImGui::GetFrameHeightWithSpacing();
+    }
+    return m_horizontal_scroll ? height + ImGui::GetStyle().ScrollbarSize : height;
+}
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/rocprofvis_event_search.h
+++ b/src/view/src/rocprofvis_event_search.h
@@ -1,0 +1,62 @@
+// Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+#pragma once
+
+#include "imgui.h"
+#include "widgets/rocprofvis_infinite_scroll_table.h"
+#include <vector>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+class EventSearch : public InfiniteScrollTable
+{
+public:
+    EventSearch(DataProvider& dp);
+    void Update() override;
+    void Render() override;
+
+    void Show();
+    void Search();
+    void Clear();
+    void SetWidth(float width);
+
+    char*  TextInput();
+    size_t TextInputLimit() const;
+    bool   FocusTextInput();
+    bool   Searched() const;
+    float  Width() const;
+
+private:
+    enum ImportantColumns
+    {
+        kId,
+        kName,
+        kTrackId,
+        kStreamId,
+        kNumImportantColumns
+    };
+
+    void FormatData() override;
+    void IndexColumns() override;
+    void RowSelected(const ImGuiMouseButton mouse_button);
+
+    bool  Open() const;
+    float Height() const;
+
+    bool  m_should_open;
+    bool  m_should_close;
+    bool  m_focus_text_input;
+    bool  m_search_deferred;
+    bool  m_searched;
+    float m_width;
+
+    char m_text_input[256];
+
+    std::vector<size_t> m_important_column_idxs;
+};
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/rocprofvis_multi_track_table.h
+++ b/src/view/src/rocprofvis_multi_track_table.h
@@ -3,8 +3,6 @@
 #pragma once
 
 #include "imgui.h"
-#include "rocprofvis_data_provider.h"
-#include "rocprofvis_event_manager.h"
 #include "widgets/rocprofvis_infinite_scroll_table.h"
 #include <string>
 #include <vector>
@@ -36,21 +34,16 @@ private:
     {
         kId,
         kName,
-        kTimeStartNs,
-        kTimeEndNs,
-        kDurationNs,
         kTrackId,
         kStreamId,
         kNumImportantColumns
     };
 
     void FormatData() override;
-    //void FetchData(const TableRequestParams& params) const override;
+    void IndexColumns() override;
+    void RowSelected(const ImGuiMouseButton mouse_button) override;
+    void RenderContextMenu();
     bool XButton(const char* id) const;
-    void RenderContextMenu() const override;
-
-    uint64_t GetTrackIdHelper(
-        const std::vector<std::vector<std::string>>& table_data) const;
 
     std::shared_ptr<TimelineSelection> m_timeline_selection;
     bool                               m_defer_track_selection_changed;
@@ -58,8 +51,9 @@ private:
     // Keep track of currently selected tracks for this table type
     std::vector<uint64_t> m_selected_tracks;
 
+    bool m_open_context_menu;
+
     std::vector<size_t> m_important_column_idxs;
-    EventManager::SubscriptionToken m_format_changed_token;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -214,7 +214,8 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
                             window_position.y + m_graph_size.y + m_scroll_position_y);
 
     if(ImGui::IsMouseClicked(ImGuiMouseButton_Right) &&
-       ImGui::IsMouseHoveringRect(win_min, win_max))
+       ImGui::IsMouseHoveringRect(win_min, win_max) &&
+       !ImGui::IsPopupOpen("", ImGuiPopupFlags_AnyPopup))
     {
         ImGui::OpenPopup("StickyNoteContextMenu");
     }

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -5,6 +5,7 @@
 #include "rocprofvis_annotations.h"
 #include "rocprofvis_appwindow.h"
 #include "rocprofvis_event_manager.h"
+#include "rocprofvis_event_search.h"
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_sidebar.h"
 #include "rocprofvis_timeline_selection.h"
@@ -34,6 +35,9 @@ TraceView::TraceView()
 , m_project_settings(nullptr)
 , m_annotations(nullptr)
 , m_settings_manager(SettingsManager::GetInstance())
+, m_event_search(nullptr)
+, m_is_sidebar_visible(true)
+, m_is_analysis_visible(true)
 {
     m_data_provider.SetTrackDataReadyCallback(
         [](uint64_t track_id, const std::string& trace_path, const data_req_info_t& req) {
@@ -174,6 +178,10 @@ TraceView::Update()
     {
         m_analysis_item->m_item->Update();
     }
+    if(m_event_search)
+    {
+        m_event_search->Update();
+    }
 }
 
 void
@@ -193,6 +201,7 @@ TraceView::CreateView()
                                   m_timeline_view->GetGraphs(), m_data_provider);
     auto analysis = std::make_shared<AnalysisView>(m_data_provider, m_track_topology,
                                                    m_timeline_selection, m_annotations);
+    m_event_search = std::make_shared<EventSearch>(m_data_provider);
 
     m_sidebar_item                 = LayoutItem::CreateFromWidget(sidebar);
     m_sidebar_item->m_visible      = m_is_sidebar_visible;
@@ -529,9 +538,12 @@ TraceView::RenderToolbar()
     ImGui::AlignTextToFramePadding();
 
     // Toolbar Controls
+    ImGui::BeginGroup();
     RenderFlowControls();
     RenderSeparator();
     RenderAnnotationControls();
+    RenderSeparator();
+    RenderEventSearch();
     RenderSeparator();
     RenderBookmarkControls();
     RenderSeparator();
@@ -546,6 +558,12 @@ TraceView::RenderToolbar()
     if(ImGui::IsItemHovered())
     {
         ImGui::SetTooltip("Reset view to default zoom and pan");
+    }
+    ImGui::EndGroup();
+    float available_width = ImGui::GetContentRegionAvail().x - ImGui::GetItemRectSize().x;
+    if(m_event_search && available_width != 0)
+    {
+        m_event_search->SetWidth(m_event_search->Width() + available_width);
     }
 
     // pop content style
@@ -672,6 +690,9 @@ TraceView::RenderBookmarkControls()
     ImGui::PushID("bookmark_toggle_dropdown");
 
     static int selected_slot = -1;
+    ImGui::SetNextItemWidth(ImGui::CalcTextSize("BookMarks").x +
+                            2 * ImGui::GetStyle().FramePadding.x +
+                            ImGui::GetFrameHeightWithSpacing());
     if(ImGui::BeginCombo("", "Bookmarks"))
     {
         if(ImGui::BeginTable("BookmarkTable", 2, ImGuiTableFlags_SizingStretchProp))
@@ -820,6 +841,42 @@ TraceView::RenderFlowControls()
 
     // Update the mode if changed
     if(mode != current_mode) arrow_layer.SetFlowDisplayMode(mode);
+}
+
+void
+TraceView::RenderEventSearch()
+{
+    if(m_event_search && m_event_search->Width() > 0)
+    {
+        SettingsManager& settings = SettingsManager::GetInstance();
+        if(m_event_search->FocusTextInput())
+        {
+            ImGui::SetKeyboardFocusHere();
+        }
+        std::pair<bool, bool> search_bar = InputTextWithClear(
+            "search_bar", "Search: hipLaunchKernel or \"hip\"\"kernel\"",
+            m_event_search->TextInput(), m_event_search->TextInputLimit(),
+            settings.GetFontManager().GetIconFont(FontType::kDefault),
+            settings.GetColor(Colors::kBgMain), settings.GetDefaultStyle(),
+            m_event_search->Width());
+        if(ImGui::IsItemClicked() && !m_event_search->Searched())
+        {
+            m_event_search->Show();
+        }
+        if(ImGui::IsItemFocused() && ImGui::IsKeyPressed(ImGuiKey_Enter))
+        {
+            m_event_search->Search();
+        }
+        if(search_bar.second)
+        {
+            m_event_search->Clear();
+        }
+        if(m_event_search->FocusTextInput())
+        {
+            ImGui::GetIO().MouseClicked[0] = false;
+        }
+        m_event_search->Render();
+    }
 }
 
 SystemTraceProjectSettings::SystemTraceProjectSettings(const std::string& project_id,

--- a/src/view/src/rocprofvis_trace_view.h
+++ b/src/view/src/rocprofvis_trace_view.h
@@ -21,6 +21,7 @@ class TrackTopology;
 class MessageDialog;
 class TraceView;
 class SettingsManager;
+class EventSearch;
 
 class SystemTraceProjectSettings : public ProjectSetting
 {
@@ -71,7 +72,8 @@ private:
     void RenderFlowControls();
     void RenderAnnotationControls();
     void RenderSeparator();
-    
+    void RenderEventSearch();
+
     std::shared_ptr<TimelineView>      m_timeline_view;
     std::shared_ptr<TimelineSelection> m_timeline_selection;
     std::shared_ptr<TrackTopology>     m_track_topology;
@@ -79,6 +81,7 @@ private:
     std::shared_ptr<HSplitContainer>   m_horizontal_split_container;
     std::shared_ptr<VSplitContainer>   m_vertical_split_container;
     std::shared_ptr<VFixedContainer>   m_timeline_container;
+    std::shared_ptr<EventSearch>       m_event_search;
 
     LayoutItem::Ptr m_sidebar_item;
     LayoutItem::Ptr m_analysis_item;
@@ -109,8 +112,8 @@ private:
     std::unique_ptr<SystemTraceProjectSettings> m_project_settings;
     // Unfortunately we should store it here because the tab appears before the view is
     // created
-    bool m_is_analysis_visible = true;
-    bool m_is_sidebar_visible = true;
+    bool m_is_analysis_visible;
+    bool m_is_sidebar_visible;
 };
 
 }  // namespace View

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
 
 #include "rocprofvis_gui_helpers.h"
+#include "icons/rocprovfis_icon_defines.h"
 #include "rocprofvis_utils.h"
 #include <cmath>
 #include <algorithm>
@@ -52,6 +53,92 @@ RocProfVis::View::RenderLoadingIndicatorDots(float dot_radius, int num_dots,
         draw_list->AddCircleFilled(ImVec2(current_dot_x, current_dot_y), dot_radius,
                                    current_color, 12);
     }
+}
+
+bool
+RocProfVis::View::IconButton(const char* icon, ImFont* icon_font, ImVec2 size,
+                             const char* tooltip, ImVec2 tooltip_padding, bool frameless,
+                             ImVec2 frame_padding, ImU32 bg_color, ImU32 bg_color_hover,
+                             ImU32 bg_color_active, const char* id)
+{
+    if(id && strlen(id) > 0)
+    {
+        ImGui::PushID(id);
+    }
+    else
+    {
+        ImGui::PushID(icon);
+    }
+    if(frameless)
+    {
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, 0);
+        ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(0, 0, 0, 0));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(0, 0, 0, 0));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(0, 0, 0, 0));
+    }
+    else
+    {
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, frame_padding);
+        ImGui::PushStyleColor(ImGuiCol_Button, bg_color);
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, bg_color_hover);
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, bg_color_active);
+    }
+    ImGui::PushFont(icon_font);
+    bool clicked = ImGui::Button(icon, size);
+    ImGui::PopFont();
+    if(tooltip && strlen(tooltip) > 0)
+    {
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, tooltip_padding);
+        if(ImGui::BeginItemTooltip())
+        {
+            ImGui::TextUnformatted(tooltip);
+            ImGui::EndTooltip();
+        }
+        ImGui::PopStyleVar();
+    }
+    ImGui::PopStyleColor(3);
+    ImGui::PopStyleVar();
+    ImGui::PopID();
+    return clicked;
+}
+
+std::pair<bool, bool>
+RocProfVis::View::InputTextWithClear(const char* id, const char* hint, char* buf,
+                                     size_t buf_size, ImFont* icon_font, ImU32 bg_color,
+                                     const ImGuiStyle& style, float width)
+{
+    bool input_cleared = false;
+    ImGui::BeginGroup();
+    ImGui::SetNextItemAllowOverlap();
+    ImGui::PushID(id);
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, bg_color);
+    ImGui::SetNextItemWidth(width);
+    bool input_changed =
+        ImGui::InputTextWithHint("##input_text_with_clear", hint, buf, buf_size);
+    ImGui::PopStyleColor();
+    if(strlen(buf) > 0)
+    {
+        ImGui::PushFont(icon_font);
+        if(width >= ImGui::CalcTextSize(ICON_X_CIRCLED).x + 2 * style.FramePadding.x)
+        {
+            ImGui::SameLine();
+            ImGui::SetCursorPosX(ImGui::GetItemRectMax().x - 2 * style.FramePadding.x -
+                                 ImGui::CalcTextSize(ICON_X_CIRCLED).x);
+            ImGui::PopFont();
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, style.FramePadding);
+            input_cleared = IconButton(ICON_X_CIRCLED, icon_font, ImVec2(0, 0), "Clear",
+                                       style.WindowPadding, false, style.FramePadding,
+                                       bg_color, bg_color, bg_color);
+            ImGui::PopStyleVar();
+        }
+        else
+        {
+            ImGui::PopFont();
+        }
+    }
+    ImGui::PopID();
+    ImGui::EndGroup();
+    return std::make_pair(input_changed, input_cleared);
 }
 
 #ifdef ROCPROFVIS_ENABLE_INTERNAL_BANNER

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -2,6 +2,7 @@
 
 #pragma once
 #include "imgui.h"
+#include <utility>
 
 namespace RocProfVis
 {
@@ -13,6 +14,19 @@ RenderLoadingIndicatorDots(float dot_radius, int num_dots, float spacing,
                            ImU32 color, float speed);
 ImVec2
 MeasureLoadingIndicatorDots(float dot_radius, int num_dots, float spacing);
+
+bool
+IconButton(const char* icon, ImFont* icon_font, ImVec2 size = ImVec2(0, 0),
+           const char* tooltip = nullptr, ImVec2 tooltip_padding = ImVec2(0, 0),
+           bool frameless = true, ImVec2 frame_padding = ImVec2(0, 0),
+           ImU32 bg_color        = IM_COL32(0, 0, 0, 0),
+           ImU32 bg_color_hover  = IM_COL32(0, 0, 0, 0),
+           ImU32 bg_color_active = IM_COL32(0, 0, 0, 0), const char* id = nullptr);
+
+std::pair<bool, bool>
+InputTextWithClear(const char* id, const char* hint, char* buf, size_t buf_size,
+                   ImFont* icon_font, ImU32 bg_color, const ImGuiStyle& style,
+                   float width = 0);
 
 #ifdef ROCPROFVIS_ENABLE_INTERNAL_BANNER
 void


### PR DESCRIPTION
1. Added search UI.
2. Moved table data changed event handler from `AnalysisView` into `InfiniteScrollTable` such that object can function without being "driven" by external component.
3. Moved time format changed event handler from `MultitrackTable` to `InfiniteScrollTable`.
4. Split important column indexing between `InfiniteScrollTable` and its derives. Added `InfiniteScrollTable::IndexColumns()` where base and derives can re-index any important columns they have. Occurs prior to `InfiniteScrollTable::Update()`. Currently `InfiniteScrollTable` is responsible for `startTs`, `endTs`, and `duration` columns.
5. Moved timeline navigation and time column formatting code from `MultitrackTable` to `InfinteScrollTable`.
6. Replaced `InfiniteScrollTable::RenderContextMenu()` with more generic `InfiniteScrollTable::RowSelected(mouse_button)`.
7. Added `m_hidden_columns` to `InfiniteScrollTable` where columns can be hidden by adding their index.
8. Added gui utils: `IconButton()`, `InputTextWithClear()`. Currently only used by search UI.

Known issue: [A search with 0 results will not clear the prior search's results](https://github.com/ROCm/rocprofiler-visualizer/pull/415).
