### PR TITLE
Removed dependency on trace start/stop timestamps loaded from process table

### DIFF
--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -635,22 +635,13 @@ rocprofvis_dm_result_t  RocprofDatabase::ReadTraceMetadata(Future* future)
 
         ShowProgress(5, "Collecting track properties",
                      kRPVDbBusy, future);
-        TraceProperties()->start_time = std::atoll(CachedTables()->GetTableCell("Process", process_id, "start"));
-        TraceProperties()->end_time = std::atoll(CachedTables()->GetTableCell("Process", process_id, "end"));
-        uint32_t split_flag = 0;
-        if (TraceProperties()->start_time > 0 && TraceProperties()->end_time > 0)
-        {
-            split_flag = kRocProfVisDmTrySplitTrack;
-        }
-        else
-        {
-            TraceProperties()->start_time = UINT64_MAX;
-            TraceProperties()->end_time = 0;
-        }
+
+        TraceProperties()->start_time = UINT64_MAX;
+        TraceProperties()->end_time = 0;
 
         if(kRocProfVisDmResultSuccess !=
            ExecuteQueryForAllTracksAsync(
-               kRocProfVisDmIncludePmcTracks | kRocProfVisDmIncludeStreamTracks | split_flag , kRPVQuerySliceByTrackSliceQuery,
+               kRocProfVisDmIncludePmcTracks | kRocProfVisDmIncludeStreamTracks , kRPVQuerySliceByTrackSliceQuery,
                "SELECT MIN(startTs), MAX(endTs), MIN(level), MAX(level), ",
                "WHERE startTs != 0 AND endTs != 0", &CallbackGetTrackProperties,
                [](rocprofvis_dm_track_params_t* params) {}))


### PR DESCRIPTION
The start and stop timestamps in rocpd_info_process doesn't seem to be always related to trace length, so it cannot be used for trace length dependent parameters calculations.
