### PR TITLE
Compute Comparison V2

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -406,7 +406,7 @@ ComputeComparisonView::UpdateMetrics()
                                             std::min(static_cast<ImU32>(
                                                          std::abs(rounded_target -
                                                                   rounded_baseline) /
-                                                         rounded_baseline * 255),
+                                                         rounded_baseline * 255 + 25),
                                                      ImU32(255));
                                     }
                                 }

--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_compute_comparison.h"
+#include "icons/rocprovfis_icon_defines.h"
 #include "rocprofvis_compute_selection.h"
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_requests.h"
@@ -11,6 +12,8 @@
 #include "widgets/rocprofvis_tab_container.h"
 #include <algorithm>
 #include <bitset>
+#include <cmath>
+#include <cstdlib>
 #include <iomanip>
 #include <sstream>
 
@@ -19,9 +22,11 @@ namespace RocProfVis
 namespace View
 {
 
-constexpr size_t BASELINE_BG_COLOR     = 4;
-constexpr size_t TARGET_BG_COLOR       = 5;
-constexpr size_t DIFFERENCE_BG_COLOR   = 2;
+constexpr int                 SIGNIFICANT_DIGITS = 2;
+const double                  ROUND_FACTOR       = std::pow(10.0, SIGNIFICANT_DIGITS);
+constexpr ImGuiColorEditFlags LEGEND_FLAGS =
+    ImGuiColorEditFlags_NoPicker | ImGuiColorEditFlags_NoInputs |
+    ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoLabel;
 constexpr size_t ROW_TAG_INVALID_MATCH = 0;
 
 ComputeComparisonView::ComputeComparisonView(
@@ -42,7 +47,6 @@ ComputeComparisonView::ComputeComparisonView(
 , m_retry_fetch(false)
 , m_filter_common_metrics(false)
 , m_layout(nullptr)
-, m_toolbar_spacer_width(0.0f)
 , m_toolbar_available_width(0.0f)
 , m_tab_container(nullptr)
 , m_bookmark_table(nullptr)
@@ -55,9 +59,6 @@ ComputeComparisonView::ComputeComparisonView(
                                 ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
                                     ImGuiTableFlags_ScrollX | ImGuiTableFlags_ScrollY,
                                 3, 1);
-    m_bookmark_table->SetColumnColor("Baseline", true, BASELINE_BG_COLOR);
-    m_bookmark_table->SetColumnColor("Target", true, TARGET_BG_COLOR);
-    m_bookmark_table->SetColumnColor("Difference", true, DIFFERENCE_BG_COLOR);
     m_bookmark_table->SetRowSelectionHandler(
         [this](const Table& table, const size_t index, const bool state) {
             if(!state)
@@ -224,7 +225,7 @@ ComputeComparisonView::FetchMetrics()
         std::vector<MetricsRequestParams::MetricID> metric_ids;
         // Fetch baseline...
         if(!m_data_provider.ComputeModel().GetKernelMetricsData(m_client_id_baseline,
-                                                          baseline_kernel_id))
+                                                                baseline_kernel_id))
         {
             m_data_provider.ComputeModel().ClearKernelMetricValues(m_client_id_baseline);
             for(const AvailableMetrics::Category* category :
@@ -245,7 +246,7 @@ ComputeComparisonView::FetchMetrics()
         metric_ids.clear();
         // Fetch target...
         if(!m_data_provider.ComputeModel().GetKernelMetricsData(m_client_id_target,
-                                                          m_target_kernel_id))
+                                                                m_target_kernel_id))
         {
             m_data_provider.ComputeModel().ClearKernelMetricValues(m_client_id_target);
             for(const AvailableMetrics::Category* category :
@@ -270,9 +271,10 @@ ComputeComparisonView::UpdateMetrics()
 {
     // Do nothing unless we have data for baseline + target...
     uint32_t kernel_id = m_compute_selection->GetSelectedKernel();
-    if(m_data_provider.ComputeModel().GetKernelMetricsData(m_client_id_baseline, kernel_id) &&
+    if(m_data_provider.ComputeModel().GetKernelMetricsData(m_client_id_baseline,
+                                                           kernel_id) &&
        m_data_provider.ComputeModel().GetKernelMetricsData(m_client_id_target,
-                                                     m_target_kernel_id))
+                                                           m_target_kernel_id))
     {
         uint32_t workload_id = m_compute_selection->GetSelectedWorkload();
         if(m_data_provider.ComputeModel().GetKernelInfo(workload_id, kernel_id) &&
@@ -286,9 +288,7 @@ ComputeComparisonView::UpdateMetrics()
                     .GetWorkload(workload_id)
                     ->available_metrics.ordered_categories;
             std::unordered_map<uint32_t, const AvailableMetrics::Entry*> row_entry;
-            std::unordered_map<uint32_t, std::vector<std::string>>       row_value_names;
-            std::unordered_map<uint32_t, std::vector<std::optional<double>>>
-                row_value_data;
+            std::unordered_map<uint32_t, std::vector<Table::Value>>      row_value;
             // Go through our available metrics...
             for(const AvailableMetrics::Category* category : baseline_categories)
             {
@@ -331,8 +331,7 @@ ComputeComparisonView::UpdateMetrics()
                                       : nullptr
                                 : nullptr;
                         row_entry.clear();
-                        row_value_names.clear();
-                        row_value_data.clear();
+                        row_value.clear();
                         if(fetched_baseline_entry)
                         {
                             row_entry[0] = fetched_baseline_entry.get()->entry;
@@ -361,65 +360,135 @@ ComputeComparisonView::UpdateMetrics()
                                           ? &fetched_target_entry->values.at(value_name)
                                           : nullptr
                                     : nullptr;
+                            const double rounded_baseline =
+                                baseline_value
+                                    ? std::round(*baseline_value * ROUND_FACTOR) /
+                                          ROUND_FACTOR
+                                    : 0.0;
+                            const double rounded_target =
+                                target_value ? std::round(*target_value * ROUND_FACTOR) /
+                                                   ROUND_FACTOR
+                                             : 0.0;
+                            // Setup customizations...
+                            std::optional<Table::DisplayProps::Color> bg_color_baseline;
+                            std::optional<Table::DisplayProps::Color> bg_color_target;
+                            std::optional<Table::DisplayProps::Color> bg_color_difference;
+                            std::optional<Table::DisplayProps::Color> text_color;
+                            std::optional<const char*>                icon;
+                            if(valid_match)
+                            {
+                                if(baseline_value && target_value &&
+                                   rounded_baseline != rounded_target)
+                                {
+                                    bg_color_baseline = Table::DisplayProps::Color{
+                                        Colors::kComparisonBase, 255
+                                    };
+                                    bg_color_target = Table::DisplayProps::Color{
+                                        Colors::kComparisonTarget, 255
+                                    };
+                                    if(rounded_target > rounded_baseline)
+                                    {
+                                        bg_color_difference = Table::DisplayProps::Color{
+                                            Colors::kComparisonGreater, 255
+                                        };
+                                        icon = ICON_ARROW_UP;
+                                    }
+                                    else
+                                    {
+                                        bg_color_difference = Table::DisplayProps::Color{
+                                            Colors::kComparisonLesser, 255
+                                        };
+                                        icon = ICON_ARROW_DOWN;
+                                    }
+                                    if(rounded_baseline != 0.0)
+                                    {
+                                        bg_color_difference.value().alpha =
+                                            std::min(static_cast<ImU32>(
+                                                         std::abs(rounded_target -
+                                                                  rounded_baseline) /
+                                                         rounded_baseline * 255),
+                                                     ImU32(255));
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                text_color =
+                                    Table::DisplayProps::Color{ Colors::kTextDim, 255 };
+                            }
                             // Merge baseline + target into one row if they match,
                             // otherwise split into two separate rows...
-                            row_value_names[0].emplace_back("Baseline " + value_name);
-                            row_value_data[0].emplace_back(
-                                baseline_value ? std::make_optional(*baseline_value)
-                                               : std::nullopt);
-                            row_value_names[0].emplace_back("Target " + value_name);
-                            row_value_data[0].emplace_back(
+                            row_value[0].emplace_back(Table::Value{
+                                "Baseline " + value_name,
+                                baseline_value ? std::make_optional(rounded_baseline)
+                                               : std::nullopt,
+                                Table::DisplayProps{ bg_color_baseline, text_color,
+                                                     std::nullopt } });
+                            row_value[0].emplace_back(Table::Value{
+                                "Target " + value_name,
                                 valid_match && target_value
-                                    ? std::make_optional(*target_value)
-                                    : std::nullopt);
-                            row_value_names[0].emplace_back("Difference##" + value_name);
-                            row_value_data[0].emplace_back(
+                                    ? std::make_optional(rounded_target)
+                                    : std::nullopt,
+                                Table::DisplayProps{ bg_color_target, text_color,
+                                                     std::nullopt } });
+                            row_value[0].emplace_back(Table::Value{
+                                "Difference##" + value_name,
                                 valid_match && baseline_value && target_value
-                                    ? std::make_optional(*target_value - *baseline_value)
-                                    : std::nullopt);
-                            row_value_names[0].emplace_back("Difference (%)##" +
-                                                            value_name);
-                            row_value_data[0].emplace_back(
+                                    ? std::make_optional(rounded_target -
+                                                         rounded_baseline)
+                                    : std::nullopt,
+                                Table::DisplayProps{ bg_color_difference, text_color,
+                                                     icon } });
+                            row_value[0].emplace_back(Table::Value{
+                                "Difference (%)##" + value_name,
                                 valid_match && baseline_value && target_value &&
-                                        *baseline_value != 0.0
+                                        rounded_baseline != 0.0
                                     ? std::make_optional(
-                                          (*target_value - *baseline_value) /
-                                          *baseline_value * 100)
-                                    : std::nullopt);
+                                          std::round((rounded_target - rounded_baseline) /
+                                                     rounded_baseline * 100 *
+                                                     ROUND_FACTOR) /
+                                          ROUND_FACTOR)
+                                    : std::nullopt,
+                                Table::DisplayProps{ bg_color_difference, text_color,
+                                                     icon } });
                             if(!valid_match && row_entry.count(1) > 0)
                             {
-                                row_value_names[1].emplace_back("Baseline " + value_name);
-                                row_value_data[1].emplace_back(std::nullopt);
-                                row_value_names[1].emplace_back("Target " + value_name);
-                                row_value_data[1].emplace_back(
-                                    target_value ? std::make_optional(*target_value)
-                                                 : std::nullopt);
-                                row_value_names[1].emplace_back("Difference##" +
-                                                                value_name);
-                                row_value_data[1].emplace_back(std::nullopt);
-                                row_value_names[1].emplace_back("Difference (%)##" +
-                                                                value_name);
-                                row_value_data[1].emplace_back(std::nullopt);
+                                row_value[1].emplace_back(Table::Value{
+                                    "Baseline " + value_name, std::nullopt,
+                                    Table::DisplayProps{ bg_color_baseline, text_color,
+                                                         std::nullopt } });
+                                row_value[1].emplace_back(Table::Value{
+                                    "Target " + value_name,
+                                    target_value ? std::make_optional(rounded_target)
+                                                 : std::nullopt,
+                                    Table::DisplayProps{ bg_color_target, text_color,
+                                                         std::nullopt } });
+                                row_value[1].emplace_back(Table::Value{
+                                    "Difference##" + value_name, std::nullopt,
+                                    Table::DisplayProps{ std::nullopt, text_color,
+                                                         std::nullopt } });
+                                row_value[1].emplace_back(Table::Value{
+                                    "Difference (%)##" + value_name, std::nullopt,
+                                    Table::DisplayProps{ std::nullopt, text_color,
+                                                         std::nullopt } });
                             }
                         }
-                        if(row_value_names.size() == row_value_data.size())
+                        for(uint32_t k = 0; k < row_value.size(); k++)
                         {
-                            for(uint32_t k = 0; k < row_value_names.size(); k++)
+                            if(row_entry.count(k) > 0 && row_value.count(k))
                             {
-                                if(row_entry.count(k) > 0 &&
-                                   row_value_names.count(k) > 0 &&
-                                   row_value_data.count(k) > 0)
-                                {
-                                    category_model.tables[i]->AddRow(
-                                        row_entry.at(k), row_value_names.at(k),
-                                        row_value_data.at(k),
-                                        valid_match
-                                            ? std::nullopt
-                                            : std::make_optional(Colors::kTextDim),
-                                        valid_match ? std::nullopt
-                                                    : std::make_optional<size_t>(
-                                                          ROW_TAG_INVALID_MATCH));
-                                }
+                                category_model.tables[i]->AddRow(
+                                    row_entry.at(k), row_value.at(k),
+                                    valid_match
+                                        ? Table::DisplayProps{}
+                                        : Table::DisplayProps{ std::nullopt,
+                                                               Table::DisplayProps::Color{
+                                                                   Colors::kTextDim,
+                                                                   255 },
+                                                               std::nullopt },
+                                    valid_match ? std::nullopt
+                                                : std::make_optional<size_t>(
+                                                      ROW_TAG_INVALID_MATCH));
                             }
                         }
                     }
@@ -436,12 +505,6 @@ ComputeComparisonView::UpdateMetrics()
                             }
                         });
                     empty &= category_model.tables[i]->Rows().empty();
-                    category_model.tables[i]->SetColumnColor("Baseline", true,
-                                                             BASELINE_BG_COLOR);
-                    category_model.tables[i]->SetColumnColor("Target", true,
-                                                             TARGET_BG_COLOR);
-                    category_model.tables[i]->SetColumnColor("Difference", true,
-                                                             DIFFERENCE_BG_COLOR);
                     if(m_filter_common_metrics)
                     {
                         category_model.tables[i]->ApplyRowFilter(ROW_TAG_INVALID_MATCH);
@@ -538,9 +601,56 @@ ComputeComparisonView::RenderToolbar()
     }
     ImGui::EndDisabled();
     VerticalSeparator(&m_settings);
-    if(m_toolbar_spacer_width != 0.0)
+    if(m_toolbar_available_width != 0.0)
     {
-        ImGui::Dummy(ImVec2(m_toolbar_spacer_width, ImGui::GetFrameHeightWithSpacing()));
+        float legend_width =
+            7.0f * style.FramePadding.x + 4.0f * ImGui::GetFrameHeight() +
+            ImGui::CalcTextSize("Baseline").x + ImGui::CalcTextSize("Target").x +
+            2.0f * ImGui::CalcTextSize("Difference[X]").x;
+        if(m_toolbar_available_width > legend_width)
+        {
+            ImGui::Dummy(ImVec2(m_toolbar_available_width - legend_width,
+                                ImGui::GetFrameHeightWithSpacing()));
+            ImGui::SameLine();
+            VerticalSeparator(&m_settings);
+            ImVec4 bg_base = ImGui::ColorConvertU32ToFloat4(
+                m_settings.GetColor(Colors::kComparisonBase));
+            ImVec4 bg_target = ImGui::ColorConvertU32ToFloat4(
+                m_settings.GetColor(Colors::kComparisonTarget));
+            ImVec4 bg_lesser = ImGui::ColorConvertU32ToFloat4(
+                m_settings.GetColor(Colors::kComparisonLesser));
+            ImVec4 bg_greater = ImGui::ColorConvertU32ToFloat4(
+                m_settings.GetColor(Colors::kComparisonGreater));
+            ImGui::SameLine();
+            ImGui::ColorEdit4("b", &bg_base.x, LEGEND_FLAGS);
+            ImGui::SameLine(0.0f, style.FramePadding.x);
+            ImGui::TextUnformatted("Baseline");
+            ImGui::SameLine(0.0f, style.FramePadding.x);
+            ImGui::ColorEdit4("t", &bg_target.x, LEGEND_FLAGS);
+            ImGui::SameLine(0.0f, style.FramePadding.x);
+            ImGui::TextUnformatted("Target");
+            ImGui::SameLine(0.0f, style.FramePadding.x);
+            ImGui::ColorEdit4("d<", &bg_lesser.x, LEGEND_FLAGS);
+            ImGui::SameLine(0.0f, style.FramePadding.x);
+            ImGui::TextUnformatted("Difference");
+            ImGui::SameLine();
+            ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+            ImGui::TextUnformatted(ICON_ARROW_DOWN);
+            ImGui::PopFont();
+            ImGui::SameLine(0.0f, style.FramePadding.x);
+            ImGui::ColorEdit4("d>", &bg_greater.x, LEGEND_FLAGS);
+            ImGui::SameLine(0.0f, style.FramePadding.x);
+            ImGui::TextUnformatted("Difference");
+            ImGui::SameLine();
+            ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+            ImGui::TextUnformatted(ICON_ARROW_UP);
+            ImGui::PopFont();
+        }
+        else
+        {
+            ImGui::Dummy(
+                ImVec2(m_toolbar_available_width, ImGui::GetFrameHeightWithSpacing()));
+        }
     }
     VerticalSeparator(&m_settings);
     if(ImGui::Button(m_filter_common_metrics ? "Show Common Metrics" : "Show All Metrics",
@@ -582,9 +692,10 @@ ComputeComparisonView::RenderToolbar()
     if(BeginItemTooltipStyled())
     {
         ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + window_width * 0.25f);
-        ImGui::TextUnformatted("Toggle displaying of mismatched (grey-shaded) metrics, such "
-                               "as archetecture specific metrics "
-                               "when comparing across GPU archetectures.");
+        ImGui::TextUnformatted(
+            "Toggle displaying of mismatched (grey-shaded) metrics, such "
+            "as archetecture specific metrics "
+            "when comparing across GPU archetectures.");
         ImGui::PopTextWrapPos();
         EndTooltipStyled();
     }
@@ -601,8 +712,8 @@ ComputeComparisonView::RenderToolbar()
         }
     }
     ImGui::SameLine();
-    m_toolbar_spacer_width =
-        std::max(0.0f, m_toolbar_spacer_width + ImGui::GetContentRegionAvail().x);
+    m_toolbar_available_width =
+        std::max(0.0f, m_toolbar_available_width + ImGui::GetContentRegionAvail().x);
     ImGui::PopStyleVar(2);
     ImGui::EndChild();
     ImGui::PopStyleVar(2);
@@ -766,8 +877,7 @@ ComputeComparisonView::UpdateBookmarks()
                 }
             }
         }
-        std::vector<std::string>           empty_name;
-        std::vector<std::optional<double>> empty_data;
+        std::vector<Table::Value> empty_value;
         for(size_t i = 0; i < m_bookmarks.size(); i++)
         {
             const Table* table     = updated_bookmarks[i].first;
@@ -785,7 +895,9 @@ ComputeComparisonView::UpdateBookmarks()
                 // Bookmark no longer exist...
                 m_bookmarks[i].row = nullptr;
                 m_bookmark_table->AddRow(
-                    m_bookmarks[i].entry, empty_name, empty_data, Colors::kTextDim,
+                    m_bookmarks[i].entry, empty_value,
+                    { std::nullopt, Table::DisplayProps::Color{ Colors::kTextDim, 255 },
+                      std::nullopt },
                     std::make_optional<size_t>(ROW_TAG_INVALID_MATCH));
                 m_bookmark_table->Rows()[m_bookmark_table->Rows().size() - 1].selected =
                     true;
@@ -822,7 +934,7 @@ ComputeComparisonView::Table::Update()
         // Deferred row removal...
         if(m_remove_row_index.value() < m_rows.size())
         {
-            for(const std::pair<const std::string, std::string>& value :
+            for(const std::pair<const std::string, Row::Value>& value :
                 m_rows[m_remove_row_index.value()].values_map)
             {
                 if(m_value_columns.count(value.first) > 0)
@@ -857,42 +969,28 @@ ComputeComparisonView::Table::Update()
         {
             if(i == Column::Selection)
             {
-                m_columns[i].type        = Column::Selection;
-                m_columns[i].name        = "";
-                m_columns[i].color_index = std::nullopt;
+                m_columns[i].type = Column::Selection;
+                m_columns[i].name = "";
             }
             else if(i == Column::MetricID)
             {
-                m_columns[i].type        = Column::MetricID;
-                m_columns[i].name        = "Metric ID";
-                m_columns[i].color_index = std::nullopt;
+                m_columns[i].type = Column::MetricID;
+                m_columns[i].name = "Metric ID";
             }
             else if(i == Column::MetricName)
             {
-                m_columns[i].type        = Column::MetricName;
-                m_columns[i].name        = "Metric";
-                m_columns[i].color_index = std::nullopt;
+                m_columns[i].type = Column::MetricName;
+                m_columns[i].name = "Metric";
             }
             else if(i == m_columns.size() - 1)
             {
-                m_columns[i].type        = Column::Unit;
-                m_columns[i].name        = "Unit";
-                m_columns[i].color_index = std::nullopt;
+                m_columns[i].type = Column::Unit;
+                m_columns[i].name = "Unit";
             }
             else if(j < m_ordered_value_names.size() &&
                     m_value_columns.count(m_ordered_value_names[j]) > 0)
             {
                 m_columns[i] = m_value_columns.at(m_ordered_value_names[j++]);
-                for(const ColumnColorRule& rule : m_column_color_rules)
-                {
-                    if(rule.fuzzy_match
-                           ? (m_columns[i].name.find(rule.name) != std::string::npos)
-                           : (m_columns[i].name == rule.name))
-                    {
-                        m_columns[i].color_index = rule.color_index;
-                        break;
-                    }
-                }
             }
         }
         // Setup rows...
@@ -906,33 +1004,40 @@ ComputeComparisonView::Table::Update()
                 {
                     case Column::Selection:
                     {
-                        row.cells[i] = std::string_view{};
+                        row.cells[i].data          = std::string_view{};
+                        row.cells[i].display_props = &row.display_props;
                         break;
                     }
                     case Column::MetricID:
                     {
-                        row.cells[i] = row.id.metric_id;
+                        row.cells[i].data          = row.id.metric_id;
+                        row.cells[i].display_props = &row.display_props;
                         break;
                     }
                     case Column::MetricName:
                     {
-                        row.cells[i] = row.entry->name;
+                        row.cells[i].data          = row.entry->name;
+                        row.cells[i].display_props = &row.display_props;
                         break;
                     }
                     case Column::Unit:
                     {
-                        row.cells[i] = row.entry->unit;
+                        row.cells[i].data          = row.entry->unit;
+                        row.cells[i].display_props = &row.display_props;
                         break;
                     }
                     default:
                     {
                         if(row.values_map.count(m_columns[i].name) > 0)
                         {
-                            row.cells[i] = row.values_map.at(m_columns[i].name);
+                            Row::Value& value = row.values_map.at(m_columns[i].name);
+                            row.cells[i].data = value.data;
+                            row.cells[i].display_props = &value.display_props;
                         }
                         else
                         {
-                            row.cells[i] = std::string_view{};
+                            row.cells[i].data          = std::string_view{};
+                            row.cells[i].display_props = &row.display_props;
                         }
                         break;
                     }
@@ -1003,14 +1108,51 @@ ComputeComparisonView::Table::Render()
                     {
                         ImGui::PushID(static_cast<int>(j));
                         ImGui::TableNextColumn();
-                        if(m_columns[j].color_index)
+                        if(m_rows[i].cells[j].display_props)
                         {
-                            ImGui::TableSetBgColor(
-                                ImGuiTableBgTarget_CellBg,
-                                (color_wheel[m_columns[j].color_index.value() %
-                                             color_wheel.size()] &
-                                 ~IM_COL32_A_MASK) |
-                                    (64 << IM_COL32_A_SHIFT));
+                            if(m_rows[i].cells[j].display_props->bg_color)
+                            {
+                                ImGui::TableSetBgColor(
+                                    ImGuiTableBgTarget_CellBg,
+                                    (m_settings.GetColor(
+                                         m_rows[i]
+                                             .cells[j]
+                                             .display_props->bg_color.value()
+                                             .color) &
+                                     ~IM_COL32_A_MASK) |
+                                        (((m_settings.GetColor(
+                                               m_rows[i]
+                                                   .cells[j]
+                                                   .display_props->bg_color.value()
+                                                   .color) >>
+                                           IM_COL32_A_SHIFT) &
+                                          0xFF) *
+                                             m_rows[i]
+                                                 .cells[j]
+                                                 .display_props->bg_color.value()
+                                                 .alpha /
+                                             255
+                                         << IM_COL32_A_SHIFT));
+                            }
+                            if(m_rows[i].cells[j].display_props->text_color)
+                            {
+                                ImGui::PushStyleColor(
+                                    ImGuiCol_Text,
+                                    m_settings.GetColor(
+                                        m_rows[i]
+                                            .cells[j]
+                                            .display_props->text_color.value()
+                                            .color));
+                            }
+                            if(m_rows[i].cells[j].display_props->icon)
+                            {
+                                ImGui::PushFont(m_settings.GetFontManager().GetIconFont(
+                                    FontType::kDefault));
+                                ImGui::TextUnformatted(
+                                    m_rows[i].cells[j].display_props->icon.value());
+                                ImGui::PopFont();
+                                ImGui::SameLine(ImGui::GetFrameHeightWithSpacing());
+                            }
                         }
                         switch(m_columns[j].type)
                         {
@@ -1031,22 +1173,15 @@ ComputeComparisonView::Table::Render()
                             }
                             default:
                             {
-                                if(m_rows[i].cells[j].empty())
+                                if(m_rows[i].cells[j].data.empty())
                                 {
                                     ImGui::TextDisabled("N/A");
                                 }
                                 else
                                 {
-                                    if(m_rows[i].text_color)
-                                    {
-                                        ImGui::PushStyleColor(
-                                            ImGuiCol_Text,
-                                            m_settings.GetColor(
-                                                m_rows[i].text_color.value()));
-                                    }
-                                    CopyableTextUnformatted(m_rows[i].cells[j].data(), "",
-                                                            COPY_DATA_NOTIFICATION, false,
-                                                            true);
+                                    CopyableTextUnformatted(
+                                        m_rows[i].cells[j].data.data(), "",
+                                        COPY_DATA_NOTIFICATION, false, true);
                                     switch(m_columns[j].type)
                                     {
                                         case Column::MetricName:
@@ -1072,12 +1207,15 @@ ComputeComparisonView::Table::Render()
                                             break;
                                         }
                                     }
-                                    if(m_rows[i].text_color)
-                                    {
-                                        ImGui::PopStyleColor();
-                                    }
                                 }
                                 break;
+                            }
+                        }
+                        if(m_rows[i].cells[j].display_props)
+                        {
+                            if(m_rows[i].cells[j].display_props->text_color)
+                            {
+                                ImGui::PopStyleColor();
                             }
                         }
                         ImGui::PopID();
@@ -1119,49 +1257,50 @@ ComputeComparisonView::Table::ReserveRows(size_t rows)
 }
 
 void
-ComputeComparisonView::Table::AddRow(const AvailableMetrics::Entry*      entry,
-                                     std::vector<std::string>&           value_names,
-                                     std::vector<std::optional<double>>& value_data,
-                                     std::optional<Colors>               text_color,
-                                     std::optional<size_t>               tag)
+ComputeComparisonView::Table::AddRow(const AvailableMetrics::Entry* entry,
+                                     std::vector<Value>&            values,
+                                     DisplayProps                   display_props,
+                                     std::optional<size_t>          tag)
 {
-    // Add a row associated with a specfic Entry...
-    if(value_names.size() == value_data.size())
+    if(entry)
     {
-        std::unordered_map<std::string, std::string> value_map;
-        for(size_t i = 0; i < value_names.size(); i++)
+        std::unordered_map<std::string, Row::Value> values_map;
+        for(size_t i = 0; i < values.size(); i++)
         {
+            values_map[values[i].name].name = values[i].name;
             // Convert data to string...
-            if(value_data[i])
+            if(values[i].data)
             {
                 std::ostringstream oss;
-                oss << std::fixed << std::setprecision(2) << value_data[i].value();
-                value_map[value_names[i]] = oss.str();
+                oss << std::fixed << std::setprecision(SIGNIFICANT_DIGITS)
+                    << values[i].data.value();
+                values_map[values[i].name].data = oss.str();
             }
             else
             {
-                value_map[value_names[i]];
+                values_map[values[i].name];
             }
             // Map value names (columns)...
-            if(m_value_columns.count(value_names[i]) == 0)
+            if(m_value_columns.count(values[i].name) == 0)
             {
-                m_ordered_value_names.push_back(value_names[i]);
-                m_value_columns[value_names[i]] =
-                    Column{ Column::Value, value_names[i], 1 };
+                m_ordered_value_names.push_back(values[i].name);
+                m_value_columns[values[i].name] =
+                    Column{ Column::Value, values[i].name, 1 };
             }
             else
             {
-                m_value_columns.at(value_names[i]).ref_count++;
+                m_value_columns.at(values[i].name).ref_count++;
             }
+            values_map[values[i].name].display_props = std::move(values[i].display_props);
         }
         m_rows.emplace_back(Row{ Row::ID{ std::to_string(entry->category_id) + "." +
                                               std::to_string(entry->table_id) + "." +
                                               std::to_string(entry->id),
                                           entry->name },
                                  entry,
-                                 std::move(value_map),
+                                 std::move(values_map),
                                  {},
-                                 text_color,
+                                 std::move(display_props),
                                  {},
                                  false });
         if(tag && tag.value() < MAX_ROW_TAGS)
@@ -1210,15 +1349,6 @@ ComputeComparisonView::Table::ClearRows()
     m_rows.clear();
     m_columns.clear();
     m_visible_row_count = 0;
-}
-
-void
-ComputeComparisonView::Table::SetColumnColor(const std::string& column_name,
-                                             bool fuzzy_match, size_t color_index)
-{
-    m_column_color_rules.push_back(
-        ColumnColorRule{ column_name, fuzzy_match, color_index });
-    m_rows_changed = true;
 }
 
 void

--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -406,7 +406,8 @@ ComputeComparisonView::UpdateMetrics()
                                             std::min(static_cast<ImU32>(
                                                          std::abs(rounded_target -
                                                                   rounded_baseline) /
-                                                         rounded_baseline * 255 + 25),
+                                                             rounded_baseline * 255 +
+                                                         25),
                                                      ImU32(255));
                                     }
                                 }

--- a/src/view/src/compute/rocprofvis_compute_comparison.h
+++ b/src/view/src/compute/rocprofvis_compute_comparison.h
@@ -76,7 +76,8 @@ private:
                 std::string  data;
                 DisplayProps display_props;
             };
-            // Render representation, rebuilt/reordered as needed when rows/columns change...
+            // Render representation, rebuilt/reordered as needed when rows/columns
+            // change...
             struct Cell
             {
                 std::string_view    data;

--- a/src/view/src/compute/rocprofvis_compute_comparison.h
+++ b/src/view/src/compute/rocprofvis_compute_comparison.h
@@ -38,6 +38,25 @@ private:
     public:
         static constexpr size_t MAX_ROW_TAGS = 8;
 
+        // Visuals supported by each cell...
+        struct DisplayProps
+        {
+            struct Color
+            {
+                Colors color;
+                ImU32  alpha;
+            };
+            std::optional<Color>       bg_color;
+            std::optional<Color>       text_color;
+            std::optional<const char*> icon;
+        };
+        // Clients populate data via Rows of Values...
+        struct Value
+        {
+            std::string           name;
+            std::optional<double> data;
+            DisplayProps          display_props;
+        };
         struct Row
         {
             struct ID
@@ -50,13 +69,26 @@ private:
                     return metric_id == other.metric_id && entry_name == other.entry_name;
                 }
             };
-            ID                                           id;
-            const AvailableMetrics::Entry*               entry;
-            std::unordered_map<std::string, std::string> values_map;
-            std::vector<std::string_view>                cells;
-            std::optional<Colors>                        text_color;
-            std::bitset<MAX_ROW_TAGS>                    tags;
-            mutable bool                                 selected;
+            // Internal persistant Value storage, never changes once added...
+            struct Value
+            {
+                std::string  name;
+                std::string  data;
+                DisplayProps display_props;
+            };
+            // Render representation, rebuilt/reordered as needed when rows/columns change...
+            struct Cell
+            {
+                std::string_view    data;
+                const DisplayProps* display_props;
+            };
+            ID                                     id;
+            const AvailableMetrics::Entry*         entry;
+            std::unordered_map<std::string, Value> values_map;
+            std::vector<Cell>                      cells;
+            DisplayProps                           display_props;
+            std::bitset<MAX_ROW_TAGS>              tags;
+            mutable bool                           selected;
 
             bool operator==(const Row& other) const { return id == other.id; }
         };
@@ -75,18 +107,14 @@ private:
 
         // Row manipulation...
         void ReserveRows(size_t rows);
-        void AddRow(const AvailableMetrics::Entry*      entry,
-                    std::vector<std::string>&           value_names,
-                    std::vector<std::optional<double>>& value_data,
-                    std::optional<Colors>               text_color = std::nullopt,
-                    std::optional<size_t>               tag        = std::nullopt);
+        void AddRow(const AvailableMetrics::Entry* entry, std::vector<Value>& values,
+                    DisplayProps          display_props = {},
+                    std::optional<size_t> tag           = std::nullopt);
         void AddRow(const Table& table, const size_t index);
         void RemoveRow(size_t index);
         void ClearRows();
 
         // Customization...
-        void SetColumnColor(const std::string& column_name, bool fuzzy_match,
-                            size_t color_index);
         void ApplyRowFilter(size_t tag);
         void RemoveRowFilter(size_t tag);
 
@@ -107,16 +135,9 @@ private:
                 Value,
                 Unit,
             };
-            Type                  type;
-            std::string           name;
-            uint32_t              ref_count;
-            std::optional<size_t> color_index;
-        };
-        struct ColumnColorRule
-        {
+            Type        type;
             std::string name;
-            bool        fuzzy_match;
-            size_t      color_index;
+            uint32_t    ref_count;
         };
 
         // Public properties...
@@ -132,7 +153,6 @@ private:
         std::vector<std::string>                m_ordered_value_names;
         std::unordered_map<std::string, Column> m_value_columns;
         std::vector<Column>                     m_columns;
-        std::vector<ColumnColorRule>            m_column_color_rules;
         std::vector<Row>                        m_rows;
 
         // Internal state...
@@ -196,7 +216,6 @@ private:
     std::unique_ptr<Table>           m_bookmark_table;
     LayoutItem*                      m_bookmark_item;
     float                            m_max_bookmark_height;
-    float                            m_toolbar_spacer_width;
     float                            m_toolbar_available_width;
 
     // Requests...

--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -5,7 +5,7 @@ namespace RocProfVis
 {
 namespace View
 {
-constexpr ImWchar icon_ranges[] = { 
+constexpr ImWchar icon_ranges[] = {
     0xF128, 0xF128,
     0xF133, 0xF133, 
     0xF13D, 0xF13D, 
@@ -18,6 +18,8 @@ constexpr ImWchar icon_ranges[] = {
     0xF306, 0xF306,
     0xF33F, 0xF33F,
     0xF35C, 0xF35C,
+    0xF35D, 0xF35D,
+    0xF366, 0xF366,
     0xF37E, 0xF37E,
     0xF3A8, 0xF3A8, 
     0xF424, 0xF424,
@@ -39,6 +41,8 @@ constexpr const char* ICON_DELETE        = u8"\uF2D7";
 constexpr const char* ICON_EYE_SLASH     = u8"\uF306";
 constexpr const char* ICON_TREE          = u8"\uF33F";
 constexpr const char* ICON_GRID          = u8"\uF35C";
+constexpr const char* ICON_ARROW_DOWN    = u8"\uF35D";
+constexpr const char* ICON_ARROW_UP      = u8"\uF366";
 constexpr const char* ICON_EDIT          = u8"\uF37E";
 constexpr const char* ICON_ARROWS_CYCLE  = u8"\uF3A8";
 constexpr const char* ICON_EYE_THIN      = u8"\uF424";

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -21,56 +21,56 @@ namespace View
 
 
 constexpr std::array DARK_THEME_COLORS = {
-    IM_COL32(52, 54, 58, 255),     // kMetaDataColor
-    IM_COL32(44, 46, 50, 255),     // kMetaDataColorSelected
-    IM_COL32(68, 70, 74, 255),     // kMetaDataSeparator
-    IM_COL32(0, 0, 0, 0),          // kTransparent
-    IM_COL32(224, 62, 62, 255),    // kTextError
-    IM_COL32(90, 200, 120, 255),   // kTextSuccess
-    IM_COL32(186, 154, 160, 255),  // kFlameChartColor
-    IM_COL32(180, 180, 190, 60),   // kGridColor
-    IM_COL32(224, 62, 62, 255),    // kGridRed
-    IM_COL32(255, 120, 120, 255),  // kSelectionBorder
-    IM_COL32(224, 62, 62, 100),    // kSelection
-    IM_COL32(170, 170, 180, 255),  // kBoundBox
-    IM_COL32(36, 38, 42, 255),     // kFillerColor
-    IM_COL32(90, 90, 100, 255),    // kScrollBarColor
-    IM_COL32(255, 140, 140, 120),  // kHighlightChart
-    IM_COL32(62, 64, 68, 255),     // kRulerBgColor
-    IM_COL32(220, 220, 220, 255),  // kRulerTextColor
-    IM_COL32(220, 220, 220, 255),  // kScrubberNumberColor
-    IM_COL32(224, 62, 62, 180),    // kArrowColor
-    IM_COL32(62, 64, 68, 255),     // kBorderColor
-    IM_COL32(90, 90, 100, 255),    // kSplitterColor
-    IM_COL32(28, 30, 34, 255),     // kBgMain
-    IM_COL32(38, 40, 44, 255),     // kBgPanel
-    IM_COL32(44, 46, 50, 255),     // kBgFrame
-    IM_COL32(224, 62, 62, 255),    // kAccentRed
-    IM_COL32(255, 140, 140, 255),  // kAccentRedHover
-    IM_COL32(181, 40, 40, 255),    // kAccentRedActive
-    IM_COL32(215, 85, 85, 255),    // kTabAccent
-    IM_COL32(235, 115, 115, 255),  // kTabAccentHover
-    IM_COL32(185, 65, 68, 255),    // kTabAccentActive
-    IM_COL32(80, 80, 90, 255),     // kBorderGray
-    IM_COL32(235, 235, 240, 255),  // kTextMain
-    IM_COL32(170, 170, 180, 255),  // kTextDim
-    IM_COL32(52, 54, 58, 255),     // kScrollBg
-    IM_COL32(100, 100, 110, 255),  // kScrollGrab
-    IM_COL32(80, 80, 90, 255),     // kTableHeaderBg
-    IM_COL32(100, 100, 110, 255),  // kTableBorderStrong
-    IM_COL32(62, 64, 68, 255),     // kTableBorderLight
-    IM_COL32(52, 54, 58, 255),     // kTableRowBg
-    IM_COL32(58, 60, 64, 255),     // kTableRowBgAlt
-    IM_COL32(255, 128, 110, 220),  // kEventHighlight
-    IM_COL32(50, 220, 100, 240),   // kEventSearchHighlight
-    IM_COL32(235, 235, 240, 69),  // kLineChartColor
-    IM_COL32(100, 100, 110, 255),  // kButton
-    IM_COL32(130, 130, 140, 255),  // kButtonHovered
-    IM_COL32(160, 160, 170, 255),  // kButtonActive
-    IM_COL32(180, 160, 60, 255),   // kBgWarning
-    IM_COL32(160, 60, 60, 255),    // kBgError
-    IM_COL32(60, 160, 60, 255),    // kBgSuccess
-    IM_COL32(60, 80, 100, 255),    // kStickyNoteYellow
+    IM_COL32(52, 54, 58, 255),     // Colors::kMetaDataColor
+    IM_COL32(44, 46, 50, 255),     // Colors::kMetaDataColorSelected
+    IM_COL32(68, 70, 74, 255),     // Colors::kMetaDataSeparator
+    IM_COL32(0, 0, 0, 0),          // Colors::kTransparent
+    IM_COL32(224, 62, 62, 255),    // Colors::kTextError
+    IM_COL32(90, 200, 120, 255),   // Colors::kTextSuccess
+    IM_COL32(186, 154, 160, 255),  // Colors::kFlameChartColor
+    IM_COL32(180, 180, 190, 60),   // Colors::kGridColor
+    IM_COL32(224, 62, 62, 255),    // Colors::kGridRed
+    IM_COL32(255, 120, 120, 255),  // Colors::kSelectionBorder
+    IM_COL32(224, 62, 62, 100),    // Colors::kSelection
+    IM_COL32(170, 170, 180, 255),  // Colors::kBoundBox
+    IM_COL32(36, 38, 42, 255),     // Colors::kFillerColor
+    IM_COL32(90, 90, 100, 255),    // Colors::kScrollBarColor
+    IM_COL32(255, 140, 140, 120),  // Colors::kHighlightChart
+    IM_COL32(62, 64, 68, 255),     // Colors::kRulerBgColor
+    IM_COL32(220, 220, 220, 255),  // Colors::kRulerTextColor
+    IM_COL32(220, 220, 220, 255),  // Colors::kScrubberNumberColor
+    IM_COL32(224, 62, 62, 180),    // Colors::kArrowColor
+    IM_COL32(62, 64, 68, 255),     // Colors::kBorderColor
+    IM_COL32(90, 90, 100, 255),    // Colors::kSplitterColor
+    IM_COL32(28, 30, 34, 255),     // Colors::kBgMain
+    IM_COL32(38, 40, 44, 255),     // Colors::kBgPanel
+    IM_COL32(44, 46, 50, 255),     // Colors::kBgFrame
+    IM_COL32(224, 62, 62, 255),    // Colors::kAccentRed
+    IM_COL32(255, 140, 140, 255),  // Colors::kAccentRedHover
+    IM_COL32(181, 40, 40, 255),    // Colors::kAccentRedActive
+    IM_COL32(215, 85, 85, 255),    // Colors::kTabAccent
+    IM_COL32(235, 115, 115, 255),  // Colors::kTabAccentHover
+    IM_COL32(185, 65, 68, 255),    // Colors::kTabAccentActive
+    IM_COL32(80, 80, 90, 255),     // Colors::kBorderGray
+    IM_COL32(235, 235, 240, 255),  // Colors::kTextMain
+    IM_COL32(170, 170, 180, 255),  // Colors::kTextDim
+    IM_COL32(52, 54, 58, 255),     // Colors::kScrollBg
+    IM_COL32(100, 100, 110, 255),  // Colors::kScrollGrab
+    IM_COL32(80, 80, 90, 255),     // Colors::kTableHeaderBg
+    IM_COL32(100, 100, 110, 255),  // Colors::kTableBorderStrong
+    IM_COL32(62, 64, 68, 255),     // Colors::kTableBorderLight
+    IM_COL32(52, 54, 58, 255),     // Colors::kTableRowBg
+    IM_COL32(58, 60, 64, 255),     // Colors::kTableRowBgAlt
+    IM_COL32(255, 128, 110, 220),  // Colors::kEventHighlight
+    IM_COL32(50, 220, 100, 240),   // Colors::kEventSearchHighlight
+    IM_COL32(235, 235, 240, 69),   // Colors::kLineChartColor
+    IM_COL32(100, 100, 110, 255),  // Colors::kButton
+    IM_COL32(130, 130, 140, 255),  // Colors::kButtonHovered
+    IM_COL32(160, 160, 170, 255),  // Colors::kButtonActive
+    IM_COL32(180, 160, 60, 255),   // Colors::kBgWarning
+    IM_COL32(160, 60, 60, 255),    // Colors::kBgError
+    IM_COL32(60, 160, 60, 255),    // Colors::kBgSuccess
+    IM_COL32(60, 80, 100, 255),    // Colors::kStickyNoteYellow
     IM_COL32(230, 240, 255, 140),  // Colors::kLineChartColorAlt
     IM_COL32(255, 0, 0, 64),       // Colors::kTrackWarningBand
     IM_COL32(60, 80, 120, 255),    // Colors::kMinimapBin1
@@ -90,7 +90,10 @@ constexpr std::array DARK_THEME_COLORS = {
     IM_COL32(0, 0, 0, 255),        // Colors::kMinimapBg
     IM_COL32(0, 0, 0, 180),        // Colors::kLoadingScreenColor
     IM_COL32(255, 255, 255, 255),  // Colors::kTextOnAccent
-
+    IM_COL32(45, 60, 95, 255),     // Colors::kComparisonBase
+    IM_COL32(30, 80, 75, 255),     // Colors::kComparisonTarget
+    IM_COL32(95, 70, 30, 255),     // Colors::kComparisonLesser
+    IM_COL32(70, 45, 90, 255),     // Colors::kComparisonGreater
     // This must follow the ordering of Colors enum.
 };
 constexpr std::array LIGHT_THEME_COLORS = {
@@ -136,7 +139,7 @@ constexpr std::array LIGHT_THEME_COLORS = {
     IM_COL32(252, 250, 248, 255),  // Colors::kTableRowBgAlt
     IM_COL32(224, 94, 78, 210),    // Colors::kEventHighlight
     IM_COL32(30, 180, 80, 230),    // Colors::kEventSearchHighlight
-    IM_COL32(0, 0, 0, 69),        // Colors::kLineChartColor
+    IM_COL32(0, 0, 0, 69),         // Colors::kLineChartColor
     IM_COL32(230, 230, 230, 255),  // Colors::kButton
     IM_COL32(210, 210, 210, 255),  // Colors::kButtonHovered
     IM_COL32(180, 180, 180, 255),  // Colors::kButtonActive
@@ -163,7 +166,10 @@ constexpr std::array LIGHT_THEME_COLORS = {
     IM_COL32(255, 255, 255, 255),  // Colors::kMinimapBg
     IM_COL32(0, 0, 0, 60),         // Colors::kLoadingScreenColor
     IM_COL32(255, 255, 255, 255),  // Colors::kTextOnAccent
-
+    IM_COL32(180, 195, 230, 255),  // Colors::kComparisonBase
+    IM_COL32(175, 220, 215, 255),  // Colors::kComparisonTarget
+    IM_COL32(235, 215, 175, 255),  // Colors::kComparisonLesser
+    IM_COL32(210, 190, 230, 255),  // Colors::kComparisonGreater
     // This must follow the ordering of Colors enum.
 };
 const std::vector<ImU32> DARK_FLAME_COLORS = {

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -128,6 +128,11 @@ enum class Colors
     kMinimapBg,
     kLoadingScreenColor,
     kTextOnAccent,
+
+    kComparisonBase,
+    kComparisonTarget,
+    kComparisonLesser,
+    kComparisonGreater,
     // Used to get the size of the enum, insert new colors before this line
     __kLastColor
 };


### PR DESCRIPTION
- Selective coloring for metrics with non-zero differences.
  - Updated `ComputeComparisonView::Table` to allow each cell to carry visual customizations:
    - Text color, BG color, icon. 
  - Removed rule-based column coloring.
- Fixed precision errors in difference values by rounding prior to calculation.
  <img width="5120" height="2676" alt="image" src="https://github.com/user-attachments/assets/1f824bdf-f0d2-461e-8151-73497030b23b" />
