### PR TITLE
Fixed AIPROFVIS-253 bug - incorrect level calculation

### DIFF
--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1698,6 +1698,7 @@ int ProfileDatabase::CalculateEventLevels(void* data, int argc, sqlite3_stmt* st
     id_value.bitfield.event_node = db_instance->GuidIndex();
     id_value.bitfield.event_op = op;
     params->m_active_events.push_back({id_value.value, start_time, end_time, level});
+    params->m_active_events.sort([](const rocprofvis_event_timing_params_t& a, const rocprofvis_event_timing_params_t& b) { return a.level < b.level;});
     callback_params->future->CountThisRow();
     {
         std::lock_guard<std::mutex> lock(db->m_level_lock);

--- a/src/model/src/database/rocprofvis_db_version.h
+++ b/src/model/src/database/rocprofvis_db_version.h
@@ -57,11 +57,12 @@ namespace DataModel
         {
             kRocOptiqTableVersionMemoryActivity = 0x0002,
             kRocOptiqTableVersionMemoryAllocate = 0x0001,
-            kRocOptiqTableVersionKernelDispatchLevel = 0x0001,
-            kRocOptiqTableVersionRegionLevel = 0x0001,
-            kRocOptiqTableVersionRegionSampleLevel = 0x0001,
-            kRocOptiqTableVersionMemoryAllocLevel = 0x0001,
-            kRocOptiqTableVersionMemoryCopyLevel = 0x0001,
+            kRocOptiqTableVersionForLevelCalculation = 0x0002,
+            kRocOptiqTableVersionKernelDispatchLevel = kRocOptiqTableVersionForLevelCalculation,
+            kRocOptiqTableVersionRegionLevel = kRocOptiqTableVersionForLevelCalculation,
+            kRocOptiqTableVersionRegionSampleLevel = kRocOptiqTableVersionForLevelCalculation,
+            kRocOptiqTableVersionMemoryAllocLevel = kRocOptiqTableVersionForLevelCalculation,
+            kRocOptiqTableVersionMemoryCopyLevel = kRocOptiqTableVersionForLevelCalculation,
             kRocOptiqTableVersionHistogram = 0x0001,
             kRocOptiqTableVersionTrackInfo = 0x0001,
         };

--- a/src/model/src/database/rocprofvis_db_version.h
+++ b/src/model/src/database/rocprofvis_db_version.h
@@ -64,7 +64,7 @@ namespace DataModel
             kRocOptiqTableVersionMemoryAllocLevel = kRocOptiqTableVersionForLevelCalculation,
             kRocOptiqTableVersionMemoryCopyLevel = kRocOptiqTableVersionForLevelCalculation,
             kRocOptiqTableVersionHistogram = 0x0001,
-            kRocOptiqTableVersionTrackInfo = 0x0001,
+            kRocOptiqTableVersionTrackInfo = 0x0002,
         };
 
         struct roc_optiq_metadata_t


### PR DESCRIPTION
## Motivation

AIPROFVIS-253 - QUEUE_EVICT_SVM: Incorrect selection for events — all clicks resolve to first event ID

## Technical Details

The problem happened due to incorrect event level calculation for complex level patterns, when one of the active events in current event stack has smaller level than some events of the same stack stored earlier
Introduced active events sorting to fix the problem