### PR TITLE
Rebrand (rename) log file and log prefix string.

### DIFF
--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -175,11 +175,11 @@ main(int argc, char** argv)
     std::string config_path = rocprofvis_get_application_config_path();
 #ifndef NDEBUG
     std::filesystem::path log_path =
-        std::filesystem::path(config_path) / "visualizer.debug.log";
+        std::filesystem::path(config_path) / "roc-optiq.debug.log";
     rocprofvis_core_enable_log(log_path.string().c_str(), spdlog::level::debug);
 #else
     std::filesystem::path log_path =
-        std::filesystem::path(config_path) / "visualizer.log";
+        std::filesystem::path(config_path) / "roc-optiq.log";
     rocprofvis_core_enable_log(log_path.string().c_str(), spdlog::level::info);
 #endif
 

--- a/src/core/src/rocprofvis_core.cpp
+++ b/src/core/src/rocprofvis_core.cpp
@@ -106,7 +106,7 @@ extern "C"
 
             g_rpv_log_ringbuffer = buffer_sink;
 
-            auto new_logger = std::make_shared<spdlog::logger>(std::move(std::string("rocprofvis-log")), sinks.begin(), sinks.end());
+            auto new_logger = std::make_shared<spdlog::logger>(std::move(std::string("roc-optiq-log")), sinks.begin(), sinks.end());
             new_logger->set_level(spdlog::level::debug);
             spdlog::details::registry::instance().initialize_logger(new_logger);
 


### PR DESCRIPTION
## Motivation

Rebrand (rename) log file and log prefix string.

Addresses ROCM-23884

## Technical Details

From:

`[2026-04-30 13:39:30.405] [rocprofvis-log] [debug] Column value value is NULL, replace with empty string
`

To:

`[2026-04-30 13:39:30.405] [roc-optiq-log] [debug] Column value value is NULL, replace with empty string
`
