### PR TITLE
Fixed overlapping samples. 

### DIFF
--- a/src/controller/inc/rocprofvis_controller_enums.h
+++ b/src/controller/inc/rocprofvis_controller_enums.h
@@ -531,9 +531,7 @@ typedef enum rocprofvis_controller_sample_properties_t : uint32_t
     // Sample value
     kRPVControllerSampleValue,
     // Sample vector end timestamp
-    kRPVControllerSampleNextTimestamp,
-    // Sample vector end value
-    kRPVControllerSampleNextValue,
+    kRPVControllerSampleEndTimestamp,
 
     // When a LOD is generated the sample will be synthetic and coalesce several real
     // samples These properties allow access to the contains samples.

--- a/src/controller/src/rocprofvis_controller_graph.cpp
+++ b/src/controller/src/rocprofvis_controller_graph.cpp
@@ -87,7 +87,7 @@ Graph::Insert(uint32_t lod, double timestamp, uint8_t level, Handle* object)
             }
             else
             {
-                object->GetDouble(kRPVControllerSampleNextTimestamp, 0, &max_timestamp);
+                object->GetDouble(kRPVControllerSampleEndTimestamp, 0, &max_timestamp);
             }
             segment->SetMaxTimestamp(max_timestamp);
 
@@ -109,7 +109,7 @@ Graph::Insert(uint32_t lod, double timestamp, uint8_t level, Handle* object)
             }
             else
             {
-                object->GetDouble(kRPVControllerSampleNextTimestamp, 0, &max_timestamp);
+                object->GetDouble(kRPVControllerSampleEndTimestamp, 0, &max_timestamp);
             }
             segment->SetMaxTimestamp(std::max(segment->GetMaxTimestamp(), max_timestamp));
             segment->Insert(timestamp, level, object);
@@ -410,7 +410,7 @@ Graph::GenerateLOD(uint32_t lod_to_generate, double start_ts, double end_ts,
                     sample->GetDouble(kRPVControllerSampleTimestamp, 0, &sample_start);
                 result =
                     (result == kRocProfVisResultSuccess)
-                    ? sample->GetDouble(kRPVControllerSampleNextTimestamp, 0, &sample_next)
+                    ? sample->GetDouble(kRPVControllerSampleEndTimestamp, 0, &sample_next)
                     : result;
                 ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
                 if(result == kRocProfVisResultSuccess)
@@ -429,16 +429,13 @@ Graph::GenerateLOD(uint32_t lod_to_generate, double start_ts, double end_ts,
                             if ((samples.size() > 0) &&
                                 (samples.front()->GetUInt64(kRPVControllerSampleType, 0, &type) == kRocProfVisResultSuccess) &&
                                 (samples.front()->GetDouble(kRPVControllerSampleTimestamp, 0,&sample_insert_ts) == kRocProfVisResultSuccess) &&
-                                (samples.back()->GetDouble(kRPVControllerSampleNextTimestamp, 0,&sample_last_ts) == kRocProfVisResultSuccess) && 
-                                (samples.back()->GetDouble(kRPVControllerSampleNextValue, 0,&sample_last_value) == kRocProfVisResultSuccess))
+                                (samples.back()->GetDouble(kRPVControllerSampleEndTimestamp, 0,&sample_last_ts) == kRocProfVisResultSuccess))
                             {
                                 SampleLOD* new_sample = m_ctx->GetMemoryManager()->NewSampleLOD(
                                     (rocprofvis_controller_primitive_type_t)type, 0,
                                     sample_insert_ts, samples, &m_lods[lod_to_generate]);
                                 new_sample->SetDouble(
-                                    kRPVControllerSampleNextTimestamp, 0, sample_last_ts);
-                                new_sample->SetDouble(
-                                    kRPVControllerSampleNextValue, 0, sample_last_value);
+                                    kRPVControllerSampleEndTimestamp, 0, sample_last_ts);
                                 Insert(lod_to_generate, sample_insert_ts, 0, new_sample);
                             }
 
@@ -460,16 +457,13 @@ Graph::GenerateLOD(uint32_t lod_to_generate, double start_ts, double end_ts,
         if ((samples.size() > 0) &&
             (samples.front()->GetUInt64(kRPVControllerSampleType, 0, &type) == kRocProfVisResultSuccess) &&
             (samples.front()->GetDouble(kRPVControllerSampleTimestamp, 0,&sample_insert_ts) == kRocProfVisResultSuccess) &&
-            (samples.back()->GetDouble(kRPVControllerSampleNextTimestamp, 0,&sample_last_ts) == kRocProfVisResultSuccess) && 
-            (samples.back()->GetDouble(kRPVControllerSampleNextValue, 0,&sample_last_value) == kRocProfVisResultSuccess))
+            (samples.back()->GetDouble(kRPVControllerSampleEndTimestamp, 0,&sample_last_ts) == kRocProfVisResultSuccess))
         {
             SampleLOD* new_sample = m_ctx->GetMemoryManager()->NewSampleLOD(
                 (rocprofvis_controller_primitive_type_t)type, 0,
                 sample_insert_ts, samples, &m_lods[lod_to_generate]);
             new_sample->SetDouble(
-                kRPVControllerSampleNextTimestamp, 0, sample_last_ts);
-            new_sample->SetDouble(
-                kRPVControllerSampleNextValue, 0, sample_last_value);
+                kRPVControllerSampleEndTimestamp, 0, sample_last_ts);
             Insert(lod_to_generate, sample_insert_ts, 0, new_sample);
             
         }

--- a/src/controller/src/rocprofvis_controller_sample.cpp
+++ b/src/controller/src/rocprofvis_controller_sample.cpp
@@ -15,8 +15,7 @@ typedef Reference<rocprofvis_controller_track_t, Track, kRPVControllerObjectType
 Sample::Sample(rocprofvis_controller_primitive_type_t type, uint64_t id, double timestamp)
 : Handle(__kRPVControllerSamplePropertiesFirst, __kRPVControllerSamplePropertiesLast)
 , m_data(0)
-, m_next_data(0)
-, m_next_timestamp(0)
+, m_end_timestamp(0)
 , m_timestamp(timestamp)
 {}
 
@@ -24,8 +23,7 @@ Sample& Sample::operator=(Sample&& other)
 {
     m_data            = other.m_data;
     m_timestamp       = other.m_timestamp;
-    m_next_data       = other.m_next_data;
-    m_next_timestamp  = other.m_next_timestamp;
+    m_end_timestamp  = other.m_end_timestamp;
     return *this;
 }
 
@@ -137,15 +135,9 @@ rocprofvis_result_t Sample::GetDouble(rocprofvis_property_t property, uint64_t i
                 result = kRocProfVisResultSuccess;
                 break;
             }
-            case kRPVControllerSampleNextTimestamp:
+            case kRPVControllerSampleEndTimestamp:
             {
-                *value = m_next_timestamp;
-                result = kRocProfVisResultSuccess;
-                break;
-            }
-            case kRPVControllerSampleNextValue:
-            {
-                *value = m_next_data;
+                *value = m_end_timestamp;
                 result = kRocProfVisResultSuccess;
                 break;
             }
@@ -243,15 +235,9 @@ rocprofvis_result_t Sample::SetDouble(rocprofvis_property_t property, uint64_t i
             result = kRocProfVisResultSuccess;
             break;
         }
-        case kRPVControllerSampleNextValue:
+        case kRPVControllerSampleEndTimestamp:
         {
-            m_next_data = value;
-            result = kRocProfVisResultSuccess;
-            break;
-        }
-        case kRPVControllerSampleNextTimestamp:
-        {
-            m_next_timestamp = value;
+            m_end_timestamp = value;
             result = kRocProfVisResultSuccess;
             break;
         }

--- a/src/controller/src/rocprofvis_controller_sample.h
+++ b/src/controller/src/rocprofvis_controller_sample.h
@@ -45,8 +45,7 @@ public:
 protected:
     double       m_data;
     double       m_timestamp;
-    double       m_next_data;
-    double       m_next_timestamp;
+    double       m_end_timestamp;
 };
 
 }

--- a/src/controller/src/rocprofvis_controller_sample_lod.cpp
+++ b/src/controller/src/rocprofvis_controller_sample_lod.cpp
@@ -208,8 +208,7 @@ rocprofvis_result_t SampleLOD::GetDouble(rocprofvis_property_t property, uint64_
             case kRPVControllerSampleType:
             case kRPVControllerSampleNumChildren:
             case kRPVControllerSampleChildIndex:
-            case kRPVControllerSampleNextTimestamp:
-            case kRPVControllerSampleNextValue:
+            case kRPVControllerSampleEndTimestamp:
             case kRPVControllerSampleTrack:
             {
                 result = Sample::GetDouble(property, index, value);
@@ -367,8 +366,7 @@ rocprofvis_result_t SampleLOD::SetDouble(rocprofvis_property_t property, uint64_
         case kRPVControllerSampleNumChildren:
         case kRPVControllerSampleChildIndex:
         case kRPVControllerSampleTimestamp:
-        case kRPVControllerSampleNextTimestamp:
-        case kRPVControllerSampleNextValue:
+        case kRPVControllerSampleEndTimestamp:
         case kRPVControllerSampleTrack:
         {
             result = Sample::SetDouble(property, index, value);

--- a/src/controller/src/rocprofvis_controller_segment.cpp
+++ b/src/controller/src/rocprofvis_controller_segment.cpp
@@ -159,7 +159,7 @@ rocprofvis_result_t Segment::Fetch(double start, double end, std::vector<Data>& 
                 (rocprofvis_controller_properties_t) ((m_type ==
                                                         kRPVControllerTrackTypeEvents)
                                                             ? kRPVControllerEventEndTimestamp
-                                                            : kRPVControllerSampleNextTimestamp);
+                                                            : kRPVControllerSampleEndTimestamp);
 
             std::map<double, Handle*>::iterator lower = entries.end();
             for(auto it = entries.begin(); it != entries.end(); ++it)

--- a/src/controller/src/rocprofvis_controller_track.cpp
+++ b/src/controller/src/rocprofvis_controller_track.cpp
@@ -398,9 +398,7 @@ rocprofvis_result_t Track::FetchFromDataModel(double start, double end, Future* 
                                     new_sample->SetDouble(
                                         kRPVControllerSampleValue, 0, last_value);
                                     new_sample->SetDouble(
-                                        kRPVControllerSampleNextTimestamp, 0, timestamp);
-                                    new_sample->SetDouble(
-                                        kRPVControllerSampleNextValue, 0, value);
+                                        kRPVControllerSampleEndTimestamp, 0, timestamp);
                                     SetObject(
                                         kRPVControllerTrackEntry, index++,
                                         (rocprofvis_handle_t*) new_sample);
@@ -412,27 +410,6 @@ rocprofvis_result_t Track::FetchFromDataModel(double start, double end, Future* 
                                 }
                                 last_value = value;
                                 last_timestamp = timestamp;
-                            }
-
-                            Sample* new_sample = m_ctx->GetMemoryManager()->NewSample(
-                                kRPVControllerPrimitiveTypeDouble,
-                                sample_id++, last_timestamp, GetSegments());
-                            if(new_sample)
-                            {
-                                new_sample->SetDouble(
-                                    kRPVControllerSampleValue, 0, last_value);
-                                new_sample->SetDouble(
-                                    kRPVControllerSampleNextTimestamp, 0, m_end_timestamp);
-                                new_sample->SetDouble(
-                                    kRPVControllerSampleNextValue, 0, value);
-                                SetObject(
-                                    kRPVControllerTrackEntry, index++,
-                                    (rocprofvis_handle_t*) new_sample);
-                            }
-                            else
-                            {
-                                result = kRocProfVisResultMemoryAllocError;
-                                break;
                             }
 
                             break;
@@ -784,7 +761,7 @@ rocprofvis_result_t Track::SetObject(rocprofvis_property_t property, uint64_t in
                     uint64_t              event_id = 0;
 
                     std::pair<double, double> timestamp = { 0,0 };
-                    std::pair<double, double> value = { 0,0 };
+                    double value = 0.0;
                     if (object_type == kRPVControllerObjectTypeEvent)
                     {  
                         result = object->GetUInt64(kRPVControllerEventLevel, 0, &level);
@@ -800,14 +777,10 @@ rocprofvis_result_t Track::SetObject(rocprofvis_property_t property, uint64_t in
                         result = object->GetDouble(kRPVControllerSampleTimestamp, 0, &timestamp.first);
                         if (result == kRocProfVisResultSuccess)
                         {
-                            result = object->GetDouble(kRPVControllerSampleNextTimestamp, 0, &timestamp.second);
+                            result = object->GetDouble(kRPVControllerSampleEndTimestamp, 0, &timestamp.second);
                             if (result == kRocProfVisResultSuccess)
                             {
-                                result = object->GetDouble(kRPVControllerSampleValue, 0, &value.first);
-                                if (result == kRocProfVisResultSuccess)
-                                {
-                                    result = object->GetDouble(kRPVControllerSampleNextValue, 0, &value.second);
-                                }
+                                result = object->GetDouble(kRPVControllerSampleValue, 0, &value);
                             }
                         }
                     }
@@ -892,11 +865,9 @@ rocprofvis_result_t Track::SetObject(rocprofvis_property_t property, uint64_t in
                                             if(new_sample)
                                             {
                                                 new_sample->SetDouble(
-                                                    kRPVControllerSampleValue, 0, value.first);
+                                                    kRPVControllerSampleValue, 0, value);
                                                 new_sample->SetDouble(
-                                                    kRPVControllerSampleNextTimestamp, 0, range.second);
-                                                new_sample->SetDouble(
-                                                    kRPVControllerSampleNextValue, 0, value.second);
+                                                    kRPVControllerSampleEndTimestamp, 0, range.second);
                                                 segment->Insert(segment_start, level, new_sample);
                                             }
                                             else

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -155,6 +155,7 @@ int ProfileDatabase::CallbackAddAnyRecord(void* data, int argc, sqlite3_stmt* st
         else {
             record.pmc.timestamp = db->Sqlite3ColumnInt64(func, stmt, azColName, 1);
             record.pmc.value = db->Sqlite3ColumnDouble(func, stmt, azColName,2);
+            callback_params->future->SetRuntimeStorageValue(kRPVFutureStorageSampleValue, record.pmc.value);
         }
         if(db->BindObject()->FuncAddRecord(
                (*(slice_array_t*) callback_params->handle)[callback_params->track_id],
@@ -499,7 +500,7 @@ rocprofvis_dm_result_t ProfileDatabase::BuildCounterSliceLeftNeighbourQuery(rocp
         query += Builder::START_SERVICE_NAME;
         query += " < ";
         query += std::to_string(start);
-        query += std::string(" ORDER BY ") + Builder::START_SERVICE_NAME + " DESC LIMIT 1 )";
+        query += std::string(" ORDER BY ") + Builder::START_SERVICE_NAME + " DESC LIMIT 1 );";
         break;
     }
     return kRocProfVisDmResultSuccess;
@@ -521,7 +522,7 @@ rocprofvis_dm_result_t ProfileDatabase::BuildCounterSliceRightNeighbourQuery(roc
         query += Builder::START_SERVICE_NAME;
         query += " > ";
         query += std::to_string(end);
-        query += std::string(" ORDER BY ") + Builder::START_SERVICE_NAME + " ASC LIMIT 1 )";
+        query += std::string(" ORDER BY ") + Builder::START_SERVICE_NAME + " ASC LIMIT 1 );";
         break;
     }
     return kRocProfVisDmResultSuccess;
@@ -801,7 +802,6 @@ rocprofvis_dm_result_t  ProfileDatabase::ReadTraceSlice(
                 }
             }
 
-
             if (result == kRocProfVisDmResultSuccess)
             {
 
@@ -815,8 +815,22 @@ rocprofvis_dm_result_t  ProfileDatabase::ReadTraceSlice(
                         rocprofvis_dm_track_params_t* props = TrackPropertiesAt(tracks[i]);
                         if (props->process.category == kRocProfVisDmPmcTrack)
                         {
+                            future->ResetRowCount();
                             if (BuildCounterSliceRightNeighbourQuery(start, end, tracks[i], query) != kRocProfVisDmResultSuccess) break;
                             if (ExecuteSQLQuery(future, query.c_str(), &slices, &CallbackAddAnyRecord) != kRocProfVisDmResultSuccess) break;
+
+                            if (future->GetProcessedRowsCount() == 0)
+                            {
+                                rocprofvis_db_record_data_t record;                              
+                                record.pmc.timestamp = TraceProperties()->end_time;   
+                                record.pmc.value = future->GetRuntimeStorageValue<double>(kRPVFutureStorageSampleValue,0);
+
+                                for (int i = 0; i < num; i++)
+                                {
+                                    if (BindObject()->FuncAddRecord(slices[tracks[i]], record) != kRocProfVisDmResultSuccess)
+                                        break;
+                                }
+                            }
                         }
                     }
                 }

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -3087,7 +3087,7 @@ DataProvider::CreateRawSampleData(const TrackRequestParams& params,
 
         double end_ts = 0;
         result        = rocprofvis_controller_get_double(
-            sample, kRPVControllerSampleNextTimestamp, 0, &end_ts);
+            sample, kRPVControllerSampleEndTimestamp, 0, &end_ts);
         ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
 
 


### PR DESCRIPTION

## Motivation
Sample overlap because last sample in a segment pointing to trace end.

## Technical Details
Made a change in data model to set last sample end timestamp to end trace timestamp only if there are no samples on a right side of requested segment.
Removed sample end value from controller Sample class. 
Renamed sample end timestamp enumeration constant.
