### PR TITLE
Fix crash when track is moved on timeline and track details is open 

### DIFF
--- a/src/view/src/rocprofvis_events.h
+++ b/src/view/src/rocprofvis_events.h
@@ -27,6 +27,7 @@ enum class RocEvents
     kSetViewRange,
     kGoToTimelineSpot,
     kTimeFormatChanged,
+    kTopologyChanged,
 #ifdef COMPUTE_UI_SUPPORT
     kComputeDataDirty,
     kComputeBlockNavigationChanged,

--- a/src/view/src/rocprofvis_track_details.h
+++ b/src/view/src/rocprofvis_track_details.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "rocprofvis_event_manager.h"
 #include "widgets/rocprofvis_widget.h"
 #include <list>
 
@@ -57,6 +58,10 @@ private:
     bool                               m_selection_dirty;
     std::list<DetailItem>              m_track_details;
     int                                m_detail_item_id;
+    bool                               m_data_valid;
+
+    EventManager::SubscriptionToken m_topology_changed_event_token;
+    EventManager::SubscriptionToken m_track_metadata_changed_event_token;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -352,6 +352,9 @@ TrackTopology::UpdateTopology()
         }
         FormatCells();
         m_topology_dirty = false;
+        EventManager::GetInstance()->AddEvent(
+            std::make_shared<RocEvent>(static_cast<int>(RocEvents::kTopologyChanged),
+                                       m_data_provider.GetTraceFilePath()));
     }
 }
 


### PR DESCRIPTION
## Motivation

Fix crash when track is moved on time line and then track details tab is viewed or is already visible.
Issue: https://github.com/ROCm/roc-optiq/issues/497

## Technical Details

Track View listens for events indicating that track metadata has changed and invalidates it self, then listens for a track topology changed message as a signal to update its topology cache.
