### PR TITLE
Fixed bug #598 

### DIFF
--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -482,6 +482,12 @@ ProfileDatabase::FindTrackIDs(
         {
             streamTrackId = it->get()->track_id;
         }
+        if (service_data.op == kRocProfVisDmOperationMemoryAllocate && trackId == -1)
+        {
+            //memory free cannot be found on any track except stream track, because it's not executed on any agent/queue
+            //thus assigning trackId to streamTrackId for further processing
+            trackId = streamTrackId;
+        }
     }
     else if(service_data.category == kRocProfVisDmPmcTrack)
     {


### PR DESCRIPTION
## Motivation

Clicking on selected stream tracks was generating column_count != cell_count assertion.

## Technical Details

Technical Details
That happened because table request event processing was returning failure status due to undefined track id.
The reason is memory allocation FREE event doesn't belong to any track except stream track. It doesn't have
agent/queue parameters.

Solution is to assign trackId = streamTrackId for this specific case.

