### PR TITLE
Sample table grouping enabled, group filtering removed, other UI clean up

### DIFF
--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -980,17 +980,19 @@ ProfileDatabase::BuildTableQuery(
     table_string_id_filter_map_t string_id_filter_map;
     std::string group_by_select;
     std::string group_by;
-    if(summary)
+    
+    bool sample_query = false;
+    if(TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == 0)
     {
-        bool sample_query = false;
-        if(TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == 0)
-        {
-            sample_query = TrackPropertiesAt(tracks[0])->process.category == kRocProfVisDmPmcTrack;
-        }
-        else
-        {
-            sample_query = (rocprofvis_dm_event_operation_t)TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == kRocProfVisDmOperationNoOp;
-        }        
+        sample_query = TrackPropertiesAt(tracks[0])->process.category == kRocProfVisDmPmcTrack;
+    }
+    else
+    {
+        sample_query = (rocprofvis_dm_event_operation_t)TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == kRocProfVisDmOperationNoOp;
+    }
+
+    if(summary)
+    {  
         BuildTableSummaryClause(sample_query, group_by_select, group_by);
     }
     else
@@ -1161,8 +1163,16 @@ ProfileDatabase::BuildTableQuery(
         else
         {
             query += group_by;
+            if(sample_query)
+            {
+                query += ", COUNT(*) as count, AVG(value) as avg_value, MIN(value) as "
+                         "min_value, MAX(value) as max_value";
+            }
+            else
+            {
             query += ", COUNT(*) as num_invocations, AVG(duration) as avg_duration, "
-                "MIN(duration) as min_duration, MAX(duration) as max_duration";
+                "MIN(duration) as min_duration, MAX(duration) as max_duration";        
+            }
         }
         query += "\n";
     }

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -992,7 +992,7 @@ ProfileDatabase::BuildTableQuery(
     }
 
     if(summary)
-    {  
+    {
         BuildTableSummaryClause(sample_query, group_by_select, group_by);
     }
     else

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1171,7 +1171,7 @@ ProfileDatabase::BuildTableQuery(
             else
             {
             query += ", COUNT(*) as num_invocations, AVG(duration) as avg_duration, "
-                "MIN(duration) as min_duration, MAX(duration) as max_duration";        
+                "MIN(duration) as min_duration, MAX(duration) as max_duration";
             }
         }
         query += "\n";

--- a/src/view/src/rocprofvis_minimap.cpp
+++ b/src/view/src/rocprofvis_minimap.cpp
@@ -541,14 +541,14 @@ Minimap::RenderLegend(float w, float h)
     ImGui::Checkbox("##events", &m_show_events);
     if(ImGui::BeginItemTooltip())
     {
-        ImGui::Text("Show/Hide Event Density");
+        ImGui::Text("Show/Hide Event Tracks");
         ImGui::EndTooltip();
     }
     ImGui::SetCursorScreenPos(ImVec2(bar_x2 - (checkbox_sz - bar_w) * 0.5f, chk_y));
     ImGui::Checkbox("##counters", &m_show_counters);
     if(ImGui::BeginItemTooltip())
     {
-        ImGui::Text("Show/Hide Counter Density");
+        ImGui::Text("Show/Hide Counter Tracks");
         ImGui::EndTooltip();
     }
 
@@ -579,8 +579,8 @@ Minimap::RenderLegend(float w, float h)
     DrawRotatedText("Event Density", ImVec2(bar_x1 - gap * 3.0f, bar_y + bar_h * 0.5f),
                     !m_show_events);
 
-    // Counter Density (Left of bar 2)
-    DrawRotatedText("Counter Density", ImVec2(bar_x2 - gap * 3.0f, bar_y + bar_h * 0.5f),
+    // Counter Value (Left of bar 2)
+    DrawRotatedText("Counter Value", ImVec2(bar_x2 - gap * 3.0f, bar_y + bar_h * 0.5f),
                     !m_show_counters);
 }
 

--- a/src/view/src/rocprofvis_multi_track_table.cpp
+++ b/src/view/src/rocprofvis_multi_track_table.cpp
@@ -23,6 +23,9 @@ constexpr const char* ID_COLUMN_NAME        = "__uuid";
 constexpr const char* EVENT_ID_COLUMN_NAME  = "id";
 constexpr const char* NAME_COLUMN_NAME      = "name";
 
+constexpr const char* FOUND_ENTRIES_TEXT_SINGLE = "Found %llu items on %llu track";
+constexpr const char* FOUND_ENTRIES_TEXT_PLURAL = "Found %llu items on %llu tracks";
+
 MultiTrackTable::MultiTrackTable(DataProvider&                      dp,
                                  std::shared_ptr<TimelineSelection> timeline_selection,
                                  TableType                          table_type)
@@ -126,19 +129,20 @@ MultiTrackTable::Render()
     auto table_params = m_data_provider.DataModel().GetTables().GetTableParams(m_table_type);
     if(table_params)
     {
-        #ifdef ROCPROFVIS_DEVELOPER_MODE
-        ImGui::Text("Cached %llu to %llu of %llu events for %llu tracks",
-                    table_params->m_start_row,
-                    table_params->m_start_row + table_params->m_req_row_count,
-                    m_data_provider.DataModel().GetTables().GetTableTotalRowCount(m_table_type),
-                    table_params->m_track_ids.size());
-        #endif
-        ImGui::Text("Found %llu events on %llu tracks",
-                    table_params->m_start_row,
-                    table_params->m_start_row + table_params->m_req_row_count,
-                    m_data_provider.DataModel().GetTables().GetTableTotalRowCount(m_table_type),
-                    table_params->m_track_ids.size());
-
+        size_t track_count = table_params->m_track_ids.size();
+        const char* text =
+            (track_count == 1) ? FOUND_ENTRIES_TEXT_SINGLE : FOUND_ENTRIES_TEXT_PLURAL;
+        ImGui::Text(
+            text,
+            m_data_provider.DataModel().GetTables().GetTableTotalRowCount(m_table_type),
+            track_count);
+#ifdef ROCPROFVIS_DEVELOPER_MODE
+        ImGui::SameLine();
+        ImGui::Text(
+            " | Cached %llu to %llu entries",
+            table_params->m_start_row,
+            table_params->m_start_row + table_params->m_req_row_count);
+#endif
     }
 
     ImGui::BeginGroup();

--- a/src/view/src/rocprofvis_multi_track_table.cpp
+++ b/src/view/src/rocprofvis_multi_track_table.cpp
@@ -211,7 +211,7 @@ MultiTrackTable::Render()
 #endif
 
     ImGui::SetNextItemAllowOverlap();
-    //Filter disabled when "group by" is selected
+    // Filter disabled when "group by" is selected
     ImGui::BeginDisabled(m_filter_options.group_by != "");
     ImGui::InputTextWithHint("##filters", "SQL WHERE comparisons",
                              m_pending_filter_options.filter,

--- a/src/view/src/rocprofvis_multi_track_table.h
+++ b/src/view/src/rocprofvis_multi_track_table.h
@@ -47,6 +47,7 @@ private:
     int                      m_group_by_selection_index;
 
     bool m_open_context_menu;
+    char m_filter_store[FILTER_SIZE];
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -235,10 +235,10 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
                               ImGuiHoveredFlags_NoPopupHierarchy) &&
        ImGui::IsMouseHoveringRect(win_min, win_max))
     {
-        ImGui::OpenPopup("StickyNoteContextMenu");
+        ImGui::OpenPopup("TimelineContextMenu");
     }
 
-    if(!ImGui::IsPopupOpen("StickyNoteContextMenu"))
+    if(!ImGui::IsPopupOpen("TimelineContextMenu"))
     {
         // Clear right-click state when popup closes
         TimelineFocusManager::GetInstance().ClearRightClickLayer();
@@ -247,7 +247,7 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
     auto style = m_settings.GetDefaultStyle();
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-    if(ImGui::BeginPopup("StickyNoteContextMenu"))
+    if(ImGui::BeginPopup("TimelineContextMenu"))
     {
         // Show "Make Time Range Selection" when there are selected events
         if(m_timeline_selection->HasSelectedEvents() &&
@@ -267,6 +267,14 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
                 ImGui::CloseCurrentPopup();
             }
         }
+        if(m_highlighted_region.first != TimelineSelection::INVALID_SELECTION_TIME ||
+           m_highlighted_region.second != TimelineSelection::INVALID_SELECTION_TIME)
+        {
+            if(ImGui::MenuItem("Remove Time Range Selection"))
+            {
+                ClearTimeRangeSelection();
+            }
+        }
 
         if(ImGui::MenuItem("Add Annotation"))
         {
@@ -277,14 +285,7 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
                                                m_tpt->GetVMaxX(), m_tpt->GetGraphSize());
             ImGui::CloseCurrentPopup();
         }
-        if(m_highlighted_region.first != TimelineSelection::INVALID_SELECTION_TIME ||
-           m_highlighted_region.second != TimelineSelection::INVALID_SELECTION_TIME)
-        {
-            if(ImGui::MenuItem("Remove Selection"))
-            {
-                ClearTimeRangeSelection();
-            }
-        }
+
 
         ImGui::EndPopup();
     }

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -231,6 +231,8 @@ InfiniteScrollTable::Render()
                           outer_size.y);
         }
 
+        // TODO: is there a more reliable way to detect Group by changes?
+        ImGui::PushID(static_cast<int>(column_names.size())); 
         if(column_names.size() &&
            ImGui::BeginTable("Event Data Table", static_cast<int>(column_names.size()),
                              table_flags, outer_size))
@@ -439,6 +441,7 @@ InfiniteScrollTable::Render()
         {
             ImGui::TextUnformatted(m_no_data_text.c_str());
         }
+        ImGui::PopID();
     }
 
     if(show_loading_indicator)

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -51,12 +51,14 @@ protected:
         kDurationNs,
         kNumTimeColumns
     };
+
+    constexpr static size_t FILTER_SIZE = 256;
     struct FilterOptions
     {
-		char        where[256];
+        char        where[FILTER_SIZE];
         std::string group_by;
-        char        group_columns[256];
-        char        filter[256];
+        char        group_columns[FILTER_SIZE];
+        char        filter[FILTER_SIZE];
     };
 
     virtual void FormatData() const;


### PR DESCRIPTION
## Motivation

Rename some of the labels and wording in the UI.
Clean up table filter interface.

## Technical Details

The updated model behaviour no longer supports (intuatively) the "where filter" when grouping is enabled, so now this is disabled  when group by column is selected.
The group by column filter box has been completely removed (except in developer mode).

The group by option has been enabled for Sample tables.

Mini map labels and Timeline context menu options have been renamed / reworded.