### PR TITLE
Add .yaml as a supported file extension.

### DIFF
--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -655,12 +655,11 @@ AppWindow::HandleOpenFile()
 
     FileFilter all_filter;
     all_filter.m_name = "All Supported";
-    all_filter.m_extensions = { "db", "rpd", "rpv" };
+    all_filter.m_extensions = { "db", "rpd", "yaml", "rpv" };
 
     FileFilter trace_filter;
     trace_filter.m_name = "Traces";
-    trace_filter.m_extensions = { "db", "rpd" };
-
+    trace_filter.m_extensions = { "db", "rpd", "yaml" };
 #ifdef JSON_TRACE_SUPPORT
     all_filter.m_extensions.push_back("json");
     trace_filter.m_extensions.push_back("json");


### PR DESCRIPTION
## Motivation

Add .yaml as a supported file extension, now that multi-node support is available.

## Technical Details

Add ".yaml" to the extension string list.