### PR TITLE
Prevent tab container root from scrolling.

### DIFF
--- a/src/view/src/widgets/rocprofvis_tab_container.cpp
+++ b/src/view/src/widgets/rocprofvis_tab_container.cpp
@@ -92,7 +92,7 @@ TabContainer::Update()
 void
 TabContainer::Render()
 {
-    ImGui::BeginChild(m_widget_name.c_str(), ImVec2(0, 0), ImGuiChildFlags_None);
+    ImGui::BeginChild(m_widget_name.c_str(), ImVec2(0, 0), ImGuiChildFlags_None, ImGuiWindowFlags_NoScrollWithMouse);
     int new_selected_tab = m_active_tab_index;
     if(!m_tabs.empty())
     {


### PR DESCRIPTION
> Not sure if this has always been a bug, or it is new, but the bottom table (child window) can be scrolled off of the screen if horizonal gesture scrolling is used.  (two finger horizontal swipe on trackpad for example).
> 
> <img width="635" height="751" alt="image" src="https://github.com/user-attachments/assets/72e98d1a-4480-4d23-b018-d94ed72126e1" />
> 
> _Originally posted by @tomk-amd in https://github.com/ROCm/roc-optiq/issues/805#issuecomment-4359652963_

> This is a generic issue with the tab container. It happens even to the project level if you open enough projects or squish the window:
> <img width="308" height="563" alt="Screenshot 2026-05-01 113111" src="https://github.com/user-attachments/assets/72be95cf-ca6a-4662-8938-205a18845524" />
> 
> _Originally posted by @drchen-amd in https://github.com/ROCm/roc-optiq/issues/805#issuecomment-4360314471_
>             