### PR TITLE
Centralized workload / kernel selection tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ list(APPEND VIEW_FILES
     src/view/src/compute/rocprofvis_navigation_manager.cpp
     src/view/src/compute/rocprofvis_compute_kernel_details.cpp
     src/view/src/compute/rocprofvis_compute_memory_chart.cpp
+    src/view/src/compute/rocprofvis_compute_selection.cpp
     src/view/src/widgets/rocprofvis_compute_widget.cpp
  
 )

--- a/src/view/src/compute/rocprofvis_compute_kernel_details.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_details.cpp
@@ -2,62 +2,103 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_compute_kernel_details.h"
+#include "rocprofvis_compute_selection.h"
 #include "rocprofvis_data_provider.h"
-#include <imgui.h>
+#include "rocprofvis_event_manager.h"
+
+#include "imgui.h"
 
 namespace RocProfVis
 {
 namespace View
 {
 
-ComputeKernelDetailsView::ComputeKernelDetailsView(DataProvider& data_provider)
+ComputeKernelDetailsView::ComputeKernelDetailsView(
+    DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
 : RocWidget()
 , m_data_provider(data_provider)
-, m_memory_chart(data_provider)
-, m_memory_chart_fetched(false)
-, m_last_provider_state(ProviderState::kInit)
-{}
+, m_memory_chart(data_provider, compute_selection)
+, m_compute_selection(compute_selection)
+, m_client_id(IdGenerator::GetInstance().GenerateId())
+{
+    // Add event listener for selection changes to trigger metric fetch for the newly
+    // selected kernel
+    auto workload_changed_handler = [this](std::shared_ptr<RocEvent> e) {
+        if(auto selection_changed_event =
+               std::dynamic_pointer_cast<ComputeSelectionChangedEvent>(e))
+        {
+            if(m_data_provider.GetTraceFilePath() !=
+               selection_changed_event->GetSourceId())
+            {
+                return;
+            }
+            // TODO: fetch pivot table data
+        }
+    };
 
-ComputeKernelDetailsView::~ComputeKernelDetailsView() {}
+    m_workload_selection_changed_token = EventManager::GetInstance()->Subscribe(
+        static_cast<int>(RocEvents::kComputeWorkloadSelectionChanged),
+        workload_changed_handler);
+
+    auto kernel_changed_handler = [this](std::shared_ptr<RocEvent> e) {
+        if(auto selection_changed_event =
+               std::dynamic_pointer_cast<ComputeSelectionChangedEvent>(e))
+        {
+            if(m_data_provider.GetTraceFilePath() !=
+               selection_changed_event->GetSourceId())
+            {
+                return;
+            }
+
+            m_memory_chart.FetchMemChartMetrics();
+        }
+    };
+
+    m_kernel_selection_changed_token = EventManager::GetInstance()->Subscribe(
+        static_cast<int>(RocEvents::kComputeKernelSelectionChanged),
+        kernel_changed_handler);
+
+    // subscribe to fetch metrics event
+    auto metrics_fetched_handler = [this](std::shared_ptr<RocEvent> e) {
+        if(auto metrics_fetched_event =
+               std::dynamic_pointer_cast<ComputeMetricsFetchedEvent>(e))
+        {
+            if(m_data_provider.GetTraceFilePath() != metrics_fetched_event->GetSourceId())
+            {
+                return;
+            }
+
+            if(m_memory_chart.GetClientId() == metrics_fetched_event->GetClientId())
+            {
+                m_memory_chart.UpdateMetrics();
+            }
+        }
+    };
+
+    m_metrics_fetched_token = EventManager::GetInstance()->Subscribe(
+        static_cast<int>(RocEvents::kComputeMetricsFetched), metrics_fetched_handler);
+}
+
+ComputeKernelDetailsView::~ComputeKernelDetailsView()
+{
+    EventManager::GetInstance()->Unsubscribe(
+        static_cast<int>(RocEvents::kComputeWorkloadSelectionChanged),
+        m_workload_selection_changed_token);
+    EventManager::GetInstance()->Unsubscribe(
+        static_cast<int>(RocEvents::kComputeKernelSelectionChanged),
+        m_kernel_selection_changed_token);
+    EventManager::GetInstance()->Unsubscribe(
+        static_cast<int>(RocEvents::kComputeMetricsFetched), m_metrics_fetched_token);
+}
 
 void
 ComputeKernelDetailsView::Update()
-{
-    ProviderState current_state = m_data_provider.GetState();
-    if(m_last_provider_state != current_state)
-    {
-        if(current_state == ProviderState::kLoading ||
-           current_state == ProviderState::kReady)
-        {
-            m_memory_chart_fetched = false;
-        }
-        m_last_provider_state = current_state;
-    }
-}
+{}
 
 void
 ComputeKernelDetailsView::Render()
 {
-    if(!m_memory_chart_fetched)
-    {
-        const std::unordered_map<uint32_t, WorkloadInfo>& workloads =
-            m_data_provider.ComputeModel().GetWorkloads();
-        if(!workloads.empty())
-        {
-            const WorkloadInfo& workload = workloads.begin()->second;
-            std::vector<uint32_t> kernel_ids;
-            for(const std::pair<const uint32_t, KernelInfo>& kernel : workload.kernels)
-            {
-                kernel_ids.push_back(kernel.second.id);
-            }
-            m_memory_chart.FetchMemChartMetrics(workload.id, kernel_ids);
-            m_memory_chart_fetched = true;
-        }
-    }
-
-    m_memory_chart.Update();
-
-    ImGui::Text("Kernel Details");
+    ImGui::Text("Memory Chart");
     m_memory_chart.Render();
 }
 

--- a/src/view/src/compute/rocprofvis_compute_kernel_details.h
+++ b/src/view/src/compute/rocprofvis_compute_kernel_details.h
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
-#include "widgets/rocprofvis_widget.h"
 #include "rocprofvis_compute_memory_chart.h"
+#include "rocprofvis_event_manager.h"
+#include "widgets/rocprofvis_widget.h"
 
 namespace RocProfVis
 {
@@ -11,22 +12,29 @@ namespace View
 {
 
 class DataProvider;
-enum class ProviderState;
+class ComputeSelection;
 
 class ComputeKernelDetailsView : public RocWidget
 {
 public:
-    ComputeKernelDetailsView(DataProvider& data_provider);
+    ComputeKernelDetailsView(DataProvider&                     data_provider,
+                             std::shared_ptr<ComputeSelection> compute_selection);
     ~ComputeKernelDetailsView();
 
-    void Render();
-    void Update();
+    void Render() override;
+    void Update() override;
 
 private:
     DataProvider&          m_data_provider;
     ComputeMemoryChartView m_memory_chart;
-    bool                   m_memory_chart_fetched;
-    ProviderState          m_last_provider_state;
+
+    std::shared_ptr<ComputeSelection> m_compute_selection;
+
+    uint64_t m_client_id;
+
+    EventManager::SubscriptionToken m_workload_selection_changed_token;
+    EventManager::SubscriptionToken m_kernel_selection_changed_token;
+    EventManager::SubscriptionToken m_metrics_fetched_token;
 };
 
 }  // namespace View

--- a/src/view/src/compute/rocprofvis_compute_memory_chart.cpp
+++ b/src/view/src/compute/rocprofvis_compute_memory_chart.cpp
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_compute_memory_chart.h"
+#include "rocprofvis_compute_selection.h"
 #include "rocprofvis_data_provider.h"
+#include "rocprofvis_requests.h"
 #include "rocprofvis_settings_manager.h"
+
 #include <algorithm>
 #include <cstdio>
 #include <imgui.h>
@@ -150,9 +153,10 @@ DrawInsetCard(ImDrawList* draw_list, float card_x, float card_y,
 // Core — data loading
 // =============================================================================
 
-ComputeMemoryChartView::ComputeMemoryChartView(DataProvider& data_provider)
+ComputeMemoryChartView::ComputeMemoryChartView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
 : m_data_provider(data_provider)
-, m_last_metrics_count(0)
+, m_compute_selection(compute_selection)
+, m_client_id(IdGenerator::GetInstance().GenerateId())
 {
     m_values.fill("-");
     m_metric_ptrs.resize(MEMCHART_METRIC_COUNT, nullptr);
@@ -169,48 +173,52 @@ ComputeMemoryChartView::GetMetricText(MemChartMetric metric) const
 }
 
 void
-ComputeMemoryChartView::FetchMemChartMetrics(uint32_t                     workload_id,
-                                             const std::vector<uint32_t>& kernel_ids)
+ComputeMemoryChartView::FetchMemChartMetrics()
 {
     m_values.fill("-");
     m_metric_ptrs.assign(MEMCHART_METRIC_COUNT, nullptr);
-    m_last_metrics_count = 0;
-    m_kernel_ids         = kernel_ids;
 
-    for(const uint32_t& kid : kernel_ids)
+    m_data_provider.ComputeModel().ClearMetricValues(m_client_id);
+
+    if(m_compute_selection)
     {
-        m_data_provider.ComputeModel().ClearMetricValues(kMemChartClientId, kid);
+        uint32_t workload_id = m_compute_selection->GetSelectedWorkload();
+        uint32_t kernel_id = m_compute_selection->GetSelectedKernel();
+
+        std::vector<uint32_t> kernel_ids = {kernel_id};
+        std::vector<MetricsRequestParams::MetricID> metric_ids;
+        metric_ids.push_back({MEMCHART_CATEGORY_ID, MEMCHART_TABLE_ID, std::nullopt});
+
+        m_data_provider.FetchMetrics(
+            MetricsRequestParams(workload_id, kernel_ids, metric_ids, m_client_id));
     }
-
-    std::vector<MetricsRequestParams::MetricID> metric_ids;
-    metric_ids.push_back({MEMCHART_CATEGORY_ID, MEMCHART_TABLE_ID, std::nullopt});
-
-    m_data_provider.FetchMetrics(
-        MetricsRequestParams(workload_id, kernel_ids, metric_ids, kMemChartClientId));
 }
 
-void
-ComputeMemoryChartView::Update()
+void 
+ComputeMemoryChartView::UpdateMetrics()
 {
     m_metric_ptrs.assign(MEMCHART_METRIC_COUNT, nullptr);
 
-    for(const uint32_t& kernel_id : m_kernel_ids)
+    if(!m_compute_selection) return;
+
+    uint32_t kernel_id = m_compute_selection->GetSelectedKernel();
+    if(kernel_id == ComputeSelection::INVALID_SELECTION_ID) return;
+
+    const std::vector<std::shared_ptr<MetricValue>>* metrics =
+        m_data_provider.ComputeModel().GetMetricsData(m_client_id, kernel_id);
+    
+    if(!metrics) return;
+
+    for(const std::shared_ptr<MetricValue>& metric : *metrics)
     {
-        const std::vector<std::shared_ptr<MetricValue>>* metrics =
-            m_data_provider.ComputeModel().GetMetricsData(kMemChartClientId, kernel_id);
-        if(!metrics) continue;
+        if(!metric || !metric->entry) continue;
+        if(metric->entry->category_id != MEMCHART_CATEGORY_ID) continue;
+        if(metric->entry->table_id != MEMCHART_TABLE_ID) continue;
 
-        for(const std::shared_ptr<MetricValue>& metric : *metrics)
+        uint32_t id = metric->entry->id;
+        if(id < MEMCHART_METRIC_COUNT)
         {
-            if(!metric || !metric->entry) continue;
-            if(metric->entry->category_id != MEMCHART_CATEGORY_ID) continue;
-            if(metric->entry->table_id != MEMCHART_TABLE_ID) continue;
-
-            uint32_t id = metric->entry->id;
-            if(id < MEMCHART_METRIC_COUNT)
-            {
-                m_metric_ptrs[id] = metric.get();
-            }
+            m_metric_ptrs[id] = metric.get();
         }
     }
 

--- a/src/view/src/compute/rocprofvis_compute_memory_chart.h
+++ b/src/view/src/compute/rocprofvis_compute_memory_chart.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <array>
+#include <memory>
 #include <string>
 #include <vector>
 #include <cstdint>
@@ -17,6 +18,7 @@ namespace View
 
 struct MetricValue;
 class DataProvider;
+class ComputeSelection;
 
 // Simple rectangle used for block positioning.
 // Each block stores its local-space position (relative to the chart origin).
@@ -92,15 +94,17 @@ enum MemChartMetric
 class ComputeMemoryChartView
 {
 public:
-    ComputeMemoryChartView(DataProvider& data_provider);
+    ComputeMemoryChartView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection);
     ~ComputeMemoryChartView();
 
     void Render();
-    void Update();
 
     // Fetch all 3.1.x metrics for the given workload and kernels
-    void FetchMemChartMetrics(uint32_t workload_id,
-                              const std::vector<uint32_t>& kernel_ids);
+    void FetchMemChartMetrics();
+
+    void UpdateMetrics();
+
+    uint64_t GetClientId() const { return m_client_id; }
 
 private:
     // Compute all block positions (called once at the start of Render)
@@ -129,11 +133,11 @@ private:
     const char* GetMetricText(MemChartMetric metric) const;
 
     DataProvider& m_data_provider;
+    std::shared_ptr<ComputeSelection> m_compute_selection;
+
     std::array<std::string, MEMCHART_METRIC_COUNT> m_values;
 
-    // Stored fetch context so Update() can query the right (store_id, kernel) slot
-    static constexpr uint64_t       kMemChartClientId = 100;
-    std::vector<uint32_t>           m_kernel_ids;
+    uint64_t m_client_id;
 
     // Cache pointers to MetricValue objects to avoid linear search every frame
     std::vector<const MetricValue*> m_metric_ptrs;

--- a/src/view/src/compute/rocprofvis_compute_selection.cpp
+++ b/src/view/src/compute/rocprofvis_compute_selection.cpp
@@ -1,0 +1,73 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_compute_selection.h"
+#include "rocprofvis_data_provider.h"
+#include "rocprofvis_event_manager.h"
+
+namespace RocProfVis
+{
+namespace View
+{
+
+ComputeSelection::ComputeSelection(DataProvider& dp)
+: m_selected_workload_id(INVALID_SELECTION_ID)
+, m_selected_kernel_id(INVALID_SELECTION_ID)
+, m_data_provider(dp)
+{}
+
+void
+ComputeSelection::SelectKernel(uint32_t kernel_id)
+{
+    if(kernel_id == m_selected_kernel_id)
+    {
+        return;
+    }
+    m_selected_kernel_id = kernel_id;
+    SendKernelSelectionChanged();
+}
+
+void
+ComputeSelection::SelectWorkload(uint32_t workload_id)
+{
+    if(workload_id == m_selected_workload_id)
+    {
+        return;
+    }
+    m_selected_workload_id = workload_id;
+    SendWorkloadSelectionChanged();
+    
+    // reset kernel selection when workload changes
+    SelectKernel(INVALID_SELECTION_ID);
+}
+
+uint32_t
+ComputeSelection::GetSelectedWorkload() const
+{
+    return m_selected_workload_id;
+}
+
+uint32_t
+ComputeSelection::GetSelectedKernel() const
+{
+    return m_selected_kernel_id;
+}
+
+void
+ComputeSelection::SendWorkloadSelectionChanged()
+{
+    EventManager::GetInstance()->AddEvent(std::make_shared<ComputeSelectionChangedEvent>(
+    static_cast<int>(RocEvents::kComputeWorkloadSelectionChanged), m_selected_workload_id,
+        m_data_provider.GetTraceFilePath()));
+}
+
+void
+ComputeSelection::SendKernelSelectionChanged()
+{
+    EventManager::GetInstance()->AddEvent(std::make_shared<ComputeSelectionChangedEvent>(
+    static_cast<int>(RocEvents::kComputeKernelSelectionChanged), m_selected_kernel_id,
+        m_data_provider.GetTraceFilePath()));
+}
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/compute/rocprofvis_compute_selection.h
+++ b/src/view/src/compute/rocprofvis_compute_selection.h
@@ -1,0 +1,40 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <cstdint>
+#include <limits>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+class DataProvider;
+
+class ComputeSelection
+{
+public:
+    ComputeSelection(DataProvider& dp);
+    ~ComputeSelection() = default;
+
+    void SelectKernel(uint32_t kernel_id);
+    void SelectWorkload(uint32_t workload_id);
+
+    uint32_t GetSelectedWorkload() const;
+    uint32_t GetSelectedKernel() const;
+
+    static constexpr uint32_t INVALID_SELECTION_ID = std::numeric_limits<uint32_t>::max();
+
+private:
+    uint32_t m_selected_workload_id;
+    uint32_t m_selected_kernel_id;
+
+    DataProvider& m_data_provider;
+
+    void SendWorkloadSelectionChanged();
+    void SendKernelSelectionChanged();
+};
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -4,6 +4,7 @@
 #include "rocprofvis_compute_view.h"
 #include "rocprofvis_compute_kernel_details.h"
 #include "implot/implot.h"
+#include "rocprofvis_event_manager.h"
 #include "rocprofvis_settings_manager.h"
 #include "model/compute/rocprofvis_compute_data_model.h"
 #include "widgets/rocprofvis_notification_manager.h"
@@ -35,8 +36,14 @@ ComputeView::ComputeView()
                 NotificationManager::GetInstance().Show(
                     "Successfully fetched metrics for client: " + std::to_string(client_id),
                     NotificationLevel::Success);
+
+                // trigger metrics fetched event to update the UI
+                EventManager::GetInstance()->AddEvent(
+                    std::make_shared<ComputeMetricsFetchedEvent>(client_id, trace_path));
             }
         });
+
+
 }
 
 ComputeView::~ComputeView() {}
@@ -72,11 +79,14 @@ ComputeView::Update()
 void
 ComputeView::CreateView()
 {
+    m_compute_selection = std::make_shared<ComputeSelection>(m_data_provider);
+
     m_tab_container = std::make_shared<TabContainer>();
-    m_tab_container->AddTab(TabItem{"Summary View", "compute_summary_view", std::make_shared<ComputeSummaryView>(m_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Kernel Details", "compute_kernel_details_view", std::make_shared<ComputeKernelDetailsView>(m_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Table View", "compute_table_view", std::make_shared<ComputeTableView>(m_data_provider), false});
-    m_tab_container->AddTab(TabItem{"Workload Details", "compute_workload_view", std::make_shared<ComputeWorkloadView>(m_data_provider), false});
+    m_tab_container->AddTab(TabItem{"Summary View", "compute_summary_view", std::make_shared<ComputeSummaryView>(m_data_provider, m_compute_selection), false});
+    m_tab_container->AddTab(TabItem{"Kernel Details", "compute_kernel_details_view", std::make_shared<ComputeKernelDetailsView2>(m_data_provider, m_compute_selection), false});
+    m_tab_container->AddTab(TabItem{"Table View", "compute_table_view", std::make_shared<ComputeTableView>(m_data_provider, m_compute_selection), false});
+    m_tab_container->AddTab(TabItem{"Workload Details", "compute_workload_view", std::make_shared<ComputeWorkloadView>(m_data_provider, m_compute_selection), false});
+    
     m_tab_container->AddTab(TabItem{"Compute Tester", "compute_tester_view", std::make_shared<ComputeTester>(m_data_provider), false});
 }
 
@@ -139,7 +149,7 @@ ComputeView::RenderToolbar()
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, frame_rounding);
     ImGui::AlignTextToFramePadding();
 
-    ImGui::Button("Compute Toolbar", ImVec2(-1, 0));
+    RenderWorkloadSelection();
 
     // pop content style
     ImGui::PopStyleVar(2);
@@ -148,20 +158,77 @@ ComputeView::RenderToolbar()
     ImGui::PopStyleVar(2);
 }
 
+void
+ComputeView::RenderWorkloadSelection()
+{
+    if(!m_compute_selection)
+    {
+        return;
+    }
+
+    const std::unordered_map<uint32_t, WorkloadInfo>& workloads =
+        m_data_provider.ComputeModel().GetWorkloads();
+
+    uint32_t workload_id = m_compute_selection->GetSelectedWorkload();
+    ImGui::Text("Workload:");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(ImGui::GetFrameHeight() * 10.0f);
+    if(ImGui::BeginCombo("##Workloads", workloads.count(workload_id) > 0
+                                          ? workloads.at(workload_id).name.c_str()
+                                          : "-"))
+    {
+        if(ImGui::Selectable("-", workload_id == ComputeSelection::INVALID_SELECTION_ID))
+        {
+            m_compute_selection->SelectWorkload(ComputeSelection::INVALID_SELECTION_ID);
+        }
+        for(const std::pair<const uint32_t, WorkloadInfo>& workload : workloads)
+        {
+            if(ImGui::Selectable(workload.second.name.c_str(),
+                                 workload_id == workload.second.id))
+            {
+                m_compute_selection->SelectWorkload(workload.second.id);
+            }
+        }
+        ImGui::EndCombo();
+    }
+    ImGui::SameLine();
+    ImGui::Text("Kernel:");
+    ImGui::SameLine();
+    uint32_t kernel_id = m_compute_selection->GetSelectedKernel();
+    const KernelInfo* kernel_info = m_data_provider.ComputeModel().GetKernelInfo(workload_id, kernel_id);
+    if(kernel_info)
+    {
+        ImGui::Text("%s", kernel_info->name.c_str());
+    }
+    else
+    {
+        ImGui::Text("-");
+    }
+}
+
 //TODO: move these to their own files
-ComputeSummaryView::ComputeSummaryView(DataProvider& data_provider)
+ComputeSummaryView::ComputeSummaryView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
 : RocWidget()
 , m_data_provider(data_provider)
+, m_compute_selection(compute_selection)
 {}
 
-ComputeTableView::ComputeTableView(DataProvider& data_provider)
+ComputeTableView::ComputeTableView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
 : RocWidget()
 , m_data_provider(data_provider)
+, m_compute_selection(compute_selection)
 {}
 
-ComputeWorkloadView::ComputeWorkloadView(DataProvider& data_provider)
+ComputeKernelDetailsView2::ComputeKernelDetailsView2(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
 : RocWidget()
 , m_data_provider(data_provider)
+, m_compute_selection(compute_selection)
+{}
+
+ComputeWorkloadView::ComputeWorkloadView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
+: RocWidget()
+, m_data_provider(data_provider)
+, m_compute_selection(compute_selection)
 {}
 
 ComputeTester::ComputeTester(DataProvider& data_provider)
@@ -555,9 +622,13 @@ ComputeTester::Render()
         }
         ImGui::NewLine();
         ImGui::BeginDisabled(m_selections.metric_ids.empty() ||
+                             m_selections.kernel_ids.empty());
 
-        m_selections.kernel_ids.empty());
-
+        if(ImGui::Button("Clear all clients"))
+        {
+            m_data_provider.ComputeModel().ClearAllMetricValues();
+        }
+        ImGui::SameLine();
         uint64_t client_id = 0;
         bool do_clear = false;
         if(ImGui::Button("Clear client 1"))

--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -83,7 +83,7 @@ ComputeView::CreateView()
 
     m_tab_container = std::make_shared<TabContainer>();
     m_tab_container->AddTab(TabItem{"Summary View", "compute_summary_view", std::make_shared<ComputeSummaryView>(m_data_provider, m_compute_selection), false});
-    m_tab_container->AddTab(TabItem{"Kernel Details", "compute_kernel_details_view", std::make_shared<ComputeKernelDetailsView2>(m_data_provider, m_compute_selection), false});
+    m_tab_container->AddTab(TabItem{"Kernel Details", "compute_kernel_details_view", std::make_shared<ComputeKernelDetailsView>(m_data_provider, m_compute_selection), false});
     m_tab_container->AddTab(TabItem{"Table View", "compute_table_view", std::make_shared<ComputeTableView>(m_data_provider, m_compute_selection), false});
     m_tab_container->AddTab(TabItem{"Workload Details", "compute_workload_view", std::make_shared<ComputeWorkloadView>(m_data_provider, m_compute_selection), false});
     
@@ -196,13 +196,24 @@ ComputeView::RenderWorkloadSelection()
     ImGui::SameLine();
     uint32_t kernel_id = m_compute_selection->GetSelectedKernel();
     const KernelInfo* kernel_info = m_data_provider.ComputeModel().GetKernelInfo(workload_id, kernel_id);
-    if(kernel_info)
+
+    std::vector<const KernelInfo*> kernel_info_list =
+        m_data_provider.ComputeModel().GetKernelInfoList(workload_id);
+    ImGui::SetNextItemWidth(ImGui::GetFrameHeight() * 10.0f);
+    if(ImGui::BeginCombo("##Kernels", kernel_info ? kernel_info->name.c_str() : "-"))
     {
-        ImGui::Text("%s", kernel_info->name.c_str());
-    }
-    else
-    {
-        ImGui::Text("-");
+        if(ImGui::Selectable("-", kernel_id == ComputeSelection::INVALID_SELECTION_ID))
+        {
+            m_compute_selection->SelectKernel(ComputeSelection::INVALID_SELECTION_ID);
+        }
+        for(const KernelInfo* info : kernel_info_list)
+        {
+            if(ImGui::Selectable(info->name.c_str(), kernel_id == info->id))
+            {
+                m_compute_selection->SelectKernel(info->id);
+            }
+        }
+        ImGui::EndCombo();
     }
 }
 
@@ -214,12 +225,6 @@ ComputeSummaryView::ComputeSummaryView(DataProvider& data_provider, std::shared_
 {}
 
 ComputeTableView::ComputeTableView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
-: RocWidget()
-, m_data_provider(data_provider)
-, m_compute_selection(compute_selection)
-{}
-
-ComputeKernelDetailsView2::ComputeKernelDetailsView2(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
 : RocWidget()
 , m_data_provider(data_provider)
 , m_compute_selection(compute_selection)

--- a/src/view/src/compute/rocprofvis_compute_view.h
+++ b/src/view/src/compute/rocprofvis_compute_view.h
@@ -5,6 +5,7 @@
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_root_view.h"
 #include "widgets/rocprofvis_tab_container.h"
+#include "rocprofvis_compute_selection.h"
 
 namespace RocProfVis
 {
@@ -33,8 +34,11 @@ public:
 
 private:
     void RenderToolbar();
+    void RenderWorkloadSelection();
 
     bool m_view_created;
+
+    std::shared_ptr<ComputeSelection> m_compute_selection;
 
     std::shared_ptr<TabContainer> m_tab_container;
 
@@ -47,31 +51,44 @@ private:
 class ComputeSummaryView: public RocWidget
 {
 public:
-    ComputeSummaryView(DataProvider& data_provider);
+    ComputeSummaryView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection);
     ~ComputeSummaryView(){};
 
 protected:
     DataProvider& m_data_provider;
+    std::shared_ptr<ComputeSelection> m_compute_selection;
+};
+
+class ComputeKernelDetailsView2: public RocWidget
+{
+public:
+    ComputeKernelDetailsView2(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection);
+    ~ComputeKernelDetailsView2(){};
+protected:
+    DataProvider& m_data_provider;
+    std::shared_ptr<ComputeSelection> m_compute_selection;
 };
 
 class ComputeTableView: public RocWidget
 {
 public:
-    ComputeTableView(DataProvider& data_provider);
+    ComputeTableView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection);
     ~ComputeTableView(){};
 
 protected:
     DataProvider& m_data_provider;
+    std::shared_ptr<ComputeSelection> m_compute_selection;
 };
 
 class ComputeWorkloadView: public RocWidget
 {
 public:
-    ComputeWorkloadView(DataProvider& data_provider);
+    ComputeWorkloadView(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection);
     ~ComputeWorkloadView(){};
 
 protected:
     DataProvider& m_data_provider;
+    std::shared_ptr<ComputeSelection> m_compute_selection;
 };
 
 class ComputeTester : public RocWidget

--- a/src/view/src/compute/rocprofvis_compute_view.h
+++ b/src/view/src/compute/rocprofvis_compute_view.h
@@ -59,16 +59,6 @@ protected:
     std::shared_ptr<ComputeSelection> m_compute_selection;
 };
 
-class ComputeKernelDetailsView2: public RocWidget
-{
-public:
-    ComputeKernelDetailsView2(DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection);
-    ~ComputeKernelDetailsView2(){};
-protected:
-    DataProvider& m_data_provider;
-    std::shared_ptr<ComputeSelection> m_compute_selection;
-};
-
 class ComputeTableView: public RocWidget
 {
 public:

--- a/src/view/src/model/compute/rocprofvis_compute_data_model.cpp
+++ b/src/view/src/model/compute/rocprofvis_compute_data_model.cpp
@@ -130,6 +130,7 @@ ComputeDataModel::Clear()
 {
     ClearAllMetricValues();
     m_workloads.clear();
+    m_kernel_selection_table.Clear();
 }
 
 void
@@ -144,6 +145,19 @@ ComputeDataModel::ClearAllMetricValues()
         store_pair.second.clear();
     }
     m_metrics.clear();
+}
+
+void
+ComputeDataModel::ClearMetricValues(uint64_t store_id)
+{
+    if (m_metrics.count(store_id)){
+        for (auto& kernel_pair : m_metrics.at(store_id)) {
+            kernel_pair.second.m_metrics_data.clear();
+            kernel_pair.second.m_metrics_map.clear();
+            kernel_pair.second.m_metrics_by_table_id.clear();
+        }
+        m_metrics.at(store_id).clear();
+    }
 }
 
 void
@@ -208,6 +222,21 @@ ComputeDataModel::GetMetricValuesByTable(uint64_t store_id, uint32_t kernel_id,
         return &m_metrics.at(store_id).at(kernel_id).m_metrics_by_table_id.at(table_key);
     }
     return nullptr;
+}
+
+std::vector<const KernelInfo*>
+ComputeDataModel::GetKernelInfoList(uint32_t workload_id) const
+{
+    std::vector<const KernelInfo*> kernel_info_list;
+    if(m_workloads.count(workload_id))
+    {
+        const WorkloadInfo& workload = m_workloads.at(workload_id);
+        for(const auto& kernel_pair : workload.kernels)
+        {
+            kernel_info_list.push_back(&kernel_pair.second);
+        }
+    }
+    return kernel_info_list;
 }
 
 const KernelInfo*

--- a/src/view/src/model/compute/rocprofvis_compute_data_model.cpp
+++ b/src/view/src/model/compute/rocprofvis_compute_data_model.cpp
@@ -128,6 +128,13 @@ ComputeDataModel::AddMetricValue(uint64_t store_id, uint32_t workload_id,
 void
 ComputeDataModel::Clear()
 {
+    ClearAllMetricValues();
+    m_workloads.clear();
+}
+
+void
+ComputeDataModel::ClearAllMetricValues()
+{
     for (auto& store_pair : m_metrics) {
         for (auto& kernel_pair : store_pair.second) {
             kernel_pair.second.m_metrics_data.clear();
@@ -137,7 +144,6 @@ ComputeDataModel::Clear()
         store_pair.second.clear();
     }
     m_metrics.clear();
-    m_workloads.clear();
 }
 
 void
@@ -200,6 +206,20 @@ ComputeDataModel::GetMetricValuesByTable(uint64_t store_id, uint32_t kernel_id,
        m_metrics.at(store_id).at(kernel_id).m_metrics_by_table_id.count(table_key))
     {
         return &m_metrics.at(store_id).at(kernel_id).m_metrics_by_table_id.at(table_key);
+    }
+    return nullptr;
+}
+
+const KernelInfo*
+ComputeDataModel::GetKernelInfo(uint32_t workload_id, uint32_t kernel_id) const
+{
+    if(m_workloads.count(workload_id))
+    {
+        const WorkloadInfo& workload = m_workloads.at(workload_id);
+        if(workload.kernels.count(kernel_id))
+        {
+            return &workload.kernels.at(kernel_id);
+        }
     }
     return nullptr;
 }

--- a/src/view/src/model/compute/rocprofvis_compute_data_model.h
+++ b/src/view/src/model/compute/rocprofvis_compute_data_model.h
@@ -59,13 +59,20 @@ public:
     MetricValuesByEntryId* GetMetricValuesByTable(uint64_t store_id, uint32_t kernel_id,
                                                   uint64_t table_key);
 
+    // Clear entire model (workloads, metrics, tables, etc)
     void Clear();
+    // Clear metric values for all stores (clients) and kernels
     void ClearAllMetricValues();
+    // Clear metric values for a specific store (client)
+    void ClearMetricValues(uint64_t store_id);
+    // Clear metric values for a specific store and kernel
     void ClearMetricValues(uint64_t store_id, uint32_t kernel_id);
 
     ComputeKernelSelectionTable& GetKernelSelectionTable();
-    const KernelInfo* GetKernelInfo(uint32_t workload_id, uint32_t kernel_id) const;
 
+    std::vector<const KernelInfo*> GetKernelInfoList(uint32_t workload_id) const;
+
+    const KernelInfo* GetKernelInfo(uint32_t workload_id, uint32_t kernel_id) const;
 
 private:
     std::unordered_map<uint32_t, WorkloadInfo> m_workloads;

--- a/src/view/src/model/compute/rocprofvis_compute_data_model.h
+++ b/src/view/src/model/compute/rocprofvis_compute_data_model.h
@@ -60,9 +60,12 @@ public:
                                                   uint64_t table_key);
 
     void Clear();
+    void ClearAllMetricValues();
     void ClearMetricValues(uint64_t store_id, uint32_t kernel_id);
 
     ComputeKernelSelectionTable& GetKernelSelectionTable();
+    const KernelInfo* GetKernelInfo(uint32_t workload_id, uint32_t kernel_id) const;
+
 
 private:
     std::unordered_map<uint32_t, WorkloadInfo> m_workloads;

--- a/src/view/src/rocprofvis_events.cpp
+++ b/src/view/src/rocprofvis_events.cpp
@@ -140,6 +140,34 @@ RocProfVis::View::ComputeTableSearchEvent::GetSearchTerm()
 {
     return m_search_term;
 }
+
+ComputeSelectionChangedEvent::ComputeSelectionChangedEvent(int event_id, uint32_t id, const std::string& source_id)
+: RocEvent(event_id, source_id)
+, m_id(id)
+{
+    m_event_type = RocEventType::kComputeSelectionChangedEvent;
+}
+
+uint32_t
+ComputeSelectionChangedEvent::GetId() const
+{
+    return m_id;
+}
+
+ComputeMetricsFetchedEvent::ComputeMetricsFetchedEvent(const uint64_t     client_id,
+                                                       const std::string& source_id)
+: RocEvent(static_cast<int>(RocEvents::kComputeMetricsFetched), source_id)
+, m_client_id(client_id)
+{
+    m_event_type = RocEventType::kComputeMetricsFetchedEvent;
+}
+
+uint64_t
+ComputeMetricsFetchedEvent::GetClientId() const
+{
+    return m_client_id;
+}
+
 #endif
 
 TabEvent::TabEvent(int event_id, const std::string& tab_id, const std::string& source_id)

--- a/src/view/src/rocprofvis_events.h
+++ b/src/view/src/rocprofvis_events.h
@@ -29,9 +29,14 @@ enum class RocEvents
     kTimeFormatChanged,
     kTopologyChanged,
 #ifdef COMPUTE_UI_SUPPORT
+    //legacy events
     kComputeDataDirty,
     kComputeBlockNavigationChanged,
     kComputeTableSearchChanged,
+    //new events
+    kComputeWorkloadSelectionChanged,
+    kComputeKernelSelectionChanged,
+    kComputeMetricsFetched,
 #endif
 };
 
@@ -49,6 +54,8 @@ enum class RocEventType
     kNavigationEvent,
 #ifdef COMPUTE_UI_SUPPORT
     kComputeTableSearchEvent,
+    kComputeSelectionChangedEvent,
+    kComputeMetricsFetchedEvent,
 #endif
 };
 
@@ -195,6 +202,28 @@ public:
 private:
     std::string m_search_term;
 };
+
+class ComputeSelectionChangedEvent : public RocEvent
+{
+public:
+    ComputeSelectionChangedEvent(int event_id, uint32_t id, const std::string& source_id);
+    uint32_t GetId() const;
+
+private:
+    uint32_t m_id;
+};
+
+class ComputeMetricsFetchedEvent : public RocEvent
+{
+public:
+    ComputeMetricsFetchedEvent(const uint64_t client_id,
+                               const std::string& source_id);
+    uint64_t GetClientId() const;
+
+private:
+    uint64_t m_client_id;
+};
+
 #endif
 
 class TabEvent : public RocEvent

--- a/src/view/src/rocprofvis_requests.h
+++ b/src/view/src/rocprofvis_requests.h
@@ -18,6 +18,26 @@ namespace RocProfVis
 namespace View
 {
 
+// Singleton class for creating unique IDs
+class IdGenerator
+{
+public:
+    static IdGenerator& GetInstance()
+    {
+        static IdGenerator instance;
+        return instance;
+    }
+
+    uint64_t GenerateId()
+    {
+        return ++m_current_id;
+    }
+
+private:
+    IdGenerator() : m_current_id(0) {}
+    uint64_t m_current_id;
+};
+
 enum class RequestType
 {
     kFetchTrack,


### PR DESCRIPTION
## Motivation

This PR introduces a centralized selection management system for the compute UI.
Emits selection change events.
Emits metrics fetched event.

## Technical Details

Refactored ComputeKernelDetailsView and ComputeMemoryChartView to use new ComputeSelection class and Events.

Metric fetching and data updates are now event-driven.

