### PR TITLE
Fixed SWDEV-569438 event overlapping in trimmed db file

### DIFF
--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -871,12 +871,14 @@ rocprofvis_dm_result_t RocprofDatabase::SaveTrimmedData(rocprofvis_dm_timestamp_
                             {
                                 query = "INSERT INTO ";
                                 query += table.first;
-                                query += " SELECT * FROM oldDb.";
+                                query += " SELECT S.* FROM oldDb.";
                                 query += table.first;
-                                query += " WHERE timestamp < ";
+                                query += " S LEFT JOIN rocpd_region R ON  S.event_id = R.event_id AND S.guid = R.guid ";
+                                query += " WHERE (timestamp < ";
                                 query += std::to_string(end);
                                 query += " AND timestamp > ";
                                 query += std::to_string(start);
+                                query += ") OR R.start == S.timestamp";
                                 query += ";";
                             }
                             else


### PR DESCRIPTION
## Motivation

[SWDEV-569438](https://ontrack-internal.amd.com/browse/SWDEV-569438)
samples [rocprof-sys] event overlaps with hip and hsa events in trimmed db file

## Technical Details

Caused by sample events that start outside of the trimmed area.
When trim samples, need to join sample table with newly created region table
to pick up those missing samples
