### PR TITLE
Table processor vs SQL mismatch

### DIFF
--- a/src/model/src/database/rocprofvis_db_packed_storage.cpp
+++ b/src/model/src/database/rocprofvis_db_packed_storage.cpp
@@ -341,6 +341,17 @@ namespace DataModel
         std::iota(m_aggregation.sort_order.begin(), m_aggregation.sort_order.end(), 0);
     }
 
+    void
+    PackedTable::ClearAggregation()
+    {
+        m_aggregation.column_def.clear();
+        m_aggregation.agg_params.clear();
+        m_aggregation.aggregation_maps.clear();
+        m_aggregation.result.clear();
+        m_aggregation.sort_order.clear();
+        m_aggregation.m_string_data.Clear();
+    }
+
     void PackedTable::SortAggregationByColumn(ProfileDatabase* db, std::string sort_column, bool sort_order) {
 
 
@@ -772,6 +783,12 @@ namespace DataModel
         std::shared_lock lock(m_mutex);
         if (id >= m_id_to_str.size()) return "";
         return m_id_to_str[id].c_str();
+    }
+
+    void StringTable::Clear() {
+        std::unique_lock lock(m_mutex);
+        m_id_to_str.clear();
+        m_str_to_id.clear();
     }
 
 }  // namespace DataModel

--- a/src/model/src/database/rocprofvis_db_packed_storage.h
+++ b/src/model/src/database/rocprofvis_db_packed_storage.h
@@ -100,6 +100,7 @@ namespace DataModel
     public:        
         uint32_t ToInt(const char* s);
         const char* ToString(uint32_t id) const;
+        void Clear();
 
     private:
         mutable std::shared_mutex m_mutex;
@@ -198,6 +199,7 @@ namespace DataModel
         void SortByColumn(ProfileDatabase * db, std::string column, bool ascending);
         bool SetupAggregation(std::string agg_spec, int num_threads);
         void FinalizeAggregation();
+        void ClearAggregation();
         void AggregateRow(ProfileDatabase * db, int row_index, int map_index);
         void SortAggregationByColumn(ProfileDatabase* db, std::string sort_column, bool sort_order);
         void RemoveRowsForSetOfTracks(std::set<uint32_t> tracks, bool remove_all);

--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -691,7 +691,10 @@ namespace DataModel
                             t.join();
                         m_merged_table.FinalizeAggregation();
                     }
-                   
+                    else
+                    {
+                        m_merged_table.ClearAggregation();
+                    }                    
                 }
             }
 


### PR DESCRIPTION
This addresses #558 example 3, where querying for kernel dispatches of an agent without any dispatches in db will still return a non-empty table.

[Problem]
In the example, there are 14 sub queries that each return 0 columns and rows as expected. However, the aggregated table contains non-zero number rows and columns that seem to be the dimensions of the previous aggregated query. The previous aggregation results are not cleared.

[Fix]
Clear the aggregation results when aggregation is not required. No action is needed when aggregation is required because the latest aggregation overwrites the previous.