### PR TITLE
Ensure proper Vulkan resource cleanup

### DIFF
--- a/src/app/src/rocprofvis_imgui_vulkan.cpp
+++ b/src/app/src/rocprofvis_imgui_vulkan.cpp
@@ -356,6 +356,17 @@ rocprofvis_imgui_backend_vk_release_after_failed_init(rocprofvis_imgui_backend_t
     }
     backend_data->m_descriptor_pool = VK_NULL_HANDLE;
 
+    // Explicitly destroy the surface before destroying the device and instance
+    // to ensure proper resource cleanup order per Vulkan spec
+    if(backend_data->m_instance != VK_NULL_HANDLE &&
+       backend_data->m_window_data.Surface != VK_NULL_HANDLE)
+    {
+        vkDestroySurfaceKHR(backend_data->m_instance,
+                            backend_data->m_window_data.Surface,
+                            backend_data->m_allocator);
+        backend_data->m_window_data.Surface = VK_NULL_HANDLE;
+    }
+
 #ifdef _DEBUG
     if(backend_data->m_debug_report != VK_NULL_HANDLE &&
        backend_data->m_instance != VK_NULL_HANDLE)
@@ -696,6 +707,16 @@ rocprofvis_imgui_backend_vk_destroy(rocprofvis_imgui_backend_t* backend)
 
         vkDestroyDescriptorPool(backend_data->m_device, backend_data->m_descriptor_pool,
                                 backend_data->m_allocator);
+
+        // Explicitly destroy the surface before destroying the device and instance
+        // to ensure proper resource cleanup order per Vulkan spec
+        if(backend_data->m_window_data.Surface != VK_NULL_HANDLE)
+        {
+            vkDestroySurfaceKHR(backend_data->m_instance,
+                                backend_data->m_window_data.Surface,
+                                backend_data->m_allocator);
+            backend_data->m_window_data.Surface = VK_NULL_HANDLE;
+        }
 
 #ifdef _DEBUG
         // Remove the debug report callback


### PR DESCRIPTION
## Motivation

This error is sent to the debug console when the application is shut down.

```
VUID-vkDestroyInstance-instance-00629(ERROR / SPEC): msgNum: -1958900200 - Validation Error: [ VUID-vkDestroyInstance-instance-00629 ] Object 0: handle = 0x2684deb2c10, type = VK_OBJECT_TYPE_INSTANCE; Object 1: handle = 0xfa21a40000000003, type = VK_OBJECT_TYPE_SURFACE_KHR; | MessageID = 0x8b3d8e18 | vkDestroyInstance(): OBJ ERROR : For VkInstance 0x2684deb2c10[], VkSurfaceKHR 0xfa21a40000000003[] has not been destroyed.
The Vulkan spec states: All child objects created using instance must have been destroyed prior to destroying instance (https://vulkan.lunarg.com/doc/view/1.4.304.1/windows/antora/spec/latest/chapters/initialization.html#VUID-vkDestroyInstance-instance-00629)
    Objects: 2
       [0]  0x2684deb2c10, type: 1, name: NULL
       [1]  0xfa21a40000000003, type: 1000000000, name: NULL
```

Not a big deal as application is terminated anyways, but let's tidy up properly.

## Technical Details

Ensure proper Vulkan resource cleanup by explicitly destroying the surface before the device and instance.
