### PR TITLE
Follow OS naming conventions for path where config settings are stored.

### DIFF
--- a/src/view/src/rocprofvis_utils.cpp
+++ b/src/view/src/rocprofvis_utils.cpp
@@ -299,12 +299,12 @@ std::string
 RocProfVis::View::get_application_config_path(bool create_dirs)
 {
 #ifdef _WIN32
-    constexpr char*       app_config_dir_name = "AMD\\ROCm-Optiq";
+    const char*           app_config_dir_name = "AMD\\ROCm-Optiq";
     const char*           local_appdata       = std::getenv("LOCALAPPDATA");
     std::filesystem::path config_dir =
         local_appdata ? local_appdata : std::filesystem::current_path();
 #else
-    constexpr char*       app_config_dir_name = "rocm-optiq";
+    const char*           app_config_dir_name = "rocm-optiq";
     const char*           xdg_config          = std::getenv("XDG_CONFIG_HOME");
     std::filesystem::path config_dir =
         xdg_config ? xdg_config


### PR DESCRIPTION
## Motivation

The config file path is using the previous "rocprofvis" name.  Use ROCm Optiq branding.

Follow OS naming conventions for paths where config settings are stored.

## Technical Details

On windows use the `AppData\Local` folder instead of the `Roaming` folder. 
Change folder path to: AMD\ROCm-Optiq

On linux use the path: rocm-optiq

## Notes

Previoius application settings will be lost, as the path has changed.
