### PR TITLE
Fix sorting metrics when some kernels do not have an entry

### DIFF
--- a/src/model/src/database/rocprofvis_db_compute.cpp
+++ b/src/model/src/database/rocprofvis_db_compute.cpp
@@ -1367,15 +1367,30 @@ void ComputeQueryFactory::ParseMetricParam(std::string metric_str, uint32_t work
 			default:
 			{
 				uint32_t metrics_column_index = sort_column_index - kRpvColumnMetrics;
-				if (metrics_column_index < a.metrics.size() && metrics_column_index < b.metrics.size())
+				const bool a_missing_metric =
+					metrics_column_index >= a.metrics.size() || std::isnan(a.metrics[metrics_column_index]);
+				const bool b_missing_metric =
+					metrics_column_index >= b.metrics.size() || std::isnan(b.metrics[metrics_column_index]);
+
+				// Keep rows with missing metric values at the end for both sort directions.
+				if (a_missing_metric || b_missing_metric)
 				{
-					return ascending ? a.metrics[metrics_column_index] < b.metrics[metrics_column_index] :
-						a.metrics[metrics_column_index] > b.metrics[metrics_column_index];
+					if (a_missing_metric != b_missing_metric)
+					{
+						return !a_missing_metric;
+					}
+					return a.kernel_uuid < b.kernel_uuid;
 				}
-				else
+
+				const double a_value = a.metrics[metrics_column_index];
+				const double b_value = b.metrics[metrics_column_index];
+
+				if (a_value == b_value)
 				{
-					return false;
+					return a.kernel_uuid < b.kernel_uuid;
 				}
+
+				return ascending ? a_value < b_value : a_value > b_value;
 			}
 			}
 			});


### PR DESCRIPTION
## Motivation

Sorting is broken when metrics are missing for some kernels.

<img width="345" height="347" alt="image" src="https://github.com/user-attachments/assets/6b53f01d-32d1-44a0-aa9d-d4644c44e335" />

## Technical Details

Fix the comparison to check for missing data