### PR TITLE
Fix kernel invocations mismatch

### DIFF
--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -659,7 +659,8 @@ namespace DataModel
                 m_last_group_str = Trim(it->parameter);
                 if (!m_last_group_str.empty())
                 {
-                    int use_threads = m_merged_table.RowCount() / 10000;
+                    static int max_events_per_thread = 10000;
+                    int use_threads = (m_merged_table.RowCount()+max_events_per_thread) / max_events_per_thread;
                     size_t thread_count = std::thread::hardware_concurrency() - 1;
                     if (use_threads < thread_count)
                         thread_count = use_threads;


### PR DESCRIPTION
## Motivation

Summary was showing less kernels invocation comparing to SQL query

## Technical Details

Aggregation is split in multiple tasks to speed up calculation.  Each task is working on one chunk of data array.
The reason of this problem was the last chunk was not properly configured.
Reworked the code to cover all data.

The change at the line 149 is not related, but it prevents further processing if no data is fetched from the database and may prevent crashes getting data from empty array down the road.
