### PR TITLE
Fix default font size map generation and default font paths

### DIFF
--- a/src/view/src/rocprofvis_font_manager.cpp
+++ b/src/view/src/rocprofvis_font_manager.cpp
@@ -108,11 +108,11 @@ FontManager::Init()
         "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
         "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
         "/usr/share/fonts/truetype/msttcorefonts/Arial.ttf",
+        // RedHat 8, Oracle 8
+        "/usr/share/fonts/dejavu/DejaVuSans.ttf",
         // RedHat 9 / 10, Oracle 9 / 10
         "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf",
         "/usr/share/fonts/liberation-sans/LiberationSans-Regular.ttf"
-        // RedHat 8, Oracle 8
-        "/usr/share/fonts/dejavu/DejaVuSans.ttf"
     };
 #endif
 


### PR DESCRIPTION
## Motivation

This PR fixes 2 issues:
- The list of available font size was not generated correctly when using the fallback font.
- The system font list locations were not correct for Redhat / Oracle linux systems.

This addresses ticket SWDEV-573080

## Technical Details

- Font path list has been updated to contain default locations for RHEL and Oracle Linux.
- Default fallback font was not resized when creating font array.

