### PR TITLE
File dialog fallback

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -203,3 +203,33 @@ cmake --build build/macos-release --preset "macOS Release Build" --parallel 4
 - macOS: the executable is in `build/<preset>/`.
 
 If you need symbol builds, use the `*-release-symbols` presets.
+
+---
+
+## File dialog behavior on Linux
+
+On Linux, `roc-optiq` uses the native [xdg-desktop-portal](https://flatpak.github.io/xdg-desktop-portal/) file chooser by default, but also ships the in-process ImGui file dialog as a fallback.
+
+The portal dialog is launched by an external D-Bus service on the host machine and is **not** compatible with remote display forwarding (e.g. `ssh -X` / `ssh -Y`): the portal parents its window on the host's compositor, so over an SSH session the dialog would appear on the host rather than on your client — or simply never appear at all if the host has no local display.
+
+To work around this, the application automatically picks the in-window ImGui dialog when it detects a remote session. Detection looks at:
+
+- `SSH_CONNECTION`, `SSH_CLIENT`, `SSH_TTY` environment variables (set by `sshd`), and
+- `DISPLAY` matching `localhost:N` with `N >= 10` (the range SSH uses for X11 forwarding).
+
+The chosen backend is logged once at startup. If the auto-detection gets it wrong (for example the SSH environment was stripped by `sudo` or `systemd-run`, or you are `ssh`'ing into the same host that also runs a local desktop), you can override it with the `--file-dialog` command-line flag:
+
+```bash
+# Force the in-process ImGui dialog regardless of detection
+roc-optiq --file-dialog=imgui
+
+# Force the native (xdg-desktop-portal) dialog
+roc-optiq --file-dialog=native
+
+# Let the app auto-detect (the default)
+roc-optiq --file-dialog=auto
+```
+
+If `xdg-desktop-portal` or D-Bus is not available on the host, the native dialog probe will fail gracefully at startup (or at the first dialog open) and the app will automatically fall back to the ImGui dialog for the remainder of the session.
+
+If you want to disable the native dialog entirely at build time (so ImGui is always used), configure with `-DUSE_NATIVE_FILE_DIALOG=OFF`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,6 @@ endif(ROCPROFVIS_DEVELOPER_MODE)
 if(ROCPROFVIS_ENABLE_INTERNAL_BANNER)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROCPROFVIS_ENABLE_INTERNAL_BANNER")
 endif(ROCPROFVIS_ENABLE_INTERNAL_BANNER)
-if(USE_NATIVE_FILE_DIALOG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_NATIVE_FILE_DIALOG")
-endif(USE_NATIVE_FILE_DIALOG)
 
 # Set GLFW library type based on option
 if(GLFW_LINK_STATIC)
@@ -260,15 +257,18 @@ if(APPLE)
 endif()
 
 # === NativeFileDialog Extended ===
+# When enabled, the native (portal) dialog is compiled in, but the in-process
+# ImGuiFileDialog is ALWAYS linked as well so the app can fall back to it at
+# runtime (e.g. when running over ssh -X where xdg-desktop-portal cannot
+# forward the dialog to the client).
 if(USE_NATIVE_FILE_DIALOG)
   set(NFD_PORTAL ON CACHE BOOL "Use xdg-desktop-portal instead of GTK")
   add_subdirectory(thirdparty/nativefiledialog-extended)
   target_link_libraries(${TARGET_NAME} PRIVATE nfd)
+  target_compile_definitions(${TARGET_NAME} PRIVATE ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG)
 endif()
-# === ImGuiFileDialog ===
-if(NOT USE_NATIVE_FILE_DIALOG)
-  target_link_libraries(${TARGET_NAME} PRIVATE ImGuiFileDialog)
-endif()
+# === ImGuiFileDialog (always linked as portable / SSH fallback) ===
+target_link_libraries(${TARGET_NAME} PRIVATE ImGuiFileDialog)
 
 # === Vulkan ===
 target_link_libraries(${TARGET_NAME} PRIVATE "${Vulkan_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,6 @@ option(USE_NATIVE_FILE_DIALOG "Use the OS native file dialog instead of ImGui fi
 option(GLFW_LINK_STATIC "Link GLFW statically instead of dynamically" ON)
 option(BUILD_TESTING "Build the testing tree" ON)
 
-if(APPLE AND USE_NATIVE_FILE_DIALOG)
-    set(USE_NATIVE_FILE_DIALOG OFF CACHE BOOL
-        "Use the OS native file dialog instead of ImGui file dialog" FORCE)
-    message(WARNING "Disabling native file dialog on macOS; it must run on the main thread.")
-endif()
-
 if(COMPUTE_UI_SUPPORT) 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCOMPUTE_UI_SUPPORT")
 endif(COMPUTE_UI_SUPPORT)

--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -116,13 +116,18 @@ parse_command_line_args(int argc, char** argv, RocProfVis::View::CLIParser& cli_
 {
     cli_parser.SetAppDescription(APP_NAME, "A visualizer for profiling ROCm Data");
     bool result = true;
-    result &= cli_parser.AddOption("v", "version", "Print application version", false);
-    result &= cli_parser.AddOption("f", "file", "Open file", true);
-    result &= cli_parser.AddOption("b", "backend", "Force rendering backend: 'vulkan' or 'opengl' (default: auto with fallback)", true);
-    result &= cli_parser.AddOption("d", "file-dialog",
-        "File dialog backend: 'auto' (default), 'native' (xdg-desktop-portal), "
-        "or 'imgui' (in-process). Use 'imgui' for ssh -X sessions.", true);
-    result &= cli_parser.AddOption("h", "help", "Help the user with commands", false);
+    result &= cli_parser.AddOption("v", "version", "Print version and exit", false);
+    result &= cli_parser.AddOption("f", "file", "Open a trace or project file", true);
+    result &= cli_parser.AddOption(
+        "b", "backend",
+        "Set rendering backend: 'auto' (default), 'vulkan', or 'opengl'", true);
+    result &= cli_parser.AddOption(
+        "d", "file-dialog",
+        "Set file dialog backend: 'auto' (default), 'native' (system file "
+        "dialog), or 'imgui' (built-in). Use 'imgui' when running over SSH",
+        true);
+    result &= cli_parser.AddOption("h", "help",
+        "Show this help message and exit", false);
     ROCPROFVIS_ASSERT(result);
 
     cli_parser.Parse(argc, argv);
@@ -183,7 +188,11 @@ main(int argc, char** argv)
     if(cli_parser.WasOptionFound("backend"))
     {
         std::string backend_str = cli_parser.GetOptionValue("backend");
-        if(backend_str == "vulkan")
+        if(backend_str == "auto")
+        {
+            backend_pref = kRPVBackendAuto;
+        }
+        else if(backend_str == "vulkan")
         {
             backend_pref = kRPVBackendForceVulkan;
         }
@@ -193,7 +202,7 @@ main(int argc, char** argv)
         }
         else
         {
-            spdlog::error("Invalid backend '{}'. Valid options: vulkan, opengl", backend_str);
+            spdlog::error("Invalid backend '{}'. Valid options: auto, vulkan, opengl", backend_str);
             return 1;
         }
     }

--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -119,6 +119,9 @@ parse_command_line_args(int argc, char** argv, RocProfVis::View::CLIParser& cli_
     result &= cli_parser.AddOption("v", "version", "Print application version", false);
     result &= cli_parser.AddOption("f", "file", "Open file", true);
     result &= cli_parser.AddOption("b", "backend", "Force rendering backend: 'vulkan' or 'opengl' (default: auto with fallback)", true);
+    result &= cli_parser.AddOption("d", "file-dialog",
+        "File dialog backend: 'auto' (default), 'native' (xdg-desktop-portal), "
+        "or 'imgui' (in-process). Use 'imgui' for ssh -X sessions.", true);
     result &= cli_parser.AddOption("h", "help", "Help the user with commands", false);
     ROCPROFVIS_ASSERT(result);
 
@@ -195,6 +198,31 @@ main(int argc, char** argv)
         }
     }
 
+    rocprofvis_view_file_dialog_preference_t fd_pref = kRocProfVisViewFileDialog_Auto;
+    if(cli_parser.WasOptionFound("file-dialog"))
+    {
+        std::string fd_str = cli_parser.GetOptionValue("file-dialog");
+        if(fd_str == "auto")
+        {
+            fd_pref = kRocProfVisViewFileDialog_Auto;
+        }
+        else if(fd_str == "native")
+        {
+            fd_pref = kRocProfVisViewFileDialog_Native;
+        }
+        else if(fd_str == "imgui")
+        {
+            fd_pref = kRocProfVisViewFileDialog_ImGui;
+        }
+        else
+        {
+            spdlog::error("Invalid --file-dialog '{}'. Valid options: auto, "
+                          "native, imgui",
+                          fd_str);
+            return 1;
+        }
+    }
+
     glfwSetErrorCallback(glfw_error_callback);
 #ifdef __linux__
     // Force X11 on Linux for multi-viewport and window positioning support
@@ -251,7 +279,7 @@ main(int argc, char** argv)
 
                 rocprofvis_view_init([window](int notification) -> void {
                     app_notification_callback(window, notification);
-                });
+                }, fd_pref);
 
                 backend.m_config(&backend, window);
 

--- a/src/app/src/rocprofvis_imgui_backend.cpp
+++ b/src/app/src/rocprofvis_imgui_backend.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_imgui_backend.h"
+#include "rocprofvis_view_module.h"
 #include "spdlog/spdlog.h"
 #include <GLFW/glfw3.h>
 #include <stdio.h>
@@ -94,8 +95,20 @@ rocprofvis_imgui_backend_setup_with_fallback(
 
         case kRPVBackendAuto:
         default:
+        {
+            // SSH X11 forwarding can cause Vulkan drivers to crash during
+            // swapchain creation rather than returning an error code.
+            // Detect this and skip straight to OpenGL.
+            bool skip_vulkan = false;
+            if(rocprofvis_view_is_remote_display_session())
+            {
+                spdlog::warn("[rpv] Remote display session detected, "
+                             "skipping Vulkan to avoid driver issues with X11 forwarding. "
+                             "Use --backend vulkan to override.");
+                skip_vulkan = true;
+            }
             // Auto mode: Try Vulkan first, fallback to OpenGL on failure
-            if(glfwVulkanSupported())
+            if(!skip_vulkan && glfwVulkanSupported())
             {
                 spdlog::info("[rpv] Vulkan is supported, attempting Vulkan backend...");
                 bOk = rocprofvis_imgui_backend_setup_vulkan(backend, *window);
@@ -112,14 +125,17 @@ rocprofvis_imgui_backend_setup_with_fallback(
             }
             else
             {
-                // Vulkan not supported, use OpenGL directly
-                spdlog::info("[rpv] Vulkan not supported by GLFW, recreating window for "
-                             "OpenGL...");
+                if(!skip_vulkan)
+                {
+                    spdlog::info("[rpv] Vulkan not supported by GLFW, recreating window "
+                                 "for OpenGL...");
+                }
                 glfwDestroyWindow(*window);
                 bOk = setup_opengl_window_and_backend(backend, window, width, height,
                                                       title);
             }
             break;
+        }
     }
 
     if(!bOk)

--- a/src/view/inc/rocprofvis_view_module.h
+++ b/src/view/inc/rocprofvis_view_module.h
@@ -48,3 +48,6 @@ rocprofvis_view_set_fullscreen_state(bool is_fullscreen);
 
 std::string
 rocprofvis_get_application_config_path();
+
+bool
+rocprofvis_view_is_remote_display_session();

--- a/src/view/inc/rocprofvis_view_module.h
+++ b/src/view/inc/rocprofvis_view_module.h
@@ -19,8 +19,17 @@ typedef enum rocprofvis_view_notification_t
     kRocProfVisViewNotification_Toggle_Fullscreen = 2,
 } rocprofvis_view_notification_t;
 
+typedef enum rocprofvis_view_file_dialog_preference_t
+{
+    kRocProfVisViewFileDialog_Auto   = 0,
+    kRocProfVisViewFileDialog_Native = 1,
+    kRocProfVisViewFileDialog_ImGui  = 2,
+} rocprofvis_view_file_dialog_preference_t;
+
 bool
-rocprofvis_view_init(std::function<void(int)> notification_callback);
+rocprofvis_view_init(std::function<void(int)>                 notification_callback,
+                     rocprofvis_view_file_dialog_preference_t file_dialog_pref =
+                         kRocProfVisViewFileDialog_Auto);
 
 void
 rocprofvis_view_render(const rocprofvis_view_render_options_t& render_options);

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -97,7 +97,8 @@ AppWindow::AppWindow()
 , m_message_dialog(std::make_unique<MessageDialog>())
 , m_tool_bar_index(0)
 , m_is_fullscreen(false)
-, m_use_native_file_dialog(should_use_native_file_dialog())
+, m_file_dialog_preference(kRocProfVisViewFileDialog_Auto)
+, m_use_native_file_dialog(false)
 , m_init_file_dialog(false)
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
 , m_is_native_file_dialog_open(false)
@@ -183,7 +184,70 @@ AppWindow::Init()
     m_tabselected_event_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kTabSelected), new_tab_selected_handler);
 
+    ConfigureFileDialogBackend();
+
     return result;
+}
+
+void
+AppWindow::ConfigureFileDialogBackend()
+{
+    bool want_native = false;
+    switch(m_file_dialog_preference)
+    {
+        case kRocProfVisViewFileDialog_ImGui:
+            want_native = false;
+            break;
+        case kRocProfVisViewFileDialog_Native:
+            want_native = true;
+            break;
+        case kRocProfVisViewFileDialog_Auto:
+        default:
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
+            want_native = !is_remote_display_session();
+#else
+            want_native = false;
+#endif
+            break;
+    }
+
+#ifndef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
+    if(want_native)
+    {
+        spdlog::warn("--file-dialog=native requested but native dialog was "
+                     "not compiled in; using ImGui.");
+        want_native = false;
+    }
+#else
+    if(want_native)
+    {
+        nfdresult_t nfd_result = NFD_Init();
+        if(nfd_result != NFD_OKAY)
+        {
+            const char* err = NFD_GetError();
+            spdlog::warn("NFD_Init failed ({}); falling back to in-process "
+                         "ImGui file dialog.",
+                         err ? err : "unknown");
+            NFD_ClearError();
+            want_native = false;
+        }
+        else
+        {
+            NFD_Quit();
+        }
+    }
+#endif
+
+    m_use_native_file_dialog.store(want_native);
+    spdlog::info("File dialog backend: {}",
+                 want_native ? "native (xdg-desktop-portal)"
+                             : "in-process ImGuiFileDialog");
+}
+
+void
+AppWindow::SetFileDialogPreference(rocprofvis_view_file_dialog_preference_t pref)
+{
+    m_file_dialog_preference = pref;
 }
 
 void
@@ -259,7 +323,7 @@ AppWindow::ShowSaveFileDialog(const std::string& title, const std::vector<FileFi
                               std::function<void(std::string)> callback)
 {
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
-    if(m_use_native_file_dialog)
+    if(m_use_native_file_dialog.load())
     {
         (void)title;
         ShowNativeFileDialog(file_filters, initial_path, callback, true);
@@ -275,7 +339,7 @@ AppWindow::ShowOpenFileDialog(const std::string& title, const std::vector<FileFi
                               std::function<void(std::string)> callback)
 {
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
-    if(m_use_native_file_dialog)
+    if(m_use_native_file_dialog.load())
     {
         (void)title;
         ShowNativeFileDialog(file_filters, initial_path, callback, false);
@@ -1070,7 +1134,17 @@ AppWindow::ShowNativeFileDialog(const std::vector<FileFilter>&   file_filters,
     }
 
     m_file_dialog_future = std::async(std::launch::async, [=]() -> std::string {
-        NFD_Init();
+        nfdresult_t init_result = NFD_Init();
+        if(init_result != NFD_OKAY)
+        {
+            const char* err = NFD_GetError();
+            spdlog::error("NFD_Init failed at dialog open: {}",
+                          err ? err : "unknown");
+            NFD_ClearError();
+            m_use_native_file_dialog.store(false);
+            return std::string();
+        }
+
         nfdu8char_t* outPath = nullptr;
 
         nfdu8filteritem_t*       filters = new nfdu8filteritem_t[file_filters.size()];
@@ -1123,7 +1197,6 @@ AppWindow::ShowNativeFileDialog(const std::vector<FileFilter>&   file_filters,
             file_path = outPath;
             if(outPath)
             {
-                // Append default extension if none provided (used to prevent linux from saving files with no extension).
                 std::filesystem::path p(file_path);
                 if(!p.has_extension())
                 {

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -1068,7 +1068,7 @@ AppWindow::ShowNativeFileDialog(const std::vector<FileFilter>&   file_filters,
         }
     }
 
-    m_file_dialog_future = std::async(std::launch::async, [=]() -> std::string {
+    auto dialog_task = [=]() -> std::string {
         NFD_Init();
         nfdu8char_t* outPath = nullptr;
 
@@ -1143,7 +1143,18 @@ AppWindow::ShowNativeFileDialog(const std::vector<FileFilter>&   file_filters,
         }
         NFD_Quit();
         return file_path;
-    });
+    };
+
+#if defined(__APPLE__)
+    // NSOpenPanel / NSSavePanel are AppKit objects and must be driven from the
+    // main thread. Run synchronously here and hand the result to the existing
+    // future-polling path via a ready promise.
+    std::promise<std::string> dialog_promise;
+    dialog_promise.set_value(dialog_task());
+    m_file_dialog_future = dialog_promise.get_future();
+#else
+    m_file_dialog_future = std::async(std::launch::async, std::move(dialog_task));
+#endif
 }
 
 #endif

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -4,11 +4,10 @@
 #include "rocprofvis_appwindow.h"
 #include "imgui.h"
 #include "implot.h"
-#ifdef USE_NATIVE_FILE_DIALOG
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
 #    include "nfd.h"
-#else
-#    include "ImGuiFileDialog.h"
 #endif
+#include "ImGuiFileDialog.h"
 
 #include "amd_rocm_optiq_logo_png.h"
 #include "rocprofvis_controller.h"
@@ -98,9 +97,9 @@ AppWindow::AppWindow()
 , m_message_dialog(std::make_unique<MessageDialog>())
 , m_tool_bar_index(0)
 , m_is_fullscreen(false)
-#ifndef USE_NATIVE_FILE_DIALOG
+, m_use_native_file_dialog(should_use_native_file_dialog())
 , m_init_file_dialog(false)
-#else
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
 , m_is_native_file_dialog_open(false)
 #endif
 , m_disable_app_interaction(false)
@@ -259,12 +258,15 @@ AppWindow::ShowSaveFileDialog(const std::string& title, const std::vector<FileFi
                               const std::string&               initial_path,
                               std::function<void(std::string)> callback)
 {
-    #ifdef USE_NATIVE_FILE_DIALOG
-    (void)title;
-    ShowNativeFileDialog(file_filters, initial_path, callback, true);
-    #else
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
+    if(m_use_native_file_dialog)
+    {
+        (void)title;
+        ShowNativeFileDialog(file_filters, initial_path, callback, true);
+        return;
+    }
+#endif
     ShowImGuiFileDialog(title, file_filters, initial_path, true, callback);
-    #endif
 }
 
 void
@@ -272,12 +274,15 @@ AppWindow::ShowOpenFileDialog(const std::string& title, const std::vector<FileFi
                               const std::string&               initial_path,
                               std::function<void(std::string)> callback)
 {
-    #ifdef USE_NATIVE_FILE_DIALOG
-    (void)title;
-    ShowNativeFileDialog(file_filters, initial_path, callback, false);
-    #else
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
+    if(m_use_native_file_dialog)
+    {
+        (void)title;
+        ShowNativeFileDialog(file_filters, initial_path, callback, false);
+        return;
+    }
+#endif
     ShowImGuiFileDialog(title, file_filters, initial_path, false, callback);
-    #endif
 }
 
 Project*
@@ -306,7 +311,7 @@ AppWindow::GetCurrentProject()
 void
 AppWindow::Update()
 {
-#ifdef USE_NATIVE_FILE_DIALOG
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
     UpdateNativeFileDialog();
 #endif
     HotkeyManager::GetInstance().ProcessInput();
@@ -380,9 +385,7 @@ AppWindow::Render()
     // ImGuiStyleVar_WindowRounding
     ImGui::PopStyleVar(3);
 
-#ifndef USE_NATIVE_FILE_DIALOG    
-     RenderFileDialog();
-#endif
+    RenderFileDialog();
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     RenderDebugOuput();
 #endif
@@ -512,7 +515,6 @@ AppWindow::RenderEmptyState()
     }
 }
 
-#ifndef USE_NATIVE_FILE_DIALOG
 void
 AppWindow::RenderFileDialog()
 {
@@ -551,7 +553,6 @@ AppWindow::RenderFileDialog()
     }
     ImGui::PopStyleVar(3);
 }
-#endif
 
 void
 AppWindow::OpenFile(std::string file_path)
@@ -629,10 +630,10 @@ AppWindow::RenderDisableScreen()
 void
 AppWindow::RenderFileMenu(Project* project)
 {
-    bool is_open_file_dialog_open = false;
-    #ifdef USE_NATIVE_FILE_DIALOG
-    is_open_file_dialog_open = m_is_native_file_dialog_open;
-    #endif
+    bool is_open_file_dialog_open = ImGuiFileDialog::Instance()->IsOpened(FILE_DIALOG_NAME);
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
+    is_open_file_dialog_open = is_open_file_dialog_open || m_is_native_file_dialog_open.load();
+#endif
 
     if(ImGui::BeginMenu("File"))
     {
@@ -1009,7 +1010,7 @@ AppWindow::RenderAboutDialog()
 
  }
 
-#ifdef USE_NATIVE_FILE_DIALOG
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
 void
 AppWindow::UpdateNativeFileDialog()
 {
@@ -1148,7 +1149,6 @@ AppWindow::ShowNativeFileDialog(const std::vector<FileFilter>&   file_filters,
 
 #endif
 
-#ifndef USE_NATIVE_FILE_DIALOG
 void
 AppWindow::ShowImGuiFileDialog(const std::string& title, const std::vector<FileFilter>& file_filters,
                           const std::string& initial_path, const bool& confirm_overwrite,
@@ -1186,7 +1186,6 @@ AppWindow::ShowImGuiFileDialog(const std::string& title, const std::vector<FileF
     ImGuiFileDialog::Instance()->OpenDialog(FILE_DIALOG_NAME, title,
                                             filter_stream.str().c_str(), config);
 }
-#endif
 
 #ifdef ROCPROFVIS_DEVELOPER_MODE
 void

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -240,8 +240,7 @@ AppWindow::ConfigureFileDialogBackend()
 
     m_use_native_file_dialog.store(want_native);
     spdlog::info("File dialog backend: {}",
-                 want_native ? "native (xdg-desktop-portal)"
-                             : "in-process ImGuiFileDialog");
+                 want_native ? "system file dialog" : "in-process ImGuiFileDialog");
 }
 
 void

--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -8,11 +8,12 @@
 #include "rocprofvis_event_manager.h"
 #include "rocprofvis_settings_panel.h"
 #include "widgets/rocprofvis_gui_helpers.h"
+#include "rocprofvis_view_module.h"
 #include "widgets/rocprofvis_split_containers.h"
 #include "widgets/rocprofvis_tab_container.h"
 
-#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
 #include <atomic>
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
 #include <future>
 #include <thread>
 #include <chrono>
@@ -72,6 +73,8 @@ public:
     void SetFullscreenState(bool is_fullscreen);
     bool GetFullscreenState() const;
 
+    void SetFileDialogPreference(rocprofvis_view_file_dialog_preference_t pref);
+
 private:
     AppWindow();
     ~AppWindow();
@@ -91,6 +94,7 @@ private:
     void HandleOpenFile();
     void HandleOpenRecentFile(const std::string& file_path);
     void HandleSaveAsFile();
+    void ConfigureFileDialogBackend();
 
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
     void UpdateNativeFileDialog();
@@ -130,11 +134,11 @@ private:
     bool m_open_about_dialog;
     bool m_disable_app_interaction;
 
-    // Whether the native (xdg-desktop-portal) dialog should be used; decided
-    // once at Init() time. When false, the in-process ImGui dialog is used,
-    // which is necessary for remote SSH sessions where the portal cannot
-    // forward its window to the client. See should_use_native_file_dialog().
-    bool                             m_use_native_file_dialog;
+    rocprofvis_view_file_dialog_preference_t m_file_dialog_preference;
+
+    // Decided at Init() time; can be downgraded to false if NFD_Init fails at
+    // runtime. Atomic because the async native-dialog lambda can flip it.
+    std::atomic<bool>                m_use_native_file_dialog;
 
     bool                             m_init_file_dialog;
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG

--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -11,7 +11,7 @@
 #include "widgets/rocprofvis_split_containers.h"
 #include "widgets/rocprofvis_tab_container.h"
 
-#ifdef USE_NATIVE_FILE_DIALOG
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
 #include <atomic>
 #include <future>
 #include <thread>
@@ -92,19 +92,18 @@ private:
     void HandleOpenRecentFile(const std::string& file_path);
     void HandleSaveAsFile();
 
-#ifdef USE_NATIVE_FILE_DIALOG
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
     void UpdateNativeFileDialog();
 
     void ShowNativeFileDialog(const std::vector<FileFilter>&   file_filters,
                               const std::string&               initial_path,
                               std::function<void(std::string)> callback,
                               bool                             save_dialog);
-#else
+#endif
     void ShowImGuiFileDialog(const std::string&             title,
                         const std::vector<FileFilter>& file_filters,
                         const std::string& initial_path, const bool& confirm_overwrite,
                         std::function<void(std::string)> callback);
-#endif
     static AppWindow* s_instance;
 
     std::shared_ptr<VFixedContainer> m_main_view;
@@ -131,9 +130,14 @@ private:
     bool m_open_about_dialog;
     bool m_disable_app_interaction;
 
-#ifndef USE_NATIVE_FILE_DIALOG
+    // Whether the native (xdg-desktop-portal) dialog should be used; decided
+    // once at Init() time. When false, the in-process ImGui dialog is used,
+    // which is necessary for remote SSH sessions where the portal cannot
+    // forward its window to the client. See should_use_native_file_dialog().
+    bool                             m_use_native_file_dialog;
+
     bool                             m_init_file_dialog;
-#else
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
     std::atomic<bool>                m_is_native_file_dialog_open;
     std::future<std::string>         m_file_dialog_future;
 #endif

--- a/src/view/src/rocprofvis_utils.cpp
+++ b/src/view/src/rocprofvis_utils.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_utils.h"
-#include "spdlog/spdlog.h"
 #include <cctype>
 #include <cmath>
 #include <cstdint>
@@ -433,25 +432,6 @@ RocProfVis::View::get_executable_name(const std::string& fullPath)
 
 namespace
 {
-// Returns true if the env var is set to a value that is neither empty nor a
-// conventional "disabled" literal ("0", "false", "no", case-insensitive).
-bool
-env_flag_enabled(const char* name)
-{
-    const char* v = std::getenv(name);
-    if(v == nullptr || v[0] == '\0')
-    {
-        return false;
-    }
-    std::string lowered(v);
-    for(char& c : lowered)
-    {
-        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-    }
-    return lowered != "0" && lowered != "false" && lowered != "no" &&
-           lowered != "off";
-}
-
 // Returns true if DISPLAY looks like an SSH X11-forwarded display, e.g.
 // "localhost:10.0". SSH always uses the "localhost:" prefix and allocates
 // display numbers starting at 10 by default (X11DisplayOffset in sshd_config).
@@ -493,69 +473,3 @@ RocProfVis::View::is_remote_display_session()
     return s_cached;
 }
 
-bool
-RocProfVis::View::should_use_native_file_dialog()
-{
-    static const bool s_cached = []() {
-        const bool force_imgui  = env_flag_enabled("ROCPROFVIS_FORCE_IMGUI_DIALOG");
-        const bool force_native = env_flag_enabled("ROCPROFVIS_FORCE_NATIVE_DIALOG");
-
-#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
-        constexpr bool have_native = true;
-#else
-        constexpr bool have_native = false;
-#endif
-
-        bool        use_native = false;
-        const char* reason     = "";
-
-        if(force_imgui)
-        {
-            use_native = false;
-            reason     = "ROCPROFVIS_FORCE_IMGUI_DIALOG is set";
-        }
-        else if(force_native && have_native)
-        {
-            use_native = true;
-            reason     = "ROCPROFVIS_FORCE_NATIVE_DIALOG is set";
-        }
-        else if(force_native && !have_native)
-        {
-            use_native = false;
-            reason     = "ROCPROFVIS_FORCE_NATIVE_DIALOG is set but native "
-                         "dialog was not compiled in";
-        }
-        else if(!have_native)
-        {
-            use_native = false;
-            reason     = "native dialog was not compiled in";
-        }
-        else if(is_remote_display_session())
-        {
-            use_native = false;
-            if(std::getenv("SSH_CONNECTION") != nullptr ||
-               std::getenv("SSH_CLIENT") != nullptr ||
-               std::getenv("SSH_TTY") != nullptr)
-            {
-                reason = "SSH session detected; xdg-desktop-portal cannot "
-                         "forward to the client";
-            }
-            else
-            {
-                reason = "DISPLAY looks like an SSH-forwarded X11 display";
-            }
-        }
-        else
-        {
-            use_native = true;
-            reason     = "local session";
-        }
-
-        spdlog::info("File dialog backend: {} ({})",
-                     use_native ? "native (xdg-desktop-portal)"
-                                : "in-process ImGuiFileDialog",
-                     reason);
-        return use_native;
-    }();
-    return s_cached;
-}

--- a/src/view/src/rocprofvis_utils.cpp
+++ b/src/view/src/rocprofvis_utils.cpp
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_utils.h"
+#include "spdlog/spdlog.h"
+#include <cctype>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <iomanip>
 #include <limits>
 #include <sstream>
+#include <string>
 #ifdef _WIN32
 #define NOMINMAX
 #include <windows.h>
@@ -424,4 +429,133 @@ RocProfVis::View::get_executable_name(const std::string& fullPath)
     return (pos == std::string::npos)
         ? fullPath
         : fullPath.substr(pos + 1);
+}
+
+namespace
+{
+// Returns true if the env var is set to a value that is neither empty nor a
+// conventional "disabled" literal ("0", "false", "no", case-insensitive).
+bool
+env_flag_enabled(const char* name)
+{
+    const char* v = std::getenv(name);
+    if(v == nullptr || v[0] == '\0')
+    {
+        return false;
+    }
+    std::string lowered(v);
+    for(char& c : lowered)
+    {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return lowered != "0" && lowered != "false" && lowered != "no" &&
+           lowered != "off";
+}
+
+// Returns true if DISPLAY looks like an SSH X11-forwarded display, e.g.
+// "localhost:10.0". SSH always uses the "localhost:" prefix and allocates
+// display numbers starting at 10 by default (X11DisplayOffset in sshd_config).
+bool
+display_looks_forwarded()
+{
+    const char* disp = std::getenv("DISPLAY");
+    if(disp == nullptr || disp[0] == '\0')
+    {
+        return false;
+    }
+    constexpr const char* kPrefix   = "localhost:";
+    constexpr size_t      kPrefixSz = 10;
+    if(std::strncmp(disp, kPrefix, kPrefixSz) != 0)
+    {
+        return false;
+    }
+    const char* num_begin = disp + kPrefixSz;
+    if(!std::isdigit(static_cast<unsigned char>(*num_begin)))
+    {
+        return false;
+    }
+    char*    end  = nullptr;
+    long     port = std::strtol(num_begin, &end, 10);
+    return end != num_begin && port >= 10;
+}
+}  // namespace
+
+bool
+RocProfVis::View::is_remote_display_session()
+{
+    static const bool s_cached = []() {
+        const bool ssh_connection = std::getenv("SSH_CONNECTION") != nullptr;
+        const bool ssh_client     = std::getenv("SSH_CLIENT") != nullptr;
+        const bool ssh_tty        = std::getenv("SSH_TTY") != nullptr;
+        const bool forwarded      = display_looks_forwarded();
+        return ssh_connection || ssh_client || ssh_tty || forwarded;
+    }();
+    return s_cached;
+}
+
+bool
+RocProfVis::View::should_use_native_file_dialog()
+{
+    static const bool s_cached = []() {
+        const bool force_imgui  = env_flag_enabled("ROCPROFVIS_FORCE_IMGUI_DIALOG");
+        const bool force_native = env_flag_enabled("ROCPROFVIS_FORCE_NATIVE_DIALOG");
+
+#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
+        constexpr bool have_native = true;
+#else
+        constexpr bool have_native = false;
+#endif
+
+        bool        use_native = false;
+        const char* reason     = "";
+
+        if(force_imgui)
+        {
+            use_native = false;
+            reason     = "ROCPROFVIS_FORCE_IMGUI_DIALOG is set";
+        }
+        else if(force_native && have_native)
+        {
+            use_native = true;
+            reason     = "ROCPROFVIS_FORCE_NATIVE_DIALOG is set";
+        }
+        else if(force_native && !have_native)
+        {
+            use_native = false;
+            reason     = "ROCPROFVIS_FORCE_NATIVE_DIALOG is set but native "
+                         "dialog was not compiled in";
+        }
+        else if(!have_native)
+        {
+            use_native = false;
+            reason     = "native dialog was not compiled in";
+        }
+        else if(is_remote_display_session())
+        {
+            use_native = false;
+            if(std::getenv("SSH_CONNECTION") != nullptr ||
+               std::getenv("SSH_CLIENT") != nullptr ||
+               std::getenv("SSH_TTY") != nullptr)
+            {
+                reason = "SSH session detected; xdg-desktop-portal cannot "
+                         "forward to the client";
+            }
+            else
+            {
+                reason = "DISPLAY looks like an SSH-forwarded X11 display";
+            }
+        }
+        else
+        {
+            use_native = true;
+            reason     = "local session";
+        }
+
+        spdlog::info("File dialog backend: {} ({})",
+                     use_native ? "native (xdg-desktop-portal)"
+                                : "in-process ImGuiFileDialog",
+                     reason);
+        return use_native;
+    }();
+    return s_cached;
 }

--- a/src/view/src/rocprofvis_utils.h
+++ b/src/view/src/rocprofvis_utils.h
@@ -255,21 +255,5 @@ get_executable_name(const std::string& fullPath);
 bool
 is_remote_display_session();
 
-/**
- * @brief Decides at startup which file-dialog backend the application should use.
- *
- * Checked in order:
- *   1. Env var `ROCPROFVIS_FORCE_IMGUI_DIALOG`  -> returns false
- *   2. Env var `ROCPROFVIS_FORCE_NATIVE_DIALOG` -> returns true (only meaningful
- *      when the native dialog was compiled in; otherwise ignored).
- *   3. Native dialog compiled in AND !is_remote_display_session() -> true
- *   4. Otherwise -> false (use the in-process ImGui dialog).
- *
- * Logs the decision and the reason exactly once via spdlog.
- * The result is cached on first call.
- */
-bool
-should_use_native_file_dialog();
-
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/rocprofvis_utils.h
+++ b/src/view/src/rocprofvis_utils.h
@@ -242,5 +242,34 @@ open_url(const std::string& url);
 std::string
 get_executable_name(const std::string& fullPath);
 
+/**
+ * @brief Detects whether the current process appears to be running in a remote
+ *        session where xdg-desktop-portal file dialogs cannot reach the user.
+ *
+ * Returns true when any of `SSH_CONNECTION`, `SSH_CLIENT`, or `SSH_TTY` is set,
+ * or when `DISPLAY` matches the pattern `localhost:N[.S]` with `N >= 10` (the
+ * display-number range SSH uses for X11 forwarding; local X servers use :0/:1).
+ *
+ * The result is cached on first call.
+ */
+bool
+is_remote_display_session();
+
+/**
+ * @brief Decides at startup which file-dialog backend the application should use.
+ *
+ * Checked in order:
+ *   1. Env var `ROCPROFVIS_FORCE_IMGUI_DIALOG`  -> returns false
+ *   2. Env var `ROCPROFVIS_FORCE_NATIVE_DIALOG` -> returns true (only meaningful
+ *      when the native dialog was compiled in; otherwise ignored).
+ *   3. Native dialog compiled in AND !is_remote_display_session() -> true
+ *   4. Otherwise -> false (use the in-process ImGui dialog).
+ *
+ * Logs the decision and the reason exactly once via spdlog.
+ * The result is cached on first call.
+ */
+bool
+should_use_native_file_dialog();
+
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/rocprofvis_view_module.cpp
+++ b/src/view/src/rocprofvis_view_module.cpp
@@ -11,9 +11,11 @@
 using namespace RocProfVis::View;
 
 bool
-rocprofvis_view_init(std::function<void(int)> notification_callback)
+rocprofvis_view_init(std::function<void(int)>                 notification_callback,
+                     rocprofvis_view_file_dialog_preference_t file_dialog_pref)
 {
     auto app = AppWindow::GetInstance();
+    app->SetFileDialogPreference(file_dialog_pref);
     bool result = app->Init();
     if(!result)
     {

--- a/src/view/src/rocprofvis_view_module.cpp
+++ b/src/view/src/rocprofvis_view_module.cpp
@@ -82,3 +82,9 @@ rocprofvis_get_application_config_path()
     // Get the application config path
     return get_application_config_path(true);
 }
+
+bool
+rocprofvis_view_is_remote_display_session()
+{
+    return is_remote_display_session();
+}


### PR DESCRIPTION
## Motivation

Improvements to the file dialog infrastructure are needed.  A number of issues exist with the current implementation such as:
- native dialog not being forwarded over remote ssh sessions
- application crashing if dbus is not present or native file dialog fails to initialize for some other reason 

## Technical Details

Runtime file dialog fallback for SSH sessions: Both the native (xdg-desktop-portal / macOS) file dialog and the built-in ImGui file dialog are now compiled into every build. 

At startup the app auto-detects remote sessions (SSH_CONNECTION, SSH_CLIENT, SSH_TTY, or forwarded DISPLAY) and transparently uses the ImGui dialog, which forwards correctly over ssh -X.

Graceful NFD_Init failure handling: NFD_Init() is probed at startup and checked again at each dialog open. If it fails (e.g. no D-Bus), the app permanently downgrades to the ImGui dialog instead of crashing.

--file-dialog CLI flag: New `--file-dialog=auto|native|imgui option (-d)`  to override auto-detection.

macOS native dialog support (merged from sw-macos-file-explorer): Removes the blanket macOS USE_NATIVE_FILE_DIALOG=OFF override. The native dialog now runs synchronously on the main thread via std::promise to satisfy AppKit's threading requirements.


## Test Plan

Build with
USE_NATIVE_FILE_DIALOG=ON
(default) on Linux — verify both dialog paths work

Build with
USE_NATIVE_FILE_DIALOG=OFF
— verify ImGui-only path compiles and runs

Run over
ssh -X
— verify auto-detection picks ImGui and file dialog appears on the client

Run
--file-dialog=imgui
locally — verify override works

Run
--file-dialog=native
over SSH — verify native is forced

Run on a system without D-Bus/portal — verify graceful fallback, no crash

Verify macOS native file dialog opens correctly (main-thread dispatch)