### PR TITLE
Miscellaneous Polish

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_kernel_details.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_details.cpp
@@ -174,11 +174,15 @@ ComputeKernelDetailsView::Update()
 void
 ComputeKernelDetailsView::Render()
 {
-    if(m_kernel_metric_table)
+    ImGui::BeginChild("kernel_details");
+    if(m_kernel_metric_table) 
+    {
         m_kernel_metric_table->Render();
+    }
 
     ImGui::Dummy(ImVec2(0.0f, KERNEL_TABLE_PANEL_PADDING));
     m_flex_container.Render();
+    ImGui::EndChild();
 }
 
 }  // namespace View

--- a/src/view/src/compute/rocprofvis_compute_memory_chart.cpp
+++ b/src/view/src/compute/rocprofvis_compute_memory_chart.cpp
@@ -340,7 +340,10 @@ ComputeMemoryChartView::ShowMetricTooltip(ImVec2 hover_min, ImVec2 hover_max,
                                           MemChartMetric metric_id,
                                           bool show_description, bool show_raw_value)
 {
-    if(!ImGui::IsMouseHoveringRect(hover_min, hover_max)) return;
+    if(!ImGui::IsMouseHoveringRect(hover_min, hover_max) ||
+       !ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows |
+                               ImGuiHoveredFlags_NoPopupHierarchy))
+        return;
     if(metric_id < 0 || metric_id >= MEMCHART_METRIC_COUNT) return;
     if(!m_metric_ptrs[metric_id]) return;
 

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -566,8 +566,7 @@ Roofline::RenderMenus(const ImVec2 region, const ImGuiStyle& style,
                       const ImPlotStyle& plot_style, bool& item_hovered)
 {
     ImVec2 window_pos = ImVec2(0.75f * region.x - 2 * plot_style.PlotPadding.x,
-                               ImGui::GetFontSize() + plot_style.PlotBorderSize +
-                                   3 * plot_style.PlotPadding.y);
+                               plot_style.PlotBorderSize + 2 * plot_style.PlotPadding.y);
     ImVec2 button_pos =
         m_show_menus ? window_pos - ImVec2(ImGui::GetFrameHeightWithSpacing(), 0.0f)
                      : ImVec2(region.x - 2 * plot_style.PlotPadding.x -

--- a/src/view/src/compute/rocprofvis_compute_summary.cpp
+++ b/src/view/src/compute/rocprofvis_compute_summary.cpp
@@ -637,18 +637,17 @@ void
 ComputeTopKernels::RenderTable(const ImPlotStyle& plot_style, TimeFormat time_format,
                                std::optional<size_t>& hovered_idx)
 {
-    ImGui::SetCursorPos(ImVec2(plot_style.PlotBorderSize + plot_style.PlotPadding.x,
-                               ImGui::GetFontSize() + plot_style.PlotBorderSize +
-                                   plot_style.PlotPadding.y +
-                                   2 * plot_style.LabelPadding.y));
+    ImGui::SetCursorPosX(plot_style.PlotBorderSize + plot_style.PlotPadding.x);
     if(ImGui::BeginTable(
            "Table", 2 + KernelInfo::NumMetrics,
            ImGuiTableFlags_ScrollY | ImGuiTableFlags_Borders | ImGuiTableFlags_Resizable,
-           ImGui::GetContentRegionAvail() -
-               ImVec2(plot_style.PlotBorderSize + plot_style.PlotPadding.x,
-                      ImGui::GetContentRegionAvail().y * 0.5f +
-                          ImGui::GetFrameHeightWithSpacing() +
-                          2 * plot_style.PlotPadding.y + plot_style.PlotBorderSize)))
+           ImVec2(ImGui::GetContentRegionAvail().x - plot_style.PlotBorderSize -
+                      plot_style.PlotPadding.x,
+                  std::min(ImGui::GetFrameHeightWithSpacing() * (NUM_TOP_KERNELS + 2),
+                           ImGui::GetContentRegionAvail().y * 0.5f -
+                               ImGui::GetFrameHeightWithSpacing() -
+                               2 * plot_style.PlotPadding.y -
+                               plot_style.PlotBorderSize))))
     {
         ImGui::TableSetupScrollFreeze(0, 1);
         ImGui::TableSetupColumn("##legend",

--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -163,13 +163,6 @@ ComputeView::GetToolbar()
 }
 
 void
-ComputeView::RenderEditMenuOptions()
-{
-    ImGui::MenuItem("Compute Edit Item");
-    ImGui::Separator();
-}
-
-void
 ComputeView::RenderToolbar()
 {
     ImGuiStyle& style          = ImGui::GetStyle();

--- a/src/view/src/compute/rocprofvis_compute_view.h
+++ b/src/view/src/compute/rocprofvis_compute_view.h
@@ -31,7 +31,6 @@ public:
     void DestroyView();
 
     std::shared_ptr<RocWidget> GetToolbar() override;
-    void                       RenderEditMenuOptions() override;
 
 private:
     void RenderToolbar();

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -499,7 +499,9 @@ AppWindow::RenderFileMenu(Project* project)
         {
             project->Save();
         }
-        if(ImGui::MenuItem("Save As", nullptr, false, project || !is_open_file_dialog_open))
+        if(ImGui::MenuItem("Save As", nullptr, false,
+                           project && project->GetTraceType() == Project::System &&
+                               !is_open_file_dialog_open))
         {
             HandleSaveAsFile();
         }
@@ -565,7 +567,6 @@ AppWindow::RenderViewMenu(Project* project)
                 tool_bar_item->m_visible = settings.show_toolbar;
             }
         }
-#ifdef COMPUTE_UI_SUPPORT
         if(ImGui::MenuItem("Fullscreen", "F11", m_is_fullscreen))
         {
             if(m_notification_callback)
@@ -576,7 +577,6 @@ AppWindow::RenderViewMenu(Project* project)
             }
         }
         ImGui::SeparatorText("System Profiler Panels");
-#endif
         if(ImGui::MenuItem("Show Advanced Details Panel", nullptr,
                            &settings.show_details_panel))
         {
@@ -610,21 +610,6 @@ AppWindow::RenderViewMenu(Project* project)
             }
         }
         ImGui::MenuItem("Show Summary", nullptr, &settings.show_summary);
-
-#ifdef COMPUTE_UI_SUPPORT
-        ImGui::SeparatorText("Compute Profiler Panels");
-        ImGui::MenuItem("Compute View Item");
-#else
-        ImGui::Separator();
-        if(ImGui::MenuItem("Fullscreen", "F11", m_is_fullscreen))
-        {
-            if(m_notification_callback)
-            {
-                m_notification_callback(
-                    rocprofvis_view_notification_t::kRocProfVisViewNotification_Toggle_Fullscreen);
-            }
-        }
-#endif
         ImGui::EndMenu();
     }
 }


### PR DESCRIPTION
-Fix regression that allowed top level tabs to be scrolled out of view on `ComputeKernelDetailsView`. 
-Prevent `ComputeMemoryChartView` tooltips from showing through dialogs like `SettingsPanel`. 
-Fix uneven padding for `Roofline `and `ComputeTopKernels` after `SectionTitle` changes.
-Limit height of `ComputeTopKernels` table to be at most 10 + 1 rows. (Currently its height is proportional to available space, so on high resolution displays, the table will scale to an excessive amount space while displaying 11 kernels at most.
-Disable saving projects for compute. Projects technically work but does not do anything besides opening a trace.
-Remove the placeholder menu entries in Edit, View since nothing has been added.

