### PR TITLE
Comparison view delta threshold control

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -123,7 +123,6 @@ ComputeComparisonView::Update()
         {
             m_tab_container->SetActiveTab(m_active_tab_id);
         }
-        m_data_changed = false;
     }
     for(const CategoryModel& category : m_categories)
     {
@@ -138,6 +137,11 @@ ComputeComparisonView::Update()
     if(m_pinned_table)
     {
         m_pinned_table->Update();
+    }
+    if(m_data_changed)
+    {
+        UpdateDifferenceHighlighting();
+        m_data_changed = false;
     }
 }
 
@@ -283,6 +287,7 @@ ComputeComparisonView::UpdateMetrics()
                                                         m_target_kernel_id))
         {
             m_categories.clear();
+            m_diff_cell_groups.clear();
             m_tab_container = std::make_unique<TabContainer>();
             std::vector<const AvailableMetrics::Category*> baseline_categories =
                 m_data_provider.ComputeModel()
@@ -376,29 +381,50 @@ ComputeComparisonView::UpdateMetrics()
                             std::optional<Table::DisplayProps::Color> bg_color_difference;
                             std::optional<Table::DisplayProps::Color> text_color;
                             std::optional<const char*>                icon;
+                            double percentage_diff = 0.0;
+                            Colors diff_color      = Colors::kComparisonGreater;
+                            ImU32  diff_alpha      = 255;
                             if(valid_match)
                             {
                                 if(baseline_value && target_value &&
                                    rounded_baseline != rounded_target)
                                 {
-                                    Colors      diff_color = Colors::kComparisonGreater;
-                                    const char* diff_icon  = ICON_ARROW_UP;
-                                    ImU32       diff_alpha = 255;
-                                    if(GetDifferenceHighlightProps(
-                                           rounded_baseline, rounded_target,
-                                           diff_color, diff_icon, diff_alpha))
+                                    const char* diff_icon =
+                                        (rounded_target > rounded_baseline)
+                                            ? ICON_ARROW_UP
+                                            : ICON_ARROW_DOWN;
+                                    diff_color =
+                                        (rounded_target > rounded_baseline)
+                                            ? Colors::kComparisonGreater
+                                            : Colors::kComparisonLesser;
+                                    if(rounded_baseline != 0.0)
                                     {
-                                        bg_color_baseline = Table::DisplayProps::Color{
-                                            Colors::kComparisonBase, 255
-                                        };
-                                        bg_color_target = Table::DisplayProps::Color{
-                                            Colors::kComparisonTarget, 255
-                                        };
-                                        bg_color_difference =
-                                            Table::DisplayProps::Color{ diff_color,
-                                                                        diff_alpha };
-                                        icon = diff_icon;
+                                        percentage_diff =
+                                            std::abs((rounded_target -
+                                                      rounded_baseline) /
+                                                     rounded_baseline * 100.0);
+                                        diff_alpha = std::min(
+                                            static_cast<ImU32>(
+                                                std::abs(rounded_target -
+                                                         rounded_baseline) /
+                                                    rounded_baseline * 255 +
+                                                25),
+                                            ImU32(255));
                                     }
+                                    else
+                                    {
+                                        percentage_diff = 100.0;
+                                    }
+                                    bg_color_baseline = Table::DisplayProps::Color{
+                                        Colors::kComparisonBase, 255
+                                    };
+                                    bg_color_target = Table::DisplayProps::Color{
+                                        Colors::kComparisonTarget, 255
+                                    };
+                                    bg_color_difference =
+                                        Table::DisplayProps::Color{ diff_color,
+                                                                    diff_alpha };
+                                    icon = diff_icon;
                                 }
                             }
                             else
@@ -413,18 +439,16 @@ ComputeComparisonView::UpdateMetrics()
                                 baseline_value ? std::make_optional(rounded_baseline)
                                                : std::nullopt,
                                 Table::DisplayProps{ bg_color_baseline, text_color,
-                                                     std::nullopt },
-                                Table::Value::Role::Baseline,
-                                value_name });
+                                                     std::nullopt } });
+                            size_t baseline_index = row_value[0].size() - 1;
+
                             row_value[0].emplace_back(Table::Value{
                                 "Target " + value_name,
                                 valid_match && target_value
                                     ? std::make_optional(rounded_target)
                                     : std::nullopt,
                                 Table::DisplayProps{ bg_color_target, text_color,
-                                                     std::nullopt },
-                                Table::Value::Role::Target,
-                                value_name });
+                                                     std::nullopt } });
                             row_value[0].emplace_back(Table::Value{
                                 "Difference##" + value_name,
                                 valid_match && baseline_value && target_value
@@ -432,9 +456,7 @@ ComputeComparisonView::UpdateMetrics()
                                                          rounded_baseline)
                                     : std::nullopt,
                                 Table::DisplayProps{ bg_color_difference, text_color,
-                                                     icon },
-                                Table::Value::Role::Difference,
-                                value_name });
+                                                     icon } });
                             row_value[0].emplace_back(Table::Value{
                                 "Difference (%)##" + value_name,
                                 valid_match && baseline_value && target_value &&
@@ -446,37 +468,43 @@ ComputeComparisonView::UpdateMetrics()
                                           ROUND_FACTOR)
                                     : std::nullopt,
                                 Table::DisplayProps{ bg_color_difference, text_color,
-                                                     icon },
-                                Table::Value::Role::DifferencePercent,
-                                value_name });
+                                                     icon } });
+                            // Track cells that are marked as different for
+                            // threshold-based recoloring...
+                            if(valid_match && bg_color_difference.has_value())
+                            {
+                                constexpr size_t FIXED_PREFIX = 3;
+                                m_diff_cell_groups.push_back(DiffCellGroup{
+                                    category_model.tables[i].get(),
+                                    category_model.tables[i]->Rows().size(),
+                                    FIXED_PREFIX + baseline_index,
+                                    FIXED_PREFIX + baseline_index + 1,
+                                    FIXED_PREFIX + baseline_index + 2,
+                                    FIXED_PREFIX + baseline_index + 3,
+                                    percentage_diff,
+                                    diff_color,
+                                    diff_alpha });
+                            }
                             if(!valid_match && row_entry.count(1) > 0)
                             {
                                 row_value[1].emplace_back(Table::Value{
                                     "Baseline " + value_name, std::nullopt,
                                     Table::DisplayProps{ bg_color_baseline, text_color,
-                                                         std::nullopt },
-                                    Table::Value::Role::Baseline,
-                                    value_name });
+                                                         std::nullopt } });
                                 row_value[1].emplace_back(Table::Value{
                                     "Target " + value_name,
                                     target_value ? std::make_optional(rounded_target)
                                                  : std::nullopt,
                                     Table::DisplayProps{ bg_color_target, text_color,
-                                                         std::nullopt },
-                                    Table::Value::Role::Target,
-                                    value_name });
+                                                         std::nullopt } });
                                 row_value[1].emplace_back(Table::Value{
                                     "Difference##" + value_name, std::nullopt,
                                     Table::DisplayProps{ std::nullopt, text_color,
-                                                         std::nullopt },
-                                    Table::Value::Role::Difference,
-                                    value_name });
+                                                         std::nullopt } });
                                 row_value[1].emplace_back(Table::Value{
                                     "Difference (%)##" + value_name, std::nullopt,
                                     Table::DisplayProps{ std::nullopt, text_color,
-                                                         std::nullopt },
-                                    Table::Value::Role::DifferencePercent,
-                                    value_name });
+                                                         std::nullopt } });
                             }
                         }
                         for(uint32_t k = 0; k < row_value.size(); k++)
@@ -497,6 +525,7 @@ ComputeComparisonView::UpdateMetrics()
                                                       ROW_TAG_INVALID_MATCH));
                             }
                         }
+
                     }
                     // Setup the table (handlers, coloring..etc)
                     category_model.tables[i]->SetRowSelectionHandler(
@@ -529,180 +558,102 @@ ComputeComparisonView::UpdateMetrics()
                 }
             }
             m_tab_container->SetAllowToolTips(true);
+
+            // Build lookup for pinned table highlighting...
+            m_diff_by_metric_id.clear();
+            for(const DiffCellGroup& dcg : m_diff_cell_groups)
+            {
+                const Table::Row& row = dcg.table->Rows()[dcg.row_index];
+                m_diff_by_metric_id[row.id.metric_id].push_back(&dcg);
+            }
         }
     }
-}
-
-bool
-ComputeComparisonView::GetDifferenceHighlightProps(double      rounded_baseline,
-                                                   double      rounded_target,
-                                                   Colors&     diff_color,
-                                                   const char*& icon,
-                                                   ImU32&      alpha) const
-{
-    if(rounded_baseline == rounded_target)
-    {
-        return false;
-    }
-
-    double percentage_diff = 0.0;
-    if(rounded_baseline != 0.0)
-    {
-        percentage_diff =
-            std::abs((rounded_target - rounded_baseline) / rounded_baseline * 100.0);
-    }
-    else if(rounded_target != 0.0)
-    {
-        // If baseline is 0 but target is not
-        percentage_diff = 100.0;
-    }
-
-    if(percentage_diff < m_percentage_threshold)
-    {
-        return false;
-    }
-
-    if(rounded_target > rounded_baseline)
-    {
-        diff_color = Colors::kComparisonGreater;
-        icon       = ICON_ARROW_UP;
-    }
-    else
-    {
-        diff_color = Colors::kComparisonLesser;
-        icon       = ICON_ARROW_DOWN;
-    }
-
-    alpha = 255;
-    if(rounded_baseline != 0.0)
-    {
-        alpha = std::min(static_cast<ImU32>(
-                             std::abs(rounded_target - rounded_baseline) /
-                                 rounded_baseline * 255 +
-                             25),
-                         ImU32(255));
-    }
-
-    return true;
 }
 
 void
 ComputeComparisonView::UpdateDifferenceHighlighting()
 {
-    auto recolor_table = [this](Table& table) {
-        std::vector<Table::Row>& rows = table.MutableRows();
-        for(Table::Row& row : rows)
+    auto apply_group = [this](DiffCellGroup& group) {
+        Table::Row& row = group.table->MutableRows()[group.row_index];
+        if(group.percent_diff >= m_percentage_threshold)
         {
-            // Skip mismatched rows. They keep their dimmed appearance.
-            if(row.tags.test(ROW_TAG_INVALID_MATCH))
-            {
-                continue;
-            }
-
-            struct ValueGroup
-            {
-                Table::Row::Value* baseline = nullptr;
-                Table::Row::Value* target   = nullptr;
-                Table::Row::Value* diff     = nullptr;
-                Table::Row::Value* diff_pct = nullptr;
-            };
-            std::unordered_map<std::string, ValueGroup> grouped_values;
-            for(auto& [_, value] : row.values_map)
-            {
-                ValueGroup& group = grouped_values[value.compare_group];
-                switch(value.role)
-                {
-                    case Table::Value::Role::Baseline:
-                    {
-                        group.baseline = &value;
-                        break;
-                    }
-                    case Table::Value::Role::Target:
-                    {
-                        group.target = &value;
-                        break;
-                    }
-                    case Table::Value::Role::Difference:
-                    {
-                        group.diff = &value;
-                        break;
-                    }
-                    case Table::Value::Role::DifferencePercent:
-                    {
-                        group.diff_pct = &value;
-                        break;
-                    }
-                    default:
-                    {
-                        break;
-                    }
-                }
-            }
-
-            for(auto& [_, group] : grouped_values)
-            {
-                if(!group.baseline || !group.target || !group.diff || !group.diff_pct)
-                {
-                    continue;
-                }
-
-                Table::Row::Value& baseline_value = *group.baseline;
-                Table::Row::Value& target_value   = *group.target;
-                Table::Row::Value& diff_value     = *group.diff;
-                Table::Row::Value& diff_pct_value = *group.diff_pct;
-
-                baseline_value.display_props.bg_color = std::nullopt;
-                target_value.display_props.bg_color   = std::nullopt;
-                diff_value.display_props.bg_color     = std::nullopt;
-                diff_pct_value.display_props.bg_color = std::nullopt;
-                diff_value.display_props.icon         = std::nullopt;
-                diff_pct_value.display_props.icon     = std::nullopt;
-
-                if(baseline_value.data.empty() || target_value.data.empty())
-                {
-                    continue;
-                }
-
-                const double rounded_baseline = std::atof(baseline_value.data.c_str());
-                const double rounded_target   = std::atof(target_value.data.c_str());
-                Colors      diff_color = Colors::kComparisonGreater;
-                const char* diff_icon  = ICON_ARROW_UP;
-                ImU32       diff_alpha = 255;
-                if(!GetDifferenceHighlightProps(rounded_baseline, rounded_target,
-                                                diff_color, diff_icon, diff_alpha))
-                {
-                    continue;
-                }
-
-                baseline_value.display_props.bg_color =
-                    Table::DisplayProps::Color{ Colors::kComparisonBase, 255 };
-                target_value.display_props.bg_color =
-                    Table::DisplayProps::Color{ Colors::kComparisonTarget, 255 };
-                diff_value.display_props.bg_color =
-                    Table::DisplayProps::Color{ diff_color, diff_alpha };
-                diff_pct_value.display_props.bg_color =
-                    Table::DisplayProps::Color{ diff_color, diff_alpha };
-                diff_value.display_props.icon     = diff_icon;
-                diff_pct_value.display_props.icon = diff_icon;
-            }
+            row.cells[group.baseline_index].display_props->bg_color =
+                Table::DisplayProps::Color{ Colors::kComparisonBase, 255 };
+            row.cells[group.target_index].display_props->bg_color =
+                Table::DisplayProps::Color{ Colors::kComparisonTarget, 255 };
+            row.cells[group.difference_index].display_props->bg_color =
+                Table::DisplayProps::Color{ group.diff_color, group.diff_alpha };
+            row.cells[group.difference_percent_index].display_props->bg_color =
+                Table::DisplayProps::Color{ group.diff_color, group.diff_alpha };
+        }
+        else
+        {
+            row.cells[group.baseline_index].display_props->bg_color = std::nullopt;
+            row.cells[group.target_index].display_props->bg_color   = std::nullopt;
+            row.cells[group.difference_index].display_props->bg_color = std::nullopt;
+            row.cells[group.difference_percent_index].display_props->bg_color =
+                std::nullopt;
         }
     };
 
-    for(CategoryModel& category : m_categories)
+    for(DiffCellGroup& group : m_diff_cell_groups)
     {
-        for(std::shared_ptr<Table>& table : category.tables)
+        apply_group(group);
+    }
+
+    // Apply to pinned table by matching source DiffCellGroups to pinned
+    // rows via row ID, then modifying values_map by value name keys...
+    if(m_pinned_table)
+    {
+        constexpr size_t FIXED_PREFIX = 3;
+        for(size_t pi = 0; pi < m_pinned_table->Rows().size(); pi++)
         {
-            if(!table)
+            Table::Row& pinned_row = m_pinned_table->MutableRows()[pi];
+            auto it = m_diff_by_metric_id.find(pinned_row.id.metric_id);
+            if(it == m_diff_by_metric_id.end())
             {
                 continue;
             }
-            recolor_table(*table);
+            for(const DiffCellGroup* src : it->second)
+            {
+                const Table::Row& src_row = src->table->Rows()[src->row_index];
+                if(src_row.id == pinned_row.id)
+                {
+                    const auto& src_names = src->table->OrderedValueNames();
+                    size_t      src_pos   = src->baseline_index - FIXED_PREFIX;
+                    auto set_bg = [&](const std::string& key,
+                                      std::optional<Table::DisplayProps::Color> color) {
+                        auto vit = pinned_row.values_map.find(key);
+                        if(vit != pinned_row.values_map.end())
+                        {
+                            vit->second.display_props.bg_color = color;
+                        }
+                    };
+                    if(src->percent_diff >= m_percentage_threshold)
+                    {
+                        set_bg(src_names[src_pos],
+                               Table::DisplayProps::Color{ Colors::kComparisonBase,
+                                                           255 });
+                        set_bg(src_names[src_pos + 1],
+                               Table::DisplayProps::Color{ Colors::kComparisonTarget,
+                                                           255 });
+                        set_bg(src_names[src_pos + 2],
+                               Table::DisplayProps::Color{ src->diff_color,
+                                                           src->diff_alpha });
+                        set_bg(src_names[src_pos + 3],
+                               Table::DisplayProps::Color{ src->diff_color,
+                                                           src->diff_alpha });
+                    }
+                    else
+                    {
+                        set_bg(src_names[src_pos], std::nullopt);
+                        set_bg(src_names[src_pos + 1], std::nullopt);
+                        set_bg(src_names[src_pos + 2], std::nullopt);
+                        set_bg(src_names[src_pos + 3], std::nullopt);
+                    }
+                }
+            }
         }
-    }
-
-    if(m_pinned_table)
-    {
-        recolor_table(*m_pinned_table);
     }
 }
 
@@ -1510,8 +1461,6 @@ ComputeComparisonView::Table::AddRow(const AvailableMetrics::Entry* entry,
                 m_value_columns.at(values[i].name).ref_count++;
             }
             values_map[values[i].name].display_props = std::move(values[i].display_props);
-            values_map[values[i].name].role          = values[i].role;
-            values_map[values[i].name].compare_group = values[i].compare_group;
         }
         m_rows.emplace_back(Row{ Row::ID{ std::to_string(entry->category_id) + "." +
                                               std::to_string(entry->table_id) + "." +

--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -46,6 +46,7 @@ ComputeComparisonView::ComputeComparisonView(
 , m_loading(false)
 , m_retry_fetch(false)
 , m_filter_common_metrics(false)
+, m_percentage_threshold(0.0f)
 , m_layout(nullptr)
 , m_toolbar_available_width(0.0f)
 , m_tab_container(nullptr)
@@ -380,35 +381,23 @@ ComputeComparisonView::UpdateMetrics()
                                 if(baseline_value && target_value &&
                                    rounded_baseline != rounded_target)
                                 {
-                                    bg_color_baseline = Table::DisplayProps::Color{
-                                        Colors::kComparisonBase, 255
-                                    };
-                                    bg_color_target = Table::DisplayProps::Color{
-                                        Colors::kComparisonTarget, 255
-                                    };
-                                    if(rounded_target > rounded_baseline)
+                                    Colors      diff_color = Colors::kComparisonGreater;
+                                    const char* diff_icon  = ICON_ARROW_UP;
+                                    ImU32       diff_alpha = 255;
+                                    if(GetDifferenceHighlightProps(
+                                           rounded_baseline, rounded_target,
+                                           diff_color, diff_icon, diff_alpha))
                                     {
-                                        bg_color_difference = Table::DisplayProps::Color{
-                                            Colors::kComparisonGreater, 255
+                                        bg_color_baseline = Table::DisplayProps::Color{
+                                            Colors::kComparisonBase, 255
                                         };
-                                        icon = ICON_ARROW_UP;
-                                    }
-                                    else
-                                    {
-                                        bg_color_difference = Table::DisplayProps::Color{
-                                            Colors::kComparisonLesser, 255
+                                        bg_color_target = Table::DisplayProps::Color{
+                                            Colors::kComparisonTarget, 255
                                         };
-                                        icon = ICON_ARROW_DOWN;
-                                    }
-                                    if(rounded_baseline != 0.0)
-                                    {
-                                        bg_color_difference.value().alpha =
-                                            std::min(static_cast<ImU32>(
-                                                         std::abs(rounded_target -
-                                                                  rounded_baseline) /
-                                                             rounded_baseline * 255 +
-                                                         25),
-                                                     ImU32(255));
+                                        bg_color_difference =
+                                            Table::DisplayProps::Color{ diff_color,
+                                                                        diff_alpha };
+                                        icon = diff_icon;
                                     }
                                 }
                             }
@@ -424,14 +413,18 @@ ComputeComparisonView::UpdateMetrics()
                                 baseline_value ? std::make_optional(rounded_baseline)
                                                : std::nullopt,
                                 Table::DisplayProps{ bg_color_baseline, text_color,
-                                                     std::nullopt } });
+                                                     std::nullopt },
+                                Table::Value::Role::Baseline,
+                                value_name });
                             row_value[0].emplace_back(Table::Value{
                                 "Target " + value_name,
                                 valid_match && target_value
                                     ? std::make_optional(rounded_target)
                                     : std::nullopt,
                                 Table::DisplayProps{ bg_color_target, text_color,
-                                                     std::nullopt } });
+                                                     std::nullopt },
+                                Table::Value::Role::Target,
+                                value_name });
                             row_value[0].emplace_back(Table::Value{
                                 "Difference##" + value_name,
                                 valid_match && baseline_value && target_value
@@ -439,7 +432,9 @@ ComputeComparisonView::UpdateMetrics()
                                                          rounded_baseline)
                                     : std::nullopt,
                                 Table::DisplayProps{ bg_color_difference, text_color,
-                                                     icon } });
+                                                     icon },
+                                Table::Value::Role::Difference,
+                                value_name });
                             row_value[0].emplace_back(Table::Value{
                                 "Difference (%)##" + value_name,
                                 valid_match && baseline_value && target_value &&
@@ -451,27 +446,37 @@ ComputeComparisonView::UpdateMetrics()
                                           ROUND_FACTOR)
                                     : std::nullopt,
                                 Table::DisplayProps{ bg_color_difference, text_color,
-                                                     icon } });
+                                                     icon },
+                                Table::Value::Role::DifferencePercent,
+                                value_name });
                             if(!valid_match && row_entry.count(1) > 0)
                             {
                                 row_value[1].emplace_back(Table::Value{
                                     "Baseline " + value_name, std::nullopt,
                                     Table::DisplayProps{ bg_color_baseline, text_color,
-                                                         std::nullopt } });
+                                                         std::nullopt },
+                                    Table::Value::Role::Baseline,
+                                    value_name });
                                 row_value[1].emplace_back(Table::Value{
                                     "Target " + value_name,
                                     target_value ? std::make_optional(rounded_target)
                                                  : std::nullopt,
                                     Table::DisplayProps{ bg_color_target, text_color,
-                                                         std::nullopt } });
+                                                         std::nullopt },
+                                    Table::Value::Role::Target,
+                                    value_name });
                                 row_value[1].emplace_back(Table::Value{
                                     "Difference##" + value_name, std::nullopt,
                                     Table::DisplayProps{ std::nullopt, text_color,
-                                                         std::nullopt } });
+                                                         std::nullopt },
+                                    Table::Value::Role::Difference,
+                                    value_name });
                                 row_value[1].emplace_back(Table::Value{
                                     "Difference (%)##" + value_name, std::nullopt,
                                     Table::DisplayProps{ std::nullopt, text_color,
-                                                         std::nullopt } });
+                                                         std::nullopt },
+                                    Table::Value::Role::DifferencePercent,
+                                    value_name });
                             }
                         }
                         for(uint32_t k = 0; k < row_value.size(); k++)
@@ -525,6 +530,179 @@ ComputeComparisonView::UpdateMetrics()
             }
             m_tab_container->SetAllowToolTips(true);
         }
+    }
+}
+
+bool
+ComputeComparisonView::GetDifferenceHighlightProps(double      rounded_baseline,
+                                                   double      rounded_target,
+                                                   Colors&     diff_color,
+                                                   const char*& icon,
+                                                   ImU32&      alpha) const
+{
+    if(rounded_baseline == rounded_target)
+    {
+        return false;
+    }
+
+    double percentage_diff = 0.0;
+    if(rounded_baseline != 0.0)
+    {
+        percentage_diff =
+            std::abs((rounded_target - rounded_baseline) / rounded_baseline * 100.0);
+    }
+    else if(rounded_target != 0.0)
+    {
+        // If baseline is 0 but target is not
+        percentage_diff = 100.0;
+    }
+
+    if(percentage_diff < m_percentage_threshold)
+    {
+        return false;
+    }
+
+    if(rounded_target > rounded_baseline)
+    {
+        diff_color = Colors::kComparisonGreater;
+        icon       = ICON_ARROW_UP;
+    }
+    else
+    {
+        diff_color = Colors::kComparisonLesser;
+        icon       = ICON_ARROW_DOWN;
+    }
+
+    alpha = 255;
+    if(rounded_baseline != 0.0)
+    {
+        alpha = std::min(static_cast<ImU32>(
+                             std::abs(rounded_target - rounded_baseline) /
+                                 rounded_baseline * 255 +
+                             25),
+                         ImU32(255));
+    }
+
+    return true;
+}
+
+void
+ComputeComparisonView::UpdateDifferenceHighlighting()
+{
+    auto recolor_table = [this](Table& table) {
+        std::vector<Table::Row>& rows = table.MutableRows();
+        for(Table::Row& row : rows)
+        {
+            // Skip mismatched rows. They keep their dimmed appearance.
+            if(row.tags.test(ROW_TAG_INVALID_MATCH))
+            {
+                continue;
+            }
+
+            struct ValueGroup
+            {
+                Table::Row::Value* baseline = nullptr;
+                Table::Row::Value* target   = nullptr;
+                Table::Row::Value* diff     = nullptr;
+                Table::Row::Value* diff_pct = nullptr;
+            };
+            std::unordered_map<std::string, ValueGroup> grouped_values;
+            for(auto& [_, value] : row.values_map)
+            {
+                ValueGroup& group = grouped_values[value.compare_group];
+                switch(value.role)
+                {
+                    case Table::Value::Role::Baseline:
+                    {
+                        group.baseline = &value;
+                        break;
+                    }
+                    case Table::Value::Role::Target:
+                    {
+                        group.target = &value;
+                        break;
+                    }
+                    case Table::Value::Role::Difference:
+                    {
+                        group.diff = &value;
+                        break;
+                    }
+                    case Table::Value::Role::DifferencePercent:
+                    {
+                        group.diff_pct = &value;
+                        break;
+                    }
+                    default:
+                    {
+                        break;
+                    }
+                }
+            }
+
+            for(auto& [_, group] : grouped_values)
+            {
+                if(!group.baseline || !group.target || !group.diff || !group.diff_pct)
+                {
+                    continue;
+                }
+
+                Table::Row::Value& baseline_value = *group.baseline;
+                Table::Row::Value& target_value   = *group.target;
+                Table::Row::Value& diff_value     = *group.diff;
+                Table::Row::Value& diff_pct_value = *group.diff_pct;
+
+                baseline_value.display_props.bg_color = std::nullopt;
+                target_value.display_props.bg_color   = std::nullopt;
+                diff_value.display_props.bg_color     = std::nullopt;
+                diff_pct_value.display_props.bg_color = std::nullopt;
+                diff_value.display_props.icon         = std::nullopt;
+                diff_pct_value.display_props.icon     = std::nullopt;
+
+                if(baseline_value.data.empty() || target_value.data.empty())
+                {
+                    continue;
+                }
+
+                const double rounded_baseline = std::atof(baseline_value.data.c_str());
+                const double rounded_target   = std::atof(target_value.data.c_str());
+                Colors      diff_color = Colors::kComparisonGreater;
+                const char* diff_icon  = ICON_ARROW_UP;
+                ImU32       diff_alpha = 255;
+                if(!GetDifferenceHighlightProps(rounded_baseline, rounded_target,
+                                                diff_color, diff_icon, diff_alpha))
+                {
+                    continue;
+                }
+
+                baseline_value.display_props.bg_color =
+                    Table::DisplayProps::Color{ Colors::kComparisonBase, 255 };
+                target_value.display_props.bg_color =
+                    Table::DisplayProps::Color{ Colors::kComparisonTarget, 255 };
+                diff_value.display_props.bg_color =
+                    Table::DisplayProps::Color{ diff_color, diff_alpha };
+                diff_pct_value.display_props.bg_color =
+                    Table::DisplayProps::Color{ diff_color, diff_alpha };
+                diff_value.display_props.icon     = diff_icon;
+                diff_pct_value.display_props.icon = diff_icon;
+            }
+        }
+    };
+
+    for(CategoryModel& category : m_categories)
+    {
+        for(std::shared_ptr<Table>& table : category.tables)
+        {
+            if(!table)
+            {
+                continue;
+            }
+            recolor_table(*table);
+        }
+    }
+
+    if(m_pinned_table)
+    {
+        recolor_table(*m_pinned_table);
     }
 }
 
@@ -606,7 +784,28 @@ ComputeComparisonView::RenderToolbar()
         ImGui::EndCombo();
     }
     ImGui::EndDisabled();
-    VerticalSeparator(&m_settings);
+    
+    float window_width = ImGui::GetWindowWidth(); 
+    VerticalSeparator(&m_settings);   
+    ImGui::TextUnformatted("Delta Threshold");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(ImGui::GetFrameHeight() * 4.0f);
+    if(ImGui::DragFloat("##threshold_percentage", &m_percentage_threshold, 0.1f,
+                        0.0f, 100.0f, "%.1f%%"))
+    {
+        UpdateDifferenceHighlighting();
+    }
+    if(BeginItemTooltipStyled())
+    {
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + window_width * 0.25f);
+        ImGui::TextUnformatted(
+            "Minimum percentage difference required to mark metrics as different. "
+            "Set to 0 to highlight all differences.");
+        ImGui::PopTextWrapPos();
+        EndTooltipStyled();
+    }
+    ImGui::SameLine();
+
     if(m_toolbar_available_width != 0.0)
     {
         float legend_width =
@@ -694,7 +893,7 @@ ComputeComparisonView::RenderToolbar()
             }
         }
     }
-    float window_width = ImGui::GetWindowWidth();
+
     if(BeginItemTooltipStyled())
     {
         ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + window_width * 0.25f);
@@ -1264,6 +1463,12 @@ ComputeComparisonView::Table::Rows() const
     return m_rows;
 }
 
+std::vector<ComputeComparisonView::Table::Row>&
+ComputeComparisonView::Table::MutableRows()
+{
+    return m_rows;
+}
+
 const std::vector<std::string>&
 ComputeComparisonView::Table::OrderedValueNames() const
 {
@@ -1312,6 +1517,8 @@ ComputeComparisonView::Table::AddRow(const AvailableMetrics::Entry* entry,
                 m_value_columns.at(values[i].name).ref_count++;
             }
             values_map[values[i].name].display_props = std::move(values[i].display_props);
+            values_map[values[i].name].role          = values[i].role;
+            values_map[values[i].name].compare_group = values[i].compare_group;
         }
         m_rows.emplace_back(Row{ Row::ID{ std::to_string(entry->category_id) + "." +
                                               std::to_string(entry->table_id) + "." +

--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -28,6 +28,7 @@ constexpr ImGuiColorEditFlags LEGEND_FLAGS =
     ImGuiColorEditFlags_NoPicker | ImGuiColorEditFlags_NoInputs |
     ImGuiColorEditFlags_NoTooltip | ImGuiColorEditFlags_NoLabel;
 constexpr size_t ROW_TAG_INVALID_MATCH = 0;
+constexpr size_t FIXED_PREFIX          = 3;
 
 ComputeComparisonView::ComputeComparisonView(
     DataProvider& data_provider, std::shared_ptr<ComputeSelection> compute_selection)
@@ -53,6 +54,7 @@ ComputeComparisonView::ComputeComparisonView(
 , m_pinned_table(nullptr)
 , m_pinned_item(nullptr)
 , m_max_pinned_height(FLT_MAX)
+, m_pinned_columns_dirty(false)
 {
     m_widget_name = GenUniqueName("ComputeComparison");
     m_pinned_table =
@@ -137,6 +139,11 @@ ComputeComparisonView::Update()
     if(m_pinned_table)
     {
         m_pinned_table->Update();
+        if(m_pinned_columns_dirty)
+        {
+            RebuildPinnedDiffEntries();
+            m_pinned_columns_dirty = false;
+        }
     }
     if(m_data_changed)
     {
@@ -473,7 +480,6 @@ ComputeComparisonView::UpdateMetrics()
                             // threshold-based recoloring...
                             if(valid_match && bg_color_difference.has_value())
                             {
-                                constexpr size_t FIXED_PREFIX = 3;
                                 m_diff_cell_groups.push_back(DiffCellGroup{
                                     category_model.tables[i].get(),
                                     category_model.tables[i]->Rows().size(),
@@ -571,10 +577,48 @@ ComputeComparisonView::UpdateMetrics()
 }
 
 void
+ComputeComparisonView::RebuildPinnedDiffEntries()
+{
+    // Pre-resolve DiffCellGroup-to-pinned-cell mappings...
+    m_pinned_diff_entries.clear();
+    std::unordered_map<std::string, size_t> col_map;
+    const auto& pinned_names = m_pinned_table->OrderedValueNames();
+    for(size_t n = 0; n < pinned_names.size(); n++)
+    {
+        col_map[pinned_names[n]] = FIXED_PREFIX + n;
+    }
+    for(size_t pi = 0; pi < m_pinned_table->Rows().size(); pi++)
+    {
+        const Table::Row& pinned_row = m_pinned_table->Rows()[pi];
+        auto it = m_diff_by_metric_id.find(pinned_row.id.metric_id);
+        if(it == m_diff_by_metric_id.end())
+        {
+            continue;
+        }
+        for(const DiffCellGroup* src : it->second)
+        {
+            const Table::Row& src_row = src->table->Rows()[src->row_index];
+            if(src_row.id == pinned_row.id)
+            {
+                const auto& src_names = src->table->OrderedValueNames();
+                size_t      src_pos   = src->baseline_index - FIXED_PREFIX;
+                auto col_it = col_map.find(src_names[src_pos]);
+                if(col_it != col_map.end())
+                {
+                    m_pinned_diff_entries.push_back({ src, pi, col_it->second });
+                }
+            }
+        }
+    }
+}
+
+void
 ComputeComparisonView::UpdateDifferenceHighlighting()
 {
-    auto apply_group = [this](DiffCellGroup& group) {
-        Table::Row& row = group.table->MutableRows()[group.row_index];
+    // Update main table cell colors based on DiffCellGroups
+    for(DiffCellGroup& group : m_diff_cell_groups)
+    {
+        const Table::Row& row = group.table->Rows()[group.row_index];
         if(group.percent_diff >= m_percentage_threshold)
         {
             row.cells[group.baseline_index].display_props->bg_color =
@@ -594,65 +638,33 @@ ComputeComparisonView::UpdateDifferenceHighlighting()
             row.cells[group.difference_percent_index].display_props->bg_color =
                 std::nullopt;
         }
-    };
-
-    for(DiffCellGroup& group : m_diff_cell_groups)
-    {
-        apply_group(group);
     }
 
-    // Apply to pinned table by matching source DiffCellGroups to pinned
-    // rows via row ID, then modifying values_map by value name keys...
-    if(m_pinned_table)
+    // Apply to pinned table using pre-resolved mappings...
+    for(const PinnedDiffEntry& entry : m_pinned_diff_entries)
     {
-        constexpr size_t FIXED_PREFIX = 3;
-        for(size_t pi = 0; pi < m_pinned_table->Rows().size(); pi++)
+        const Table::Row& pinned_row =
+            m_pinned_table->Rows()[entry.pinned_row_index];
+        size_t base = entry.pinned_base_index;
+        if(entry.source->percent_diff >= m_percentage_threshold)
         {
-            Table::Row& pinned_row = m_pinned_table->MutableRows()[pi];
-            auto it = m_diff_by_metric_id.find(pinned_row.id.metric_id);
-            if(it == m_diff_by_metric_id.end())
-            {
-                continue;
-            }
-            for(const DiffCellGroup* src : it->second)
-            {
-                const Table::Row& src_row = src->table->Rows()[src->row_index];
-                if(src_row.id == pinned_row.id)
-                {
-                    const auto& src_names = src->table->OrderedValueNames();
-                    size_t      src_pos   = src->baseline_index - FIXED_PREFIX;
-                    auto set_bg = [&](const std::string& key,
-                                      std::optional<Table::DisplayProps::Color> color) {
-                        auto vit = pinned_row.values_map.find(key);
-                        if(vit != pinned_row.values_map.end())
-                        {
-                            vit->second.display_props.bg_color = color;
-                        }
-                    };
-                    if(src->percent_diff >= m_percentage_threshold)
-                    {
-                        set_bg(src_names[src_pos],
-                               Table::DisplayProps::Color{ Colors::kComparisonBase,
-                                                           255 });
-                        set_bg(src_names[src_pos + 1],
-                               Table::DisplayProps::Color{ Colors::kComparisonTarget,
-                                                           255 });
-                        set_bg(src_names[src_pos + 2],
-                               Table::DisplayProps::Color{ src->diff_color,
-                                                           src->diff_alpha });
-                        set_bg(src_names[src_pos + 3],
-                               Table::DisplayProps::Color{ src->diff_color,
-                                                           src->diff_alpha });
-                    }
-                    else
-                    {
-                        set_bg(src_names[src_pos], std::nullopt);
-                        set_bg(src_names[src_pos + 1], std::nullopt);
-                        set_bg(src_names[src_pos + 2], std::nullopt);
-                        set_bg(src_names[src_pos + 3], std::nullopt);
-                    }
-                }
-            }
+            pinned_row.cells[base].display_props->bg_color =
+                Table::DisplayProps::Color{ Colors::kComparisonBase, 255 };
+            pinned_row.cells[base + 1].display_props->bg_color =
+                Table::DisplayProps::Color{ Colors::kComparisonTarget, 255 };
+            pinned_row.cells[base + 2].display_props->bg_color =
+                Table::DisplayProps::Color{ entry.source->diff_color,
+                                           entry.source->diff_alpha };
+            pinned_row.cells[base + 3].display_props->bg_color =
+                Table::DisplayProps::Color{ entry.source->diff_color,
+                                           entry.source->diff_alpha };
+        }
+        else
+        {
+            pinned_row.cells[base].display_props->bg_color     = std::nullopt;
+            pinned_row.cells[base + 1].display_props->bg_color = std::nullopt;
+            pinned_row.cells[base + 2].display_props->bg_color = std::nullopt;
+            pinned_row.cells[base + 3].display_props->bg_color = std::nullopt;
         }
     }
 }
@@ -970,6 +982,7 @@ ComputeComparisonView::AddPinnedMetric(const Table& table, const size_t index)
         row.selected          = true;
         m_pinned_metrics.emplace_back(PinnedModel{ row.id, row.entry, &row });
         m_pinned_table->AddRow(table, index);
+        m_pinned_columns_dirty = true;
     }
 }
 
@@ -1004,6 +1017,7 @@ ComputeComparisonView::RemovePinnedMetric(const Table& table, const size_t index
         m_pinned_metrics.erase(std::remove(m_pinned_metrics.begin(), m_pinned_metrics.end(),
                                       PinnedModel{ row.id, row.entry, &row }),
                           m_pinned_metrics.end());
+        m_pinned_columns_dirty = true;
     }
 }
 
@@ -1067,6 +1081,7 @@ ComputeComparisonView::UpdatePinnedMetrics()
                     true;
             }
         }
+        m_pinned_columns_dirty = true;
     }
 }
 
@@ -1403,12 +1418,6 @@ ComputeComparisonView::Table::Render()
 
 const std::vector<ComputeComparisonView::Table::Row>&
 ComputeComparisonView::Table::Rows() const
-{
-    return m_rows;
-}
-
-std::vector<ComputeComparisonView::Table::Row>&
-ComputeComparisonView::Table::MutableRows()
 {
     return m_rows;
 }

--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -784,14 +784,59 @@ ComputeComparisonView::RenderToolbar()
         ImGui::EndCombo();
     }
     ImGui::EndDisabled();
-    
-    float window_width = ImGui::GetWindowWidth(); 
-    VerticalSeparator(&m_settings);   
-    ImGui::TextUnformatted("Delta Threshold");
     ImGui::SameLine();
-    ImGui::SetNextItemWidth(ImGui::GetFrameHeight() * 4.0f);
-    if(ImGui::DragFloat("##threshold_percentage", &m_percentage_threshold, 0.1f,
-                        0.0f, 100.0f, "%.1f%%"))
+
+    float window_width = ImGui::GetWindowWidth();
+
+    float delta_threshold_width = ImGui::GetFrameHeight() * 3.0f;
+    float legend_width =
+        8.0f * style.FramePadding.x + 4.0f * ImGui::GetFrameHeight() +
+        ImGui::CalcTextSize("Baseline").x + ImGui::CalcTextSize("Target").x +
+        2.0f * ImGui::CalcTextSize("Difference[X]").x + delta_threshold_width;
+
+    if(m_toolbar_available_width > legend_width)
+    {
+        ImGui::Dummy(ImVec2(m_toolbar_available_width - legend_width,
+                            ImGui::GetFrameHeightWithSpacing()));
+    }
+    ImGui::SameLine();
+    VerticalSeparator(&m_settings);
+    ImVec4 bg_base =
+        ImGui::ColorConvertU32ToFloat4(m_settings.GetColor(Colors::kComparisonBase));
+    ImVec4 bg_target =
+        ImGui::ColorConvertU32ToFloat4(m_settings.GetColor(Colors::kComparisonTarget));
+    ImVec4 bg_lesser =
+        ImGui::ColorConvertU32ToFloat4(m_settings.GetColor(Colors::kComparisonLesser));
+    ImVec4 bg_greater =
+        ImGui::ColorConvertU32ToFloat4(m_settings.GetColor(Colors::kComparisonGreater));
+    ImGui::SameLine();
+    ImGui::ColorEdit4("b", &bg_base.x, LEGEND_FLAGS);
+    ImGui::SameLine(0.0f, style.FramePadding.x);
+    ImGui::TextUnformatted("Baseline");
+    ImGui::SameLine(0.0f, style.FramePadding.x);
+    ImGui::ColorEdit4("t", &bg_target.x, LEGEND_FLAGS);
+    ImGui::SameLine(0.0f, style.FramePadding.x);
+    ImGui::TextUnformatted("Target");
+    ImGui::SameLine(0.0f, style.FramePadding.x);
+    ImGui::ColorEdit4("d<", &bg_lesser.x, LEGEND_FLAGS);
+    ImGui::SameLine(0.0f, style.FramePadding.x);
+    ImGui::TextUnformatted("Difference");
+    ImGui::SameLine();
+    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+    ImGui::TextUnformatted(ICON_ARROW_DOWN);
+    ImGui::PopFont();
+    ImGui::SameLine(0.0f, style.FramePadding.x);
+    ImGui::ColorEdit4("d>", &bg_greater.x, LEGEND_FLAGS);
+    ImGui::SameLine(0.0f, style.FramePadding.x);
+    ImGui::TextUnformatted("Difference");
+    ImGui::SameLine();
+    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+    ImGui::TextUnformatted(ICON_ARROW_UP);
+    ImGui::PopFont();
+    ImGui::SameLine(0.0f, style.FramePadding.x);
+    ImGui::SetNextItemWidth(ImGui::GetFrameHeight() * 3.0f);
+    if(ImGui::DragFloat("##threshold_percentage", &m_percentage_threshold, 0.1f, 0.0f,
+                        100.0f, "%.1f%%"))
     {
         UpdateDifferenceHighlighting();
     }
@@ -804,59 +849,7 @@ ComputeComparisonView::RenderToolbar()
         ImGui::PopTextWrapPos();
         EndTooltipStyled();
     }
-    ImGui::SameLine();
 
-    if(m_toolbar_available_width != 0.0)
-    {
-        float legend_width =
-            7.0f * style.FramePadding.x + 4.0f * ImGui::GetFrameHeight() +
-            ImGui::CalcTextSize("Baseline").x + ImGui::CalcTextSize("Target").x +
-            2.0f * ImGui::CalcTextSize("Difference[X]").x;
-        if(m_toolbar_available_width > legend_width)
-        {
-            ImGui::Dummy(ImVec2(m_toolbar_available_width - legend_width,
-                                ImGui::GetFrameHeightWithSpacing()));
-            ImGui::SameLine();
-            VerticalSeparator(&m_settings);
-            ImVec4 bg_base = ImGui::ColorConvertU32ToFloat4(
-                m_settings.GetColor(Colors::kComparisonBase));
-            ImVec4 bg_target = ImGui::ColorConvertU32ToFloat4(
-                m_settings.GetColor(Colors::kComparisonTarget));
-            ImVec4 bg_lesser = ImGui::ColorConvertU32ToFloat4(
-                m_settings.GetColor(Colors::kComparisonLesser));
-            ImVec4 bg_greater = ImGui::ColorConvertU32ToFloat4(
-                m_settings.GetColor(Colors::kComparisonGreater));
-            ImGui::SameLine();
-            ImGui::ColorEdit4("b", &bg_base.x, LEGEND_FLAGS);
-            ImGui::SameLine(0.0f, style.FramePadding.x);
-            ImGui::TextUnformatted("Baseline");
-            ImGui::SameLine(0.0f, style.FramePadding.x);
-            ImGui::ColorEdit4("t", &bg_target.x, LEGEND_FLAGS);
-            ImGui::SameLine(0.0f, style.FramePadding.x);
-            ImGui::TextUnformatted("Target");
-            ImGui::SameLine(0.0f, style.FramePadding.x);
-            ImGui::ColorEdit4("d<", &bg_lesser.x, LEGEND_FLAGS);
-            ImGui::SameLine(0.0f, style.FramePadding.x);
-            ImGui::TextUnformatted("Difference");
-            ImGui::SameLine();
-            ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
-            ImGui::TextUnformatted(ICON_ARROW_DOWN);
-            ImGui::PopFont();
-            ImGui::SameLine(0.0f, style.FramePadding.x);
-            ImGui::ColorEdit4("d>", &bg_greater.x, LEGEND_FLAGS);
-            ImGui::SameLine(0.0f, style.FramePadding.x);
-            ImGui::TextUnformatted("Difference");
-            ImGui::SameLine();
-            ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
-            ImGui::TextUnformatted(ICON_ARROW_UP);
-            ImGui::PopFont();
-        }
-        else
-        {
-            ImGui::Dummy(
-                ImVec2(m_toolbar_available_width, ImGui::GetFrameHeightWithSpacing()));
-        }
-    }
     VerticalSeparator(&m_settings);
     if(ImGui::Button(m_filter_common_metrics ? "Show Common Metrics" : "Show All Metrics",
                      ImVec2(ImGui::CalcTextSize("Show Common Metrics").x +

--- a/src/view/src/compute/rocprofvis_compute_comparison.h
+++ b/src/view/src/compute/rocprofvis_compute_comparison.h
@@ -53,19 +53,9 @@ private:
         // Clients populate data via Rows of Values...
         struct Value
         {
-            enum class Role
-            {
-                Other,
-                Baseline,
-                Target,
-                Difference,
-                DifferencePercent,
-            };
             std::string           name;
             std::optional<double> data;
             DisplayProps          display_props;
-            Role                  role = Role::Other;
-            std::string           compare_group;
         };
         struct Row
         {
@@ -79,21 +69,20 @@ private:
                     return metric_id == other.metric_id && entry_name == other.entry_name;
                 }
             };
-            // Internal persistant Value storage, never changes once added...
+            // Internal persistant Value storage, never changes once added
+            // except for DisplayProps...
             struct Value
             {
-                std::string       name;
-                std::string       data;
-                DisplayProps      display_props;
-                Table::Value::Role role = Table::Value::Role::Other;
-                std::string       compare_group;
+                std::string  name;
+                std::string  data;
+                DisplayProps display_props;
             };
             // Render representation, rebuilt/reordered as needed when rows/columns
             // change...
             struct Cell
             {
-                std::string_view    data;
-                const DisplayProps* display_props;
+                std::string_view data;
+                DisplayProps*    display_props;
             };
             ID                                     id;
             const AvailableMetrics::Entry*         entry;
@@ -195,13 +184,29 @@ private:
             return row_id == other.row_id;
         }
     };
+    
+
+    struct DiffCellGroup
+    {
+        Table* table;
+        size_t row_index;
+        size_t baseline_index;
+        size_t target_index;
+        size_t difference_index;
+        size_t difference_percent_index;
+        double percent_diff;
+        Colors diff_color;
+        ImU32  diff_alpha;
+    };
+
+    // created during UpdateMetrics, used for updating the cells colors when threshold changes
+    std::vector<DiffCellGroup> m_diff_cell_groups;
+    // lookup from metric_id to DiffCellGroups, rebuilt when m_diff_cell_groups changes
+    std::unordered_map<std::string, std::vector<const DiffCellGroup*>> m_diff_by_metric_id;
 
     void FetchMetrics();
     void UpdateMetrics();
     void UpdateDifferenceHighlighting();
-    bool GetDifferenceHighlightProps(double rounded_baseline, double rounded_target,
-                                     Colors& diff_color, const char*& icon,
-                                     ImU32& alpha) const;
 
     void RenderToolbar();
     void RenderCategory(const size_t i);

--- a/src/view/src/compute/rocprofvis_compute_comparison.h
+++ b/src/view/src/compute/rocprofvis_compute_comparison.h
@@ -53,9 +53,19 @@ private:
         // Clients populate data via Rows of Values...
         struct Value
         {
+            enum class Role
+            {
+                Other,
+                Baseline,
+                Target,
+                Difference,
+                DifferencePercent,
+            };
             std::string           name;
             std::optional<double> data;
             DisplayProps          display_props;
+            Role                  role = Role::Other;
+            std::string           compare_group;
         };
         struct Row
         {
@@ -72,9 +82,11 @@ private:
             // Internal persistant Value storage, never changes once added...
             struct Value
             {
-                std::string  name;
-                std::string  data;
-                DisplayProps display_props;
+                std::string       name;
+                std::string       data;
+                DisplayProps      display_props;
+                Table::Value::Role role = Table::Value::Role::Other;
+                std::string       compare_group;
             };
             // Render representation, rebuilt/reordered as needed when rows/columns
             // change...
@@ -104,6 +116,7 @@ private:
 
         // Getters...
         const std::vector<Row>&         Rows() const;
+        std::vector<Row>&               MutableRows();
         const std::vector<std::string>& OrderedValueNames() const;
 
         // Row manipulation...
@@ -185,6 +198,10 @@ private:
 
     void FetchMetrics();
     void UpdateMetrics();
+    void UpdateDifferenceHighlighting();
+    bool GetDifferenceHighlightProps(double rounded_baseline, double rounded_target,
+                                     Colors& diff_color, const char*& icon,
+                                     ImU32& alpha) const;
 
     void RenderToolbar();
     void RenderCategory(const size_t i);
@@ -199,6 +216,7 @@ private:
     uint32_t m_target_workload_id;
     uint32_t m_target_kernel_id;
     bool     m_filter_common_metrics;
+    float    m_percentage_threshold;
 
     // Internal state...
     bool        m_inputs_changed;

--- a/src/view/src/compute/rocprofvis_compute_comparison.h
+++ b/src/view/src/compute/rocprofvis_compute_comparison.h
@@ -105,7 +105,6 @@ private:
 
         // Getters...
         const std::vector<Row>&         Rows() const;
-        std::vector<Row>&               MutableRows();
         const std::vector<std::string>& OrderedValueNames() const;
 
         // Row manipulation...
@@ -204,9 +203,21 @@ private:
     // lookup from metric_id to DiffCellGroups, rebuilt when m_diff_cell_groups changes
     std::unordered_map<std::string, std::vector<const DiffCellGroup*>> m_diff_by_metric_id;
 
+    // Pre-resolved mapping from DiffCellGroup to pinned table cell index,
+    // rebuilt after pinned table columns change
+    struct PinnedDiffEntry
+    {
+        const DiffCellGroup* source;
+        size_t               pinned_row_index;
+        size_t               pinned_base_index;
+    };
+    std::vector<PinnedDiffEntry> m_pinned_diff_entries;
+    bool                         m_pinned_columns_dirty;
+
     void FetchMetrics();
     void UpdateMetrics();
     void UpdateDifferenceHighlighting();
+    void RebuildPinnedDiffEntries();
 
     void RenderToolbar();
     void RenderCategory(const size_t i);


### PR DESCRIPTION
## Motivation

Add a configurable delta-threshold control for compute comparison metrics.  Allows user to suppress the noise of minor deviations or filter out .changes below a certain level.

## Technical Details

Add metadata fields to Value Structs (used for locating / matching cells when updating bg colors):
            Role                  role = Role::Other;
            std::string           compare_group;
Add control to toolbar, call UpdateDifferenceHighlighting() on value change.