### PR TITLE
Don't use TM symbol in name.

### DIFF
--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -111,7 +111,7 @@ main(int, char**)
         glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
 #endif        
         GLFWwindow* window =
-            glfwCreateWindow(1280, 720, "ROCm (TM) Optiq Beta", nullptr, nullptr);
+            glfwCreateWindow(1280, 720, "ROCm(TM) Optiq Beta", nullptr, nullptr);
         rocprofvis_imgui_backend_t backend;
 
         // Drop file callback


### PR DESCRIPTION
## Motivation

Don't use TM symbol in name.

## Technical Details

The (TM) symbol does not seem to be supported in all font sets.  Some OS targets (Ubuntu 22/24) display garbage characters as a result, for example in the task bar when trying to render the application name.