### PR TITLE
Fix: Settings delta detection not always working.

### DIFF
--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -44,6 +44,7 @@ SettingsPanel::Show()
     m_should_open               = true;
     m_category                  = Display;
     m_usersettings_initial      = m_usersettings;
+    m_usersettings_previous     = m_usersettings;
     m_font_settings.dpi_scaling = m_usersettings.display_settings.dpi_based_scaling;
     m_font_settings.size_index  = m_usersettings.display_settings.font_size_index;
 }
@@ -154,7 +155,8 @@ SettingsPanel::Render()
 
         if(m_settings_changed)
         {
-            m_settings.ApplyUserSettings(m_usersettings_initial, m_settings_confirmed);
+            m_settings.ApplyUserSettings(m_usersettings_previous, m_settings_confirmed);
+            m_usersettings_previous = m_settings.GetUserSettings();
             m_settings_changed   = false;
             m_settings_confirmed = false;
         }

--- a/src/view/src/rocprofvis_settings_panel.h
+++ b/src/view/src/rocprofvis_settings_panel.h
@@ -53,6 +53,7 @@ private:
     const UserSettings& m_usersettings_default;
     // Copy of settings on Show().
     UserSettings m_usersettings_initial;
+    UserSettings m_usersettings_previous;
     // Seperate store for font settings to keep changes isolated to preview.
     FontSettings m_font_settings;
 };


### PR DESCRIPTION
## Motivation

Settings delta detection would fail if settings were changed back to initial settings.

## Technical Details

Add a member variable to remember previous settings to use for deltas.
