### PR TITLE
Enable test coverage for new CI workflow files

### DIFF
--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -92,6 +92,13 @@ jobs:
             echo "❌ ${{ env.BUILD_FILE_NAME }} was not built!"
             exit 1
           fi
+      
+      - name: Run Tests
+        run: |
+          cd ${{ env.BUILD_DIR }}
+          ctest \
+            --output-on-failure \
+            --no-tests=error
 
       - name: Prepare Distribution Artifacts
         run: |

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -95,6 +95,8 @@ jobs:
       
       - name: Run Tests
         run: |
+          curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
+          dnf install -y git-lfs
           cd ${{ env.BUILD_DIR }}
           ctest \
             --output-on-failure \

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -76,8 +76,15 @@ jobs:
         os-version: ${{ fromJson(inputs.os_version) }}
 
     steps:
+      - name: Install git-lfs
+        if: false
+        run: |
+          curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
+          dnf install -y git-lfs
+
       - uses: actions/checkout@v6
         with:
+          lfs: true
           submodules: true
 
       - name: Build, Make, and Verify Installation
@@ -95,8 +102,6 @@ jobs:
       
       - name: Run Tests
         run: |
-          curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
-          dnf install -y git-lfs
           cd ${{ env.BUILD_DIR }}
           ctest \
             --output-on-failure \

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -77,7 +77,6 @@ jobs:
 
     steps:
       - name: Install git-lfs
-        if: false
         run: |
           curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
           dnf install -y git-lfs

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -76,11 +76,6 @@ jobs:
         os-version: ${{ fromJson(inputs.os_version) }}
 
     steps:
-      - name: Install git-lfs
-        run: |
-          curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash
-          dnf install -y git-lfs
-
       - uses: actions/checkout@v6
         with:
           lfs: true

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -77,7 +77,6 @@ jobs:
 
     steps:
       - name: Install git-lfs
-        if: false
         run: |
           apt install -y git-lfs 
 

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Run Tests
         run: |
+          apt install -y git-lfs 
           cd ${{ env.BUILD_DIR }}
           ctest \
             --output-on-failure \

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -76,8 +76,14 @@ jobs:
         os-version: ${{ fromJson(inputs.os_version) }}
 
     steps:
+      - name: Install git-lfs
+        if: false
+        run: |
+          apt install -y git-lfs 
+
       - uses: actions/checkout@v6
         with:
+          lfs: true
           submodules: true
 
       - name: Build, Make, and Verify Installation
@@ -95,7 +101,6 @@ jobs:
 
       - name: Run Tests
         run: |
-          apt install -y git-lfs 
           cd ${{ env.BUILD_DIR }}
           ctest \
             --output-on-failure \

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -76,10 +76,6 @@ jobs:
         os-version: ${{ fromJson(inputs.os_version) }}
 
     steps:
-      - name: Install git-lfs
-        run: |
-          apt install -y git-lfs 
-
       - uses: actions/checkout@v6
         with:
           lfs: true

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -93,6 +93,13 @@ jobs:
             exit 1
           fi
 
+      - name: Run Tests
+        run: |
+          cd ${{ env.BUILD_DIR }}
+          ctest \
+            --output-on-failure \
+            --no-tests=error
+
       - name: Prepare Distribution Artifacts
         run: |
           mkdir ${{ env.DIST_DIR }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -107,6 +107,14 @@ jobs:
             exit 1
           }
 
+      - name: Run Tests
+        run: |
+          cd ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}
+          ctest \
+            -C ${{ env.BINARY_DIR }} \
+            --output-on-failure \
+            --no-tests=error
+
       - name: Prepare Distribution Artifacts
         run: |
           mkdir ${{ env.DIST_DIR }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -66,7 +66,7 @@ env:
 jobs:
   windows:
     name: Windows ${{ matrix.os-version }} • Optiq CI • GitHub Artifacts (${{ inputs.upload_to_github }}) • S3 Artifacts (${{ inputs.upload_to_s3 }})
-    runs-on: windows-${{ matrix.os-version }}
+    runs-on: windows-${{ matrix.os-version }}-vs2026
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
+          lfs: true
           submodules: true
       
       - name: Install Vulkan SDK

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -66,7 +66,7 @@ env:
 jobs:
   windows:
     name: Windows ${{ matrix.os-version }} • Optiq CI • GitHub Artifacts (${{ inputs.upload_to_github }}) • S3 Artifacts (${{ inputs.upload_to_s3 }})
-    runs-on: windows-${{ matrix.os-version }}-vs2026
+    runs-on: windows-${{ matrix.os-version }}
     permissions:
       id-token: write
       contents: read
@@ -99,7 +99,7 @@ jobs:
       - name: Build, Make, and Verify Installation
         run: |
           mkdir build
-          cmake --preset "${{ inputs.cmake_config_preset }}" -DROCPROFVIS_ENABLE_INTERNAL_BANNER=${{ env.ENABLE_INTERNAL_BANNER }}
+          cmake --preset "${{ inputs.cmake_config_preset }}" -G "Visual Studio 18 2026" -DROCPROFVIS_ENABLE_INTERNAL_BANNER=${{ env.ENABLE_INTERNAL_BANNER }}
           cmake --build ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }} --preset "${{ inputs.cmake_build_preset }}" --parallel 4
           if (Test-Path "${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/${env:BUILD_FILE_NAME}.exe") {
             Write-Host "✅ $env:BUILD_FILE_NAME has been successfully built!"

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -111,9 +111,9 @@ jobs:
       - name: Run Tests
         run: |
           cd ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}
-          ctest \
-            -C ${{ env.BINARY_DIR }} \
-            --output-on-failure \
+          ctest `
+            -C ${{ env.BINARY_DIR }} `
+            --output-on-failure `
             --no-tests=error
 
       - name: Prepare Distribution Artifacts

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,7 @@
             "name": "windows-base",
             "description": "Base settings for Windows Visual Studio builds of ROCm Optiq.",
             "hidden": true,
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "installDir": "${sourceDir}/install/${presetName}",
             "cacheVariables": {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,7 @@
             "name": "windows-base",
             "description": "Base settings for Windows Visual Studio builds of ROCm Optiq.",
             "hidden": true,
-            "generator": "Visual Studio 18 2026",
+            "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "installDir": "${sourceDir}/install/${presetName}",
             "cacheVariables": {

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -25,7 +25,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && rm -rf awscliv2.zip ./aws
 
 # Install git-lfs
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash \
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash && \
     dnf install -y git-lfs
 
 WORKDIR /home

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -24,5 +24,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && ./aws/install \
     && rm -rf awscliv2.zip ./aws
 
+# Install git-lfs
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash \
+    dnf install -y git-lfs
+
 WORKDIR /home
 SHELL [ "/bin/bash", "--login", "-c" ]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -8,7 +8,7 @@ SHELL [ "/bin/bash", "-c" ]
 
 # Install Dependencies
 RUN apt update -y && \
-    apt install -y build-essential cmake curl git libncurses-dev libwayland-dev \
+    apt install -y build-essential cmake curl git git-lfs libncurses-dev libwayland-dev \
     libx11-dev libxcursor-dev libxi-dev libxinerama-dev libxkbcommon-dev \
     libxrandr-dev pkg-config wget xorg-dev libdbus-1-dev unzip
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Enables CTest coverage for Ubuntu, RedHat, and Windows.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `ci-ubuntu.yml`, `ci-redhat.yml`, and `ci-windows.yml` to include a `Run Tests` step
  - Checkout step updated to include `lfs: true` option to avoid file corruption on file needed for test to pass
  - For Windows, due to a runner change by GitHub, VS 2022 is no longer present so updated the CMake command to use `VS2026` as the generator instead
    - Temporary workaround until issue resolved
- Updated Dockerfiles to include `git-lfs` installation
  - Already manually triggered updates for the images to include the change

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure workflows run and pass successfully, including test coverage

## Test Result

<!-- Briefly summarize test outcomes. -->
Workflows pass along with the tests

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
