### PR TITLE
Fix regression caused by change from %llu to %lu

### DIFF
--- a/src/view/src/rocprofvis_event_search.cpp
+++ b/src/view/src/rocprofvis_event_search.cpp
@@ -89,13 +89,13 @@ EventSearch::Render()
             auto table_params = m_data_provider.GetTableParams(m_table_type);
             if(table_params)
             {
-                ImGui::Text("Showing %lu to %lu of %lu result(s)",
+                ImGui::Text("Showing %llu to %llu of %llu result(s)",
                             table_params->m_start_row,
                             table_params->m_start_row + table_params->m_req_row_count,
                             m_data_provider.GetTableTotalRowCount(m_table_type));
             }
 #else
-            ImGui::Text("Showing %lu result(s)",
+            ImGui::Text("Showing %llu result(s)",
                         m_data_provider.GetTableTotalRowCount(m_table_type));
 #endif
             if(m_should_close)

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -256,8 +256,8 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
             ImGui::Text("Start: %s", label.c_str());
             label = nanosecond_to_formatted_str(chart_item.event.m_duration, time_format);
             ImGui::Text("Duration: %s", label.c_str());
-            ImGui::Text("Id: %lu", chart_item.event.m_id);
-            ImGui::Text("DB Id: %lu", event_id.bitfield.db_event_id);
+            ImGui::Text("Id: %llu", chart_item.event.m_id);
+            ImGui::Text("DB Id: %llu", event_id.bitfield.db_event_id);
             ImGui::EndTooltip();
             ImGui::PopStyleVar();
             m_has_drawn_tool_tip = true;

--- a/src/view/src/rocprofvis_multi_track_table.cpp
+++ b/src/view/src/rocprofvis_multi_track_table.cpp
@@ -126,7 +126,7 @@ MultiTrackTable::Render()
     auto table_params = m_data_provider.GetTableParams(m_table_type);
     if(table_params)
     {
-        ImGui::Text("Cached %lu to %lu of %lu events for %lu tracks",
+        ImGui::Text("Cached %llu to %llu of %llu events for %llu tracks",
                     table_params->m_start_row,
                     table_params->m_start_row + table_params->m_req_row_count,
                     m_data_provider.GetTableTotalRowCount(m_table_type),


### PR DESCRIPTION
## Motivation

Fix regression caused by format specifier change from %llu to %lu.  On windows %lu is treated as 32bit.

## Technical Details

Use %llu when formatting 64bit numbers
