### PR TITLE
SWDEV-570760 - [Roc-optiq][ROCm-Visualizer]: Moving up/down in Timeline View by mouse dragging is very slow compared to previous versions

### DIFF
--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -550,7 +550,8 @@ FlameTrackItem::RecalculateTrackHeight()
 void
 FlameTrackItem::RenderChart(float graph_width)
 {
-    ImGui::BeginChild("FV", ImVec2(graph_width, m_track_content_height), false);
+    ImGui::BeginChild("FV", ImVec2(graph_width, m_track_content_height), false,
+                      ImGuiWindowFlags_NoMouseInputs);
     ImDrawList* draw_list = ImGui::GetWindowDrawList();
 
     int colorCount = static_cast<int>(m_settings.GetColorWheel().size());

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -100,7 +100,8 @@ LineTrackItem::RenderHighlightBand(ImDrawList* draw_list, const ImVec2& cursor_p
 void
 LineTrackItem::BoxPlotRender(float graph_width)
 {
-    ImGui::BeginChild("LV", ImVec2(graph_width, m_track_content_height), false);
+    ImGui::BeginChild("LV", ImVec2(graph_width, m_track_content_height), false,
+                      ImGuiWindowFlags_NoMouseInputs);
     ImDrawList* draw_list = ImGui::GetWindowDrawList();
 
     ImVec2 cursor_position = ImGui::GetCursorScreenPos();

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -995,7 +995,8 @@ TimelineView::RenderGraphView()
                 ImGui::PushStyleColor(ImGuiCol_ChildBg, selection_color);
                 ImGui::PushID(i);
                 if(ImGui::BeginChild("", ImVec2(0, track_height), false,
-                                     window_flags | ImGuiWindowFlags_NoScrollbar))
+                                     window_flags | ImGuiWindowFlags_NoScrollbar |
+                                         ImGuiWindowFlags_NoMouseInputs))
                 {
                     // call update function (TODO: move this to timeline's update
                     // function?)
@@ -1447,9 +1448,7 @@ TimelineView::RenderHistogram()
                            vmax_label.c_str());
     }
 
-    m_stop_user_interaction |= !ImGui::IsWindowHovered(
-        ImGuiHoveredFlags_RootAndChildWindows | ImGuiHoveredFlags_NoPopupHierarchy);
-    if(!m_resize_activity && !m_stop_user_interaction)
+    if(!m_resize_activity && !m_stop_user_interaction && ImGui::IsWindowHovered())
     {
         HandleHistogramTouch();
     }
@@ -1503,7 +1502,7 @@ TimelineView::RenderTraceView()
     m_pixels_per_ns = (m_graph_size.x) / (m_v_max_x - m_v_min_x);
 
     m_stop_user_interaction |= !ImGui::IsWindowHovered(
-        ImGuiHoveredFlags_RootAndChildWindows | ImGuiHoveredFlags_NoPopupHierarchy);
+        ImGuiHoveredFlags_ChildWindows | ImGuiHoveredFlags_NoPopupHierarchy);
 
     RenderGrid();
 


### PR DESCRIPTION
[Problem]
-Timeline container does not consider itself hovered when dragging as IsWindowHovered(root&child) seems to bind itself to top of window stack rather than called window. 

[Fix]
-Have track items on top of timeline container set ImGuiWindowFlags_NoMouseInputs.
