### PR TITLE
Show error message if file cannot be opened

### DIFF
--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -643,6 +643,11 @@ AppWindow::OpenFile(std::string file_path)
         default:
         {
             SettingsManager::GetInstance().RemoveRecentFile(file_path);
+            // show error dialog
+            ShowMessageDialog(
+                "Failed to Open File",
+                "The file could not be opened:\n\n" + file_path +
+                    "\n\nPlease make sure the file is a valid trace or project file.");
             break;
         }
     }

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -643,11 +643,6 @@ AppWindow::OpenFile(std::string file_path)
         default:
         {
             SettingsManager::GetInstance().RemoveRecentFile(file_path);
-            // show error dialog
-            ShowMessageDialog(
-                "Failed to Open File",
-                "The file could not be opened:\n\n" + file_path +
-                    "\n\nPlease make sure the file is a valid trace or project file.");
             break;
         }
     }

--- a/src/view/src/rocprofvis_project.cpp
+++ b/src/view/src/rocprofvis_project.cpp
@@ -69,11 +69,22 @@ Project::Open(std::string& file_path)
         {
             result = OpenTrace(file_path);
         }
+
+        if(result == Failed)
+        {
+            // show error dialog
+            AppWindow::GetInstance()->ShowMessageDialog(
+                "Error",
+                "The file could not be opened:\n\n" + file_path +
+                    "\n\nPlease make sure the file is a valid trace or project file.");
+            spdlog::error("Failed to open file: {}, invalid trace or project file", file_path);                    
+        }
     }
     else
     {
         AppWindow::GetInstance()->ShowMessageDialog("Error",
                                                     "File does not exist: " + file_path);
+        spdlog::error("Failed to open file: {}, file does not exist", file_path);                                                    
     }
     return result;
 }


### PR DESCRIPTION
## Motivation

Show error message if file cannot be opened (rocprofvis_controller_alloc fails).

## Technical Details

If a file fails to open at the Detection phase the UI does not provide any feedback to the user.  `rocprofvis_controller_alloc()` will return null if no valid controller trace object can service this file. Show an error message when this happens.
