### PR TITLE
Fix race condition when compute analysis file loads before view is created

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -44,7 +44,14 @@ ComputeView::ComputeView()
             const auto& workloads = m_data_provider.ComputeModel().GetWorkloads();  
             if(!workloads.empty())
             {
-                m_compute_selection->SelectWorkload(workloads.begin()->first);
+                if(m_compute_selection) 
+                {
+                    m_compute_selection->SelectWorkload(workloads.begin()->first);
+                }
+                else
+                {
+                    spdlog::warn("Selection manager not available, workload not selected");
+                }
             }
         }
     });
@@ -119,6 +126,14 @@ void
 ComputeView::CreateView()
 {
     m_compute_selection = std::make_shared<ComputeSelection>(m_data_provider);
+    // When launched remotely, for example over ssh, the UI make take long to init, and the data provider
+    // may have already loaded an analysis if the application was launched with --file flag.
+    // Check if one exists and if it does set the workload.
+    const auto& workloads = m_data_provider.ComputeModel().GetWorkloads();  
+    if(!workloads.empty())
+    {
+        m_compute_selection->SelectWorkload(workloads.begin()->first);
+    }
 
     m_tab_container = std::make_shared<TabContainer>();
     m_tab_container->AddTab(TabItem{"Summary View", "compute_summary_view", std::make_shared<ComputeSummaryView>(m_data_provider, m_compute_selection), false});


### PR DESCRIPTION
## Motivation

Fix issue: https://github.com/ROCm/roc-optiq/issues/788

## Technical Details

The application crashed due to a race condition.  The ComputeSelection object gets initialized (created) when the view is created.  Callbacks are created in the ComputeView constructor and the compute selection is used by a callback.

In the scenario where the application is launched from a remote ssh session and a file is passed as a command line argument the analysis file is loaded before the view is created.  The callback fires but the selection object was not created yet and a seg fault is the result.

Fix: Check object validity before using and check if workloads are available after creating selection object incase callback could not be processed.

Todo: Re-think the whole flow in the future, but for now this will address the crash. 