### PR TITLE
ROCM-2128 - [ROCm QA][Optiq]: Kernel summary not sorted after gpu index >0 in bar and table summary view.

### DIFF
--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -541,7 +541,7 @@ namespace DataModel
         auto InvalidateSorting = [&]()
         {
             m_sort_order = true;
-            m_sort_column = "id";
+            m_sort_column = "";
         };
         
 
@@ -565,6 +565,7 @@ namespace DataModel
         {
             InvalidateFiltering();
             InvalidateGrouping();
+            InvalidateSorting();
         }
 
         bool filtered = !m_last_filter_str.empty();


### PR DESCRIPTION
[Problem]
-Sorting is skipped for subsequent queries when queries with identical sort order and column are ran back-to-back. For summary top kernels, the same query is ran for each gpu agent, so only first gpu is shown sorted.

[Fix]
-Invalidate and run sorting when query changes.