### PR TITLE
[ROCM-23685] - Difference in UI/UX b/w different OS's

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -579,23 +579,23 @@ ComputeComparisonView::RenderToolbar()
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Compare With:");
     ImGui::SameLine(0, style.ItemSpacing.x);
-    const std::unordered_map<uint32_t, WorkloadInfo>& workloads =
-        m_data_provider.ComputeModel().GetWorkloads();
+    const std::vector<const WorkloadInfo*>& workloads =
+        m_data_provider.ComputeModel().GetWorkloadList();
+    const WorkloadInfo* target_workload =
+        m_data_provider.ComputeModel().GetWorkload(m_target_workload_id);
     ImGui::SetNextItemWidth(ImGui::GetFrameHeight() * 10.0f);
     ImGui::BeginDisabled(workloads.empty());
     if(ImGui::BeginCombo("##TargetWorkloads",
-                         workloads.count(m_target_workload_id) > 0
-                             ? workloads.at(m_target_workload_id).name.c_str()
-                             : "-"))
+                         target_workload ? target_workload->name.c_str() : "-"))
     {
-        for(const std::pair<const uint32_t, WorkloadInfo>& workload : workloads)
+        for(const WorkloadInfo* workload : workloads)
         {
-            if(ImGui::Selectable(workload.second.name.c_str(),
-                                 m_target_workload_id == workload.second.id))
+            if(ImGui::Selectable(workload->name.c_str(),
+                                 m_target_workload_id == workload->id))
             {
-                if(m_target_workload_id != workload.second.id)
+                if(m_target_workload_id != workload->id)
                 {
-                    m_target_workload_id = workload.second.id;
+                    m_target_workload_id = workload->id;
                     std::vector<const KernelInfo*> kernel_list =
                         m_data_provider.ComputeModel().GetKernelInfoList(
                             m_target_workload_id);

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -114,13 +114,8 @@ Roofline::Update()
 {
     if(m_workload_changed)
     {
-        m_workload = nullptr;
-        const std::unordered_map<uint32_t, WorkloadInfo>& workloads =
-            m_data_provider.ComputeModel().GetWorkloads();
-        if(workloads.count(m_requested_workload_id) > 0)
-        {
-            m_workload = &workloads.at(m_requested_workload_id);
-        }
+        m_workload =
+            m_data_provider.ComputeModel().GetWorkload(m_requested_workload_id);
         if(m_workload)
         {
             m_items.resize(__KRPVControllerRooflineCeilingComputeTypeLast +

--- a/src/view/src/compute/rocprofvis_compute_summary.cpp
+++ b/src/view/src/compute/rocprofvis_compute_summary.cpp
@@ -243,12 +243,8 @@ ComputeTopKernels::Update()
             m_kernels.clear();
             m_padded_info = nullptr;
             m_padded_idx  = std::nullopt;
-            const std::unordered_map<uint32_t, WorkloadInfo>& workloads =
-                m_data_provider.ComputeModel().GetWorkloads();
-            if(workloads.count(m_requested_workload_id) > 0)
-            {
-                m_workload = &workloads.at(m_requested_workload_id);
-            }
+            m_workload =
+                m_data_provider.ComputeModel().GetWorkload(m_requested_workload_id);
             if(m_workload)
             {
                 std::vector<const KernelInfo*> all_kernels =

--- a/src/view/src/compute/rocprofvis_compute_table_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_table_view.cpp
@@ -99,14 +99,14 @@ ComputeTableView::RebuildTabs()
     if(workload_id == ComputeSelection::INVALID_SELECTION_ID)
         return;
 
-    const auto& workloads = m_data_provider.ComputeModel().GetWorkloads();
-    if(!workloads.count(workload_id))
+    const WorkloadInfo* workload =
+        m_data_provider.ComputeModel().GetWorkload(workload_id);
+    if(!workload)
         return;
 
-    const auto& workload = workloads.at(workload_id);
     m_tabs = std::make_shared<TabContainer>();
     m_tabs->SetAllowToolTips(true);
-    for(const auto* cat : workload.available_metrics.ordered_categories)
+    for(const auto* cat : workload->available_metrics.ordered_categories)
     {
         auto widget = std::make_shared<RocCustomWidget>(
             [this, cat]() { RenderCategory(*cat); });
@@ -129,21 +129,21 @@ ComputeTableView::FetchAllMetrics()
         return;
     }
 
-    const auto& workloads = m_data_provider.ComputeModel().GetWorkloads();
-    if(!workloads.count(workload_id))
+    const WorkloadInfo* workload =
+        m_data_provider.ComputeModel().GetWorkload(workload_id);
+    if(!workload)
         return;
 
-    const auto& workload = workloads.at(workload_id);
     std::vector<uint32_t>                   kernel_ids = { kernel_id };
     std::vector<MetricsRequestParams::MetricID> metric_ids;
-    for(const auto* cat : workload.available_metrics.ordered_categories)
+    for(const auto* cat : workload->available_metrics.ordered_categories)
     {
         for(const auto* tbl : cat->ordered_tables)
             metric_ids.push_back({ cat->id, tbl->id, std::nullopt });
     }
 
     bool success = m_data_provider.FetchMetrics(
-        MetricsRequestParams(workload.id, kernel_ids, metric_ids, m_client_id));
+        MetricsRequestParams(workload->id, kernel_ids, metric_ids, m_client_id));
 
     if(!success)
     {
@@ -195,12 +195,11 @@ ComputeTableView::RebuildTableDataCache()
         return;
     }
 
-    const auto& workloads = model.GetWorkloads();
-    if(!workloads.count(workload_id))
+    const WorkloadInfo* workload = model.GetWorkload(workload_id);
+    if(!workload)
         return;
 
-    const auto& workload = workloads.at(workload_id);
-    for(const auto* cat : workload.available_metrics.ordered_categories)
+    for(const auto* cat : workload->available_metrics.ordered_categories)
     {
         for(const auto* tbl : cat->ordered_tables)
         {

--- a/src/view/src/compute/rocprofvis_compute_tester.cpp
+++ b/src/view/src/compute/rocprofvis_compute_tester.cpp
@@ -55,15 +55,14 @@ ComputeTester::Update()
 void
 ComputeTester::Render()
 {
-    const std::unordered_map<uint32_t, WorkloadInfo>& workloads =
-        m_data_provider.ComputeModel().GetWorkloads();
+    const std::vector<const WorkloadInfo*>& workloads =
+        m_data_provider.ComputeModel().GetWorkloadList();
 
     uint32_t global_workload_id = m_compute_selection
                                      ? m_compute_selection->GetSelectedWorkload()
                                      : ComputeSelection::INVALID_SELECTION_ID;
-    const WorkloadInfo* selected_wl = workloads.count(global_workload_id)
-                                         ? &workloads.at(global_workload_id)
-                                         : nullptr;
+    const WorkloadInfo* selected_wl =
+        m_data_provider.ComputeModel().GetWorkload(global_workload_id);
     m_query_builder.SetWorkload(selected_wl);
 
     if(ImGui::Button("Open Query Builder"))
@@ -82,34 +81,36 @@ ComputeTester::Render()
     m_query_builder.Render();
     ImGui::NewLine();
 
+    const WorkloadInfo* selected_workload =
+        m_data_provider.ComputeModel().GetWorkload(m_selections.workload_id);
     ImGui::SetNextItemWidth(ImGui::GetFrameHeight() * 15.0f);
     if(ImGui::BeginCombo("Workloads",
-                         workloads.count(m_selections.workload_id) > 0
-                             ? workloads.at(m_selections.workload_id).name.c_str()
-                             : "-"))
+                         selected_workload ? selected_workload->name.c_str() : "-"))
     {
         if(ImGui::Selectable("-", m_selections.workload_id == 0))
         {
             m_selections.workload_id = 0;
         }
-        for(const std::pair<const uint32_t, WorkloadInfo>& workload : workloads)
+        for(const WorkloadInfo* workload : workloads)
         {
-            if(ImGui::Selectable(workload.second.name.c_str(),
-                                 m_selections.workload_id == workload.second.id))
+            if(ImGui::Selectable(workload->name.c_str(),
+                                 m_selections.workload_id == workload->id))
             {
-                m_selections.workload_id = workload.second.id;
+                m_selections.workload_id = workload->id;
                 m_selections.kernel_ids.clear();
                 m_selections.metric_ids.clear();
             }
         }
         ImGui::EndCombo();
     }
-    if(workloads.count(m_selections.workload_id) > 0)
+    const WorkloadInfo* current_workload =
+        m_data_provider.ComputeModel().GetWorkload(m_selections.workload_id);
+    if(current_workload)
     {
         ImGui::BeginChild("sv");
         ImGui::BeginChild("info", ImVec2(0, 0),
                           ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
-        const WorkloadInfo& workload = workloads.at(m_selections.workload_id);
+        const WorkloadInfo& workload = *current_workload;
         if(workload.system_info.size() == 2 &&
            workload.system_info[0].size() == workload.system_info[1].size())
         {
@@ -912,11 +913,10 @@ ComputeTester::Render()
         ImGui::InputText("Metric ID (e.g. 3.1.2)", m_value_names_input,
                          sizeof(m_value_names_input));
 
-        const WorkloadInfo& wl = workloads.at(m_selections.workload_id);
         ImGui::Text("Workload: %s (metrics: %zu, categories: %zu)",
-                    wl.name.c_str(),
-                    wl.available_metrics.list.size(),
-                    wl.available_metrics.tree.size());
+                    workload.name.c_str(),
+                    workload.available_metrics.list.size(),
+                    workload.available_metrics.tree.size());
 
         std::string input(m_value_names_input);
         auto        dot1 = input.find('.');
@@ -933,9 +933,9 @@ ComputeTester::Render()
 
             ImGui::Text("Looking up: cat=%u, table=%u, entry=%u", cat_id, tbl_id, entry_id);
 
-            if(wl.available_metrics.tree.count(cat_id))
+            if(workload.available_metrics.tree.count(cat_id))
             {
-                const auto& cat = wl.available_metrics.tree.at(cat_id);
+                const auto& cat = workload.available_metrics.tree.at(cat_id);
                 if(cat.tables.count(tbl_id))
                 {
                     const auto& tbl = cat.tables.at(tbl_id);

--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -47,12 +47,13 @@ ComputeView::ComputeView()
         else
         {
             // select the first workload by default when a trace is loaded
-            const auto& workloads = m_data_provider.ComputeModel().GetWorkloads();  
+            const std::vector<const WorkloadInfo*>& workloads =
+                m_data_provider.ComputeModel().GetWorkloadList();
             if(!workloads.empty())
             {
-                if(m_compute_selection) 
+                if(m_compute_selection)
                 {
-                    m_compute_selection->SelectWorkload(workloads.begin()->first);
+                    m_compute_selection->SelectWorkload(workloads.front()->id);
                 }
                 else
                 {
@@ -139,10 +140,11 @@ ComputeView::CreateView()
     // When launched remotely, for example over ssh, the UI make take long to init, and the data provider
     // may have already loaded an analysis if the application was launched with --file flag.
     // Check if one exists and if it does set the workload.
-    const auto& workloads = m_data_provider.ComputeModel().GetWorkloads();  
+    const std::vector<const WorkloadInfo*>& workloads =
+        m_data_provider.ComputeModel().GetWorkloadList();
     if(!workloads.empty())
     {
-        m_compute_selection->SelectWorkload(workloads.begin()->first);
+        m_compute_selection->SelectWorkload(workloads.front()->id);
     }
     m_preset_browser    = std::make_unique<PresetBrowser>();
     m_tab_container = std::make_shared<TabContainer>();
@@ -248,25 +250,26 @@ ComputeView::RenderWorkloadSelection()
 
     const ImGuiStyle& style          = SettingsManager::GetInstance().GetDefaultStyle();
 
-    const std::unordered_map<uint32_t, WorkloadInfo>& workloads =
-        m_data_provider.ComputeModel().GetWorkloads();
+    const std::vector<const WorkloadInfo*>& workloads =
+        m_data_provider.ComputeModel().GetWorkloadList();
 
-    uint32_t workload_id = m_compute_selection->GetSelectedWorkload();
+    uint32_t            workload_id       = m_compute_selection->GetSelectedWorkload();
+    const WorkloadInfo* selected_workload =
+        m_data_provider.ComputeModel().GetWorkload(workload_id);
     ImGui::Text("Workload:");
     ImGui::SameLine();
     ImGui::SetNextItemWidth(ImGui::GetFrameHeight() * 10.0f);
     ImGui::BeginDisabled(workloads.empty());
-    if(ImGui::BeginCombo("##Workloads", workloads.count(workload_id) > 0
-                                          ? workloads.at(workload_id).name.c_str()
-                                          : "-"))
+    if(ImGui::BeginCombo("##Workloads",
+                         selected_workload ? selected_workload->name.c_str() : "-"))
     {
 
-        for(const std::pair<const uint32_t, WorkloadInfo>& workload : workloads)
+        for(const WorkloadInfo* workload : workloads)
         {
-            if(ImGui::Selectable(workload.second.name.c_str(),
-                                 workload_id == workload.second.id))
+            if(ImGui::Selectable(workload->name.c_str(),
+                                 workload_id == workload->id))
             {
-                m_compute_selection->SelectWorkload(workload.second.id);
+                m_compute_selection->SelectWorkload(workload->id);
             }
         }
         ImGui::EndCombo();

--- a/src/view/src/model/compute/rocprofvis_compute_data_model.cpp
+++ b/src/view/src/model/compute/rocprofvis_compute_data_model.cpp
@@ -46,10 +46,10 @@ ComputeKernelSelectionTable::Clear()
 
 ComputeDataModel::ComputeDataModel() {}
 
-const std::unordered_map<uint32_t, WorkloadInfo>&
-ComputeDataModel::GetWorkloads() const
+const std::vector<const WorkloadInfo*>&
+ComputeDataModel::GetWorkloadList() const
 {
-    return m_workloads;
+    return m_ordered_workloads;
 }
 
 const WorkloadInfo*
@@ -78,6 +78,34 @@ ComputeDataModel::AddWorkload(WorkloadInfo& workload)
     uint32_t id = workload.id;
     m_workloads[id] = std::move(workload);
     OrderAvailableMetrics(m_workloads[id]);
+    OrderKernels(m_workloads[id]);
+    OrderWorkloads();
+}
+
+void
+ComputeDataModel::OrderKernels(WorkloadInfo& workload)
+{
+    workload.ordered_kernels.clear();
+    workload.ordered_kernels.reserve(workload.kernels.size());
+    for(const std::pair<const uint32_t, KernelInfo>& kernel_pair : workload.kernels)
+    {
+        workload.ordered_kernels.push_back(&kernel_pair.second);
+    }
+    std::sort(workload.ordered_kernels.begin(), workload.ordered_kernels.end(),
+              [](const KernelInfo* a, const KernelInfo* b) { return a->id < b->id; });
+}
+
+void
+ComputeDataModel::OrderWorkloads()
+{
+    m_ordered_workloads.clear();
+    m_ordered_workloads.reserve(m_workloads.size());
+    for(const std::pair<const uint32_t, WorkloadInfo>& workload_pair : m_workloads)
+    {
+        m_ordered_workloads.push_back(&workload_pair.second);
+    }
+    std::sort(m_ordered_workloads.begin(), m_ordered_workloads.end(),
+              [](const WorkloadInfo* a, const WorkloadInfo* b) { return a->id < b->id; });
 }
 
 void
@@ -272,6 +300,7 @@ ComputeDataModel::Clear()
 {
     ClearAllMetricValues();
     m_workloads.clear();
+    m_ordered_workloads.clear();
     m_kernel_selection_table.Clear();
 }
 
@@ -434,11 +463,7 @@ ComputeDataModel::GetKernelInfoList(uint32_t workload_id) const
     std::vector<const KernelInfo*> kernel_info_list;
     if(m_workloads.count(workload_id))
     {
-        const WorkloadInfo& workload = m_workloads.at(workload_id);
-        for(const auto& kernel_pair : workload.kernels)
-        {
-            kernel_info_list.push_back(&kernel_pair.second);
-        }
+        kernel_info_list = m_workloads.at(workload_id).ordered_kernels;
     }
     return kernel_info_list;
 }

--- a/src/view/src/model/compute/rocprofvis_compute_data_model.h
+++ b/src/view/src/model/compute/rocprofvis_compute_data_model.h
@@ -41,7 +41,7 @@ public:
     ComputeDataModel();
     ~ComputeDataModel() = default;
 
-    const std::unordered_map<uint32_t, WorkloadInfo>& GetWorkloads() const;
+    const std::vector<const WorkloadInfo*>& GetWorkloadList() const;
     const WorkloadInfo* GetWorkload(uint32_t workload_id) const;
 
     const std::vector<std::shared_ptr<MetricValue>>* GetKernelMetricsData(
@@ -116,8 +116,11 @@ public:
 
 private:
     void OrderAvailableMetrics(WorkloadInfo& workload);
+    void OrderKernels(WorkloadInfo& workload);
+    void OrderWorkloads();
 
     std::unordered_map<uint32_t, WorkloadInfo> m_workloads;
+    std::vector<const WorkloadInfo*>           m_ordered_workloads;  // built from map values; never null
 
     struct MetricStore
     {

--- a/src/view/src/model/compute/rocprofvis_compute_model_types.h
+++ b/src/view/src/model/compute/rocprofvis_compute_model_types.h
@@ -119,6 +119,7 @@ struct WorkloadInfo
     std::vector<std::vector<std::string>>    profiling_config;
     AvailableMetrics                         available_metrics;
     std::unordered_map<uint32_t, KernelInfo> kernels;
+    std::vector<const KernelInfo*>           ordered_kernels;  // built from map values; never null
     Roofline                                 roofline;
 };
 

--- a/src/view/src/widgets/rocprofvis_compute_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_compute_widget.cpp
@@ -561,10 +561,8 @@ PinnedMetricTable::UpdateColumns(MetricId                        metric_id,
 const AvailableMetrics::Table&
 PinnedMetricTable::GetTable(const MetricId& metric_id, uint32_t workload_id)
 {
-    const auto& tree = m_data_provider.ComputeModel()
-                           .GetWorkloads()
-                           .at(workload_id)
-                           .available_metrics.tree;
+    const std::unordered_map<uint32_t, AvailableMetrics::Category>& tree =
+        m_data_provider.ComputeModel().GetWorkload(workload_id)->available_metrics.tree;
     return tree.at(metric_id.category_id).tables.at(metric_id.table_id);
 }
 
@@ -575,12 +573,13 @@ PinnedMetricTable::HasMetricInCurrentWorkload(const MetricId& metric_id) const
     if(workload_id == ComputeSelection::INVALID_SELECTION_ID)
         return false;
 
-    const auto& workloads = m_data_provider.ComputeModel().GetWorkloads();
-    auto workload_it = workloads.find(workload_id);
-    if(workload_it == workloads.end())
+    const WorkloadInfo* workload =
+        m_data_provider.ComputeModel().GetWorkload(workload_id);
+    if(!workload)
         return false;
 
-    const auto& tree = workload_it->second.available_metrics.tree;
+    const std::unordered_map<uint32_t, AvailableMetrics::Category>& tree =
+        workload->available_metrics.tree;
     auto category_it = tree.find(metric_id.category_id);
     if(category_it == tree.end())
         return false;
@@ -718,11 +717,13 @@ MetricTableWidget::UpdateTable()
         return;
     }
 
-    auto& model = m_data_provider.ComputeModel();
-    if(!model.GetWorkloads().count(workload_id))
+    ComputeDataModel&   model    = m_data_provider.ComputeModel();
+    const WorkloadInfo* workload = model.GetWorkload(workload_id);
+    if(!workload)
         return;
 
-    const auto& tree = model.GetWorkloads().at(workload_id).available_metrics.tree;
+    const std::unordered_map<uint32_t, AvailableMetrics::Category>& tree =
+        workload->available_metrics.tree;
     if(!tree.count(m_category_id) || !tree.at(m_category_id).tables.count(m_table_id))
         return;
 
@@ -764,10 +765,12 @@ WorkloadMetricTableWidget::UpdateTable()
         return;
     }
 
-    auto& model = m_data_provider.ComputeModel();
-    if(!model.GetWorkloads().count(workload_id)) return;
+    ComputeDataModel&   model    = m_data_provider.ComputeModel();
+    const WorkloadInfo* workload = model.GetWorkload(workload_id);
+    if(!workload) return;
 
-    const auto& tree = model.GetWorkloads().at(workload_id).available_metrics.tree;
+    const std::unordered_map<uint32_t, AvailableMetrics::Category>& tree =
+        workload->available_metrics.tree;
     if(!tree.count(m_category_id) || !tree.at(m_category_id).tables.count(m_table_id))
         return;
 


### PR DESCRIPTION
- Compute view dropdowns iterated unordered_maps directly, producing arbitrary order. Mirror the pattern from 5120c59a: maintain parallel ordered vectors built once when workloads are added, and route lookups through GetWorkload(id) / GetWorkloadList().

