### PR TITLE
Fixed occasional crash

### DIFF
--- a/src/controller/src/rocprofvis_controller_segment.cpp
+++ b/src/controller/src/rocprofvis_controller_segment.cpp
@@ -332,7 +332,7 @@ SegmentTimeline& SegmentTimeline::operator=(SegmentTimeline&& other)
 
 void SegmentTimeline::Init(double segment_start_time, double segment_duration, uint32_t num_segments, size_t num_items)
 {
-    std::shared_lock<std::shared_mutex> lock(m_mutex);
+    std::unique_lock<std::shared_mutex> lock(m_mutex);
     m_segment_duration = segment_duration;
     m_num_segments = num_segments;
     m_segment_start_time = segment_start_time;


### PR DESCRIPTION
## Motivation

Occasional crash happens mostly manifesting in BitSet initialization

## Technical Details

It's hard to reproduce, but the any initialization should take unique lock.
It seems the change fixes the problem

