### PR TITLE
View Regressions

### DIFF
--- a/src/view/src/rocprofvis_event_search.cpp
+++ b/src/view/src/rocprofvis_event_search.cpp
@@ -79,6 +79,7 @@ EventSearch::Render()
         ImGui::SetNextWindowPos(
             ImVec2(ImGui::GetItemRectMin().x,
                    ImGui::GetItemRectMax().y + ImGui::GetStyle().FramePadding.y));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
         if(ImGui::BeginPopup("event_search", ImGuiWindowFlags_NoFocusOnAppearing))
         {
             if(m_data_provider.IsRequestPending(GetRequestID()) ||
@@ -111,6 +112,7 @@ EventSearch::Render()
             }
             ImGui::EndPopup();
         }
+        ImGui::PopStyleVar();
     }
 }
 

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -17,10 +17,10 @@ namespace RocProfVis
 namespace View
 {
 
-constexpr ImGuiTreeNodeFlags CATEGORY_HEADER_FLAGS =
-    ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanLabelWidth;
-constexpr ImVec2 DEFAULT_WINDOW_PADDING = ImVec2(4.0f, 4.0f);
-constexpr float  TREE_LINE_W           = 1.5f;
+constexpr ImGuiTreeNodeFlags HEADER_FLAGS = ImGuiTreeNodeFlags_DefaultOpen |
+                                            ImGuiTreeNodeFlags_SpanLabelWidth |
+                                            ImGuiTreeNodeFlags_Framed;
+constexpr float TREE_LINE_W = 1.5f;
 
 class TreeConnector
 {
@@ -82,8 +82,7 @@ SideBar::Render()
                                   m_settings.GetColor(Colors::kBgFrame)));
 
         const TopologyModel& topology = m_track_topology->GetTopology();
-        if(ImGui::TreeNodeEx("Project",
-                             CATEGORY_HEADER_FLAGS | ImGuiTreeNodeFlags_Framed))
+        if(ImGui::TreeNodeEx("Project", HEADER_FLAGS))
         {
             TreeConnector project_tc(m_settings);
             if(!topology.nodes.empty())
@@ -117,8 +116,7 @@ SideBar::Render()
                 if(use_header)
                 {
                     project_tc.Branch();
-                    header_open =
-                        ImGui::CollapsingHeader("Uncategorized", CATEGORY_HEADER_FLAGS);
+                    header_open = ImGui::CollapsingHeader("Uncategorized", HEADER_FLAGS);
                     ImGui::Indent();
                 }
                 if(header_open)
@@ -385,7 +383,7 @@ SideBar::DrawTopology(const TopologyModel& topology,
         ImGui::SameLine();
     }
 
-    if(ImGui::TreeNodeEx(topology.node_header.c_str(), CATEGORY_HEADER_FLAGS))
+    if(ImGui::TreeNodeEx(topology.node_header.c_str(), HEADER_FLAGS))
     {
         new_button_state = DrawNodes(topology.nodes, new_button_state, true);
         if(new_button_state == EyeButtonState::kAllHidden)
@@ -436,7 +434,7 @@ SideBar::DrawNodes(const std::vector<NodeModel>& nodes,
             }
 
             ImGui::PushID(static_cast<int>(node.info->id));
-            if(ImGui::TreeNodeEx(node.info->host_name.c_str(), CATEGORY_HEADER_FLAGS))
+            if(ImGui::TreeNodeEx(node.info->host_name.c_str(), HEADER_FLAGS))
             {
                 new_button_state = DrawNode(node, new_button_state, true);
                 if(new_button_state == EyeButtonState::kAllHidden)
@@ -481,7 +479,7 @@ SideBar::DrawNode(const NodeModel& node, EyeButtonState parent_eye_button_state,
     }
 
     tc.Branch();
-    bool open = ImGui::TreeNodeEx(node.processor_header.c_str(), CATEGORY_HEADER_FLAGS);
+    bool open = ImGui::TreeNodeEx(node.processor_header.c_str(), HEADER_FLAGS);
 
     if(!node.processors.empty() && open)
     {
@@ -499,7 +497,7 @@ SideBar::DrawNode(const NodeModel& node, EyeButtonState parent_eye_button_state,
     }
 
     tc.Branch();
-    open = ImGui::TreeNodeEx(node.process_header.c_str(), CATEGORY_HEADER_FLAGS);
+    open = ImGui::TreeNodeEx(node.process_header.c_str(), HEADER_FLAGS);
 
     if(!node.processes.empty() && open)
     {
@@ -561,7 +559,7 @@ SideBar::DrawProcesses(const std::vector<ProcessModel>& processes,
                 ImGui::SameLine();
             }
 
-            if(ImGui::TreeNodeEx(process.header.c_str(), CATEGORY_HEADER_FLAGS))
+            if(ImGui::TreeNodeEx(process.header.c_str(), HEADER_FLAGS))
             {
                 TreeConnector ps_tc(m_settings);
                 if(!process.streams.empty())
@@ -651,7 +649,7 @@ SideBar::DrawProcessors(const std::vector<ProcessorModel>& processors,
             EyeButtonState instrumented_thread_button_state = EyeButtonState::kAllHidden;
             EyeButtonState sampled_thread_button_state      = EyeButtonState::kAllHidden;
 
-            if(ImGui::TreeNodeEx(processor.header.c_str(), CATEGORY_HEADER_FLAGS))
+            if(ImGui::TreeNodeEx(processor.header.c_str(), HEADER_FLAGS))
             {
                 TreeConnector proc_tc(m_settings);
                 if(!processor.queues.empty())
@@ -724,8 +722,7 @@ SideBar::DrawCollapsable(const std::vector<Model>& container,
         }
 
         ImGui::SameLine();
-        open = ImGui::TreeNodeEx(collapsable_header.c_str(),
-            CATEGORY_HEADER_FLAGS | ImGuiTreeNodeFlags_Framed);
+        open = ImGui::TreeNodeEx(collapsable_header.c_str(), HEADER_FLAGS);
     }
     if(open)
     {

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -671,7 +671,6 @@ TraceView::RenderToolbar()
 
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, style.FramePadding);
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, style.FrameRounding);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
     ImGui::AlignTextToFramePadding();
 
     // Toolbar Controls
@@ -731,7 +730,7 @@ TraceView::RenderToolbar()
         m_event_search->SetWidth(m_event_search->Width() + available_width);
     }
 
-    ImGui::PopStyleVar(3);
+    ImGui::PopStyleVar(2);
     ImGui::EndChild();
 
     ImVec2      child_min = ImGui::GetItemRectMin();
@@ -1017,6 +1016,7 @@ TraceView::RenderFlowControls()
             mode = static_cast<FlowDisplayMode>(i);
         }
 
+        ImGui::PopStyleColor(3);
         if(ImGui::IsItemHovered())
         {
             ImGui::PopFont();
@@ -1024,7 +1024,6 @@ TraceView::RenderFlowControls()
             ImGui::PushFont(icon_font);
         }
 
-        ImGui::PopStyleColor(3);
         ImGui::PopID();
         ImGui::SameLine();
     }

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -254,6 +254,8 @@ InfiniteScrollTable::Render()
 
         // TODO: is there a more reliable way to detect Group by changes?
         ImGui::PushID(static_cast<int>(column_names.size())); 
+        ImGui::PushStyleColor(ImGuiCol_ChildBg,
+                              m_settings.GetColor(Colors::kFillerColor));
         if(column_names.size() &&
            ImGui::BeginTable("Event Data Table", static_cast<int>(column_names.size()),
                              table_flags, outer_size))
@@ -473,12 +475,14 @@ InfiniteScrollTable::Render()
         {
             ImGui::TextUnformatted(m_no_data_text.c_str());
         }
+        ImGui::PopStyleColor();
         ImGui::PopID();
     }
 
     if(show_loading_indicator)
     {
-        RenderLoadingIndicator(m_settings.GetColor(Colors::kTextMain));
+        RenderLoadingIndicator(m_settings.GetColor(Colors::kTextMain),
+                               m_widget_name.c_str());
     }
 
     ImGui::EndChild();


### PR DESCRIPTION
- https://github.com/ROCm/roc-optiq/pull/745
  - `InfiniteScrollTable`s do not show loading indicators when fetching while not empty.
- https://github.com/ROCm/roc-optiq/pull/744
   - `EventSearch` asserts, has a bunch of rectangles around results, has mismatched bg vs other `InfiniteScrollTable`s
   - `TraceView` toolbar spacing lopsided, flow controls have unreadable white on white tool tips.
   - `Sidebar` headers arrows are different sizes 