### PR TITLE
Fixed Arrow Render Issue #481

### DIFF
--- a/src/model/src/database/rocprofvis_db_query_factory.cpp
+++ b/src/model/src/database/rocprofvis_db_query_factory.cpp
@@ -1772,7 +1772,7 @@ namespace DataModel
                             Builder::QParam("E2.category_id"),
                             Builder::QParam("K2.kernel_id"),
                             Builder::QParam("L.level"),
-                            Builder::QParam("R.end"),
+                            Builder::QParam("K2.end"),
 
                         },
                     {


### PR DESCRIPTION
Motivation --> https://github.com/ROCm/rocprofiler-visualizer/issues/481

This PR addresses an issue where clicking on a hipLaunch event correctly navigates to the corresponding kernel dispatch event in the queue track, but clicking on the kernel dispatch event does not show a flow relation pointing back to the hipLaunch event. This inconsistency in navigation impacts trace analysis and debugging workflows.

Technical Details

The issue was caused by an incorrect field being used in the query logic. Specifically, R.end was mistakenly used instead of the correct K2.end, which prevented the reverse flow relation from being established. The fix updates the query in the query factory to use K2.end, ensuring bidirectional flow linkage between hipLaunch and kernel dispatch events.

Test Plan

Used the rocpd-transpose.db sample to validate the fix.
Verified that clicking on a kernel dispatch event now correctly shows the flow relation back to the corresponding hipLaunch event.
Ensured that existing functionality for forward navigation from hipLaunch to kernel dispatch remains intact.

Test Result

After applying the fix, the reverse flow relation from kernel dispatch to hipLaunch is now visible and correctly rendered in the UI.
All existing tests pass, and no regressions were observed.