### PR TITLE
Use the new font uploading aproach for the fonts

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -676,7 +676,8 @@ ComputeComparisonView::RenderToolbar()
     ImGui::SameLine(0.0f, style.FramePadding.x);
     ImGui::TextUnformatted("Difference");
     ImGui::SameLine();
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                    m_settings.GetFontManager().GetFontSize(FontType::kDefault));
     ImGui::TextUnformatted(ICON_ARROW_DOWN);
     ImGui::PopFont();
     ImGui::SameLine(0.0f, style.FramePadding.x);
@@ -684,7 +685,8 @@ ComputeComparisonView::RenderToolbar()
     ImGui::SameLine(0.0f, style.FramePadding.x);
     ImGui::TextUnformatted("Difference");
     ImGui::SameLine();
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                    m_settings.GetFontManager().GetFontSize(FontType::kDefault));
     ImGui::TextUnformatted(ICON_ARROW_UP);
     ImGui::PopFont();
     ImGui::SameLine(0.0f, style.FramePadding.x);
@@ -756,10 +758,11 @@ ComputeComparisonView::RenderToolbar()
         ImGui::TextUnformatted("Pinned");
         ImGui::SameLine();
 
-        ImFont* icon_font = m_settings.GetFontManager().GetIconFont(FontType::kDefault);
+        ImFont* icon_font      = m_settings.GetFontManager().GetIconFont(FontType::kDefault);
+        float   icon_font_size = m_settings.GetFontManager().GetFontSize(FontType::kDefault);
         const char* icon =
             m_pinned_item->m_visible ? ICON_CHEVRON_DOWN : ICON_CHEVRON_LEFT;
-        ImGui::PushFont(icon_font);
+        ImGui::PushFont(icon_font, icon_font_size);
         // use larger icon for consistent spacing
         ImVec2 icon_size = ImGui::CalcTextSize(ICON_CHEVRON_DOWN);
         ImGui::PopFont();
@@ -1303,8 +1306,8 @@ ComputeComparisonView::Table::Render()
                             }
                             if(m_rows[i].cells[j].display_props->icon)
                             {
-                                ImGui::PushFont(m_settings.GetFontManager().GetIconFont(
-                                    FontType::kDefault));
+                                ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                                                m_settings.GetFontManager().GetFontSize(FontType::kDefault));
                                 ImGui::TextUnformatted(
                                     m_rows[i].cells[j].display_props->icon.value());
                                 ImGui::PopFont();

--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -676,8 +676,7 @@ ComputeComparisonView::RenderToolbar()
     ImGui::SameLine(0.0f, style.FramePadding.x);
     ImGui::TextUnformatted("Difference");
     ImGui::SameLine();
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                    m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
     ImGui::TextUnformatted(ICON_ARROW_DOWN);
     ImGui::PopFont();
     ImGui::SameLine(0.0f, style.FramePadding.x);
@@ -685,8 +684,7 @@ ComputeComparisonView::RenderToolbar()
     ImGui::SameLine(0.0f, style.FramePadding.x);
     ImGui::TextUnformatted("Difference");
     ImGui::SameLine();
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                    m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
     ImGui::TextUnformatted(ICON_ARROW_UP);
     ImGui::PopFont();
     ImGui::SameLine(0.0f, style.FramePadding.x);
@@ -1306,8 +1304,7 @@ ComputeComparisonView::Table::Render()
                             }
                             if(m_rows[i].cells[j].display_props->icon)
                             {
-                                ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                                                m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+                                ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
                                 ImGui::TextUnformatted(
                                     m_rows[i].cells[j].display_props->icon.value());
                                 ImGui::PopFont();

--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -676,7 +676,7 @@ ComputeComparisonView::RenderToolbar()
     ImGui::SameLine(0.0f, style.FramePadding.x);
     ImGui::TextUnformatted("Difference");
     ImGui::SameLine();
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+    ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
     ImGui::TextUnformatted(ICON_ARROW_DOWN);
     ImGui::PopFont();
     ImGui::SameLine(0.0f, style.FramePadding.x);
@@ -684,7 +684,7 @@ ComputeComparisonView::RenderToolbar()
     ImGui::SameLine(0.0f, style.FramePadding.x);
     ImGui::TextUnformatted("Difference");
     ImGui::SameLine();
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+    ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
     ImGui::TextUnformatted(ICON_ARROW_UP);
     ImGui::PopFont();
     ImGui::SameLine(0.0f, style.FramePadding.x);
@@ -756,8 +756,8 @@ ComputeComparisonView::RenderToolbar()
         ImGui::TextUnformatted("Pinned");
         ImGui::SameLine();
 
-        ImFont* icon_font      = m_settings.GetFontManager().GetIconFont(FontType::kDefault);
-        float   icon_font_size = m_settings.GetFontManager().GetFontSize(FontType::kDefault);
+        ImFont* icon_font = m_settings.GetFontManager().GetFont(FontType::kIcon);
+        float   icon_font_size = m_settings.GetFontManager().GetFontSize(FontSize::kDefault);
         const char* icon =
             m_pinned_item->m_visible ? ICON_CHEVRON_DOWN : ICON_CHEVRON_LEFT;
         ImGui::PushFont(icon_font, icon_font_size);
@@ -1304,7 +1304,9 @@ ComputeComparisonView::Table::Render()
                             }
                             if(m_rows[i].cells[j].display_props->icon)
                             {
-                                ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+                                ImGui::PushFont(
+                                    m_settings.GetFontManager().GetFont(FontType::kIcon),
+                                    0.0f);
                                 ImGui::TextUnformatted(
                                     m_rows[i].cells[j].display_props->icon.value());
                                 ImGui::PopFont();

--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -223,7 +223,8 @@ KernelMetricTable::Render()
     int remove_index = -1;
 
     SettingsManager& settings     = SettingsManager::GetInstance();
-    ImFont*          icon_font  = settings.GetFontManager().GetIconFont(FontType::kDefault);
+    ImFont*          icon_font      = settings.GetFontManager().GetIconFont(FontType::kDefault);
+    float            icon_font_size = settings.GetFontManager().GetFontSize(FontType::kDefault);
     const ImGuiStyle &style = settings.GetDefaultStyle();
     const float      cell_padding = style.CellPadding.x * 2.0f;
     const float      char_width = ImGui::CalcTextSize("M").x;
@@ -249,7 +250,7 @@ KernelMetricTable::Render()
     ImGui::AlignTextToFramePadding();
     const char* icon = m_show_kernel_table ? ICON_CHEVRON_DOWN : ICON_CHEVRON_RIGHT;
     
-    ImGui::PushFont(icon_font);
+    ImGui::PushFont(icon_font, icon_font_size);
     ImVec2 icon_size = ImGui::CalcTextSize(ICON_CHEVRON_DOWN); // use larger icon for consistent spacing
     ImGui::PopFont();
 

--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -223,7 +223,7 @@ KernelMetricTable::Render()
     int remove_index = -1;
 
     SettingsManager& settings     = SettingsManager::GetInstance();
-    ImFont*          icon_font = settings.GetFontManager().GetIconFont(FontType::kDefault);
+    ImFont*           icon_font    = settings.GetFontManager().GetFont(FontType::kIcon);
     const ImGuiStyle &style = settings.GetDefaultStyle();
     const float      cell_padding = style.CellPadding.x * 2.0f;
     const float      char_width = ImGui::CalcTextSize("M").x;

--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -223,8 +223,7 @@ KernelMetricTable::Render()
     int remove_index = -1;
 
     SettingsManager& settings     = SettingsManager::GetInstance();
-    ImFont*          icon_font      = settings.GetFontManager().GetIconFont(FontType::kDefault);
-    float            icon_font_size = settings.GetFontManager().GetFontSize(FontType::kDefault);
+    ImFont*          icon_font = settings.GetFontManager().GetIconFont(FontType::kDefault);
     const ImGuiStyle &style = settings.GetDefaultStyle();
     const float      cell_padding = style.CellPadding.x * 2.0f;
     const float      char_width = ImGui::CalcTextSize("M").x;
@@ -250,7 +249,7 @@ KernelMetricTable::Render()
     ImGui::AlignTextToFramePadding();
     const char* icon = m_show_kernel_table ? ICON_CHEVRON_DOWN : ICON_CHEVRON_RIGHT;
     
-    ImGui::PushFont(icon_font, icon_font_size);
+    ImGui::PushFont(icon_font, 0.0f);
     ImVec2 icon_size = ImGui::CalcTextSize(ICON_CHEVRON_DOWN); // use larger icon for consistent spacing
     ImGui::PopFont();
 

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -696,7 +696,8 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         }
         ImGui::SetCursorPos(button_pos +
                             ImVec2(0.0f, menus_on_bottom ? -button_size : button_size));
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                        m_settings.GetFontManager().GetFontSize(FontType::kDefault));
         if(ImGui::Button(m_menus_mode == Legend ? ICON_GEAR : ICON_LIST,
                          ImVec2(button_size, button_size)))
         {
@@ -828,8 +829,8 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                 }
                 else
                 {
-                    ImGui::PushFont(
-                        m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+                    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                                    m_settings.GetFontManager().GetFontSize(FontType::kDefault));
                     ImGui::TextUnformatted(m_items[i].visible ? ICON_EYE
                                                               : ICON_EYE_SLASH);
                     ImGui::PopFont();

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -696,8 +696,7 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         }
         ImGui::SetCursorPos(button_pos +
                             ImVec2(0.0f, menus_on_bottom ? -button_size : button_size));
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                        m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
         if(ImGui::Button(m_menus_mode == Legend ? ICON_GEAR : ICON_LIST,
                          ImVec2(button_size, button_size)))
         {
@@ -829,8 +828,7 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                 }
                 else
                 {
-                    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                                    m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+                    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
                     ImGui::TextUnformatted(m_items[i].visible ? ICON_EYE
                                                               : ICON_EYE_SLASH);
                     ImGui::PopFont();

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -696,7 +696,7 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         }
         ImGui::SetCursorPos(button_pos +
                             ImVec2(0.0f, menus_on_bottom ? -button_size : button_size));
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
         if(ImGui::Button(m_menus_mode == Legend ? ICON_GEAR : ICON_LIST,
                          ImVec2(button_size, button_size)))
         {
@@ -828,7 +828,7 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                 }
                 else
                 {
-                    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+                    ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
                     ImGui::TextUnformatted(m_items[i].visible ? ICON_EYE
                                                               : ICON_EYE_SLASH);
                     ImGui::PopFont();

--- a/src/view/src/compute/rocprofvis_compute_summary.cpp
+++ b/src/view/src/compute/rocprofvis_compute_summary.cpp
@@ -426,8 +426,7 @@ ComputeTopKernels::RenderChartContent()
 
     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + plot_style.PlotPadding.y);
     ImGui::BeginGroup();
-    if(IconButton(ICON_CHART_PIE,
-                  m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+    if(IconButton(ICON_CHART_PIE, m_settings.GetFontManager().GetFont(FontType::kIcon),
                   ImVec2(0, 0), nullptr, false, style.FramePadding,
                   m_settings.GetColor(m_display_mode == Pie ? Colors::kButton
                                                             : Colors::kTransparent),
@@ -437,8 +436,7 @@ ComputeTopKernels::RenderChartContent()
         m_display_mode = Pie;
     }
     ImGui::SameLine();
-    if(IconButton(ICON_CHART_BAR,
-                  m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+    if(IconButton(ICON_CHART_BAR, m_settings.GetFontManager().GetFont(FontType::kIcon),
                   ImVec2(0, 0), nullptr, false, style.FramePadding,
                   m_settings.GetColor(m_display_mode == Bar ? Colors::kButton
                                                             : Colors::kTransparent),

--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -311,7 +311,7 @@ ComputeView::RenderPresets()
         ImGui::SameLine();
         ImGui::SetCursorPosX(ImGui::GetCursorPosX() + style.ItemSpacing.x);
         if(IconButton(ICON_CHEVRON_DOWN,
-                      m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault),
+                      m_settings_manager.GetFontManager().GetFont(FontType::kIcon),
                       ImVec2(0.0f, 0.0f), nullptr, false, style.FramePadding,
                       m_settings_manager.GetColor(Colors::kTransparent),
                       m_settings_manager.GetColor(Colors::kButtonHovered),

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -501,11 +501,11 @@ AppWindow::RenderEmptyState()
     }
 
     // --- Title ---
-    ImFont* title_font = settings.GetFontManager().GetFont(FontType::kLarge);
-    if(title_font) ImGui::PushFont(title_font, settings.GetFontManager().GetFontSize(FontType::kLarge));
+
+    ImGui::PushFont(NULL, settings.GetFontManager().GetFontSize(FontSize::kLarge));
     CenterNextTextItem("Open a trace or project");
     ImGui::TextUnformatted("Open a trace or project");
-    if(title_font) ImGui::PopFont();
+    ImGui::PopFont();
 
     ImGui::Dummy(ImVec2(0.0f, font_size * 0.25f));
 
@@ -1025,14 +1025,13 @@ AppWindow::RenderAboutDialog()
                               ImGuiWindowFlags_AlwaysAutoResize |
                                   ImGuiWindowFlags_NoMove))
     {
-        ImFont* large_font =
-            SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kLarge);
-        if(large_font) ImGui::PushFont(large_font, SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kLarge));
+        ImGui::PushFont(NULL, SettingsManager::GetInstance().GetFontManager().GetFontSize(
+                                  FontSize::kLarge));
 
         ImGui::SetCursorPosX(
             (ImGui::GetWindowSize().x - ImGui::CalcTextSize(NAME_LABEL).x) * 0.5f);
         ImGui::TextUnformatted(NAME_LABEL);
-        if(large_font) ImGui::PopFont();
+        ImGui::PopFont();
 
         ImGui::Spacing();
         ImGui::Separator();

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -502,7 +502,7 @@ AppWindow::RenderEmptyState()
 
     // --- Title ---
     ImFont* title_font = settings.GetFontManager().GetFont(FontType::kLarge);
-    if(title_font) ImGui::PushFont(title_font);
+    if(title_font) ImGui::PushFont(title_font, settings.GetFontManager().GetFontSize(FontType::kLarge));
     CenterNextTextItem("Open a trace or project");
     ImGui::TextUnformatted("Open a trace or project");
     if(title_font) ImGui::PopFont();
@@ -1027,7 +1027,7 @@ AppWindow::RenderAboutDialog()
     {
         ImFont* large_font =
             SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kLarge);
-        if(large_font) ImGui::PushFont(large_font);
+        if(large_font) ImGui::PushFont(large_font, SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kLarge));
 
         ImGui::SetCursorPosX(
             (ImGui::GetWindowSize().x - ImGui::CalcTextSize(NAME_LABEL).x) * 0.5f);

--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -102,7 +102,7 @@ EventsView::RenderBasicData(const EventInfo* event_data)
 
     ImFont* large_font = m_settings.GetFontManager().GetFont(FontType::kLarge);
 
-    ImGui::PushFont(large_font);
+    ImGui::PushFont(large_font, m_settings.GetFontManager().GetFontSize(FontType::kLarge));
 
     const auto& info = event_data->basic_info;
 

--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -100,9 +100,7 @@ EventsView::RenderBasicData(const EventInfo* event_data)
     ImVec4 headerColor =
         ImGui::ColorConvertU32ToFloat4(m_settings.GetColor(Colors::kSplitterColor));
 
-    ImFont* large_font = m_settings.GetFontManager().GetFont(FontType::kLarge);
-
-    ImGui::PushFont(large_font, m_settings.GetFontManager().GetFontSize(FontType::kLarge));
+    ImGui::PushFont(NULL, m_settings.GetFontManager().GetFontSize(FontSize::kLarge));
 
     const auto& info = event_data->basic_info;
 

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -485,8 +485,8 @@ FlameTrackItem::RenderTooltip(ChartItem& chart_item, int color_index)
         }
 
         ImGui::Text("%u events", chart_item.event.m_child_count);
-        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kSmall),
-                        m_settings.GetFontManager().GetFontSize(FontType::kSmall));
+        ImGui::PushFont(NULL,
+                        m_settings.GetFontManager().GetFontSize(FontSize::kSmall));
         ImGui::PushStyleVar(ImGuiStyleVar_CellPadding,
                             ImVec2(ImGui::GetStyle().CellPadding.x, 0.0f));
         if(ImGui::BeginTable("ChildEventsTable", 3,

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -485,7 +485,8 @@ FlameTrackItem::RenderTooltip(ChartItem& chart_item, int color_index)
         }
 
         ImGui::Text("%u events", chart_item.event.m_child_count);
-        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kSmall));
+        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kSmall),
+                        m_settings.GetFontManager().GetFontSize(FontType::kSmall));
         ImGui::PushStyleVar(ImGuiStyleVar_CellPadding,
                             ImVec2(ImGui::GetStyle().CellPadding.x, 0.0f));
         if(ImGui::BeginTable("ChildEventsTable", 3,

--- a/src/view/src/rocprofvis_font_manager.cpp
+++ b/src/view/src/rocprofvis_font_manager.cpp
@@ -24,71 +24,61 @@ constexpr std::array FONT_AVAILABLE_SIZES = { 7.0f,  8.0f,  9.0f,  10.0f, 11.0f,
                                               17.0f, 18.0f, 19.0f, 20.0f, 21.0f,
                                               23.0f, 25.0f, 27.0f, 29.0f, 33.0f };
 
+// Size offsets applied to the base index to produce kSmall/kMedium/kMedLarge/kLarge.
+static constexpr int kSizeOffsets[FontManager::kNumTypes] = { -1, 0, 1, 2 };
+
 FontManager::FontManager() {}
 
 FontManager::~FontManager() {}
 
 ImFont*
-FontManager::GetIconFontByIndex(int idx)
+FontManager::GetIconFontByIndex(int /*idx*/)
 {
-    if(idx < 0 || idx >= static_cast<int>(m_all_icon_fonts.size())) return nullptr;
-    return m_all_icon_fonts[idx];
+    return m_icon_font;
 }
 
 ImFont*
-FontManager::GetFontByIndex(int idx)
+FontManager::GetFontByIndex(int /*idx*/)
 {
-    if(idx < 0 || idx >= static_cast<int>(m_all_fonts.size())) return nullptr;
-    return m_all_fonts[idx];
+    return m_text_font;
 }
 
 int
 FontManager::GetDPIScaledFontIndex()
 {
-    constexpr float DPI_EXPONENT =
-        0.75f;  // Adjust as needed. Higher values increase size more rapidly.
+    constexpr float DPI_EXPONENT = 0.75f;
 
-    float           scaled_size =
-        BASE_FONT_SIZE * std::pow(SettingsManager::GetInstance().GetDPI(), DPI_EXPONENT); 
- 
+    float scaled_size =
+        BASE_FONT_SIZE * std::pow(SettingsManager::GetInstance().GetDPI(), DPI_EXPONENT);
 
-    // Find the index of the font size closest to scaled_size
+    // Find the index of the available size closest to scaled_size.
     int best_index = 0;
-    for(int i = 1; i < m_all_fonts.size(); i++)
+    for(int i = 1; i < static_cast<int>(m_available_sizes.size()); ++i)
     {
-        if(std::abs(m_all_fonts[i]->LegacySize - scaled_size) <
-           std::abs(m_all_fonts[i - 1]->LegacySize - scaled_size))
+        if(std::abs(m_available_sizes[i] - scaled_size) <
+           std::abs(m_available_sizes[i - 1] - scaled_size))
             best_index = i;
     }
-
     return best_index;
 }
 
 void
 FontManager::SetFontSize(int idx)
 {
-    constexpr int num_types = static_cast<int>(FontType::__kLastFont);
+    if(m_available_sizes.empty()) return;
+    idx = std::max(0, std::min(idx, static_cast<int>(m_available_sizes.size()) - 1));
 
-    if(num_types == 0 || m_all_fonts.empty()) return;
-    if(idx < 0 || idx >= static_cast<int>(m_all_fonts.size())) return;
- 
-    static const int offsets[] = { -1, 0, 1, 2 };
-
-    m_fonts.resize(num_types);
-    m_icon_fonts.resize(num_types);
-
-    for(int i = 0; i < num_types; ++i)
+    for(int i = 0; i < kNumTypes; ++i)
     {
-        int font_idx = idx + offsets[i];
-        font_idx =
-            std::max(0, std::min(font_idx, static_cast<int>(m_all_fonts.size()) - 1));
-        m_fonts[i]      = m_all_fonts[font_idx];
-        m_icon_fonts[i] = m_all_icon_fonts[font_idx];
+        int size_idx = std::max(0, std::min(idx + kSizeOffsets[i],
+                                            static_cast<int>(m_available_sizes.size()) - 1));
+        m_sizes[i] = m_available_sizes[size_idx];
     }
 
-    ImFont* default_font       = m_fonts[static_cast<int>(FontType::kDefault)];
-    ImGui::GetIO().FontDefault = default_font;
-    ImGui::GetStyle()._NextFrameFontSizeBase = default_font->LegacySize;
+    // Set the default font and its base size for the next frame.
+    ImGui::GetIO().FontDefault                   = m_text_font;
+    ImGui::GetStyle()._NextFrameFontSizeBase     = m_sizes[static_cast<int>(FontType::kDefault)];
+
     EventManager::GetInstance()->AddEvent(
         std::make_shared<RocEvent>(static_cast<int>(RocEvents::kFontSizeChanged)));
 }
@@ -97,35 +87,27 @@ bool
 FontManager::Init()
 {
     ImGuiIO& io = ImGui::GetIO();
-    m_fonts.clear();
-
-    const int num_types = static_cast<int>(FontType::__kLastFont);
 
 #ifdef _WIN32
     const char* font_paths[] = { "C:\\Windows\\Fonts\\arial.ttf" };
 #elif __APPLE__
     const char* font_paths[] = {
-        // macOS system fonts
         "/System/Library/Fonts/Helvetica.ttc",
         "/System/Library/Fonts/HelveticaNeue.ttc",
         "/System/Library/Fonts/Supplemental/Arial.ttf",
         "/System/Library/Fonts/Supplemental/Verdana.ttf",
         "/Library/Fonts/Arial.ttf",
         "/Library/Fonts/Microsoft/Arial.ttf",
-        // SF Pro (newer macOS)
         "/System/Library/Fonts/SFNSDisplay.ttf",
         "/System/Library/Fonts/SFNS.ttf"
     };
 #else
     const char* font_paths[] = {
-        // Ubuntu / Debian
         "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
         "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
         "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
         "/usr/share/fonts/truetype/msttcorefonts/Arial.ttf",
-        // RedHat 8, Oracle 8
         "/usr/share/fonts/dejavu/DejaVuSans.ttf",
-        // RedHat 9 / 10, Oracle 9 / 10
         "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf",
         "/usr/share/fonts/liberation-sans/LiberationSans-Regular.ttf"
     };
@@ -141,72 +123,65 @@ FontManager::Init()
         }
     }
 
-    // Prepare storage
-    m_all_fonts.resize(FONT_AVAILABLE_SIZES.size(), nullptr);
-    m_fonts.resize(num_types);
-    m_icon_fonts.resize(num_types);
+    m_available_sizes.assign(FONT_AVAILABLE_SIZES.begin(), FONT_AVAILABLE_SIZES.end());
 
-    ImFontConfig config;
-    config.FontDataOwnedByAtlas = false;
-
-    // Load all font sizes once
-    for(int sz = 0; sz < FONT_AVAILABLE_SIZES.size(); ++sz)
+    // In ImGui 1.92+ a single ImFont* is dynamically sizable — load one atlas entry per
+    // typeface (size 0.0f lets the backend choose the rasterisation density automatically).
+    if(font_path)
     {
-        ImFont* font = nullptr;
-        if(font_path)
-        {
-            font = io.Fonts->AddFontFromFileTTF(font_path, FONT_AVAILABLE_SIZES[sz]);
-        }
-        else
-        {
-            ImFontConfig fallback_config;
-            fallback_config.SizePixels = FONT_AVAILABLE_SIZES[sz];
-            font                       = io.Fonts->AddFontDefault(&fallback_config);
-        }
-        m_all_fonts[sz] = font;
+        m_text_font = io.Fonts->AddFontFromFileTTF(font_path, 0.0f);
+    }
+    else
+    {
+        ImFontConfig fallback_config;
+        fallback_config.SizePixels = BASE_FONT_SIZE;
+        m_text_font                = io.Fonts->AddFontDefault(&fallback_config);
     }
 
-    // Load all icon fonts
-    m_all_icon_fonts.resize(FONT_AVAILABLE_SIZES.size(), nullptr);
+    ImFontConfig icon_config;
+    icon_config.FontDataOwnedByAtlas = false;
+    // Merge icon glyphs into a separate font object so icon PushFont() still works.
+    m_icon_font = io.Fonts->AddFontFromMemoryCompressedTTF(
+        &icon_font_compressed_data, icon_font_compressed_size, 0.0f, &icon_config, icon_ranges);
 
-    for(int sz = 0; sz < FONT_AVAILABLE_SIZES.size(); ++sz)
-    {
-        ImFont* icon_font = io.Fonts->AddFontFromMemoryCompressedTTF(
-            &icon_font_compressed_data, icon_font_compressed_size,
-            FONT_AVAILABLE_SIZES[sz], &config, icon_ranges);
-        m_all_icon_fonts[sz] = icon_font;
-    }
+    // Initialise sizes to the default base index so GetFontSize() is valid before
+    // SetFontSize() is called for the first time.
+    int default_idx = static_cast<int>(std::distance(
+        FONT_AVAILABLE_SIZES.begin(),
+        std::find(FONT_AVAILABLE_SIZES.begin(), FONT_AVAILABLE_SIZES.end(), BASE_FONT_SIZE)));
+    if(default_idx >= static_cast<int>(m_available_sizes.size())) default_idx = 6; // fallback to index of 13.0f
+    SetFontSize(default_idx);
 
-    // Don't call Build() - ImGui 1.92+ backend handles font atlas building automatically
+    // Don't call Build() - ImGui 1.92+ backend handles font atlas building automatically.
     return true;
 }
 
-const std::vector<ImFont*>
-FontManager::GetAvailableFonts() const
+const std::vector<float>
+FontManager::GetAvailableSizes() const
 {
-    return m_all_fonts;
+    return m_available_sizes;
 }
 
 ImFont*
 FontManager::GetFont(FontType font_type)
 {
-    if(static_cast<int>(font_type) < 0 ||
-       static_cast<int>(font_type) >= static_cast<int>(FontType::__kLastFont))
-    {
-        return nullptr;  // Invalid font type
-    }
-    return m_fonts[static_cast<int>(font_type)];
+    (void)font_type;
+    return m_text_font;
 }
 
 ImFont*
 FontManager::GetIconFont(FontType font_type)
 {
-    if(static_cast<int>(font_type) < 0 ||
-       static_cast<int>(font_type) >= static_cast<int>(FontType::__kLastFont))
-    {
-        return nullptr;  // Invalid font type
-    }
-    return m_icon_fonts[static_cast<int>(font_type)];
+    (void)font_type;
+    return m_icon_font;
+}
+
+float
+FontManager::GetFontSize(FontType font_type) const
+{
+    int idx = static_cast<int>(font_type);
+    if(idx < 0 || idx >= kNumTypes) return BASE_FONT_SIZE;
+    return m_sizes[idx];
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_font_manager.cpp
+++ b/src/view/src/rocprofvis_font_manager.cpp
@@ -54,7 +54,8 @@ FontManager::GetDPIScaledFontIndex()
 void
 FontManager::SetFontSize(int idx)
 {
-    if(m_available_sizes.empty()) return;
+    if(m_available_sizes.empty())
+        return;
     idx = std::max(0, std::min(idx, static_cast<int>(m_available_sizes.size()) - 1));
 
     for(int i = 0; i < kNumTypes; ++i)
@@ -138,7 +139,9 @@ FontManager::Init()
     int default_idx = static_cast<int>(std::distance(
         FONT_AVAILABLE_SIZES.begin(),
         std::find(FONT_AVAILABLE_SIZES.begin(), FONT_AVAILABLE_SIZES.end(), BASE_FONT_SIZE)));
-    if(default_idx >= static_cast<int>(m_available_sizes.size())) default_idx = 6; // fallback to index of 13.0f
+
+    if(default_idx >= static_cast<int>(m_available_sizes.size()))
+        default_idx = 6; // fallback to index of 13.0f
     SetFontSize(default_idx);
 
     // Don't call Build() - ImGui 1.92+ backend handles font atlas building automatically.
@@ -169,7 +172,8 @@ float
 FontManager::GetFontSize(FontType font_type) const
 {
     int idx = static_cast<int>(font_type);
-    if(idx < 0 || idx >= kNumTypes) return BASE_FONT_SIZE;
+    if(idx < 0 || idx >= kNumTypes)
+        return BASE_FONT_SIZE;
     return m_sizes[idx];
 }
 

--- a/src/view/src/rocprofvis_font_manager.cpp
+++ b/src/view/src/rocprofvis_font_manager.cpp
@@ -31,22 +31,11 @@ FontManager::FontManager() {}
 
 FontManager::~FontManager() {}
 
-ImFont*
-FontManager::GetIconFontByIndex(int /*idx*/)
-{
-    return m_icon_font;
-}
-
-ImFont*
-FontManager::GetFontByIndex(int /*idx*/)
-{
-    return m_text_font;
-}
-
 int
 FontManager::GetDPIScaledFontIndex()
 {
-    constexpr float DPI_EXPONENT = 0.75f;
+    constexpr float DPI_EXPONENT =
+        0.75f;  // Adjust as needed. Higher values increase size more rapidly.
 
     float scaled_size =
         BASE_FONT_SIZE * std::pow(SettingsManager::GetInstance().GetDPI(), DPI_EXPONENT);
@@ -92,22 +81,27 @@ FontManager::Init()
     const char* font_paths[] = { "C:\\Windows\\Fonts\\arial.ttf" };
 #elif __APPLE__
     const char* font_paths[] = {
+        // macOS system fonts
         "/System/Library/Fonts/Helvetica.ttc",
         "/System/Library/Fonts/HelveticaNeue.ttc",
         "/System/Library/Fonts/Supplemental/Arial.ttf",
         "/System/Library/Fonts/Supplemental/Verdana.ttf",
         "/Library/Fonts/Arial.ttf",
         "/Library/Fonts/Microsoft/Arial.ttf",
+        // SF Pro (newer macOS)
         "/System/Library/Fonts/SFNSDisplay.ttf",
         "/System/Library/Fonts/SFNS.ttf"
     };
 #else
     const char* font_paths[] = {
+        // Ubuntu / Debian
         "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
         "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
         "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
         "/usr/share/fonts/truetype/msttcorefonts/Arial.ttf",
+        // RedHat 8, Oracle 8
         "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+        // RedHat 9 / 10, Oracle 9 / 10
         "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf",
         "/usr/share/fonts/liberation-sans/LiberationSans-Regular.ttf"
     };
@@ -125,8 +119,6 @@ FontManager::Init()
 
     m_available_sizes.assign(FONT_AVAILABLE_SIZES.begin(), FONT_AVAILABLE_SIZES.end());
 
-    // In ImGui 1.92+ a single ImFont* is dynamically sizable — load one atlas entry per
-    // typeface (size 0.0f lets the backend choose the rasterisation density automatically).
     if(font_path)
     {
         m_text_font = io.Fonts->AddFontFromFileTTF(font_path, 0.0f);
@@ -140,12 +132,9 @@ FontManager::Init()
 
     ImFontConfig icon_config;
     icon_config.FontDataOwnedByAtlas = false;
-    // Merge icon glyphs into a separate font object so icon PushFont() still works.
     m_icon_font = io.Fonts->AddFontFromMemoryCompressedTTF(
         &icon_font_compressed_data, icon_font_compressed_size, 0.0f, &icon_config, icon_ranges);
 
-    // Initialise sizes to the default base index so GetFontSize() is valid before
-    // SetFontSize() is called for the first time.
     int default_idx = static_cast<int>(std::distance(
         FONT_AVAILABLE_SIZES.begin(),
         std::find(FONT_AVAILABLE_SIZES.begin(), FONT_AVAILABLE_SIZES.end(), BASE_FONT_SIZE)));

--- a/src/view/src/rocprofvis_font_manager.cpp
+++ b/src/view/src/rocprofvis_font_manager.cpp
@@ -25,7 +25,7 @@ constexpr std::array FONT_AVAILABLE_SIZES = { 7.0f,  8.0f,  9.0f,  10.0f, 11.0f,
                                               23.0f, 25.0f, 27.0f, 29.0f, 33.0f };
 
 // Size offsets applied to the base index to produce kSmall/kMedium/kMedLarge/kLarge.
-static constexpr int kSizeOffsets[FontManager::kNumTypes] = { -1, 0, 1, 2 };
+static constexpr int kSizeOffsets[FontManager::kNumSizes] = { -1, 0, 1, 2 };
 
 FontManager::FontManager() {}
 
@@ -58,7 +58,7 @@ FontManager::SetFontSize(int idx)
         return;
     idx = std::max(0, std::min(idx, static_cast<int>(m_available_sizes.size()) - 1));
 
-    for(int i = 0; i < kNumTypes; ++i)
+    for(int i = 0; i < kNumSizes; ++i)
     {
         int size_idx = std::max(0, std::min(idx + kSizeOffsets[i],
                                             static_cast<int>(m_available_sizes.size()) - 1));
@@ -157,22 +157,22 @@ FontManager::GetAvailableSizes() const
 ImFont*
 FontManager::GetFont(FontType font_type)
 {
-    (void)font_type;
-    return m_text_font;
-}
-
-ImFont*
-FontManager::GetIconFont(FontType font_type)
-{
-    (void)font_type;
-    return m_icon_font;
+    switch(font_type)
+    {
+        case FontType::kMainText:
+            return m_text_font;
+        case FontType::kIcon:
+            return m_icon_font;
+        default:
+            return m_text_font;
+    }
 }
 
 float
-FontManager::GetFontSize(FontType font_type) const
+FontManager::GetFontSize(FontSize font_size) const
 {
-    int idx = static_cast<int>(font_type);
-    if(idx < 0 || idx >= kNumTypes)
+    int idx = static_cast<int>(font_size);
+    if(idx < 0 || idx >= kNumSizes)
         return BASE_FONT_SIZE;
     return m_sizes[idx];
 }

--- a/src/view/src/rocprofvis_font_manager.h
+++ b/src/view/src/rocprofvis_font_manager.h
@@ -50,11 +50,7 @@ private:
 
     ImFont* m_text_font = nullptr;
     ImFont* m_icon_font = nullptr;
-
-    // Per-FontType sizes derived from the chosen base index.
     std::array<float, kNumTypes> m_sizes{};
-
-    // Available base sizes (mirrors FONT_AVAILABLE_SIZES for the settings combo).
     std::vector<float> m_available_sizes;
 };
 

--- a/src/view/src/rocprofvis_font_manager.h
+++ b/src/view/src/rocprofvis_font_manager.h
@@ -47,9 +47,6 @@ public:
     // Returns the pixel size to pass to PushFont() for a given FontType.
     float GetFontSize(FontType font_type) const;
 
-    // Legacy index-based accessors kept for settings panel compatibility.
-    ImFont* GetFontByIndex(int idx);
-    ImFont* GetIconFontByIndex(int idx);
     int     GetDPIScaledFontIndex();
 
     void SetFontSize(int idx);

--- a/src/view/src/rocprofvis_font_manager.h
+++ b/src/view/src/rocprofvis_font_manager.h
@@ -14,12 +14,21 @@ namespace View
 
 enum class FontType
 {
+    kMainText,
+    kIcon,
+    // Used to get the size of the enum, insert new fonts before this line
+    __kLastFont,
+    kDefault = kMainText
+};
+
+enum class FontSize
+{
     kSmall,
     kMedium,
     kMedLarge,
     kLarge,
     // Used to get the size of the enum, insert new fonts before this line
-    __kLastFont,
+    __kLastSize,
     kDefault = kMedium
 };
 
@@ -39,18 +48,17 @@ public:
 
     const std::vector<float> GetAvailableSizes() const;
     ImFont*                  GetFont(FontType font_type);
-    ImFont*                  GetIconFont(FontType font_type);
-    float                    GetFontSize(FontType font_type) const;
+    float                    GetFontSize(FontSize font_type) const;
     int                      GetDPIScaledFontIndex();
     void                     SetFontSize(int idx);
 
-    static constexpr int kNumTypes = static_cast<int>(FontType::__kLastFont);
+    static constexpr int kNumSizes = static_cast<int>(FontSize::__kLastSize);
 
 private:
 
     ImFont* m_text_font = nullptr;
     ImFont* m_icon_font = nullptr;
-    std::array<float, kNumTypes> m_sizes{};
+    std::array<float, kNumSizes> m_sizes{};
     std::vector<float> m_available_sizes;
 };
 

--- a/src/view/src/rocprofvis_font_manager.h
+++ b/src/view/src/rocprofvis_font_manager.h
@@ -37,19 +37,12 @@ public:
      */
     bool Init();
 
-    // Returns the available base sizes (one entry per loaded atlas size slot).
     const std::vector<float> GetAvailableSizes() const;
-
-    // Returns the single text/icon ImFont* (same for all FontTypes in 1.92 dynamic sizing).
-    ImFont* GetFont(FontType font_type);
-    ImFont* GetIconFont(FontType font_type);
-
-    // Returns the pixel size to pass to PushFont() for a given FontType.
-    float GetFontSize(FontType font_type) const;
-
-    int     GetDPIScaledFontIndex();
-
-    void SetFontSize(int idx);
+    ImFont*                  GetFont(FontType font_type);
+    ImFont*                  GetIconFont(FontType font_type);
+    float                    GetFontSize(FontType font_type) const;
+    int                      GetDPIScaledFontIndex();
+    void                     SetFontSize(int idx);
 
     static constexpr int kNumTypes = static_cast<int>(FontType::__kLastFont);
 

--- a/src/view/src/rocprofvis_font_manager.h
+++ b/src/view/src/rocprofvis_font_manager.h
@@ -54,8 +54,9 @@ public:
 
     void SetFontSize(int idx);
 
-private:
     static constexpr int kNumTypes = static_cast<int>(FontType::__kLastFont);
+
+private:
 
     ImFont* m_text_font = nullptr;
     ImFont* m_icon_font = nullptr;

--- a/src/view/src/rocprofvis_font_manager.h
+++ b/src/view/src/rocprofvis_font_manager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "imgui.h"
+#include <array>
 #include <vector>
 
 namespace RocProfVis
@@ -36,20 +37,34 @@ public:
      */
     bool Init();
 
-    const std::vector<ImFont*> GetAvailableFonts() const;
-    ImFont*                    GetFont(FontType font_type);
-    ImFont*                    GetIconFont(FontType font_type);
-    ImFont*                    GetFontByIndex(int idx);
-    ImFont*                    GetIconFontByIndex(int idx);
-    int                        GetDPIScaledFontIndex();
+    // Returns the available base sizes (one entry per loaded atlas size slot).
+    const std::vector<float> GetAvailableSizes() const;
+
+    // Returns the single text/icon ImFont* (same for all FontTypes in 1.92 dynamic sizing).
+    ImFont* GetFont(FontType font_type);
+    ImFont* GetIconFont(FontType font_type);
+
+    // Returns the pixel size to pass to PushFont() for a given FontType.
+    float GetFontSize(FontType font_type) const;
+
+    // Legacy index-based accessors kept for settings panel compatibility.
+    ImFont* GetFontByIndex(int idx);
+    ImFont* GetIconFontByIndex(int idx);
+    int     GetDPIScaledFontIndex();
 
     void SetFontSize(int idx);
 
 private:
-    std::vector<ImFont*> m_fonts;
-    std::vector<ImFont*> m_icon_fonts;
-    std::vector<ImFont*> m_all_fonts;
-    std::vector<ImFont*> m_all_icon_fonts;
+    static constexpr int kNumTypes = static_cast<int>(FontType::__kLastFont);
+
+    ImFont* m_text_font = nullptr;
+    ImFont* m_icon_font = nullptr;
+
+    // Per-FontType sizes derived from the chosen base index.
+    std::array<float, kNumTypes> m_sizes{};
+
+    // Available base sizes (mirrors FONT_AVAILABLE_SIZES for the settings combo).
+    std::vector<float> m_available_sizes;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_minimap.cpp
+++ b/src/view/src/rocprofvis_minimap.cpp
@@ -523,17 +523,19 @@ Minimap::RenderLegend(float w, float h)
     dl->AddRect(ImVec2(bar_x2, bar_y), ImVec2(bar_x2 + bar_w, bar_y + bar_h),
                 !m_show_counters ? DimColor(border_col) : border_col);
 
-    ImFont* font = sm.GetFontManager().GetFont(FontType::kSmall);
+    ImFont* font = sm.GetFontManager().GetFont(FontType::kDefault);
     float   cx   = pos.x + w * 0.5f;
 
     const char* txt_max = "Max";
     ImVec2      sz_max  = ImGui::CalcTextSize(txt_max);
-    dl->AddText(font, sm.GetFontManager().GetFontSize(FontType::kSmall),ImVec2(cx - sz_max.x * 0.5f, pos.y),
-                sm.GetColor(Colors::kTextMain), txt_max);
+    dl->AddText(font, sm.GetFontManager().GetFontSize(FontSize::kSmall),
+                ImVec2(cx - sz_max.x * 0.5f, pos.y), sm.GetColor(Colors::kTextMain),
+                txt_max);
 
     const char* txt_min = "Min";
     ImVec2      sz_min  = ImGui::CalcTextSize(txt_min);
-    dl->AddText(font, sm.GetFontManager().GetFontSize(FontType::kSmall),ImVec2(cx - sz_min.x * 0.5f, bar_y + bar_h + gap),
+    dl->AddText(font, sm.GetFontManager().GetFontSize(FontSize::kSmall),
+                ImVec2(cx - sz_min.x * 0.5f, bar_y + bar_h + gap),
                 sm.GetColor(Colors::kTextMain), txt_min);
 
     // Checkboxes
@@ -556,7 +558,7 @@ Minimap::RenderLegend(float w, float h)
         ImVec2 draw_pos = ImVec2(center.x - tsz.x * 0.5f, center.y - tsz.y * 0.5f);
 
         int v_start = dl->VtxBuffer.Size;
-        dl->AddText(font, sm.GetFontManager().GetFontSize(FontType::kSmall),draw_pos, text_col, text);
+        dl->AddText(font, sm.GetFontManager().GetFontSize(FontSize::kSmall),draw_pos, text_col, text);
         int v_end = dl->VtxBuffer.Size;
 
         // Rotate 90� CCW: (x,y) -> (y, -x) relative to center

--- a/src/view/src/rocprofvis_minimap.cpp
+++ b/src/view/src/rocprofvis_minimap.cpp
@@ -528,12 +528,12 @@ Minimap::RenderLegend(float w, float h)
 
     const char* txt_max = "Max";
     ImVec2      sz_max  = ImGui::CalcTextSize(txt_max);
-    dl->AddText(font, font->LegacySize, ImVec2(cx - sz_max.x * 0.5f, pos.y),
+    dl->AddText(font, sm.GetFontManager().GetFontSize(FontType::kSmall),ImVec2(cx - sz_max.x * 0.5f, pos.y),
                 sm.GetColor(Colors::kTextMain), txt_max);
 
     const char* txt_min = "Min";
     ImVec2      sz_min  = ImGui::CalcTextSize(txt_min);
-    dl->AddText(font, font->LegacySize, ImVec2(cx - sz_min.x * 0.5f, bar_y + bar_h + gap),
+    dl->AddText(font, sm.GetFontManager().GetFontSize(FontType::kSmall),ImVec2(cx - sz_min.x * 0.5f, bar_y + bar_h + gap),
                 sm.GetColor(Colors::kTextMain), txt_min);
 
     // Checkboxes
@@ -556,7 +556,7 @@ Minimap::RenderLegend(float w, float h)
         ImVec2 draw_pos = ImVec2(center.x - tsz.x * 0.5f, center.y - tsz.y * 0.5f);
 
         int v_start = dl->VtxBuffer.Size;
-        dl->AddText(font, font->LegacySize, draw_pos, text_col, text);
+        dl->AddText(font, sm.GetFontManager().GetFontSize(FontType::kSmall),draw_pos, text_col, text);
         int v_end = dl->VtxBuffer.Size;
 
         // Rotate 90� CCW: (x,y) -> (y, -x) relative to center

--- a/src/view/src/rocprofvis_presets.cpp
+++ b/src/view/src/rocprofvis_presets.cpp
@@ -322,7 +322,7 @@ PresetBrowser::Render()
         popup_style.PushPopupStyles();
         if(ImGui::BeginPopup("preset_browser"))
         {
-            ImGui::PushFont(icons);
+            ImGui::PushFont(icons, m_settings.GetFontManager().GetFontSize(FontType::kDefault));
             float manage_width =
                 ImGui::CalcTextSize(ICON_OPEN).x + ImGui::CalcTextSize(ICON_ARCHIVE).x +
                 ImGui::CalcTextSize(ICON_TRASH_CAN).x + 2.0f * style.ItemSpacing.x;

--- a/src/view/src/rocprofvis_presets.cpp
+++ b/src/view/src/rocprofvis_presets.cpp
@@ -314,7 +314,7 @@ PresetBrowser::Render()
     if(ImGui::IsPopupOpen("preset_browser"))
     {
         const ImGuiStyle& style = m_settings.GetDefaultStyle();
-        ImFont* icons = m_settings.GetFontManager().GetIconFont(FontType::kDefault);
+        ImFont* icons = m_settings.GetFontManager().GetFont(FontType::kIcon);
         ImGui::SetNextWindowSize(ImGui::GetWindowSize() * 0.2f);
         ImGui::SetNextWindowPos(
             ImVec2(m_pos_x - ImGui::GetWindowWidth() * 0.2f, m_pos_y));

--- a/src/view/src/rocprofvis_presets.cpp
+++ b/src/view/src/rocprofvis_presets.cpp
@@ -322,7 +322,7 @@ PresetBrowser::Render()
         popup_style.PushPopupStyles();
         if(ImGui::BeginPopup("preset_browser"))
         {
-            ImGui::PushFont(icons, m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+            ImGui::PushFont(icons, 0.0f);
             float manage_width =
                 ImGui::CalcTextSize(ICON_OPEN).x + ImGui::CalcTextSize(ICON_ARCHIVE).x +
                 ImGui::CalcTextSize(ICON_TRASH_CAN).x + 2.0f * style.ItemSpacing.x;

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -36,11 +36,6 @@ SettingsPanel::SettingsPanel(SettingsManager& settings)
 , m_font_settings({ m_usersettings.display_settings.dpi_based_scaling,
                     m_usersettings.display_settings.font_size_index })
 {
-    for(float size : m_fonts.GetAvailableSizes())
-    {
-        m_font_sizes.emplace_back(std::to_string(static_cast<int>(size)));
-        m_font_sizes_ptr.emplace_back(m_font_sizes.back().c_str());
-    }
 }
 
 SettingsPanel::~SettingsPanel() {}
@@ -255,8 +250,20 @@ SettingsPanel::RenderDisplayOptions()
     ImGui::SameLine();
     ImGui::SetNextItemWidth(ImGui::CalcTextSize("00").x + 2 * style.FramePadding.x +
                             ImGui::GetFrameHeightWithSpacing());
-    ImGui::Combo("##font_size", &m_font_settings.size_index, m_font_sizes_ptr.data(),
-                 static_cast<int>(m_font_sizes_ptr.size()));
+    const auto& available_sizes   = m_fonts.GetAvailableSizes();
+    std::string current_label     = std::to_string(static_cast<int>(available_sizes[m_font_settings.size_index]));
+    if(ImGui::BeginCombo("##font_size", current_label.c_str()))
+    {
+        for(int i = 0; i < static_cast<int>(available_sizes.size()); ++i)
+        {
+            std::string label = std::to_string(static_cast<int>(available_sizes[i]));
+            if(ImGui::Selectable(label.c_str(), i == m_font_settings.size_index))
+                m_font_settings.size_index = i;
+            if(i == m_font_settings.size_index)
+                ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+    }
     ImGui::SameLine();
     ImGui::BeginDisabled(m_font_settings.size_index >
                          static_cast<int>(m_fonts.GetAvailableSizes().size()) - 2);
@@ -277,7 +284,6 @@ SettingsPanel::RenderDisplayOptions()
     ImFont* preview_font = m_fonts.GetFont(FontType::kDefault);
     int     preview_idx  = m_font_settings.dpi_scaling ? m_fonts.GetDPIScaledFontIndex()
                                                         : m_font_settings.size_index;
-    const auto& available_sizes = m_fonts.GetAvailableSizes();
     float preview_size = available_sizes.empty() ? m_fonts.GetFontSize(FontType::kDefault)
                        : available_sizes[std::max(0, std::min(preview_idx,
                              static_cast<int>(available_sizes.size()) - 1))];

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -284,7 +284,7 @@ SettingsPanel::RenderDisplayOptions()
     ImFont* preview_font = m_fonts.GetFont(FontType::kDefault);
     int     preview_idx  = m_font_settings.dpi_scaling ? m_fonts.GetDPIScaledFontIndex()
                                                         : m_font_settings.size_index;
-    float preview_size = available_sizes.empty() ? m_fonts.GetFontSize(FontType::kDefault)
+    float preview_size = available_sizes.empty() ? m_fonts.GetFontSize(FontSize::kDefault)
                        : available_sizes[std::max(0, std::min(preview_idx,
                              static_cast<int>(available_sizes.size()) - 1))];
     if(preview_font)
@@ -377,7 +377,7 @@ SettingsPanel::ResetButton()
                           m_settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,
                           m_settings.GetColor(Colors::kTransparent));
-    ImGui::PushFont(m_fonts.GetIconFont(FontType::kDefault), 0.0f);
+    ImGui::PushFont(m_fonts.GetFont(FontType::kIcon), 0.0f);
     clicked = ImGui::Button(ICON_ARROWS_CYCLE);
     ImGui::PopFont();
     ImGui::PopStyleColor(3);

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -377,7 +377,7 @@ SettingsPanel::ResetButton()
                           m_settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,
                           m_settings.GetColor(Colors::kTransparent));
-    ImGui::PushFont(m_fonts.GetIconFont(FontType::kDefault), m_fonts.GetFontSize(FontType::kDefault));
+    ImGui::PushFont(m_fonts.GetIconFont(FontType::kDefault), 0.0f);
     clicked = ImGui::Button(ICON_ARROWS_CYCLE);
     ImGui::PopFont();
     ImGui::PopStyleColor(3);

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -36,9 +36,9 @@ SettingsPanel::SettingsPanel(SettingsManager& settings)
 , m_font_settings({ m_usersettings.display_settings.dpi_based_scaling,
                     m_usersettings.display_settings.font_size_index })
 {
-    for(const ImFont* font : m_fonts.GetAvailableFonts())
+    for(float size : m_fonts.GetAvailableSizes())
     {
-        m_font_sizes.emplace_back(std::to_string(static_cast<int>(font->LegacySize)));
+        m_font_sizes.emplace_back(std::to_string(static_cast<int>(size)));
         m_font_sizes_ptr.emplace_back(m_font_sizes.back().c_str());
     }
 }
@@ -259,7 +259,7 @@ SettingsPanel::RenderDisplayOptions()
                  static_cast<int>(m_font_sizes_ptr.size()));
     ImGui::SameLine();
     ImGui::BeginDisabled(m_font_settings.size_index >
-                         m_fonts.GetAvailableFonts().size() - 2);
+                         static_cast<int>(m_fonts.GetAvailableSizes().size()) - 2);
     if(ImGui::Button("+", ImVec2(button_width, 0)))
     {
         m_font_settings.size_index++;
@@ -274,14 +274,18 @@ SettingsPanel::RenderDisplayOptions()
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Preview");
     ImGui::SameLine();
-    ImFont* preview_font = m_fonts.GetFontByIndex(m_font_settings.dpi_scaling
-                                                      ? m_fonts.GetDPIScaledFontIndex()
-                                                      : m_font_settings.size_index);
+    ImFont* preview_font = m_fonts.GetFont(FontType::kDefault);
+    int     preview_idx  = m_font_settings.dpi_scaling ? m_fonts.GetDPIScaledFontIndex()
+                                                        : m_font_settings.size_index;
+    const auto& available_sizes = m_fonts.GetAvailableSizes();
+    float preview_size = available_sizes.empty() ? m_fonts.GetFontSize(FontType::kDefault)
+                       : available_sizes[std::max(0, std::min(preview_idx,
+                             static_cast<int>(available_sizes.size()) - 1))];
     if(preview_font)
     {
         ImGui::Spacing();
         ImGui::SameLine();
-        ImGui::PushFont(preview_font);
+        ImGui::PushFont(preview_font, preview_size);
         ImGui::GetWindowDrawList()->AddRectFilled(
             ImGui::GetCursorScreenPos() - ImVec2(style.FramePadding.x, 0),
             ImGui::GetCursorScreenPos() + ImGui::CalcTextSize("AMD ROCm(TM) Optiq") +
@@ -367,7 +371,7 @@ SettingsPanel::ResetButton()
                           m_settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,
                           m_settings.GetColor(Colors::kTransparent));
-    ImGui::PushFont(m_fonts.GetIconFont(FontType::kDefault));
+    ImGui::PushFont(m_fonts.GetIconFont(FontType::kDefault), m_fonts.GetFontSize(FontType::kDefault));
     clicked = ImGui::Button(ICON_ARROWS_CYCLE);
     ImGui::PopFont();
     ImGui::PopStyleColor(3);

--- a/src/view/src/rocprofvis_settings_panel.h
+++ b/src/view/src/rocprofvis_settings_panel.h
@@ -5,7 +5,6 @@
 
 #include "rocprofvis_hotkey_manager.h"
 #include "rocprofvis_settings_manager.h"
-#include <list>
 
 namespace RocProfVis
 {
@@ -51,9 +50,6 @@ private:
     bool                     m_settings_changed;
     bool                     m_settings_confirmed;
     Category                 m_category;
-    std::list<std::string>   m_font_sizes;
-    std::vector<const char*> m_font_sizes_ptr;
-
     SettingsManager& m_settings;
     FontManager&     m_fonts;
     UserSettings&    m_usersettings;

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -145,7 +145,8 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     bool display = graph.display;
     if(show_eye_button)
     {
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                        m_settings.GetFontManager().GetFontSize(FontType::kDefault));
         if(ImGui::Button(display ? ICON_EYE : ICON_EYE_SLASH))
         {
             graph.display         = !graph.display;
@@ -159,7 +160,8 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
             SetTooltipStyled("Toggle Track Visibility");
 
         ImGui::SameLine();
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                        m_settings.GetFontManager().GetFontSize(FontType::kDefault));
         if(ImGui::Button(ICON_ARROWS_SHRINK))
         {
             EventManager::GetInstance()->AddEvent(std::make_shared<ScrollToTrackEvent>(
@@ -438,7 +440,8 @@ SideBar::EyeButtonState
 SideBar::DrawEyeButton(EyeButtonState eye_button_state)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                    m_settings.GetFontManager().GetFontSize(FontType::kDefault));
 
     ImVec2 eye_size = ImGui::CalcTextSize(ICON_EYE);
     float  button_w = eye_size.x + ImGui::GetStyle().FramePadding.x * 2;

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -145,8 +145,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     bool display = graph.display;
     if(show_eye_button)
     {
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                        m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
         if(ImGui::Button(display ? ICON_EYE : ICON_EYE_SLASH))
         {
             graph.display         = !graph.display;
@@ -160,8 +159,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
             SetTooltipStyled("Toggle Track Visibility");
 
         ImGui::SameLine();
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                        m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
         if(ImGui::Button(ICON_ARROWS_SHRINK))
         {
             EventManager::GetInstance()->AddEvent(std::make_shared<ScrollToTrackEvent>(
@@ -440,8 +438,7 @@ SideBar::EyeButtonState
 SideBar::DrawEyeButton(EyeButtonState eye_button_state)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                    m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
 
     ImVec2 eye_size = ImGui::CalcTextSize(ICON_EYE);
     float  button_w = eye_size.x + ImGui::GetStyle().FramePadding.x * 2;

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -145,7 +145,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     bool display = graph.display;
     if(show_eye_button)
     {
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
         if(ImGui::Button(display ? ICON_EYE : ICON_EYE_SLASH))
         {
             graph.display         = !graph.display;
@@ -159,7 +159,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
             SetTooltipStyled("Toggle Track Visibility");
 
         ImGui::SameLine();
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
         if(ImGui::Button(ICON_ARROWS_SHRINK))
         {
             EventManager::GetInstance()->AddEvent(std::make_shared<ScrollToTrackEvent>(
@@ -438,7 +438,7 @@ SideBar::EyeButtonState
 SideBar::DrawEyeButton(EyeButtonState eye_button_state)
 {
     ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
-    ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+    ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
 
     ImVec2 eye_size = ImGui::CalcTextSize(ICON_EYE);
     float  button_w = eye_size.x + ImGui::GetStyle().FramePadding.x * 2;

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -136,8 +136,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         std::string child_id = "StickyButtonArea##" + std::to_string(m_id);
         ImGui::BeginChild(child_id.c_str(), m_size, false, ImGuiWindowFlags_None);
 
-        ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetIconFont(
-            FontType::kDefault);
+        ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
         ImGui::PushFont(icon_font, 0.0f);
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
@@ -223,7 +222,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         // Edit button (left of close)
         ImGui::SetCursorPos(ImVec2(sticky_size.x - edit_btn_size * 2 - margin,
                                    (header_height - edit_btn_size) / 2));
-        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon), 0.0f);
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kTransparent));
@@ -240,7 +239,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
         ImGui::SetCursorPos(ImVec2(sticky_size.x - edit_btn_size - margin / 2,
                                    (header_height - edit_btn_size) / 2));
-        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon), 0.0f);
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kTransparent));
@@ -307,8 +306,7 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     {
         ImVec2 icon_pos = ImVec2(window_position.x + x, window_position.y + y);
 
-        ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetIconFont(
-            FontType::kDefault);
+        ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
         ImGui::PushFont(icon_font, 0.0f);
         ImVec2 icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
         ImGui::PopFont();

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -138,7 +138,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
         ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetIconFont(
             FontType::kDefault);
-        ImGui::PushFont(icon_font, SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
+        ImGui::PushFont(icon_font, 0.0f);
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kTransparent));
@@ -223,8 +223,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         // Edit button (left of close)
         ImGui::SetCursorPos(ImVec2(sticky_size.x - edit_btn_size * 2 - margin,
                                    (header_height - edit_btn_size) / 2));
-        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault),
-                        SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
+        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kTransparent));
@@ -241,8 +240,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
         ImGui::SetCursorPos(ImVec2(sticky_size.x - edit_btn_size - margin / 2,
                                    (header_height - edit_btn_size) / 2));
-        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault),
-                        SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
+        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kTransparent));
@@ -311,7 +309,7 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
 
         ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetIconFont(
             FontType::kDefault);
-        ImGui::PushFont(icon_font, SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
+        ImGui::PushFont(icon_font, 0.0f);
         ImVec2 icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
         ImGui::PopFont();
 

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -138,7 +138,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
         ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetIconFont(
             FontType::kDefault);
-        ImGui::PushFont(icon_font);
+        ImGui::PushFont(icon_font, SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kTransparent));
@@ -223,8 +223,8 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         // Edit button (left of close)
         ImGui::SetCursorPos(ImVec2(sticky_size.x - edit_btn_size * 2 - margin,
                                    (header_height - edit_btn_size) / 2));
-        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(
-            FontType::kDefault));
+        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault),
+                        SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kTransparent));
@@ -241,8 +241,8 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
         ImGui::SetCursorPos(ImVec2(sticky_size.x - edit_btn_size - margin / 2,
                                    (header_height - edit_btn_size) / 2));
-        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(
-            FontType::kDefault));
+        ImGui::PushFont(SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault),
+                        SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kTransparent));
@@ -311,7 +311,7 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
 
         ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetIconFont(
             FontType::kDefault);
-        ImGui::PushFont(icon_font);
+        ImGui::PushFont(icon_font, SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
         ImVec2 icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
         ImGui::PopFont();
 

--- a/src/view/src/rocprofvis_summary_view.cpp
+++ b/src/view/src/rocprofvis_summary_view.cpp
@@ -543,7 +543,7 @@ TopKernels::Render()
                                        plot_style.PlotPadding.y));
         ImGui::BeginGroup();
         if(IconButton(ICON_CHART_PIE,
-                      m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                      m_settings.GetFontManager().GetFont(FontType::kIcon),
                       ImVec2(0, 0), nullptr, false, style.FramePadding,
                       m_settings.GetColor(m_display_mode == Pie ? Colors::kButton
                                                                 : Colors::kTransparent),
@@ -554,7 +554,7 @@ TopKernels::Render()
         }
         ImGui::SameLine();
         if(IconButton(ICON_CHART_BAR,
-                      m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                      m_settings.GetFontManager().GetFont(FontType::kIcon),
                       ImVec2(0, 0), nullptr, false, style.FramePadding,
                       m_settings.GetColor(m_display_mode == Bar ? Colors::kButton
                                                                 : Colors::kTransparent),
@@ -565,7 +565,7 @@ TopKernels::Render()
         }
         ImGui::SameLine();
         if(IconButton(ICON_LIST,
-                      m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                      m_settings.GetFontManager().GetFont(FontType::kIcon),
                       ImVec2(0, 0), nullptr, false, style.FramePadding,
                       m_settings.GetColor(m_display_mode == Table ? Colors::kButton
                                                                   : Colors::kTransparent),

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1491,8 +1491,8 @@ TimelineView::RenderHistogram()
     ImVec2      ruler_pos       = ImGui::GetCursorScreenPos();
     float       ruler_width     = m_tpt->GetGraphSizeX();
     float       tick_top        = ruler_pos.y + 2.0f;
-    ImFont*     font            = m_settings.GetFontManager().GetFont(FontType::kSmall);
-    float       label_font_size = m_settings.GetFontManager().GetFontSize(FontType::kSmall);
+    ImFont*     font            = m_settings.GetFontManager().GetFont(FontType::kDefault);
+    float       label_font_size = m_settings.GetFontManager().GetFontSize(FontSize::kSmall);
 
     std::string label =
         nanosecond_to_formatted_str(m_tpt->GetRangeX(), time_format, true) + "gap";

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1492,7 +1492,7 @@ TimelineView::RenderHistogram()
     float       ruler_width     = m_tpt->GetGraphSizeX();
     float       tick_top        = ruler_pos.y + 2.0f;
     ImFont*     font            = m_settings.GetFontManager().GetFont(FontType::kSmall);
-    float       label_font_size = font->LegacySize;
+    float       label_font_size = m_settings.GetFontManager().GetFontSize(FontType::kSmall);
 
     std::string label =
         nanosecond_to_formatted_str(m_tpt->GetRangeX(), time_format, true) + "gap";

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -675,7 +675,7 @@ TraceView::RenderToolbar()
     VerticalSeparator(&m_settings_manager);
     
     ImFont* icon_font =
-        m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
+        m_settings_manager.GetFontManager().GetFont(FontType::kIcon);
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
     ImGui::PushFont(icon_font, 0.0f);
     if(ImGui::Button(ICON_COMPASS))
@@ -749,7 +749,7 @@ TraceView::RenderAnnotationControls()
     ImGui::SameLine();
 
     ImFont* icon_font =
-        m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
+        m_settings_manager.GetFontManager().GetFont(FontType::kIcon);
     ImGui::PushFont(icon_font, 0.0f);
     ImGui::BeginGroup();
 
@@ -908,7 +908,7 @@ TraceView::RenderBookmarkControls()
                 ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(0, 0, 0, 0));
                 ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(0, 0, 0, 0));
                 ImFont* icon_font =
-                    m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
+                    m_settings_manager.GetFontManager().GetFont(FontType::kIcon);
                 ImGui::PushFont(icon_font, 0.0f);
                 if(used)
                 {
@@ -979,7 +979,7 @@ TraceView::RenderFlowControls()
     FlowDisplayMode mode = current_mode;
 
     ImFont* icon_font =
-        m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
+        m_settings_manager.GetFontManager().GetFont(FontType::kIcon);
     ImGui::PushFont(icon_font, 0.0f);
 
     ImGui::BeginGroup();
@@ -1061,7 +1061,7 @@ TraceView::RenderEventSearch()
         std::pair<bool, bool> search_bar = InputTextWithClear(
             "search_bar", "Search: hipLaunchKernel or \"hip\"\"kernel\"",
             m_event_search->TextInput(), m_event_search->TextInputLimit(),
-            settings.GetFontManager().GetIconFont(FontType::kDefault),
+            settings.GetFontManager().GetFont(FontType::kIcon),
             settings.GetColor(Colors::kBgMain), settings.GetDefaultStyle(),
             m_event_search->Width());
         if(ImGui::IsItemClicked() && m_event_search->Searched())

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -676,8 +676,9 @@ TraceView::RenderToolbar()
     
     ImFont* icon_font =
         m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
+    float icon_font_size = m_settings_manager.GetFontManager().GetFontSize(FontType::kDefault);
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
-    ImGui::PushFont(icon_font);
+    ImGui::PushFont(icon_font, icon_font_size);
     if(ImGui::Button(ICON_COMPASS))
     {
         m_show_minimap_popup = !m_show_minimap_popup;
@@ -750,7 +751,8 @@ TraceView::RenderAnnotationControls()
 
     ImFont* icon_font =
         m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
-    ImGui::PushFont(icon_font);
+    float icon_font_size = m_settings_manager.GetFontManager().GetFontSize(FontType::kDefault);
+    ImGui::PushFont(icon_font, icon_font_size);
     ImGui::BeginGroup();
 
     bool   is_sticky_visible = m_annotations->IsVisibile();
@@ -786,7 +788,7 @@ TraceView::RenderAnnotationControls()
     {
         ImGui::PopFont();
         SetTooltipStyled("Show Annotation Layer");
-        ImGui::PushFont(icon_font);
+        ImGui::PushFont(icon_font, icon_font_size);
     }
     ImGui::PopID();
     ImGui::SameLine();
@@ -815,7 +817,7 @@ TraceView::RenderAnnotationControls()
     {
         ImGui::PopFont();
         SetTooltipStyled("Hide Annotation Layer");
-        ImGui::PushFont(icon_font);
+        ImGui::PushFont(icon_font, icon_font_size);
     }
     ImGui::PopID();
     ImGui::SameLine();
@@ -843,7 +845,7 @@ TraceView::RenderAnnotationControls()
     {
         ImGui::PopFont();
         SetTooltipStyled("Add New Annotation");
-        ImGui::PushFont(icon_font);
+        ImGui::PushFont(icon_font, icon_font_size);
     }
     ImGui::PopID();
 
@@ -909,7 +911,8 @@ TraceView::RenderBookmarkControls()
                 ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(0, 0, 0, 0));
                 ImFont* icon_font =
                     m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
-                ImGui::PushFont(icon_font);
+                float icon_font_size = m_settings_manager.GetFontManager().GetFontSize(FontType::kDefault);
+                ImGui::PushFont(icon_font, icon_font_size);
                 if(used)
                 {
                     if(ImGui::Button(ICON_DELETE))
@@ -922,8 +925,8 @@ TraceView::RenderBookmarkControls()
                 }
                 else
                 {
-                    ImGui::PushFont(icon_font);
-                    ImGui::PushFont(icon_font);
+                    ImGui::PushFont(icon_font, icon_font_size);
+                    ImGui::PushFont(icon_font, icon_font_size);
                     if(ImGui::Button(ICON_ADD_NOTE))
                     {
                         m_bookmarks[i] = m_timeline_view->GetViewCoords();
@@ -980,7 +983,8 @@ TraceView::RenderFlowControls()
 
     ImFont* icon_font =
         m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
-    ImGui::PushFont(icon_font);
+    float icon_font_size = m_settings_manager.GetFontManager().GetFontSize(FontType::kDefault);
+    ImGui::PushFont(icon_font, icon_font_size);
 
     ImGui::BeginGroup();
     for(int i = 0; i <= static_cast<int>(FlowDisplayMode::__kLastMode); ++i)
@@ -1011,7 +1015,7 @@ TraceView::RenderFlowControls()
         {
             ImGui::PopFont();
             SetTooltipStyled("%s", flow_tool_tips[i]);
-            ImGui::PushFont(icon_font);
+            ImGui::PushFont(icon_font, icon_font_size);
         }
 
         ImGui::PopID();
@@ -1038,7 +1042,7 @@ TraceView::RenderFlowControls()
     {
         ImGui::PopFont();
         SetTooltipStyled("Flow Render Style");
-        ImGui::PushFont(icon_font);
+        ImGui::PushFont(icon_font, icon_font_size);
     }
     ImGui::PopFont();
 

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -676,9 +676,8 @@ TraceView::RenderToolbar()
     
     ImFont* icon_font =
         m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
-    float icon_font_size = m_settings_manager.GetFontManager().GetFontSize(FontType::kDefault);
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
-    ImGui::PushFont(icon_font, icon_font_size);
+    ImGui::PushFont(icon_font, 0.0f);
     if(ImGui::Button(ICON_COMPASS))
     {
         m_show_minimap_popup = !m_show_minimap_popup;
@@ -751,8 +750,7 @@ TraceView::RenderAnnotationControls()
 
     ImFont* icon_font =
         m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
-    float icon_font_size = m_settings_manager.GetFontManager().GetFontSize(FontType::kDefault);
-    ImGui::PushFont(icon_font, icon_font_size);
+    ImGui::PushFont(icon_font, 0.0f);
     ImGui::BeginGroup();
 
     bool   is_sticky_visible = m_annotations->IsVisibile();
@@ -788,7 +786,7 @@ TraceView::RenderAnnotationControls()
     {
         ImGui::PopFont();
         SetTooltipStyled("Show Annotation Layer");
-        ImGui::PushFont(icon_font, icon_font_size);
+        ImGui::PushFont(icon_font, 0.0f);
     }
     ImGui::PopID();
     ImGui::SameLine();
@@ -817,7 +815,7 @@ TraceView::RenderAnnotationControls()
     {
         ImGui::PopFont();
         SetTooltipStyled("Hide Annotation Layer");
-        ImGui::PushFont(icon_font, icon_font_size);
+        ImGui::PushFont(icon_font, 0.0f);
     }
     ImGui::PopID();
     ImGui::SameLine();
@@ -845,7 +843,7 @@ TraceView::RenderAnnotationControls()
     {
         ImGui::PopFont();
         SetTooltipStyled("Add New Annotation");
-        ImGui::PushFont(icon_font, icon_font_size);
+        ImGui::PushFont(icon_font, 0.0f);
     }
     ImGui::PopID();
 
@@ -911,8 +909,7 @@ TraceView::RenderBookmarkControls()
                 ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(0, 0, 0, 0));
                 ImFont* icon_font =
                     m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
-                float icon_font_size = m_settings_manager.GetFontManager().GetFontSize(FontType::kDefault);
-                ImGui::PushFont(icon_font, icon_font_size);
+                ImGui::PushFont(icon_font, 0.0f);
                 if(used)
                 {
                     if(ImGui::Button(ICON_DELETE))
@@ -925,8 +922,8 @@ TraceView::RenderBookmarkControls()
                 }
                 else
                 {
-                    ImGui::PushFont(icon_font, icon_font_size);
-                    ImGui::PushFont(icon_font, icon_font_size);
+                    ImGui::PushFont(icon_font, 0.0f);
+                    ImGui::PushFont(icon_font, 0.0f);
                     if(ImGui::Button(ICON_ADD_NOTE))
                     {
                         m_bookmarks[i] = m_timeline_view->GetViewCoords();
@@ -983,8 +980,7 @@ TraceView::RenderFlowControls()
 
     ImFont* icon_font =
         m_settings_manager.GetFontManager().GetIconFont(FontType::kDefault);
-    float icon_font_size = m_settings_manager.GetFontManager().GetFontSize(FontType::kDefault);
-    ImGui::PushFont(icon_font, icon_font_size);
+    ImGui::PushFont(icon_font, 0.0f);
 
     ImGui::BeginGroup();
     for(int i = 0; i <= static_cast<int>(FlowDisplayMode::__kLastMode); ++i)
@@ -1015,7 +1011,7 @@ TraceView::RenderFlowControls()
         {
             ImGui::PopFont();
             SetTooltipStyled("%s", flow_tool_tips[i]);
-            ImGui::PushFont(icon_font, icon_font_size);
+            ImGui::PushFont(icon_font, 0.0f);
         }
 
         ImGui::PopID();
@@ -1042,7 +1038,7 @@ TraceView::RenderFlowControls()
     {
         ImGui::PopFont();
         SetTooltipStyled("Flow Render Style");
-        ImGui::PushFont(icon_font, icon_font_size);
+        ImGui::PushFont(icon_font, 0.0f);
     }
     ImGui::PopFont();
 

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -253,7 +253,7 @@ TrackItem::RenderMetaArea()
         ImGui::SetCursorPos(
             ImVec2((m_reorder_grip_width - grid_icon_width) / 2,
                    (container_size.y - ImGui::GetTextLineHeightWithSpacing()) / 2));
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
 
         ImGui::TextUnformatted(ICON_GRID);
         float menu_button_width = ImGui::CalcTextSize(ICON_GEAR).x;
@@ -277,8 +277,8 @@ TrackItem::RenderMetaArea()
         //         }
         //     }
         // }
-        ImFont* large_font = m_settings.GetFontManager().GetFont(FontType::kLarge);
-        ImGui::PushFont(large_font, m_settings.GetFontManager().GetFontSize(FontType::kLarge));
+        ImFont* large_font = m_settings.GetFontManager().GetFont(FontType::kDefault);
+        ImGui::PushFont(large_font, m_settings.GetFontManager().GetFontSize(FontSize::kLarge));
 
         float available_for_text =
             content_size.x - (m_meta_area_scale_width + menu_button_width + grid_icon_width + arrow_width +
@@ -320,7 +320,7 @@ TrackItem::RenderMetaArea()
                                        m_meta_area_scale_width - menu_button_width,
                                    m_metadata_padding.y));
         IconButton(ICON_GEAR,
-                   m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+                   m_settings.GetFontManager().GetFont(FontType::kIcon));
         if(ImGui::IsItemHovered())
             SetTooltipStyled("Track Options");
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
@@ -847,8 +847,8 @@ Pill::RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
     {
         return;
     }
-    ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kSmall),
-                    settings.GetFontManager().GetFontSize(FontType::kSmall));
+    ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kDefault),
+                    settings.GetFontManager().GetFontSize(FontSize::kSmall));
 
     ImVec2 pillbox_pos(reorder_grip_width, container_size.y - m_pillbox_size.y - 2.0f);
 

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -253,7 +253,8 @@ TrackItem::RenderMetaArea()
         ImGui::SetCursorPos(
             ImVec2((m_reorder_grip_width - grid_icon_width) / 2,
                    (container_size.y - ImGui::GetTextLineHeightWithSpacing()) / 2));
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
+                        m_settings.GetFontManager().GetFontSize(FontType::kDefault));
 
         ImGui::TextUnformatted(ICON_GRID);
         float menu_button_width = ImGui::CalcTextSize(ICON_GEAR).x;
@@ -278,7 +279,7 @@ TrackItem::RenderMetaArea()
         //     }
         // }
         ImFont* large_font = m_settings.GetFontManager().GetFont(FontType::kLarge);
-        ImGui::PushFont(large_font);
+        ImGui::PushFont(large_font, m_settings.GetFontManager().GetFontSize(FontType::kLarge));
 
         float available_for_text =
             content_size.x - (m_meta_area_scale_width + menu_button_width + grid_icon_width + arrow_width +
@@ -847,7 +848,8 @@ Pill::RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
     {
         return;
     }
-    ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kSmall));
+    ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kSmall),
+                    settings.GetFontManager().GetFontSize(FontType::kSmall));
 
     ImVec2 pillbox_pos(reorder_grip_width, container_size.y - m_pillbox_size.y - 2.0f);
 

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -253,8 +253,7 @@ TrackItem::RenderMetaArea()
         ImGui::SetCursorPos(
             ImVec2((m_reorder_grip_width - grid_icon_width) / 2,
                    (container_size.y - ImGui::GetTextLineHeightWithSpacing()) / 2));
-        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault),
-                        m_settings.GetFontManager().GetFontSize(FontType::kDefault));
+        ImGui::PushFont(m_settings.GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
 
         ImGui::TextUnformatted(ICON_GRID);
         float menu_button_width = ImGui::CalcTextSize(ICON_GEAR).x;

--- a/src/view/src/widgets/rocprofvis_editable_textfield.cpp
+++ b/src/view/src/widgets/rocprofvis_editable_textfield.cpp
@@ -153,7 +153,7 @@ EditableTextField::ButtonSize() const
 {
     ImFont* icon_font =
         SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault);
-    ImGui::PushFont(icon_font);
+    ImGui::PushFont(icon_font, SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
     float size = ImGui::CalcTextSize(ICON_ARROWS_CYCLE).x;
     ImGui::PopFont();
     return size;

--- a/src/view/src/widgets/rocprofvis_editable_textfield.cpp
+++ b/src/view/src/widgets/rocprofvis_editable_textfield.cpp
@@ -55,7 +55,7 @@ EditableTextField::DrawPlainText()
     if(m_show_reset_button)
     {
         if(IconButton(ICON_ARROWS_CYCLE,
-                      settings.GetFontManager().GetIconFont(FontType::kDefault)))
+                      settings.GetFontManager().GetFont(FontType::kIcon)))
         {
             RevertToDefault();
         }
@@ -152,7 +152,7 @@ float
 EditableTextField::ButtonSize() const
 {
     ImFont* icon_font =
-        SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault);
+        SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
     ImGui::PushFont(icon_font, 0.0f);
     float size = ImGui::CalcTextSize(ICON_ARROWS_CYCLE).x;
     ImGui::PopFont();

--- a/src/view/src/widgets/rocprofvis_editable_textfield.cpp
+++ b/src/view/src/widgets/rocprofvis_editable_textfield.cpp
@@ -153,7 +153,7 @@ EditableTextField::ButtonSize() const
 {
     ImFont* icon_font =
         SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault);
-    ImGui::PushFont(icon_font, SettingsManager::GetInstance().GetFontManager().GetFontSize(FontType::kDefault));
+    ImGui::PushFont(icon_font, 0.0f);
     float size = ImGui::CalcTextSize(ICON_ARROWS_CYCLE).x;
     ImGui::PopFont();
     return size;

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -470,7 +470,7 @@ XButton(const char* id, const char * tool_tip_label, SettingsManager* settings)
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,
                           settings->GetColor(Colors::kTransparent));
     ImGui::PushStyleVarX(ImGuiStyleVar_FramePadding, 0);
-    ImGui::PushFont(settings->GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
+    ImGui::PushFont(settings->GetFontManager().GetFont(FontType::kIcon), 0.0f);
     if(id && strlen(id) > 0)
     {
         ImGui::PushID(id);
@@ -499,9 +499,9 @@ SectionTitle(const char* text, bool large, SettingsManager* settings)
         settings = &SettingsManager::GetInstance();
     }
 
-    FontType font_type = large ? FontType::kLarge : FontType::kMedLarge;
-    ImGui::PushFont(settings->GetFontManager().GetFont(font_type),
-                    settings->GetFontManager().GetFontSize(font_type));
+    FontSize font_size = large ? FontSize::kLarge : FontSize::kMedLarge;
+    ImGui::PushFont(settings->GetFontManager().GetFont(FontType::kDefault),
+                    settings->GetFontManager().GetFontSize(font_size));
     ImGui::SeparatorText(text);
     ImGui::PopFont();
 }

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -239,7 +239,7 @@ IconButton(const char* icon, ImFont* icon_font, ImVec2 size, const char* tooltip
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, bg_color_hover);
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, bg_color_active);
     }
-    ImGui::PushFont(icon_font);
+    ImGui::PushFont(icon_font, ImGui::GetFontSize());
     bool clicked = ImGui::Button(icon, size);
     ImGui::PopFont();
     if(tooltip && strlen(tooltip) > 0 && BeginItemTooltipStyled())
@@ -286,7 +286,7 @@ InputTextWithClear(const char* id, const char* hint, char* buf,
     ImGui::PopStyleColor();
     if(strlen(buf) > 0)
     {
-        ImGui::PushFont(icon_font);
+        ImGui::PushFont(icon_font, ImGui::GetFontSize());
         if(width >= ImGui::CalcTextSize(ICON_X_CIRCLED).x + 2 * style.FramePadding.x)
         {
             ImGui::SameLine();
@@ -470,7 +470,8 @@ XButton(const char* id, const char * tool_tip_label, SettingsManager* settings)
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,
                           settings->GetColor(Colors::kTransparent));
     ImGui::PushStyleVarX(ImGuiStyleVar_FramePadding, 0);
-    ImGui::PushFont(settings->GetFontManager().GetIconFont(FontType::kDefault));
+    ImGui::PushFont(settings->GetFontManager().GetIconFont(FontType::kDefault),
+                    settings->GetFontManager().GetFontSize(FontType::kDefault));
     if(id && strlen(id) > 0)
     {
         ImGui::PushID(id);
@@ -500,7 +501,8 @@ SectionTitle(const char* text, bool large, SettingsManager* settings)
     }
 
     FontType font_type = large ? FontType::kLarge : FontType::kMedLarge;
-    ImGui::PushFont(settings->GetFontManager().GetFont(font_type));
+    ImGui::PushFont(settings->GetFontManager().GetFont(font_type),
+                    settings->GetFontManager().GetFontSize(font_type));
     ImGui::SeparatorText(text);
     ImGui::PopFont();
 }

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -239,7 +239,7 @@ IconButton(const char* icon, ImFont* icon_font, ImVec2 size, const char* tooltip
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, bg_color_hover);
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, bg_color_active);
     }
-    ImGui::PushFont(icon_font, ImGui::GetFontSize());
+    ImGui::PushFont(icon_font, 0.0f);
     bool clicked = ImGui::Button(icon, size);
     ImGui::PopFont();
     if(tooltip && strlen(tooltip) > 0 && BeginItemTooltipStyled())
@@ -286,7 +286,7 @@ InputTextWithClear(const char* id, const char* hint, char* buf,
     ImGui::PopStyleColor();
     if(strlen(buf) > 0)
     {
-        ImGui::PushFont(icon_font, ImGui::GetFontSize());
+        ImGui::PushFont(icon_font, 0.0f);
         if(width >= ImGui::CalcTextSize(ICON_X_CIRCLED).x + 2 * style.FramePadding.x)
         {
             ImGui::SameLine();
@@ -470,8 +470,7 @@ XButton(const char* id, const char * tool_tip_label, SettingsManager* settings)
     ImGui::PushStyleColor(ImGuiCol_ButtonActive,
                           settings->GetColor(Colors::kTransparent));
     ImGui::PushStyleVarX(ImGuiStyleVar_FramePadding, 0);
-    ImGui::PushFont(settings->GetFontManager().GetIconFont(FontType::kDefault),
-                    settings->GetFontManager().GetFontSize(FontType::kDefault));
+    ImGui::PushFont(settings->GetFontManager().GetIconFont(FontType::kDefault), 0.0f);
     if(id && strlen(id) > 0)
     {
         ImGui::PushID(id);


### PR DESCRIPTION
## Motivation
Use the modern imgui approach for loading fonts, for dynamic font resizing.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Now only two fonts are loaded: the main font and the icon font. When using PushFont, you must specify the font size, or 0.0f if the font size should not be changed.
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
Check that fonts work correctly on different sizes and systems, and that icons are displayed correctly.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
