### PR TITLE
Fixed stream track table data crash on sorting and aggregation

### DIFF
--- a/src/model/src/database/rocprofvis_db_packed_storage.h
+++ b/src/model/src/database/rocprofvis_db_packed_storage.h
@@ -186,6 +186,7 @@ namespace DataModel
         const std::vector<FilterExpression::SqlAggregation>& GetAggregationSpec() const { return m_aggregation.agg_params; }
         const std::vector<MergedColumnDef>& GetMergedColumns() const { return m_merged_columns; }
         DbInstance* GetDbInstanceForRow(ProfileDatabase * db, int row_index);
+        DbInstance* GetDbInstanceForRow(ProfileDatabase* db, PackedRow* row);
         uint32_t SortedIndex(uint32_t index) { return m_sort_order[index]; };
 
         void Merge(std::vector<std::unique_ptr<PackedTable>>& tables);


### PR DESCRIPTION

## Motivation

Application crashes when sort or aggregate stream track table data.
This is multi-node feature regression 

## Technical Details

The reason for crash is track number not properly detected for events that exist only on stream track.
As a result database instance was null.
Reworked track and database instance detection for table rows.
