### PR TITLE
Use map instead of vector for CLI parser

### DIFF
--- a/src/app/src/rocprofvis_cli_parser.cpp
+++ b/src/app/src/rocprofvis_cli_parser.cpp
@@ -174,5 +174,13 @@ CLIParser::AttachToConsole()
 #endif
 }
 
+void
+CLIParser::DetachFromConsole()
+{
+#ifdef _WIN32
+    FreeConsole();
+#endif
+}
+
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/app/src/rocprofvis_cli_parser.h
+++ b/src/app/src/rocprofvis_cli_parser.h
@@ -45,6 +45,7 @@ public:
     std::string GetHelp() const;
 
     static void AttachToConsole();
+    static void DetachFromConsole();
 
 private:
     std::string                         m_app_name;


### PR DESCRIPTION
Use map instead of vector for CLI parser.
Additional error checking added.