### PR TITLE
Fixed missing events with zero duration

### DIFF
--- a/src/controller/src/rocprofvis_controller_graph.cpp
+++ b/src/controller/src/rocprofvis_controller_graph.cpp
@@ -338,7 +338,7 @@ Graph::GenerateLOD(uint32_t lod_to_generate, double start_ts, double end_ts,
                 {
                     ROCPROFVIS_ASSERT(level == event_level || level == UINT64_MAX);
 
-                    if (event_start < end_ts && event_end > start_ts)
+                    if (event_start < end_ts && event_end >= start_ts)
                     {
                         if((event_start >= min_ts && event_start <= max_ts) &&
                             (event_end >= min_ts && event_end <= max_ts))


### PR DESCRIPTION
## Motivation

[SWDEV-565178](https://ontrack-internal.amd.com/browse/SWDEV-565178)
Some events with 0 duration are missing from trace

## Technical Details
Existing condition to check the event crossing a region is not sufficient for zero duration events.
Changing condition so the event end does not have to be just bigger than region start, but also equal 
