### PR TITLE
Blank TrackDetail header names regression.

### DIFF
--- a/src/view/src/model/rocprofvis_model_types.h
+++ b/src/view/src/model/rocprofvis_model_types.h
@@ -62,7 +62,6 @@ struct TrackInfo
 
     uint64_t                           index;  // index of the track in the controller
     uint64_t                           id;     // id of the track in the controller
-    std::string                        name;   // name of the track
     rocprofvis_controller_track_type_t track_type;       // the type of track
     double                             min_ts;           // starting time stamp of track
     double                             max_ts;           // ending time stamp of track

--- a/src/view/src/model/rocprofvis_timeline_model.cpp
+++ b/src/view/src/model/rocprofvis_timeline_model.cpp
@@ -360,8 +360,9 @@ TimelineModel::DumpMetaData() const
     {
         spdlog::debug("Track index {}, id {}, name {}, min ts {}, max ts {}, type {}, "
                       "num entries {}, min value {}, max value {}",
-                      track_info->index, track_info->id, track_info->name,
-                      track_info->min_ts, track_info->max_ts,
+                      track_info->index, track_info->id,
+                      track_info->main_name + track_info->sub_name, track_info->min_ts,
+                      track_info->max_ts,
                       track_info->track_type == kRPVControllerTrackTypeSamples ? "Samples"
                                                                                : "Events",
                       track_info->num_entries, track_info->min_value,

--- a/src/view/src/model/rocprofvis_trace_data_model.cpp
+++ b/src/view/src/model/rocprofvis_trace_data_model.cpp
@@ -10,6 +10,88 @@ namespace View
 
 TraceDataModel::TraceDataModel() {}
 
+std::string
+TraceDataModel::BuildTrackName(uint64_t track_id) const
+{
+    const TrackInfo* track_info = m_timeline.GetTrack(track_id);
+    if(!track_info)
+    {
+        return "";
+    }
+
+    const TopologyDataModel& tdm = m_topology;
+
+    std::string       name;
+    std::string       device_type_label;
+    const DeviceInfo* device_info   = tdm.GetDevice(track_info->agent_or_pid);
+    const ProcessInfo* process_info = tdm.GetProcess(track_info->topology.process_id);
+
+    if(device_info)
+    {
+        tdm.GetDeviceTypeLabel(*device_info, device_type_label);
+    }
+
+    switch(track_info->topology.type)
+    {
+        case TrackInfo::TrackType::Queue:
+        {
+            // If the category is not "GPU Queue", use it as the name
+            // For example, "Memory Copy", "Memory Allocation", etc
+            if(track_info->category != "GPU Queue")
+            {
+                name = track_info->category;
+            }
+            else
+            {
+                name = track_info->sub_name;
+            }
+            if(process_info && tdm.ProcessCount() > 1)
+            {
+                name += " (PID:" + std::to_string(process_info->id) + ")";
+            }
+            break;
+        }
+        case TrackInfo::TrackType::Stream:
+        {
+            name = track_info->main_name;
+            if(device_info)
+            {
+                name +=
+                    " (" + device_type_label + ": " + device_info->product_name + ")";
+            }
+            break;
+        }
+        case TrackInfo::TrackType::InstrumentedThread:
+        {
+            name = track_info->sub_name;
+            break;
+        }
+        case TrackInfo::TrackType::SampledThread:
+        {
+            name = track_info->sub_name + " (S)";
+            break;
+        }
+        case TrackInfo::TrackType::Counter:
+        {
+            // Get Processor (device) type label from using track's agent_or_pid, ex:
+            // "GPU0".
+            name = track_info->sub_name;
+            if(process_info && tdm.ProcessCount() > 1)
+            {
+                name += " (PID:" + std::to_string(process_info->id) + ")";
+            }
+            break;
+        }
+        default:
+        {
+            name = track_info->category + ":" + track_info->main_name + ":" +
+                   track_info->sub_name;
+            break;
+        }
+    }
+    return name;
+}
+
 void
 TraceDataModel::Clear()
 {

--- a/src/view/src/model/rocprofvis_trace_data_model.h
+++ b/src/view/src/model/rocprofvis_trace_data_model.h
@@ -51,6 +51,9 @@ public:
     const std::string& GetTraceFilePath() const { return m_trace_file_path; }
     void SetTraceFilePath(const std::string& path) { m_trace_file_path = path; }
 
+    // Build display name for a track from topology/timeline data
+    std::string BuildTrackName(uint64_t track_id) const;
+
     // Clear all data
     void Clear();
 

--- a/src/view/src/rocprofvis_track_details.cpp
+++ b/src/view/src/rocprofvis_track_details.cpp
@@ -77,7 +77,7 @@ TrackDetails::Render()
             for(DetailItem& detail : m_track_details)
             {
                 ImGui::PushID(detail.id);
-                if(ImGui::CollapsingHeader(detail.track_name->c_str(),
+                if(ImGui::CollapsingHeader(detail.track_name.c_str(),
                                            ImGuiTreeNodeFlags_DefaultOpen))
                 {
                     ImGui::TextUnformatted("Node: ");
@@ -145,7 +145,8 @@ TrackDetails::Update()
                 m_data_provider.DataModel().GetTimeline().GetTrack(item.track_id);
             if(metadata && metadata->topology.type != TrackInfo::TrackType::Unknown)
             {
-                item.track_name = &metadata->name;
+                item.track_name =
+                    m_data_provider.DataModel().BuildTrackName(item.track_id);
 
                 const uint64_t& node_id    = metadata->topology.node_id;
                 const uint64_t& process_id = metadata->topology.process_id;
@@ -324,9 +325,9 @@ TrackDetails::HandleTrackSelectionChanged(const uint64_t track_id, const bool se
 {
     if(selected)
     {
-        m_track_details.emplace_front(DetailItem{ m_detail_item_id++, track_id, nullptr,
+        m_track_details.emplace_front(DetailItem{ m_detail_item_id++, track_id, "",
                                                   nullptr, nullptr, nullptr, nullptr,
-                                                  nullptr, nullptr });
+                                                  nullptr, nullptr, nullptr });
     }
     else if(track_id == TimelineSelection::INVALID_SELECTION_ID)
     {
@@ -334,7 +335,7 @@ TrackDetails::HandleTrackSelectionChanged(const uint64_t track_id, const bool se
     }
     else
     {
-        m_track_details.remove(DetailItem{ 0, track_id, nullptr, nullptr, nullptr,
+        m_track_details.remove(DetailItem{ 0, track_id, "", nullptr, nullptr, nullptr,
                                            nullptr, nullptr, nullptr, nullptr });
     }
     m_selection_dirty = true;

--- a/src/view/src/rocprofvis_track_details.h
+++ b/src/view/src/rocprofvis_track_details.h
@@ -5,6 +5,7 @@
 #include "rocprofvis_event_manager.h"
 #include "widgets/rocprofvis_widget.h"
 #include <list>
+#include <string>
 
 namespace RocProfVis
 {
@@ -36,7 +37,7 @@ private:
     {
         const int          id;
         const uint64_t     track_id;
-        const std::string* track_name;
+        std::string        track_name;
         NodeModel*         node;
         ProcessModel*      process;
         ProcessorModel*    processor;

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -64,7 +64,7 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id,
         return;
     }
 
-    SetTrackName(track_info);
+    m_name = m_data_provider.DataModel().BuildTrackName(m_track_id);
     SetMetaAreaLabel(track_info);
     SetDefaultPillLabel(track_info);
 }
@@ -682,81 +682,6 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
         default:
         {
             m_meta_area_label = m_name;
-            break;
-        }
-    }
-}
-
-void
-TrackItem::SetTrackName(const TrackInfo* track_info)
-{
-    TopologyDataModel& tdm = m_data_provider.DataModel().GetTopology();
-
-    std::string       device_type_label;
-    const DeviceInfo* device_info = tdm.GetDevice(track_info->agent_or_pid);
-    const ProcessInfo* process_info = tdm.GetProcess(track_info->topology.process_id);
-
-    if(device_info)
-    {
-        tdm.GetDeviceTypeLabel(*device_info, device_type_label);
-    }
-
-    switch(track_info->topology.type)
-    {
-        case TrackInfo::TrackType::Queue:
-        {
-            // If the category is not "GPU Queue", use it as the name
-            // For example, "Memory Copy", "Memory Allocation", etc
-            if(track_info->category != "GPU Queue")
-            {
-                m_name = track_info->category;
-
-            }
-            else
-            {
-                m_name = track_info->sub_name;
-            }
-            if (process_info && tdm.ProcessCount() > 1)
-            {
-                m_name += " (PID:" + std::to_string(process_info->id) + ")";
-            }
-            break;
-        }
-        case TrackInfo::TrackType::Stream:
-        {
-            m_name = track_info->main_name;
-            if(device_info)
-            {
-                m_name +=
-                    " (" + device_type_label + ": " + device_info->product_name + ")";
-            }
-            break;
-        }
-        case TrackInfo::TrackType::InstrumentedThread:
-        {
-            m_name = track_info->sub_name;
-            break;
-        }
-        case TrackInfo::TrackType::SampledThread:
-        {
-            m_name = track_info->sub_name + " (S)";
-            break;
-        }
-        case TrackInfo::TrackType::Counter:
-        {
-            // Get Processor (device) type label from using track's agent_or_pid, ex:
-            // "GPU0".
-            m_name = track_info->sub_name;
-            if (process_info && tdm.ProcessCount() > 1)
-            {
-                m_name += " (PID:" + std::to_string(process_info->id) + ")";
-            }
-            break;
-        }
-        default:
-        {
-            m_name = track_info->category + ":" + track_info->main_name + ":" +
-                     track_info->sub_name;
             break;
         }
     }

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -124,7 +124,6 @@ protected:
     void FetchHelper();
     void SetDefaultPillLabel(const TrackInfo* track_info);
     void SetMetaAreaLabel(const TrackInfo* track_info);
-    void SetTrackName(const TrackInfo* track_info);
 
     uint64_t              m_track_id;
     float                 m_track_height;


### PR DESCRIPTION
[Problem]
- `TrackInfo.name` which `TrackDetails` relied on for header names became deprecated.

[Fix]
- Move `TrackItem::SetTrackName `into `TraceDataModel` as `BuildTrackName`, use it to populate the `TrackDetails` headers.
- Remove `TrackInfo.name`.