### PR TITLE
Proper cancellation sequence

### DIFF
--- a/src/controller/src/rocprofvis_controller_track.cpp
+++ b/src/controller/src/rocprofvis_controller_track.cpp
@@ -274,7 +274,6 @@ rocprofvis_result_t Track::FetchFromDataModel(double start, double end, Future* 
 
     for(int i = 0; i < futures.size(); i++)
     {  
-        if(future->IsCancelled()) break;
         rocprofvis_dm_result_t dm_result = rocprofvis_db_future_wait(futures[i], UINT64_MAX);
         if(kRocProfVisDmResultSuccess == dm_result)
         {

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -110,24 +110,31 @@ DataProvider::SetSelectedState(const std::string& id)
 void
 DataProvider::FreeRequests()
 {
-    for(auto item : m_requests)
+    for (auto item : m_requests)
     {
         data_req_info_t& req = item.second;
-
-        if(req.request_future)
+        if (req.request_future)
         {
-            spdlog::debug("FreeRequests: cancelling request {} of type {}",
-                          req.request_id, static_cast<int>(req.request_type));
+            spdlog::warn("FreeRequests: cancelling request {} of type {}",
+                req.request_id, static_cast<int>(req.request_type));
 
             rocprofvis_result_t result =
                 rocprofvis_controller_future_cancel(req.request_future);
             if(result != kRocProfVisResultSuccess)
             {
                 spdlog::warn("Failed to cancel request {}: {}", req.request_id,
-                             static_cast<int>(result));
+                    static_cast<int>(result));
             }
+        }
+    }
+    for(auto item : m_requests)
+    {
+        data_req_info_t& req = item.second;
 
-            result = rocprofvis_controller_future_wait(req.request_future, FLT_MAX);
+        if(req.request_future)
+        {
+
+            rocprofvis_result_t result = rocprofvis_controller_future_wait(req.request_future, FLT_MAX);
             if(result != kRocProfVisResultSuccess)
             {
                 spdlog::warn("Failed to wait for request {}: {}", req.request_id,


### PR DESCRIPTION
## Motivation

UI cannot cancel and wait for each cancelled request in loop, because there is many simultaneous threads running at the same time and the cancelled request's thread may be blocked by other threads.

## Technical Details

Cancelling all requests first, then waiting.