### PR TITLE
SWDEV-563103 - [CQE][ROCm-Visualizer]: omp_target_emi count is shown as 4 instead of 5

### DIFF
--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -623,7 +623,7 @@ ProfileDatabase::BuildTableQuery(
         query += std::to_string(start);
         query += " and ";
         query += Builder::END_SERVICE_NAME;
-        query += " < ";
+        query += " <= ";
         query += std::to_string(end);
     }
     if (group && strlen(group))


### PR DESCRIPTION
[Problem]
-Table query misses the last occurrence of this event because its endTs is same as the trace's endTs:
<img width="1335" height="281" alt="image" src="https://github.com/user-attachments/assets/6b878f11-9cce-4002-a078-47facfff0212" />


[Fix]
-Make table query endTs condition inclusive.