### PR TITLE
Fix cell barchart rectangles not clipping

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -557,7 +557,7 @@ KernelMetricTable::Render()
                                         m_compute_selection->SelectKernel(
                                             m_selected_kernel_id_local);
                                     }
-                                }                                
+                                }
                                 selectable_placed = true;
                             }
                             else

--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -38,11 +38,11 @@ constexpr std::string_view FILTER_TEXT_HINT_NUMERICAL = ">, <, =, >=, <=, !=";
 constexpr float            COL_FILTER_CHAR_LIMIT      = static_cast<float>(
     std::max(FILTER_TEXT_HINT_STR.length(), FILTER_TEXT_HINT_NUMERICAL.length()));
 
-constexpr float COL_NAME_CHAR_LIMIT       = 50.0f;
+constexpr float COL_NAME_CHAR_LIMIT       = 40.0f;
 constexpr float COL_DEFAULT_CHAR_LIMIT    = 30.0f;
 constexpr float COL_INVOCATION_CHAR_LIMIT = COL_FILTER_CHAR_LIMIT;
 
-constexpr float kTooltipMaxWidth = 400.0f;
+constexpr float kTooltipMaxWidth = 600.0f;
 
 KernelMetricTable::KernelMetricTable(DataProvider&                     data_provider,
                                      std::shared_ptr<ComputeSelection> compute_selection)
@@ -520,6 +520,17 @@ KernelMetricTable::Render()
                             ImGuiTableColumnFlags flags = ImGui::TableGetColumnFlags(col);
                             bool is_visible = (flags & ImGuiTableColumnFlags_IsVisible) != 0;
                             bool is_enabled = (flags & ImGuiTableColumnFlags_IsEnabled) != 0;
+                            bool need_tooltip = false;
+                            if(col == NAME_COLUMN_INDEX)
+                            {
+                                // Measure text and if larger than the cell, use a tooltip
+                                ImVec2 text_size = ImGui::CalcTextSize(cell.c_str());
+                                float available_width = ImGui::GetContentRegionAvail().x;
+                                if(text_size.x > available_width)
+                                {
+                                    need_tooltip = true;
+                                }
+                            }
 
                             if(!selectable_placed && is_visible && is_enabled)
                             {
@@ -546,7 +557,7 @@ KernelMetricTable::Render()
                                         m_compute_selection->SelectKernel(
                                             m_selected_kernel_id_local);
                                     }
-                                }
+                                }                                
                                 selectable_placed = true;
                             }
                             else
@@ -590,6 +601,16 @@ KernelMetricTable::Render()
                                     }
                                     ImGui::TextUnformatted(cell.c_str());
                                 }
+                            }
+                            if(need_tooltip && ImGui::IsItemHovered())
+                            {
+                                ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),
+                                                                    ImVec2(kTooltipMaxWidth, FLT_MAX));
+                                BeginTooltipStyled();
+                                ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + kTooltipMaxWidth);
+                                ImGui::TextUnformatted(cell.c_str());
+                                ImGui::PopTextWrapPos();
+                                EndTooltipStyled();
                             }
                         }
                         ImGui::PopID();  // Pop row ID

--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -570,14 +570,21 @@ KernelMetricTable::Render()
                                                     std::abs(val) / it->second);
                                                 ratio = std::min(ratio, 1.0f);
 
-                                                ImVec2 pos = ImGui::GetCursorScreenPos();
-                                                float  w   = ImGui::GetContentRegionAvail().x;
-                                                float  h   = ImGui::GetTextLineHeightWithSpacing();
-                                                ImGui::GetWindowDrawList()->AddRectFilled(
+                                                ImVec2     pos       = ImGui::GetCursorScreenPos();
+                                                float      w         = ImGui::GetContentRegionAvail().x;
+                                                float      h         = ImGui::GetTextLineHeightWithSpacing();
+                                                ImDrawList* draw_list = ImGui::GetWindowDrawList();
+                                                // Intersect with the current clip rect so the bar is
+                                                // correctly hidden behind frozen rows/columns when the
+                                                // table is scrolled vertically.
+                                                draw_list->PushClipRect(
+                                                    pos, ImVec2(pos.x + w, pos.y + h), true);
+                                                draw_list->AddRectFilled(
                                                     pos,
                                                     ImVec2(pos.x + w * ratio, pos.y + h),
                                                     SettingsManager::GetInstance().GetColor(
                                                         Colors::kHighlightChart));
+                                                draw_list->PopClipRect();
                                             }
                                         }
                                     }


### PR DESCRIPTION

## Motivation

<img width="1582" height="738" alt="image" src="https://github.com/user-attachments/assets/0454244d-d396-4966-a441-8781587c2ff1" />

When table is scrolled vertically, the cell's barchart rectangles stop clipping correctly.

--------

Also add a tooltip if kernel name does not fit in the column.

<img width="1385" height="410" alt="image" src="https://github.com/user-attachments/assets/dcd009a3-9ace-4644-aefe-555ece6b5cad" />

## Technical Details

Bar Overlap Issue:
Clip bar when drawing to fix issues with bar rendering on top of pinned column.

Name tooltip:
Auto detect if text does not fit and only render the tool tip in this case.
