### PR TITLE
Fix build on linux systems that have libtbb-dev installed

### DIFF
--- a/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
+++ b/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
@@ -7,7 +7,6 @@
 #include "rocprofvis_controller_sample.h"
 #include "rocprofvis_controller_sample_lod.h"
 #include <chrono>
-#include <execution>
 #include <cmath>
 #include "spdlog/spdlog.h"
 #if defined(_MSC_VER)

--- a/src/controller/src/system/rocprofvis_controller_segment.cpp
+++ b/src/controller/src/system/rocprofvis_controller_segment.cpp
@@ -10,7 +10,6 @@
 #include "rocprofvis_controller_future.h"
 
 #include <algorithm>
-#include <execution>
 
 namespace RocProfVis
 {

--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -44,6 +44,17 @@ target_link_libraries(${PROJECT_NAME} spdlog)
 target_link_libraries(${PROJECT_NAME} yaml-cpp)
 target_link_libraries(${PROJECT_NAME} json)
 
+# TBB is conditionally required on Linux when libtbb-dev is installed
+# - Windows MSVC: Has its own parallel backend, doesn't need TBB
+# - macOS: Parallel execution not yet supported in libc++
+# - Linux GCC: Auto-detects TBB headers and switches to TBB backend if available
+find_package(TBB QUIET)
+if(TBB_FOUND)
+    target_link_libraries(${PROJECT_NAME} TBB::tbb)
+    message(STATUS "TBB found and linked for parallel execution policies")
+else()
+    message(STATUS "TBB not found - parallel execution will use platform default")
+endif()
 
 add_executable(${PROJECT_NAME}-test ${MAIN_SRC} )
 target_include_directories(${PROJECT_NAME}-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../core/inc)


### PR DESCRIPTION
## Motivation

The build fails on linux systems that have libtbb-dev installed.

## Technical Details

The issue occurs due to how GCC's libstdc++ implements C++17 parallel execution policies (`<execution>` header):

1. **Auto-detection mechanism**: libstdc++ uses `__has_include(<tbb/tbb.h>)` to detect if TBB headers are available
2. **Backend selection**:
   - When TBB headers are **present** (i.e., `libtbb-dev` installed) → Uses `_PSTL_PAR_BACKEND_TBB`
   - When TBB headers are **absent** → Uses `_PSTL_PAR_BACKEND_SERIAL` (sequential fallback)
3. **The TBB backend generates symbols** that require linking against `libtbb`, but this wasn't configured in CMake

This behavior is **environment-dependent**:
- ✅ Builds without `libtbb-dev` work fine (uses serial backend)
- ❌ Builds with `libtbb-dev` fail (TBB backend requires linking)

## Platform Differences

- **Linux (GCC)**: Auto-detects and uses TBB if available (requires linking when present)
- **Windows (MSVC)**: Has its own built-in parallel backend (no TBB needed)
- **macOS (Clang/libc++)**: Parallel execution not yet supported (already handled with `__APPLE__` check)

## Solution

Add conditional TBB detection and linking in `src/model/CMakeLists.txt`:

```
# TBB is conditionally required on Linux when libtbb-dev is installed
# - Windows MSVC: Has its own parallel backend, doesn't need TBB
# - macOS: Parallel execution not yet supported in libc++
# - Linux GCC: Auto-detects TBB headers and switches to TBB backend if available
find_package(TBB QUIET)
if(TBB_FOUND)
    target_link_libraries(${PROJECT_NAME} TBB::tbb)
    message(STATUS "TBB found and linked for parallel execution policies")
else()
    message(STATUS "TBB not found - parallel execution will use platform default")
endif()
```