### PR TITLE
Fixed repetitive event selection crash

### DIFF
--- a/src/controller/src/system/rocprofvis_controller_event.cpp
+++ b/src/controller/src/system/rocprofvis_controller_event.cpp
@@ -182,8 +182,8 @@ Event::FetchDataModelFlowTraceProperty(uint64_t event_id, Array& array,
                         result = kRocProfVisResultTimeout;
                     }
                 }
-                rocprofvis_dm_delete_event_property_for(
-                    dm_trace_handle, kRPVDMEventFlowTrace, dm_event_id);
+                rocprofvis_dm_delete_event_property(
+                    dm_trace_handle, kRPVDMEventFlowTrace, dm_flowtrace);
             }
             rocprofvis_db_future_free(object);
         }
@@ -293,7 +293,7 @@ Event::FetchDataModelStackTraceProperty(uint64_t event_id, Array& array,
                         result = kRocProfVisResultTimeout;
                     }
                 }
-                rocprofvis_dm_delete_event_property_for(dm_trace_handle, kRPVDMEventStackTrace, dm_event_id);
+                rocprofvis_dm_delete_event_property(dm_trace_handle, kRPVDMEventStackTrace, dm_stacktrace);
             }
             rocprofvis_db_future_free(object);
         }
@@ -439,8 +439,8 @@ Event::FetchDataModelExtendedDataProperty(uint64_t event_id, Array& array, rocpr
                         result = kRocProfVisResultTimeout;
                     }
                 }
-                rocprofvis_dm_delete_event_property_for(dm_trace_handle,
-                                                        kRPVDMEventExtData, dm_event_id);
+                rocprofvis_dm_delete_event_property(dm_trace_handle,
+                                                        kRPVDMEventExtData, dm_extdata);
             }
             rocprofvis_db_future_free(object);
         }

--- a/src/model/inc/rocprofvis_interface.h
+++ b/src/model/inc/rocprofvis_interface.h
@@ -338,6 +338,23 @@ rocprofvis_dm_result_t  rocprofvis_dm_delete_event_property_for(
                                     rocprofvis_dm_trace_t,
                                     rocprofvis_dm_event_property_type_t,
                                     rocprofvis_dm_event_id_t);     
+/****************************************************************************************************
+* @brief Delete event property object of specified type
+*
+* @param trace trace object handle created with rocprofvis_dm_create_trace()
+* @param type type of property
+*                             kRPVDMEventFlowTrace,
+*                             kRPVDMEventStackTrace,
+*                             kRPVDMEventExtData,
+* @param object reference
+*
+* @return status of operation
+*
+***************************************************************************************************/
+rocprofvis_dm_result_t  rocprofvis_dm_delete_event_property( 
+    rocprofvis_dm_trace_t,
+    rocprofvis_dm_event_property_type_t,
+    rocprofvis_dm_handle_t); 
 
 /****************************************************************************************************
  * @brief Delete all event property objects of specified type

--- a/src/model/src/common/rocprofvis_c_interface.cpp
+++ b/src/model/src/common/rocprofvis_c_interface.cpp
@@ -607,6 +607,28 @@ rocprofvis_dm_result_t  rocprofvis_dm_delete_event_property_for(
 }     
 
 /****************************************************************************************************
+* @brief Delete event property object of specified type
+*                                                     
+* @param trace trace object handle created with rocprofvis_dm_create_trace()
+* @param type type of property
+*                             kEventFlowTrace,
+*                             kEventStackTrace,
+*                             kEventExtData,
+* @param object reference
+* 
+* @return status of operation
+* 
+***************************************************************************************************/
+rocprofvis_dm_result_t  rocprofvis_dm_delete_event_property(
+    rocprofvis_dm_trace_t trace,
+    rocprofvis_dm_event_property_type_t type,
+    rocprofvis_dm_handle_t object){
+    PROFILE;
+    ROCPROFVIS_ASSERT_MSG_RETURN(trace, RocProfVis::DataModel::ERROR_TRACE_CANNOT_BE_NULL,
+        kRocProfVisDmResultInvalidParameter);
+    return ((RocProfVis::DataModel::Trace*)trace)->DeleteEventProperty(type, object);
+} 
+/****************************************************************************************************
  * @brief Delete all event property objects of specified type
  *                                                     
  * @param trace trace object handle created with rocprofvis_dm_create_trace()

--- a/src/model/src/database/rocprofvis_db.cpp
+++ b/src/model/src/database/rocprofvis_db.cpp
@@ -103,7 +103,7 @@ rocprofvis_dm_result_t   Database::ReadEventPropertyAsync(
     rocprofvis_dm_result_t result =  BindObject()->FuncCheckEventPropertyExists(BindObject()->trace_object, type, event_id);
     if(result != kRocProfVisDmResultNotLoaded)
     {
-        return future->SetPromise(result);
+        return future->SetPromise(kRocProfVisDmResultResourceBusy);
     }
     try {
         future->SetWorker(std::move(std::thread(ReadEventPropertyStatic, this, type, event_id, future)));

--- a/src/model/src/datamodel/rocprofvis_dm_trace.h
+++ b/src/model/src/datamodel/rocprofvis_dm_trace.h
@@ -75,6 +75,11 @@ class Trace : public DmBase{
         // @param event_id - 60-bit event id and 4-bit operation type
         // @return status of operation 
         rocprofvis_dm_result_t                          DeleteEventPropertyFor(rocprofvis_dm_event_property_type_t type, rocprofvis_dm_event_id_t event_id);
+        // Method to delete flowtrace, stacktrace and extended data property objects for event
+        // @param type - property type (kEventFlowTrace, kEventStackTrace or kEventExtData)
+        // @param object reference
+        // @return status of operation 
+        rocprofvis_dm_result_t                          DeleteEventProperty(rocprofvis_dm_event_property_type_t type, rocprofvis_dm_handle_t object);
         // Method to delete flowtrace, stacktrace and extended data property objects for all events
         // @param type - property type (kEventFlowTrace, kEventStackTrace or kEventExtData)
         // @return status of operation 


### PR DESCRIPTION
## Motivation

When selecting an event, multiple requests issued to a database, some of them time consuming.
If user deselects event, no cancellation is issued.
Then user may continue clicking on the event until it crashes.

## Technical Details

The reason of crash is all events data stored in data model per event ID. Deletion is done by providing event ID as well. So at some point controller will start deleting data for an ID while another thread is filling data for the same ID. The process cannot be locked using standard locking mechanism.

This problem can be fixed if UI cancels all the requests for an ID before requesting the same data again

The other way is presented here. 1) deleting event data using handler, not ID 2) failing request when data for specified ID already exists.
