### PR TITLE
File dialog improvements

### DIFF
--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -36,6 +36,9 @@ public:
     void ShowConfirmationDialog(const std::string& title, const std::string& message,
                                 std::function<void()> on_confirm_callback) const;
     void ShowMessageDialog(const std::string& title, const std::string& message) const;
+    void ShowFileDialog(const std::string& title, const std::string& file_filter,
+                        const std::string& initial_path, const bool& confirm_overwrite,
+                        std::function<void(std::string)> callback);
 
     Project* GetProject(const std::string& id);
     Project* GetCurrentProject();
@@ -53,7 +56,7 @@ private:
     void RenderViewMenu(Project* project);
     void RenderHelpMenu();
 
-    void RenderFileDialogs();
+    void RenderFileDialog();
     void RenderAboutDialog();
 
     void HandleTabClosed(std::shared_ptr<RocEvent> e);
@@ -85,13 +88,15 @@ private:
     bool m_analysis_bar_visible;
     bool m_sidebar_visible;
     bool m_histogram_visible;
+    bool m_init_file_dialog;
 
     std::unique_ptr<ConfirmationDialog> m_confirmation_dialog;
     std::unique_ptr<MessageDialog>      m_message_dialog;
     std::unique_ptr<SettingsPanel>      m_settings_panel;
 
-    int m_tool_bar_index;
-    std::function<void(int)> m_notification_callback;
+    int                              m_tool_bar_index;
+    std::function<void(int)>         m_notification_callback;
+    std::function<void(std::string)> m_file_dialog_callback;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_project.cpp
+++ b/src/view/src/rocprofvis_project.cpp
@@ -93,24 +93,10 @@ Project::Save()
 void
 Project::SaveAs(const std::string& file_path)
 {
-    if(std::filesystem::exists(file_path))
-    {
-        AppWindow::GetInstance()->ShowConfirmationDialog(
-            "Confirm Save", "File already exists. Do you want to overwrite it?",
-            [this, file_path]() {
-                m_project_file_path = file_path;
-                m_name = std::filesystem::path(m_project_file_path).filename().string();
-                AppWindow::GetInstance()->SetTabLabel(GetName(), GetID());
-                Save();
-            });
-    }
-    else
-    {
-        m_project_file_path = file_path;
-        m_name = std::filesystem::path(m_project_file_path).filename().string();
-        AppWindow::GetInstance()->SetTabLabel(GetName(), GetID());
-        Save();
-    }
+    m_project_file_path = file_path;
+    m_name              = std::filesystem::path(m_project_file_path).filename().string();
+    AppWindow::GetInstance()->SetTabLabel(GetName(), GetID());
+    Save();
 }
 
 void
@@ -284,25 +270,6 @@ Project::IsTrimSaveAllowed()
 
 void
 Project::TrimSave(const std::string& file_path_str)
-{
-    // Check if file already exists
-    std::error_code ec;
-    if(std::filesystem::exists(file_path_str, ec))
-    {
-        // Show confirmation dialog
-        AppWindow::GetInstance()->ShowConfirmationDialog(
-            "Confirm Save", "File already exists. Do you want to overwrite it?",
-            [this, file_path_str]() { TrimSaveOverwrite(file_path_str); });
-        return;
-    }
-    else
-    {
-        TrimSaveOverwrite(file_path_str);
-    }
-}
-
-void
-Project::TrimSaveOverwrite(const std::string& file_path_str)
 {
     if(m_trace_type == System)
     {

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -91,7 +91,6 @@ public:
     // many)
     bool IsTrimSaveAllowed();
     void TrimSave(const std::string& file_path_str);
-    void TrimSaveOverwrite(const std::string& file_path_str);
 
 private:
     /*


### PR DESCRIPTION
-Add `AppWindow::ShowFileDialog()`, a callback-based interface for displaying and handling the file dialog. This allows for objects throughout the application to conveniently handle file dialogs via `AppWindow::GetInstance()`. It also cuts down on code duplication from having unique dialogs for each use case (save trace, save project, open file) when no more than one can be active at a time.
-Remove `FILE_SAVE_DIALOG_NAME` and `PROJECT_SAVE_DIALOG_NAME`. Merged into `FILE_DIALOG_NAME` via new interface.
-Make the file dialog a modal pop up to prevent inputs leaking through.
-Removed custom overwrite confirmation handling in favor of built-in functionality. Once callback is fired, overwrite has been approved.