### PR TITLE
Better "pill" labels for counter tracks

### DIFF
--- a/src/view/src/model/rocprofvis_topology_model.cpp
+++ b/src/view/src/model/rocprofvis_topology_model.cpp
@@ -194,5 +194,45 @@ TopologyDataModel::Clear()
     ClearCounters();
 }
 
+std::string TopologyDataModel::GetDeviceTypeLabelForCounter(uint64_t counter_id) const
+{
+    const CounterInfo* counter_info = GetCounter(counter_id);
+    if(!counter_info)
+    {
+        return "Unknown Device";
+    }
+
+    const DeviceInfo* device_info = GetDevice(counter_info->device_id);
+    if(device_info)
+    {
+        switch (device_info->type)
+        {
+            case rocprofvis_controller_processor_type_t::kRPVControllerProcessorTypeCPU:
+                return "CPU" + std::to_string(device_info->type_index);
+            case rocprofvis_controller_processor_type_t::kRPVControllerProcessorTypeGPU:
+                return "GPU" + std::to_string(device_info->type_index);
+            default:
+                break;
+        }
+    }
+    return "Unknown Device";
+}
+
+std::string TopologyDataModel::GetDeviceProductLabelForCounter(uint64_t counter_id) const
+{
+    const CounterInfo* counter_info = GetCounter(counter_id);
+    if(!counter_info)
+    {
+        return "Unknown";
+    }
+
+    const DeviceInfo* device_info = GetDevice(counter_info->device_id);
+    if(device_info)
+    {
+        return device_info->product_name;
+    }
+    return "Unknown";
+}
+
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/model/rocprofvis_topology_model.h
+++ b/src/view/src/model/rocprofvis_topology_model.h
@@ -70,6 +70,10 @@ public:
     // Clear all topology data
     void Clear();
 
+    // Helpers
+    std::string GetDeviceTypeLabelForCounter(uint64_t counter_id) const;
+    std::string GetDeviceProductLabelForCounter(uint64_t counter_id) const;
+
 private:
     std::unordered_map<uint64_t, NodeInfo>    m_nodes;
     std::unordered_map<uint64_t, DeviceInfo>  m_devices;

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -492,7 +492,16 @@ TrackItem::SetDefaultPillLabel(const TrackInfo* track_info)
         case TrackInfo::Topology::Counter:
         {
             m_pill.Show();
-            m_pill.SetLabel("COUNTER");
+            // Get counter type label from topology model, ex: "GPU0"
+            std::string pill_label =
+                m_data_provider.DataModel().GetTopology().GetDeviceTypeLabelForCounter(
+                    track_info->topology.id);
+            m_pill.SetLabel(pill_label);
+            // Get counter product label from topology model, ex: "AMD Radeon RX 6800 XT"
+            std::string counter_product_label =
+                m_data_provider.DataModel().GetTopology().GetDeviceProductLabelForCounter(
+                    track_info->topology.id);
+            m_pill.SetTooltipLabel(counter_product_label);
             break;
         }
         default:
@@ -674,6 +683,12 @@ Pill::SetLabel(std::string label)
 }
 
 void
+Pill::SetTooltipLabel(std::string label)
+{
+    m_tooltip_label = label;
+}
+
+void
 Pill::Activate()
 {
     m_active = true;
@@ -731,6 +746,14 @@ Pill::RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
     ImVec2 text_pos = pillbox_pos + ImVec2(padding_x, padding_y);
     ImGui::SetCursorPos(text_pos);
     ImGui::TextUnformatted(m_pill_label.c_str());
+    if(!m_tooltip_label.empty() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+    {
+        if(ImGui::BeginItemTooltip())
+        {
+            ImGui::TextUnformatted(m_tooltip_label.c_str());
+            ImGui::EndTooltip();
+        }
+    }    
     ImGui::PopStyleColor();
 
     ImGui::PopFont();

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -44,6 +44,7 @@ class Pill
 public:
     Pill(std::string label, bool shown, bool active);
     void SetLabel(std::string label);
+    void SetTooltipLabel(std::string label);
     void Activate();
     void Deactivate();
     void Show();
@@ -54,6 +55,7 @@ private:
     bool        m_show_pill_label;
     bool        m_active;
     std::string m_pill_label;
+    std::string m_tooltip_label;
 };
 
 class TrackItem

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -42,7 +42,7 @@ private:
 class Pill
 {
 public:
-    Pill(std::string label, bool shown, bool active);
+    Pill(const std::string& label, bool shown, bool active);
     void SetLabel(const std::string& label);
     void SetTooltipLabel(std::string label);
     void Activate();


### PR DESCRIPTION
## Motivation

Better "pill" labels for counter tracks

## Technical Details

Show the device associated with the counter as the "pill" label.
Show the device product name on the tool tip when "pill" is hovered.

<img width="870" height="415" alt="image" src="https://github.com/user-attachments/assets/0cbf7ffa-2684-4db4-8402-8d40de759010" />
