### PR TITLE
Fix sample query.

### DIFF
--- a/src/model/src/database/rocprofvis_db_query_builder.h
+++ b/src/model/src/database/rocprofvis_db_query_builder.h
@@ -96,7 +96,7 @@ typedef struct rocprofvis_db_sqlite_rocpd_table_query_format
 
 typedef struct rocprofvis_db_sqlite_sample_table_query_format
 {
-    static constexpr const int NUM_PARAMS = 8;
+    static constexpr const int NUM_PARAMS = 7;
     ProfileDatabase*           owner;
     std::string                parameters[NUM_PARAMS];
     std::vector<std::string>   from;


### PR DESCRIPTION
[Problem]
-Counter track tables and summary hardware utilization fails to load for .db traces. This is because #620 added an extra parameter to the query which was then left unpopulated. This results in invalid queries due to extra comma before FROM, for example:
```
SELECT 0 as op, S.timestamp as startTs, S.timestamp as endTs, PMC_I.nid as nodeId, PMC_I.agent_id as agentId, PMC_I.id as counterId, PMC_E.value as counterValue,  FROM rocpd_pmc_event_8bd1bfb5a93c2e80ca2b826eef086004 PMC_E  INNER JOIN rocpd_info_pmc_8bd1bfb5a93c2e80ca2b826eef086004 PMC_I ON PMC_I.id = PMC_E.pmc_id  INNER JOIN rocpd_sample_8bd1bfb5a93c2e80ca2b826eef086004 S ON S.event_id = PMC_E.event_id  where (nodeId,agentId,counterId) IN ((9162464413581981795,1,2358)) and endTs >= 4123437185792 and startTs < 4124408125071
```

[Fix]
-Revert the extra parameter. .db counter track tables do not display ID.