### PR TITLE
Show tab tooltips on table view so full name of tab can be seen if it is elided.

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_table_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_table_view.cpp
@@ -98,7 +98,7 @@ ComputeTableView::RebuildTabs()
 
     const auto& workload = workloads.at(workload_id);
     m_tabs = std::make_shared<TabContainer>();
-    m_tabs->SetAllowToolTips(false);
+    m_tabs->SetAllowToolTips(true);
     for(const auto& cp : workload.available_metrics.tree)
     {
         const auto& cat    = cp.second;

--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -126,6 +126,7 @@ ComputeView::CreateView()
 #ifdef DEVELOPER_MODE
     m_tab_container->AddTab(TabItem{"Compute Tester", "compute_tester_view", std::make_shared<ComputeTester>(m_data_provider, m_compute_selection), false});
 #endif
+    m_tab_container->SetAllowToolTips(false);
 }
 
 void


### PR DESCRIPTION
## Motivation

Show tab tooltips on table view so full name of tab can be seen if it is elided.

