### PR TITLE
Fix tooltip being shown over overlapping window.

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -643,7 +643,9 @@ KernelMetricTable::Render()
                                     ImGui::TextUnformatted(cell.c_str());
                                 }
                             }
-                            bool cell_hovered = ImGui::IsMouseHoveringRect(cell_min, cell_max, true);
+                            bool cell_hovered =
+                                ImGui::IsWindowHovered() &&
+                                ImGui::IsMouseHoveringRect(cell_min, cell_max, true);
                             if(need_tooltip && cell_hovered)
                             {
                                 ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),


### PR DESCRIPTION
## Motivation

Fix tooltip being shown over overlapping window on Kernel Details view.

<img width="1031" height="499" alt="image" src="https://github.com/user-attachments/assets/5332f6a3-db70-47ac-9bc1-0a7d39ce0632" />


