### PR TITLE
Track Cleanup

### DIFF
--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -8,6 +8,7 @@ namespace View
 constexpr ImWchar icon_ranges[] = {
     0xF123, 0xF125,
     0xF128, 0xF128,
+    0xF130, 0xF130,
     0xF133, 0xF133, 
     0xF13D, 0xF13D, 
     0xF1FE, 0xF1FE, 
@@ -31,6 +32,7 @@ constexpr ImWchar icon_ranges[] = {
 };
 
 constexpr const char* ICON_X_CIRCLED     = u8"\uF128";
+constexpr const char* ICON_DRAG          = u8"\uF130";
 constexpr const char* ICON_EYE           = u8"\uF133";
 constexpr const char* ICON_GEAR          = u8"\uF13D";
 constexpr const char* ICON_CHAIN         = u8"\uF1FE";

--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -8,7 +8,6 @@ namespace View
 constexpr ImWchar icon_ranges[] = {
     0xF123, 0xF125,
     0xF128, 0xF128,
-    0xF130, 0xF130,
     0xF133, 0xF133, 
     0xF13D, 0xF13D, 
     0xF1FE, 0xF1FE, 
@@ -32,7 +31,6 @@ constexpr ImWchar icon_ranges[] = {
 };
 
 constexpr const char* ICON_X_CIRCLED     = u8"\uF128";
-constexpr const char* ICON_DRAG          = u8"\uF130";
 constexpr const char* ICON_EYE           = u8"\uF133";
 constexpr const char* ICON_GEAR          = u8"\uF13D";
 constexpr const char* ICON_CHAIN         = u8"\uF1FE";

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -110,6 +110,18 @@ FlameTrackItem::FlameTrackItem(DataProvider&                      dp,
 void
 FlameTrackItem::RenderMetaAreaExpand()
 {
+    int visible_levels =
+        static_cast<int>(std::floor(m_track_content_height / m_level_height));
+
+    const bool show_expand   = visible_levels < m_max_level + 1;
+    const bool show_contract = !show_expand &&
+                               m_track_height > std::max(m_max_level * m_level_height +
+                                                             m_level_height,
+                                                         DEFAULT_TRACK_HEIGHT);
+
+    if(!show_expand && !show_contract)
+        return;
+
     ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
                           m_settings.GetColor(Colors::kTransparent));
@@ -119,10 +131,7 @@ FlameTrackItem::RenderMetaAreaExpand()
         ImVec2(ImGui::GetContentRegionMax() - m_metadata_padding -
                ImVec2(ImGui::GetTextLineHeight(), ImGui::GetTextLineHeight())));
 
-    int visible_levels =
-        static_cast<int>(std::floor(m_track_content_height / m_level_height));
-
-    if(visible_levels < m_max_level + 1)
+    if(show_expand)
     {
         if(ImGui::ArrowButton("##expand", ImGuiDir_Down))
         {
@@ -131,9 +140,7 @@ FlameTrackItem::RenderMetaAreaExpand()
         }
         if(ImGui::IsItemHovered()) SetTooltipStyled("Expand track to see all events");
     }
-    else if(m_track_height >
-            std::max(m_max_level * m_level_height + m_level_height,
-                     DEFAULT_TRACK_HEIGHT))  // stand-in for default height..
+    else
     {
         if(ImGui::ArrowButton("##contract", ImGuiDir_Up))
         {

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -119,9 +119,14 @@ FlameTrackItem::RenderMetaAreaExpand()
         ImVec2(ImGui::GetContentRegionMax() - m_metadata_padding -
                ImVec2(ImGui::GetTextLineHeight(), ImGui::GetTextLineHeight())));
 
-    int visible_levels = static_cast<int>(std::ceil(m_track_height / m_level_height));
+    // Use the chart's drawable height (m_track_content_height) so the calculation
+    // matches the area events are actually rendered into. A level only counts as
+    // "visible" if it fits fully, otherwise we'd offer to expand even when all
+    // events are already on screen.
+    int visible_levels =
+        static_cast<int>(std::floor(m_track_content_height / m_level_height));
 
-    if(visible_levels <= m_max_level + 1)
+    if(visible_levels < m_max_level + 1)
     {
         if(ImGui::ArrowButton("##expand", ImGuiDir_Down))
         {
@@ -654,13 +659,7 @@ FlameTrackItem::RenderChart(float graph_width)
             continue;  // Skip if the item is not visible in the current view
         }
 
-        if(m_event_color_mode == EventColorMode::kByTimeLevel)
-        {
-            color_index =
-                static_cast<uint64_t>(item.event.m_start_ts + item.event.m_level) %
-                colorCount;
-        }
-        else if(m_event_color_mode == EventColorMode::kByEventName)
+        if(m_event_color_mode == EventColorMode::kByEventName)
         {
             color_index = static_cast<uint64_t>(item.name_hash) % colorCount;
         }
@@ -748,12 +747,6 @@ FlameTrackItem::RenderMetaAreaOptions()
 
     if(ImGui::RadioButton("Color by Name", mode == EventColorMode::kByEventName))
         mode = EventColorMode::kByEventName;
-    ImGui::SameLine();
-    if(ImGui::RadioButton("Color by Time Level", mode == EventColorMode::kByTimeLevel))
-        mode = EventColorMode::kByTimeLevel;
-    ImGui::SameLine();
-    if(ImGui::RadioButton("No Color", mode == EventColorMode::kNone))
-        mode = EventColorMode::kNone;
     m_event_color_mode = mode;
 
     if(ImGui::Checkbox("Compact Mode", &m_compact_mode))

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -121,8 +121,7 @@ FlameTrackItem::RenderMetaAreaExpand()
                   std::floor((m_track_content_height + m_level_padding) / level_stride))
             : 0;
 
-    const float full_track_height =
-        (m_max_level + 1.0f) * m_level_height + m_max_level * m_level_padding;
+    const float full_track_height = FullTrackHeight();
 
     const bool show_expand   = visible_levels < m_max_level + 1;
     const bool show_contract = !show_expand &&
@@ -640,10 +639,19 @@ FlameTrackItem::RenderTooltip(ChartItem& chart_item, int color_index)
 void
 FlameTrackItem::RecalculateTrackHeight()
 {
-    const float full_track_height =
-        (m_max_level + 1.0f) * m_level_height + m_max_level * m_level_padding;
-    m_track_height         = std::max(full_track_height, DEFAULT_TRACK_HEIGHT);
+    m_track_height         = std::max(FullTrackHeight(), DEFAULT_TRACK_HEIGHT);
     m_track_height_changed = true;
+}
+
+float
+FlameTrackItem::FullTrackHeight() const
+{
+    // Parent TrackItem shrinks the chart's content area by 1 px on top and bottom
+    // (metadata_shrink_padding); add that 2 px back so a "fully expanded" track
+    // actually fits every level + the inter-level padding.
+    constexpr float kMetaShrinkAllowance = 2.0f;
+    return (m_max_level + 1.0f) * m_level_height +
+           m_max_level * m_level_padding + kMetaShrinkAllowance;
 }
 
 void
@@ -781,9 +789,7 @@ FlameTrackItem::RenderMetaAreaOptions()
                 RecalculateTrackHeight();
             }
         }
-        const float full_track_height =
-            (m_max_level + 1.0f) * m_level_height + m_max_level * m_level_padding;
-        if(m_track_height > std::max(full_track_height, DEFAULT_TRACK_HEIGHT))
+        if(m_track_height > std::max(FullTrackHeight(), DEFAULT_TRACK_HEIGHT))
         {
             RecalculateTrackHeight();
         }

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -119,10 +119,6 @@ FlameTrackItem::RenderMetaAreaExpand()
         ImVec2(ImGui::GetContentRegionMax() - m_metadata_padding -
                ImVec2(ImGui::GetTextLineHeight(), ImGui::GetTextLineHeight())));
 
-    // Use the chart's drawable height (m_track_content_height) so the calculation
-    // matches the area events are actually rendered into. A level only counts as
-    // "visible" if it fits fully, otherwise we'd offer to expand even when all
-    // events are already on screen.
     int visible_levels =
         static_cast<int>(std::floor(m_track_content_height / m_level_height));
 

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -110,6 +110,23 @@ FlameTrackItem::FlameTrackItem(DataProvider&                      dp,
 void
 FlameTrackItem::RenderMetaAreaExpand()
 {
+    // Pre-existing bug: this function always pushed the cursor to the bottom-right of
+    // the meta area via SetCursorPos before deciding whether to draw an arrow. When
+    // neither the expand nor the contract arrow ended up rendering, no item was
+    // submitted after the SetCursorPos and ImGui's
+    // ErrorCheckUsingSetCursorPosToExtendParentBoundaries asserted at the surrounding
+    // EndChild because the cursor advanced past CursorMaxPos with nothing to anchor
+    // the bound expansion (see imgui.cpp ~ line 11427 / imgui issue #5548).
+    //
+    // The original code (Sept 2025) hit this any time a single-event flame track sat
+    // at default height. Bumping DEFAULT_TRACK_HEIGHT and tightening the visibility
+    // check earlier in this branch made 2-event tracks at default height fall into
+    // the same "no arrow" path too, which is the common case, so the assert started
+    // firing constantly (especially while dragging since every frame redraws every
+    // visible track).
+    //
+    // Fix: figure out which arrow we're going to draw up front and return early when
+    // there's nothing to render so we don't touch the cursor at all.
     int visible_levels =
         static_cast<int>(std::floor(m_track_content_height / m_level_height));
 

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -364,7 +364,7 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
         rectColor = m_settings.GetColorWheel()[color_index];
     }
 
-    const float rounding = std::min(1.0f, (rectMax.y - rectMin.y) * 0.1f);
+    const float rounding = std::min(3.0f, (rectMax.y - rectMin.y) * 0.2f);
     draw_list->AddRectFilled(rectMin, rectMax, rectColor, rounding);
 
     if(rectMax.x - rectMin.x > MIN_LABEL_WIDTH)
@@ -704,7 +704,7 @@ FlameTrackItem::RenderChart(float graph_width)
         double normalized_duration =
             std::max(item.event.m_duration * m_tpt->GetPixelsPerNs(), 1.0);
 
-        const float rounding = std::min(1.0f, m_level_height * 0.1f) + 1.0f;
+        const float rounding = std::min(3.0f, m_level_height * 0.2f) + 1.0f;
         ImVec2 start_position =
             ImVec2(static_cast<float>(normalized_start),
                    item.event.m_level * (m_level_height + m_level_padding));

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -53,6 +53,7 @@ FlameTrackItem::FlameTrackItem(DataProvider&                      dp,
 , m_event_color_mode(EventColorMode::kByEventName)
 , m_text_padding(SettingsManager::GetInstance().GetDefaultIMGUIStyle().FramePadding)
 , m_level_height(SettingsManager::GetInstance().GetEventLevelHeight())
+, m_level_padding(SettingsManager::GetInstance().GetEventLevelPadding())
 , m_timeline_selection(timeline_selection)
 , m_deferred_click_handled(false)
 , m_has_drawn_tool_tip(false)
@@ -102,7 +103,8 @@ FlameTrackItem::FlameTrackItem(DataProvider&                      dp,
         m_compact_mode     = m_flame_track_project_settings.CompactMode();
         if(m_compact_mode)
         {
-            m_level_height = m_settings.GetEventLevelCompactHeight();
+            m_level_height  = m_settings.GetEventLevelCompactHeight();
+            m_level_padding = m_settings.GetEventLevelCompactPadding();
         }
     }
 }
@@ -127,13 +129,22 @@ FlameTrackItem::RenderMetaAreaExpand()
     //
     // Fix: figure out which arrow we're going to draw up front and return early when
     // there's nothing to render so we don't touch the cursor at all.
+    // A level occupies m_level_height pixels and is followed by m_level_padding pixels
+    // of empty space before the next level. The first level has no leading padding, so
+    // N visible levels need N*level_height + (N-1)*level_padding pixels of content.
+    const float level_stride = m_level_height + m_level_padding;
     int visible_levels =
-        static_cast<int>(std::floor(m_track_content_height / m_level_height));
+        (level_stride > 0.0f)
+            ? static_cast<int>(
+                  std::floor((m_track_content_height + m_level_padding) / level_stride))
+            : 0;
+
+    const float full_track_height =
+        (m_max_level + 1.0f) * m_level_height + m_max_level * m_level_padding;
 
     const bool show_expand   = visible_levels < m_max_level + 1;
     const bool show_contract = !show_expand &&
-                               m_track_height > std::max(m_max_level * m_level_height +
-                                                             m_level_height,
+                               m_track_height > std::max(full_track_height,
                                                          DEFAULT_TRACK_HEIGHT);
 
     if(!show_expand && !show_contract)
@@ -371,14 +382,24 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
         rectColor = m_settings.GetColorWheel()[color_index];
     }
 
-    float rounding = 2.0f;
+    // Clamp rounding so very short boxes (compact mode) don't end up nearly circular.
+    const float rounding = std::min(3.0f, (rectMax.y - rectMin.y) * 0.2f);
     draw_list->AddRectFilled(rectMin, rectMax, rectColor, rounding);
 
     if(rectMax.x - rectMin.x > MIN_LABEL_WIDTH)
     {
         draw_list->PushClipRect(rectMin, rectMax, true);
+
+        // Vertically center the label inside the box. Fall back to the text padding
+        // offset when the box is shorter than the text (compact mode), so the text
+        // doesn't get pushed above the box.
+        const float text_line_height = ImGui::GetTextLineHeight();
+        const float box_height       = rectMax.y - rectMin.y;
+        const float centered_offset_y =
+            std::max(m_text_padding.y, (box_height - text_line_height) * 0.5f);
+
         ImVec2 textPos =
-            ImVec2(rectMin.x + m_text_padding.x, rectMin.y + m_text_padding.y);
+            ImVec2(rectMin.x + m_text_padding.x, rectMin.y + centered_offset_y);
 
         if(chart_item.event.m_child_count > 1)
         {
@@ -395,7 +416,7 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
                 // If the rectangle is partially outside the viewport then start rendering
                 // the text at the viewport edge to maintain readability.
                 textPos = ImVec2(draw_list->GetClipRectMin().x + m_text_padding.x,
-                                 rectMin.y + m_text_padding.y);
+                                 rectMin.y + centered_offset_y);
                 draw_list->AddText(textPos, m_settings.GetColor(Colors::kTextMain),
                                    chart_item.event.m_name.c_str());
             }
@@ -639,8 +660,10 @@ FlameTrackItem::RenderTooltip(ChartItem& chart_item, int color_index)
 void
 FlameTrackItem::RecalculateTrackHeight()
 {
-    m_track_height = std::max(m_max_level * m_level_height + m_level_height + 2.0f,
-                              DEFAULT_TRACK_HEIGHT);
+    // (max_level + 1) levels stacked with (max_level) inter-level gaps.
+    const float full_track_height =
+        (m_max_level + 1.0f) * m_level_height + m_max_level * m_level_padding;
+    m_track_height         = std::max(full_track_height, DEFAULT_TRACK_HEIGHT);
     m_track_height_changed = true;
 }
 
@@ -669,9 +692,12 @@ FlameTrackItem::RenderChart(float graph_width)
 
         ImVec2 start_position;
 
-        // Calculate the start position based on the normalized start time and level
+        // Calculate the start position based on the normalized start time and level.
+        // Each level is offset by level_height plus a small inter-level padding so
+        // stacked events are visually separated.
         start_position = ImVec2(static_cast<float>(normalized_start),
-                                item.event.m_level * m_level_height);
+                                item.event.m_level *
+                                    (m_level_height + m_level_padding));
 
         if(normalized_end < container_pos.x ||
            normalized_start > container_pos.x + graph_width)
@@ -702,10 +728,12 @@ FlameTrackItem::RenderChart(float graph_width)
         double normalized_duration =
             std::max(item.event.m_duration * m_tpt->GetPixelsPerNs(), 1.0);
 
-        float  rounding = 2.0f;
+        // Match the rounding used by the filled event box, slightly enlarged so the
+        // highlight border traces the outside of the box's corners cleanly.
+        const float rounding = std::min(3.0f, m_level_height * 0.2f) + 1.0f;
         ImVec2 start_position =
             ImVec2(static_cast<float>(normalized_start),
-                   item.event.m_level * m_level_height);
+                   item.event.m_level * (m_level_height + m_level_padding));
 
         ImVec2 cursor_position = ImGui::GetCursorScreenPos();
 
@@ -767,17 +795,21 @@ FlameTrackItem::RenderMetaAreaOptions()
     {
         if(m_compact_mode)
         {
-            m_level_height = m_settings.GetEventLevelCompactHeight();
+            m_level_height  = m_settings.GetEventLevelCompactHeight();
+            m_level_padding = m_settings.GetEventLevelCompactPadding();
         }
         else
         {
-            m_level_height = m_settings.GetEventLevelHeight();
+            m_level_height  = m_settings.GetEventLevelHeight();
+            m_level_padding = m_settings.GetEventLevelPadding();
             if(m_is_expanded)
             {
                 RecalculateTrackHeight();
             }
         }
-        if(m_track_height > std::max(m_max_level * m_level_height + m_level_height, DEFAULT_TRACK_HEIGHT))
+        const float full_track_height =
+            (m_max_level + 1.0f) * m_level_height + m_max_level * m_level_padding;
+        if(m_track_height > std::max(full_track_height, DEFAULT_TRACK_HEIGHT))
         {
             RecalculateTrackHeight();
         }

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -364,7 +364,7 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
         rectColor = m_settings.GetColorWheel()[color_index];
     }
 
-    const float rounding = std::min(1.5f, (rectMax.y - rectMin.y) * 0.15f);
+    const float rounding = std::min(1.0f, (rectMax.y - rectMin.y) * 0.1f);
     draw_list->AddRectFilled(rectMin, rectMax, rectColor, rounding);
 
     if(rectMax.x - rectMin.x > MIN_LABEL_WIDTH)
@@ -704,7 +704,7 @@ FlameTrackItem::RenderChart(float graph_width)
         double normalized_duration =
             std::max(item.event.m_duration * m_tpt->GetPixelsPerNs(), 1.0);
 
-        const float rounding = std::min(1.5f, m_level_height * 0.15f) + 1.0f;
+        const float rounding = std::min(1.0f, m_level_height * 0.1f) + 1.0f;
         ImVec2 start_position =
             ImVec2(static_cast<float>(normalized_start),
                    item.event.m_level * (m_level_height + m_level_padding));

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -364,7 +364,7 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
         rectColor = m_settings.GetColorWheel()[color_index];
     }
 
-    const float rounding = std::min(3.0f, (rectMax.y - rectMin.y) * 0.2f);
+    const float rounding = std::min(1.5f, (rectMax.y - rectMin.y) * 0.15f);
     draw_list->AddRectFilled(rectMin, rectMax, rectColor, rounding);
 
     if(rectMax.x - rectMin.x > MIN_LABEL_WIDTH)
@@ -704,7 +704,7 @@ FlameTrackItem::RenderChart(float graph_width)
         double normalized_duration =
             std::max(item.event.m_duration * m_tpt->GetPixelsPerNs(), 1.0);
 
-        const float rounding = std::min(3.0f, m_level_height * 0.2f) + 1.0f;
+        const float rounding = std::min(1.5f, m_level_height * 0.15f) + 1.0f;
         ImVec2 start_position =
             ImVec2(static_cast<float>(normalized_start),
                    item.event.m_level * (m_level_height + m_level_padding));

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -743,12 +743,6 @@ FlameTrackItem::RenderMetaAreaScale()
 void
 FlameTrackItem::RenderMetaAreaOptions()
 {
-    EventColorMode mode = m_event_color_mode;
-
-    if(ImGui::RadioButton("Color by Name", mode == EventColorMode::kByEventName))
-        mode = EventColorMode::kByEventName;
-    m_event_color_mode = mode;
-
     if(ImGui::Checkbox("Compact Mode", &m_compact_mode))
     {
         if(m_compact_mode)

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -112,26 +112,8 @@ FlameTrackItem::FlameTrackItem(DataProvider&                      dp,
 void
 FlameTrackItem::RenderMetaAreaExpand()
 {
-    // Pre-existing bug: this function always pushed the cursor to the bottom-right of
-    // the meta area via SetCursorPos before deciding whether to draw an arrow. When
-    // neither the expand nor the contract arrow ended up rendering, no item was
-    // submitted after the SetCursorPos and ImGui's
-    // ErrorCheckUsingSetCursorPosToExtendParentBoundaries asserted at the surrounding
-    // EndChild because the cursor advanced past CursorMaxPos with nothing to anchor
-    // the bound expansion (see imgui.cpp ~ line 11427 / imgui issue #5548).
-    //
-    // The original code (Sept 2025) hit this any time a single-event flame track sat
-    // at default height. Bumping DEFAULT_TRACK_HEIGHT and tightening the visibility
-    // check earlier in this branch made 2-event tracks at default height fall into
-    // the same "no arrow" path too, which is the common case, so the assert started
-    // firing constantly (especially while dragging since every frame redraws every
-    // visible track).
-    //
-    // Fix: figure out which arrow we're going to draw up front and return early when
-    // there's nothing to render so we don't touch the cursor at all.
-    // A level occupies m_level_height pixels and is followed by m_level_padding pixels
-    // of empty space before the next level. The first level has no leading padding, so
-    // N visible levels need N*level_height + (N-1)*level_padding pixels of content.
+    // Decide which arrow (if any) to draw before touching the cursor. SetCursorPos
+    // without a follow-up item trips ImGui's CursorMaxPos assert (imgui issue #5548).
     const float level_stride = m_level_height + m_level_padding;
     int visible_levels =
         (level_stride > 0.0f)
@@ -382,7 +364,6 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
         rectColor = m_settings.GetColorWheel()[color_index];
     }
 
-    // Clamp rounding so very short boxes (compact mode) don't end up nearly circular.
     const float rounding = std::min(3.0f, (rectMax.y - rectMin.y) * 0.2f);
     draw_list->AddRectFilled(rectMin, rectMax, rectColor, rounding);
 
@@ -390,9 +371,8 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
     {
         draw_list->PushClipRect(rectMin, rectMax, true);
 
-        // Vertically center the label inside the box. Fall back to the text padding
-        // offset when the box is shorter than the text (compact mode), so the text
-        // doesn't get pushed above the box.
+        // Center label vertically; fall back to top padding when the box is shorter
+        // than the text (compact mode).
         const float text_line_height = ImGui::GetTextLineHeight();
         const float box_height       = rectMax.y - rectMin.y;
         const float centered_offset_y =
@@ -660,7 +640,6 @@ FlameTrackItem::RenderTooltip(ChartItem& chart_item, int color_index)
 void
 FlameTrackItem::RecalculateTrackHeight()
 {
-    // (max_level + 1) levels stacked with (max_level) inter-level gaps.
     const float full_track_height =
         (m_max_level + 1.0f) * m_level_height + m_max_level * m_level_padding;
     m_track_height         = std::max(full_track_height, DEFAULT_TRACK_HEIGHT);
@@ -692,9 +671,6 @@ FlameTrackItem::RenderChart(float graph_width)
 
         ImVec2 start_position;
 
-        // Calculate the start position based on the normalized start time and level.
-        // Each level is offset by level_height plus a small inter-level padding so
-        // stacked events are visually separated.
         start_position = ImVec2(static_cast<float>(normalized_start),
                                 item.event.m_level *
                                     (m_level_height + m_level_padding));
@@ -728,8 +704,6 @@ FlameTrackItem::RenderChart(float graph_width)
         double normalized_duration =
             std::max(item.event.m_duration * m_tpt->GetPixelsPerNs(), 1.0);
 
-        // Match the rounding used by the filled event box, slightly enlarged so the
-        // highlight border traces the outside of the box's corners cleanly.
         const float rounding = std::min(3.0f, m_level_height * 0.2f) + 1.0f;
         ImVec2 start_position =
             ImVec2(static_cast<float>(normalized_start),

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -101,6 +101,7 @@ private:
     EventColorMode                     m_event_color_mode;
     ImVec2                             m_text_padding;
     float                              m_level_height;
+    float                              m_level_padding;
     std::vector<uint64_t>              m_selected_event_id;
     std::shared_ptr<TimelineSelection> m_timeline_selection;
     FlameTrackProjectSettings          m_flame_track_project_settings;

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -24,7 +24,6 @@ enum class EventColorMode
 {
     kNone,
     kByEventName,
-    kByTimeLevel,
     __kCount
 };
 

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -97,6 +97,10 @@ private:
     void RenderTooltip(ChartItem& chart_item, int color_index);
     void RecalculateTrackHeight();
 
+    // Track height needed to fully display every level (including the inter-level
+    // padding and the metadata area's vertical shrink allowance).
+    float FullTrackHeight() const;
+
     std::vector<ChartItem>             m_chart_items;
     EventColorMode                     m_event_color_mode;
     ImVec2                             m_text_padding;

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -194,7 +194,7 @@ inline constexpr const char* CONTRAST_LIGHT_COLORMAP_NAME = "contrast_light";
 inline constexpr const char*  SETTINGS_FILE_NAME = "settings_application.json";
 inline constexpr float        EVENT_LEVEL_HEIGHT = 40.0f;
 inline constexpr float        COMPACT_EVENT_HEIGHT = 6.0f;
-inline constexpr float        EVENT_LEVEL_PADDING = 2.0f;
+inline constexpr float        EVENT_LEVEL_PADDING = 1.0f;
 inline constexpr float        EVENT_LEVEL_COMPACT_PADDING = 1.0f;
 
 SettingsManager&

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -194,8 +194,8 @@ inline constexpr const char* CONTRAST_LIGHT_COLORMAP_NAME = "contrast_light";
 inline constexpr const char*  SETTINGS_FILE_NAME = "settings_application.json";
 inline constexpr float        EVENT_LEVEL_HEIGHT = 40.0f;
 inline constexpr float        COMPACT_EVENT_HEIGHT = 6.0f;
-inline constexpr float        EVENT_LEVEL_PADDING = 4.0f;
-inline constexpr float        EVENT_LEVEL_COMPACT_PADDING = 2.0f;
+inline constexpr float        EVENT_LEVEL_PADDING = 2.0f;
+inline constexpr float        EVENT_LEVEL_COMPACT_PADDING = 1.0f;
 
 SettingsManager&
 SettingsManager::GetInstance()

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -194,6 +194,8 @@ inline constexpr const char* CONTRAST_LIGHT_COLORMAP_NAME = "contrast_light";
 inline constexpr const char*  SETTINGS_FILE_NAME = "settings_application.json";
 inline constexpr float        EVENT_LEVEL_HEIGHT = 40.0f;
 inline constexpr float        COMPACT_EVENT_HEIGHT = 6.0f;
+inline constexpr float        EVENT_LEVEL_PADDING = 4.0f;
+inline constexpr float        EVENT_LEVEL_COMPACT_PADDING = 2.0f;
 
 SettingsManager&
 SettingsManager::GetInstance()
@@ -724,6 +726,18 @@ const float
 SettingsManager::GetEventLevelCompactHeight() const
 {
     return COMPACT_EVENT_HEIGHT;
+}
+
+const float
+SettingsManager::GetEventLevelPadding() const
+{
+    return EVENT_LEVEL_PADDING;
+}
+
+const float
+SettingsManager::GetEventLevelCompactPadding() const
+{
+    return EVENT_LEVEL_COMPACT_PADDING;
 }
 
 void

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -206,6 +206,10 @@ public:
     const float GetEventLevelHeight() const;
     const float GetEventLevelCompactHeight() const;
 
+    // Vertical spacing between stacked event levels within a flame track.
+    const float GetEventLevelPadding() const;
+    const float GetEventLevelCompactPadding() const;
+
 
 private:
     SettingsManager();

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -206,7 +206,6 @@ public:
     const float GetEventLevelHeight() const;
     const float GetEventLevelCompactHeight() const;
 
-    // Vertical spacing between stacked event levels within a flame track.
     const float GetEventLevelPadding() const;
     const float GetEventLevelCompactPadding() const;
 

--- a/src/view/src/rocprofvis_timeline_arrow.cpp
+++ b/src/view/src/rocprofvis_timeline_arrow.cpp
@@ -54,12 +54,13 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
         return;
     }
 
-    SettingsManager& settings     = SettingsManager::GetInstance();
-    ImU32            color        = settings.GetColor(Colors::kArrowColor);
-    float            thickness    = LINE_THICKNESS;
-    float            head_size    = ARROW_HEAD_SIZE;
-    float            level_height = settings.GetEventLevelHeight();
-    TimelineModel&   tlm          = m_data_provider.DataModel().GetTimeline();
+    SettingsManager& settings      = SettingsManager::GetInstance();
+    ImU32            color         = settings.GetColor(Colors::kArrowColor);
+    float            thickness     = LINE_THICKNESS;
+    float            head_size     = ARROW_HEAD_SIZE;
+    float            level_height  = settings.GetEventLevelHeight();
+    float            level_padding = settings.GetEventLevelPadding();
+    TimelineModel&   tlm           = m_data_provider.DataModel().GetTimeline();
 
     for(const EventInfo* event : m_selected_event_data)
     {
@@ -80,17 +81,20 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
             }
             if(origin_track.chart->IsCompactMode())
             {
-                level_height = settings.GetEventLevelCompactHeight();
+                level_height  = settings.GetEventLevelCompactHeight();
+                level_padding = settings.GetEventLevelCompactPadding();
             }
             else
             {
-                level_height = settings.GetEventLevelHeight();
+                level_height  = settings.GetEventLevelHeight();
+                level_padding = settings.GetEventLevelPadding();
             }
 
             float origin_x = tpt->RawTimeToPixel(origin.end_timestamp);
-            float origin_y = track_position_y.at(origin.track_id) +
-                             std::min(level_height * origin.level + level_height / 2,
-                                      origin_track.chart->GetTrackHeight());
+            float origin_y =
+                track_position_y.at(origin.track_id) +
+                std::min((level_height + level_padding) * origin.level + level_height / 2,
+                         origin_track.chart->GetTrackHeight());
             ImVec2 p_origin = ImVec2(window.x + origin_x, window.y + origin_y);
 
             for(size_t i = 1; i < flows.size(); ++i)
@@ -104,17 +108,21 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
 
                 if(target_track.chart->IsCompactMode())
                 {
-                    level_height = settings.GetEventLevelCompactHeight();
+                    level_height  = settings.GetEventLevelCompactHeight();
+                    level_padding = settings.GetEventLevelCompactPadding();
                 }
                 else
                 {
-                    level_height = settings.GetEventLevelHeight();
+                    level_height  = settings.GetEventLevelHeight();
+                    level_padding = settings.GetEventLevelPadding();
                 }
 
                 float target_x = tpt->RawTimeToPixel(target.start_timestamp);
-                float target_y = track_position_y.at(target.track_id) +
-                                 std::min(level_height * target.level + level_height / 2,
-                                          target_track.chart->GetTrackHeight());
+                float target_y =
+                    track_position_y.at(target.track_id) +
+                    std::min((level_height + level_padding) * target.level +
+                                 level_height / 2,
+                             target_track.chart->GetTrackHeight());
                 ImVec2 p_target = ImVec2(window.x + target_x, window.y + target_y);
 
                 if(p_origin.x == p_target.x && p_origin.y == p_target.y) continue;
@@ -178,32 +186,39 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
 
                 if(from_track.chart->IsCompactMode())
                 {
-                    level_height = settings.GetEventLevelCompactHeight();
+                    level_height  = settings.GetEventLevelCompactHeight();
+                    level_padding = settings.GetEventLevelCompactPadding();
                 }
                 else
                 {
-                    level_height = settings.GetEventLevelHeight();
+                    level_height  = settings.GetEventLevelHeight();
+                    level_padding = settings.GetEventLevelPadding();
                 }
 
                 float from_x = tpt->RawTimeToPixel(from.end_timestamp);
-                float from_y = track_position_y.at(from.track_id) +
-                               std::min(level_height * from.level + level_height / 2,
-                                        from_track.chart->GetTrackHeight());
+                float from_y =
+                    track_position_y.at(from.track_id) +
+                    std::min((level_height + level_padding) * from.level +
+                                 level_height / 2,
+                             from_track.chart->GetTrackHeight());
                 ImVec2 p_from = ImVec2(window.x + from_x, window.y + from_y);
 
                 if(to_track.chart->IsCompactMode())
                 {
-                    level_height = settings.GetEventLevelCompactHeight();
+                    level_height  = settings.GetEventLevelCompactHeight();
+                    level_padding = settings.GetEventLevelCompactPadding();
                 }
                 else
                 {
-                    level_height = settings.GetEventLevelHeight();
+                    level_height  = settings.GetEventLevelHeight();
+                    level_padding = settings.GetEventLevelPadding();
                 }
 
                 float to_x = tpt->RawTimeToPixel(to.start_timestamp);
-                float to_y = track_position_y.at(to.track_id) +
-                             std::min(level_height * to.level + level_height / 2,
-                                      to_track.chart->GetTrackHeight());
+                float to_y =
+                    track_position_y.at(to.track_id) +
+                    std::min((level_height + level_padding) * to.level + level_height / 2,
+                             to_track.chart->GetTrackHeight());
                 ImVec2 p_to = ImVec2(window.x + to_x, window.y + to_y);
 
                 if(p_from.x == p_to.x && p_from.y == p_to.y) continue;

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -246,30 +246,18 @@ TrackItem::RenderMetaArea()
                                        anim_speed);
         }
 
-        // 2x3 grid of dots used as the reorder grip decoration.
-        float dot_radius      = 1.5f;
-        float dot_spacing     = 5.0f;
-        int   grip_cols       = 2;
-        int   grip_rows       = 3;
-        float grip_block_w    = (grip_cols - 1) * dot_spacing;
-        float grip_block_h    = (grip_rows - 1) * dot_spacing;
-        float grid_icon_width = grip_block_w + dot_radius * 2.0f;
+        // Reordering grip decoration
+        float grid_icon_width = ImGui::CalcTextSize(ICON_DRAG).x;
         float arrow_width     = ImGui::GetTextLineHeight();
 
-        ImU32       grip_color    = m_settings.GetColor(Colors::kTextDim);
-        ImVec2      win_pos       = ImGui::GetWindowPos();
-        float       grip_origin_x = win_pos.x + (m_reorder_grip_width - grip_block_w) * 0.5f;
-        float       grip_origin_y = win_pos.y + (container_size.y - grip_block_h) * 0.5f;
-        ImDrawList* draw_list     = ImGui::GetWindowDrawList();
-        for(int col = 0; col < grip_cols; ++col)
-        {
-            for(int row = 0; row < grip_rows; ++row)
-            {
-                ImVec2 center(grip_origin_x + col * dot_spacing,
-                              grip_origin_y + row * dot_spacing);
-                draw_list->AddCircleFilled(center, dot_radius, grip_color);
-            }
-        }
+        ImGui::SetCursorPos(
+            ImVec2((m_reorder_grip_width - grid_icon_width) / 2,
+                   (container_size.y - ImGui::GetTextLineHeightWithSpacing()) / 2));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+        ImGui::PushStyleColor(ImGuiCol_Text, m_settings.GetColor(Colors::kTextDim));
+        ImGui::TextUnformatted(ICON_DRAG);
+        ImGui::PopStyleColor();
+        ImGui::PopFont();
 
         ImGui::SetCursorPos(m_metadata_padding + ImVec2(m_reorder_grip_width, 0));
         // Adjust content size to account for padding

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -247,7 +247,7 @@ TrackItem::RenderMetaArea()
         }
 
         // Reordering grip decoration
-        float grid_icon_width = ImGui::CalcTextSize(ICON_DRAG).x;
+        float grid_icon_width = ImGui::CalcTextSize(ICON_GRID).x;
         float arrow_width     = ImGui::GetTextLineHeight();
 
         ImGui::SetCursorPos(
@@ -255,7 +255,7 @@ TrackItem::RenderMetaArea()
                    (container_size.y - ImGui::GetTextLineHeightWithSpacing()) / 2));
         ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
         ImGui::PushStyleColor(ImGuiCol_Text, m_settings.GetColor(Colors::kTextDim));
-        ImGui::TextUnformatted(ICON_DRAG);
+        ImGui::TextUnformatted(ICON_GRID);
         ImGui::PopStyleColor();
         ImGui::PopFont();
 

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -246,32 +246,28 @@ TrackItem::RenderMetaArea()
                                        anim_speed);
         }
 
-        // Reordering grip decoration: a 2x3 grid of grey dots painted directly via
-        // the draw list. The actual draggable hotspot is set up by TimelineView in
-        // a transparent overlay child sized to m_reorder_grip_width.
-        constexpr float kGripDotRadius  = 1.5f;
-        constexpr float kGripDotSpacing = 5.0f;
-        constexpr int   kGripCols       = 2;
-        constexpr int   kGripRows       = 3;
-        const float grip_block_w = (kGripCols - 1) * kGripDotSpacing;
-        const float grip_block_h = (kGripRows - 1) * kGripDotSpacing;
-        const float grid_icon_width = grip_block_w + kGripDotRadius * 2.0f;
-        const float arrow_width     = ImGui::GetTextLineHeight();
+        // 2x3 grid of dots used as the reorder grip decoration.
+        float dot_radius      = 1.5f;
+        float dot_spacing     = 5.0f;
+        int   grip_cols       = 2;
+        int   grip_rows       = 3;
+        float grip_block_w    = (grip_cols - 1) * dot_spacing;
+        float grip_block_h    = (grip_rows - 1) * dot_spacing;
+        float grid_icon_width = grip_block_w + dot_radius * 2.0f;
+        float arrow_width     = ImGui::GetTextLineHeight();
 
-        const ImU32  grip_color = m_settings.GetColor(Colors::kTextDim);
-        const ImVec2 win_pos    = ImGui::GetWindowPos();
-        const float  grip_origin_x =
-            win_pos.x + (m_reorder_grip_width - grip_block_w) * 0.5f;
-        const float  grip_origin_y =
-            win_pos.y + (container_size.y - grip_block_h) * 0.5f;
-        ImDrawList* draw_list = ImGui::GetWindowDrawList();
-        for(int col = 0; col < kGripCols; ++col)
+        ImU32       grip_color    = m_settings.GetColor(Colors::kTextDim);
+        ImVec2      win_pos       = ImGui::GetWindowPos();
+        float       grip_origin_x = win_pos.x + (m_reorder_grip_width - grip_block_w) * 0.5f;
+        float       grip_origin_y = win_pos.y + (container_size.y - grip_block_h) * 0.5f;
+        ImDrawList* draw_list     = ImGui::GetWindowDrawList();
+        for(int col = 0; col < grip_cols; ++col)
         {
-            for(int row = 0; row < kGripRows; ++row)
+            for(int row = 0; row < grip_rows; ++row)
             {
-                const ImVec2 center(grip_origin_x + col * kGripDotSpacing,
-                                    grip_origin_y + row * kGripDotSpacing);
-                draw_list->AddCircleFilled(center, kGripDotRadius, grip_color);
+                ImVec2 center(grip_origin_x + col * dot_spacing,
+                              grip_origin_y + row * dot_spacing);
+                draw_list->AddCircleFilled(center, dot_radius, grip_color);
             }
         }
 
@@ -331,7 +327,6 @@ TrackItem::RenderMetaArea()
             EndTooltipStyled();
         }
 
-        // Right-click anywhere in the metadata area opens the track options menu.
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
                             m_settings.GetDefaultStyle().WindowPadding);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -246,19 +246,34 @@ TrackItem::RenderMetaArea()
                                        anim_speed);
         }
 
-        // Reordering grip decoration
-        float grid_icon_width = ImGui::CalcTextSize(ICON_GRID).x;
-        float arrow_width       = ImGui::GetTextLineHeight();
+        // Reordering grip decoration: a 2x3 grid of grey dots painted directly via
+        // the draw list. The actual draggable hotspot is set up by TimelineView in
+        // a transparent overlay child sized to m_reorder_grip_width.
+        constexpr float kGripDotRadius  = 1.5f;
+        constexpr float kGripDotSpacing = 5.0f;
+        constexpr int   kGripCols       = 2;
+        constexpr int   kGripRows       = 3;
+        const float grip_block_w = (kGripCols - 1) * kGripDotSpacing;
+        const float grip_block_h = (kGripRows - 1) * kGripDotSpacing;
+        const float grid_icon_width = grip_block_w + kGripDotRadius * 2.0f;
+        const float arrow_width     = ImGui::GetTextLineHeight();
 
-        ImGui::SetCursorPos(
-            ImVec2((m_reorder_grip_width - grid_icon_width) / 2,
-                   (container_size.y - ImGui::GetTextLineHeightWithSpacing()) / 2));
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
-
-        ImGui::TextUnformatted(ICON_GRID);
-        float menu_button_width = ImGui::CalcTextSize(ICON_GEAR).x;
-      
-        ImGui::PopFont();
+        const ImU32  grip_color = m_settings.GetColor(Colors::kTextDim);
+        const ImVec2 win_pos    = ImGui::GetWindowPos();
+        const float  grip_origin_x =
+            win_pos.x + (m_reorder_grip_width - grip_block_w) * 0.5f;
+        const float  grip_origin_y =
+            win_pos.y + (container_size.y - grip_block_h) * 0.5f;
+        ImDrawList* draw_list = ImGui::GetWindowDrawList();
+        for(int col = 0; col < kGripCols; ++col)
+        {
+            for(int row = 0; row < kGripRows; ++row)
+            {
+                const ImVec2 center(grip_origin_x + col * kGripDotSpacing,
+                                    grip_origin_y + row * kGripDotSpacing);
+                draw_list->AddCircleFilled(center, kGripDotRadius, grip_color);
+            }
+        }
 
         ImGui::SetCursorPos(m_metadata_padding + ImVec2(m_reorder_grip_width, 0));
         // Adjust content size to account for padding
@@ -281,7 +296,7 @@ TrackItem::RenderMetaArea()
         ImGui::PushFont(large_font);
 
         float available_for_text =
-            content_size.x - (m_meta_area_scale_width + menu_button_width + grid_icon_width + arrow_width +
+            content_size.x - (m_meta_area_scale_width + grid_icon_width + arrow_width +
             4.0f * m_metadata_padding.x + 2.0f);
 
         if(available_for_text < 0.0f) available_for_text = 0.0f;
@@ -316,23 +331,14 @@ TrackItem::RenderMetaArea()
             EndTooltipStyled();
         }
 
-        ImGui::SetCursorPos(ImVec2(m_metadata_padding.x + content_size.x -
-                                       m_meta_area_scale_width - menu_button_width,
-                                   m_metadata_padding.y));
-        IconButton(ICON_GEAR,
-                   m_settings.GetFontManager().GetIconFont(FontType::kDefault));
-        if(ImGui::IsItemHovered())
-            SetTooltipStyled("Track Options");
+        // Right-click anywhere in the metadata area opens the track options menu.
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
                             m_settings.GetDefaultStyle().WindowPadding);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
                             m_settings.GetDefaultStyle().FrameRounding);
-        ImGui::SetNextWindowPos(ImGui::GetCursorScreenPos() +
-                                ImVec2(content_size.x - m_meta_area_scale_width -
-                                           menu_button_width -
-                                           ImGui::GetStyle().FramePadding.x,
-                                       0));
-        if(ImGui::BeginPopupContextItem("", ImGuiPopupFlags_MouseButtonLeft))
+        if(ImGui::BeginPopupContextWindow("##TrackOptionsPopup",
+                                          ImGuiPopupFlags_MouseButtonRight |
+                                              ImGuiPopupFlags_NoOpenOverItems))
         {
             RenderMetaAreaOptions();
             ImGui::EndPopup();

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -16,7 +16,7 @@ namespace RocProfVis
 namespace View
 {
 
-inline constexpr float DEFAULT_TRACK_HEIGHT = 84.0f;
+inline constexpr float DEFAULT_TRACK_HEIGHT = 82.0f;
 
 class SettingsManager;
 class TrackItem;

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -16,7 +16,7 @@ namespace RocProfVis
 namespace View
 {
 
-inline constexpr float DEFAULT_TRACK_HEIGHT = 82.0f;
+inline constexpr float DEFAULT_TRACK_HEIGHT = 81.0f;
 
 class SettingsManager;
 class TrackItem;

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -16,7 +16,9 @@ namespace RocProfVis
 namespace View
 {
 
-inline constexpr float DEFAULT_TRACK_HEIGHT = 82.0f;
+// Sized to fit two event levels (40 px each) plus the 4 px inter-level padding
+// used by flame tracks: 2 * 40 + 1 * 4 = 84.
+inline constexpr float DEFAULT_TRACK_HEIGHT = 84.0f;
 
 class SettingsManager;
 class TrackItem;

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -16,9 +16,6 @@ namespace RocProfVis
 namespace View
 {
 
-// Sized so the default track is exactly 2 event levels tall (2 * EVENT_LEVEL_HEIGHT)
-// plus the 2px metadata shrink padding applied in RenderMetaArea. This lets a track
-// with 2 events render in full without the expand arrow.
 inline constexpr float DEFAULT_TRACK_HEIGHT = 82.0f;
 
 class SettingsManager;

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -16,7 +16,10 @@ namespace RocProfVis
 namespace View
 {
 
-inline constexpr float DEFAULT_TRACK_HEIGHT = 75.0f;
+// Sized so the default track is exactly 2 event levels tall (2 * EVENT_LEVEL_HEIGHT)
+// plus the 2px metadata shrink padding applied in RenderMetaArea. This lets a track
+// with 2 events render in full without the expand arrow.
+inline constexpr float DEFAULT_TRACK_HEIGHT = 82.0f;
 
 class SettingsManager;
 class TrackItem;

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -16,7 +16,7 @@ namespace RocProfVis
 namespace View
 {
 
-inline constexpr float DEFAULT_TRACK_HEIGHT = 81.0f;
+inline constexpr float DEFAULT_TRACK_HEIGHT = 83.0f;
 
 class SettingsManager;
 class TrackItem;

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -16,8 +16,6 @@ namespace RocProfVis
 namespace View
 {
 
-// Sized to fit two event levels (40 px each) plus the 4 px inter-level padding
-// used by flame tracks: 2 * 40 + 1 * 4 = 84.
 inline constexpr float DEFAULT_TRACK_HEIGHT = 84.0f;
 
 class SettingsManager;


### PR DESCRIPTION
Cleaned up the track sidebar UX in a few small ways: bumped the default track height to fit two event rows (so 2-event tracks no longer prompt to expand), replaced the gear button with a right-click context menu on the metadata area, dimmed the reorder grip to kTextDim grey, dropped the "Color by Time Level" mode entirely along with the "No Color" / "Color by Name" radios so the track options menu is just Compact Mode now. 