### PR TITLE
Correct IDs for sample event search.

### DIFF
--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -968,8 +968,9 @@ rocprofvis_dm_result_t RocprofDatabase::BuildTableStringIdFilter( rocprofvis_dm_
         }
         if(!string_ids.empty())
         {
-            filter[kRocProfVisDmOperationLaunch] = " R.name_id IN (" + string_ids;
+            filter[kRocProfVisDmOperationLaunch] = " SAMPLE.id IS NULL AND R.name_id IN (" + string_ids;
             filter[kRocProfVisDmOperationDispatch] = " K.region_name_id IN (" + string_ids;
+            filter[kRocProfVisDmOperationLaunchSample] = "R.name_id IN (" + string_ids;
             if(!kernel_ids.empty())
             {
                 filter[kRocProfVisDmOperationDispatch] += ") OR K.kernel_id IN (" + kernel_ids;

--- a/src/view/src/rocprofvis_event_search.cpp
+++ b/src/view/src/rocprofvis_event_search.cpp
@@ -164,7 +164,8 @@ EventSearch::Search()
             m_data_provider.CancelRequest(GetRequestID());
             m_search_deferred = !m_data_provider.FetchTable(TableRequestParams(
                 m_req_table_type, {},
-                { kRocProfVisDmOperationLaunch, kRocProfVisDmOperationDispatch },
+                { kRocProfVisDmOperationLaunch, kRocProfVisDmOperationDispatch,
+                  kRocProfVisDmOperationLaunchSample },
                 m_data_provider.GetStartTime(), m_data_provider.GetEndTime(), "", "", "",
                 { terms }, 0, m_fetch_chunk_size));
             m_searched        = true;
@@ -319,8 +320,9 @@ EventSearch::Height() const
     uint64_t results = m_data_provider.GetTableTotalRowCount(m_table_type);
     if(results > 0)
     {
-        height = (2 + std::min(results, MAX_RESULTS_DISPLAYED)) *
-                 ImGui::GetFrameHeightWithSpacing();
+        height = (m_horizontal_scroll ? ImGui::GetStyle().ScrollbarSize : 0) +
+                 (2 + std::min(results, MAX_RESULTS_DISPLAYED)) *
+                     ImGui::GetFrameHeightWithSpacing();
     }
     else
     {
@@ -328,7 +330,7 @@ EventSearch::Height() const
                      ? 2 * ImGui::GetFrameHeightWithSpacing()
                      : ImGui::GetFrameHeightWithSpacing();
     }
-    return m_horizontal_scroll ? height + ImGui::GetStyle().ScrollbarSize : height;
+    return height;
 }
 
 }  // namespace View


### PR DESCRIPTION
-Add launch sample op type to search query.
-Minor change to dropdown height calculation when 0 results are returned.