### PR TITLE
Don't block UI thread during DataProvider teardown

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -101,6 +101,13 @@ ComputeView::ComputeView()
 
 ComputeView::~ComputeView() {}
 
+std::optional<DataProviderCleanupWork>
+ComputeView::DetachProviderCleanup()
+{
+    DataProviderCleanupWork cleanup_work = m_data_provider.DetachCleanupWork();
+    return cleanup_work;
+}
+
 void
 ComputeView::Update()
 {

--- a/src/view/src/compute/rocprofvis_compute_view.h
+++ b/src/view/src/compute/rocprofvis_compute_view.h
@@ -29,6 +29,7 @@ public:
     void DestroyView();
 
     std::shared_ptr<RocWidget> GetToolbar() override;
+    std::optional<DataProviderCleanupWork> DetachProviderCleanup() override;
 
 private:
     void RenderToolbar();

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -53,6 +53,9 @@ constexpr const char* SUPPORTED_FILE_TYPES_HINT   = "Supported types: .db, .rpd,
 
 constexpr float STATUS_BAR_HEIGHT = 30.0f;
 
+constexpr const char* CLEANUP_MESSAGE = "Waiting for requests to finish cleanup...";
+constexpr const char* CLOSING_MESSAGE = "Closing...";
+
 // For testing DataProvider
 void
 RenderProviderTest(DataProvider& provider);
@@ -788,6 +791,9 @@ AppWindow::RenderShutdownState()
         ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(360.0f * dpi, 0.0f), ImGuiCond_Always);
 
+    PopUpStyle ps;
+    ps.PushPopupStyles();
+    ps.CenterPopup();
     if(ImGui::BeginPopupModal(SHUTDOWN_DIALOG_NAME, nullptr,
                               ImGuiWindowFlags_NoResize |
                                   ImGuiWindowFlags_NoMove |
@@ -795,16 +801,27 @@ AppWindow::RenderShutdownState()
     {
         if(m_provider_cleanup_jobs.empty())
         {
-            ImGui::TextUnformatted("Closing...");
+            CenterNextTextItem(CLOSING_MESSAGE);
+            ImGui::TextUnformatted(CLOSING_MESSAGE);
         }
         else
         {
-            ImGui::TextUnformatted("Waiting for requests to finish cleanup...");
+            CenterNextTextItem(CLEANUP_MESSAGE);
+            ImGui::TextUnformatted(CLEANUP_MESSAGE);
             ImGui::Spacing();
-            ImGui::Text("Cleanup jobs remaining: %zu", m_provider_cleanup_jobs.size());
+            // Draw indicator dots to show that the app is still responsive
+            RenderLoadingIndicator(SettingsManager::GetInstance().GetColor(Colors::kTextMain),
+                                   nullptr, kCenterHorizontal);
+            ImGui::Spacing();
+            const std::string remaining_message =
+                "Cleanup jobs remaining: " +
+                std::to_string(m_provider_cleanup_jobs.size());
+            CenterNextTextItem(remaining_message.c_str());
+            ImGui::TextUnformatted(remaining_message.c_str());
         }
         ImGui::EndPopup();
     }
+    ps.PopStyles();
 }
 
 void

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -473,8 +473,8 @@ AppWindow::StartProviderCleanup(DataProviderCleanupWork cleanup_work,
                           std::to_string(++m_next_provider_cleanup_id);
 
     const std::string message =
-        "Closing trace: " + cleanup_label + " (" +
-        std::to_string(cleanup_work.requests.size()) + " request(s))";
+        "Closing trace: " + cleanup_label + ", canceling " +
+        std::to_string(cleanup_work.requests.size()) + " request(s)";
     NotificationManager::GetInstance().ShowPersistent(job.notification_id, message,
                                                       NotificationLevel::Info);
 

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -404,6 +404,12 @@ AppWindow::BeginAppShutdown()
     m_shutdown_requested      = true;
     m_disable_app_interaction = true;
 
+    NotificationManager::GetInstance().ShowPersistent(
+        APP_SHUTDOWN_NOTIFICATION_ID,
+        "Closing traces... " + std::to_string(m_provider_cleanup_jobs.size()) +
+            " cleanup job(s) remaining",
+        NotificationLevel::Info);
+
     for(auto& item : m_projects)
     {
         if(item.second)
@@ -513,15 +519,6 @@ AppWindow::UpdateProviderCleanups()
         if(m_provider_cleanup_jobs.empty())
         {
             NotificationManager::GetInstance().Hide(APP_SHUTDOWN_NOTIFICATION_ID);
-        }
-        else
-        {
-            NotificationManager::GetInstance().ShowPersistent(
-                APP_SHUTDOWN_NOTIFICATION_ID,
-                "Closing traces... " +
-                    std::to_string(m_provider_cleanup_jobs.size()) +
-                    " cleanup job(s) remaining",
-                NotificationLevel::Info);
         }
         RequestExitIfProviderCleanupsComplete();
     }

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -28,6 +28,7 @@
 #include "widgets/rocprofvis_notification_manager.h"
 #include <filesystem>
 #include <sstream>
+#include <utility>
 
 namespace RocProfVis
 {
@@ -38,6 +39,8 @@ constexpr ImVec2      FILE_DIALOG_SIZE       = ImVec2(480.0f, 360.0f);
 constexpr const char* FILE_DIALOG_NAME       = "ChooseFileDlgKey";
 constexpr const char* TAB_CONTAINER_SRC_NAME = "MainTabContainer";
 constexpr const char* ABOUT_DIALOG_NAME      = "About##_dialog";
+constexpr const char* APP_SHUTDOWN_NOTIFICATION_ID = "provider_cleanup_app_shutdown";
+constexpr const char* SHUTDOWN_DIALOG_NAME = "Closing Traces##_shutdown";
 constexpr float EMPTY_STATE_CONTENT_EM      = 32.0f;
 constexpr float EMPTY_STATE_BUTTON_EM       = 10.0f;
 constexpr float EMPTY_STATE_LOGO_EM         = 12.0f;
@@ -104,7 +107,10 @@ AppWindow::AppWindow()
 , m_is_native_file_dialog_open(false)
 #endif
 , m_disable_app_interaction(false)
+, m_shutdown_requested(false)
+, m_exit_notification_sent(false)
 , m_restore_fullscreen_later(false)
+, m_next_provider_cleanup_id(0)
 {}
 
 AppWindow::~AppWindow()
@@ -113,6 +119,14 @@ AppWindow::~AppWindow()
                                              m_tabclosed_event_token);
     EventManager::GetInstance()->Unsubscribe(static_cast<int>(RocEvents::kTabSelected),
                                              m_tabselected_event_token);
+    for(auto& job : m_provider_cleanup_jobs)
+    {
+        if(job.future.valid())
+        {
+            job.future.get();
+        }
+    }
+    m_provider_cleanup_jobs.clear();
     m_projects.clear();
 }
 
@@ -151,7 +165,11 @@ AppWindow::Init()
     m_tab_container->EnableSendChangeEvent(true);
 
     main_area_item.m_item = std::make_shared<RocCustomWidget>([this]() {
-        if(m_tab_container && !m_tab_container->GetTabs().empty())
+        if(m_shutdown_requested)
+        {
+            RenderShutdownState();
+        }
+        else if(m_tab_container && !m_tab_container->GetTabs().empty())
         {
             m_tab_container->Render();
         }
@@ -270,12 +288,16 @@ AppWindow::SetTabLabel(const std::string& label, const std::string& id)
 void
 AppWindow::ShowCloseConfirm()
 {
+    if(m_shutdown_requested)
+    {
+        RequestExitIfProviderCleanupsComplete();
+        return;
+    }
+
     if(m_tab_container->GetTabs().size() == 0 ||
        SettingsManager::GetInstance().GetUserSettings().dont_ask_before_exit)
     {
-        if(m_notification_callback)
-            m_notification_callback(
-                rocprofvis_view_notification_t::kRocProfVisViewNotification_Exit_App);
+        BeginAppShutdown();
         return;
     }
 
@@ -284,11 +306,7 @@ AppWindow::ShowCloseConfirm()
         "Confirm Close",
         "Are you sure you want to close the application? Any "
         "unsaved data will be lost.",
-        [this]() {
-            if(m_notification_callback)
-                m_notification_callback(
-                    rocprofvis_view_notification_t::kRocProfVisViewNotification_Exit_App);
-        });
+        [this]() { BeginAppShutdown(); });
 }
 
 void
@@ -372,11 +390,170 @@ AppWindow::GetCurrentProject()
 }
 
 void
+AppWindow::BeginAppShutdown()
+{
+    if(m_shutdown_requested)
+    {
+        RequestExitIfProviderCleanupsComplete();
+        return;
+    }
+
+    m_shutdown_requested      = true;
+    m_disable_app_interaction = true;
+
+    for(auto& item : m_projects)
+    {
+        if(item.second)
+        {
+            item.second->Close();
+            DetachProjectProviderCleanup(*item.second,
+                                         ProviderCleanupReason::kAppShutdown);
+        }
+    }
+
+#ifdef ROCPROFVIS_DEVELOPER_MODE
+    StartProviderCleanup(m_test_data_provider.DetachCleanupWork(),
+                         "developer data provider",
+                         ProviderCleanupReason::kAppShutdown);
+#endif
+
+    m_projects.clear();
+    if(m_main_view)
+    {
+        m_main_view->GetMutableAt(m_tool_bar_index)->m_item = nullptr;
+    }
+
+    if(!m_provider_cleanup_jobs.empty())
+    {
+        NotificationManager::GetInstance().ShowPersistent(
+            APP_SHUTDOWN_NOTIFICATION_ID, "Closing traces...",
+            NotificationLevel::Info);
+    }
+
+    RequestExitIfProviderCleanupsComplete();
+}
+
+void
+AppWindow::DetachProjectProviderCleanup(Project& project, ProviderCleanupReason reason)
+{
+    std::shared_ptr<RootView> root_view =
+        std::dynamic_pointer_cast<RootView>(project.GetView());
+    if(!root_view)
+    {
+        return;
+    }
+
+    std::optional<DataProviderCleanupWork> cleanup_work =
+        root_view->DetachProviderCleanup();
+    if(cleanup_work)
+    {
+        StartProviderCleanup(std::move(*cleanup_work), project.GetName(), reason);
+    }
+}
+
+void
+AppWindow::StartProviderCleanup(DataProviderCleanupWork cleanup_work,
+                                const std::string&    label,
+                                ProviderCleanupReason reason)
+{
+    if(cleanup_work.requests.empty() && !cleanup_work.controller)
+    {
+        return;
+    }
+
+    const std::string cleanup_label =
+        label.empty() ? cleanup_work.trace_file_path : label;
+    ProviderCleanupJob job;
+    job.label           = cleanup_label;
+    job.reason          = reason;
+    job.notification_id = "provider_cleanup_" +
+                          std::to_string(++m_next_provider_cleanup_id);
+
+    const std::string message =
+        "Closing trace: " + cleanup_label + " (" +
+        std::to_string(cleanup_work.requests.size()) + " request(s))";
+    NotificationManager::GetInstance().ShowPersistent(job.notification_id, message,
+                                                      NotificationLevel::Info);
+
+    job.future = std::async(
+        std::launch::async,
+        [cleanup_work = std::move(cleanup_work)]() mutable {
+            return DataProvider::CleanupDetachedResources(std::move(cleanup_work));
+        });
+    m_provider_cleanup_jobs.push_back(std::move(job));
+}
+
+void
+AppWindow::UpdateProviderCleanups()
+{
+    for(auto it = m_provider_cleanup_jobs.begin(); it != m_provider_cleanup_jobs.end();)
+    {
+        if(it->future.valid() &&
+           it->future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+        {
+            DataProviderCleanupResult result = it->future.get();
+            spdlog::info("Provider cleanup completed for {} ({} request(s))",
+                         result.trace_file_path.empty() ? it->label
+                                                        : result.trace_file_path,
+                         result.request_count);
+            NotificationManager::GetInstance().Hide(it->notification_id);
+            it = m_provider_cleanup_jobs.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    if(m_shutdown_requested)
+    {
+        if(m_provider_cleanup_jobs.empty())
+        {
+            NotificationManager::GetInstance().Hide(APP_SHUTDOWN_NOTIFICATION_ID);
+        }
+        else
+        {
+            NotificationManager::GetInstance().ShowPersistent(
+                APP_SHUTDOWN_NOTIFICATION_ID,
+                "Closing traces... " +
+                    std::to_string(m_provider_cleanup_jobs.size()) +
+                    " cleanup job(s) remaining",
+                NotificationLevel::Info);
+        }
+        RequestExitIfProviderCleanupsComplete();
+    }
+}
+
+void
+AppWindow::RequestExitIfProviderCleanupsComplete()
+{
+    if(!m_shutdown_requested || m_exit_notification_sent ||
+       !m_provider_cleanup_jobs.empty())
+    {
+        return;
+    }
+
+    m_exit_notification_sent = true;
+    m_disable_app_interaction = false;
+    if(m_notification_callback)
+    {
+        m_notification_callback(
+            rocprofvis_view_notification_t::kRocProfVisViewNotification_Exit_App);
+    }
+}
+
+void
 AppWindow::Update()
 {
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
     UpdateNativeFileDialog();
 #endif
+    UpdateProviderCleanups();
+    if(m_shutdown_requested)
+    {
+        return;
+    }
+
     HotkeyManager::GetInstance().ProcessInput();
     EventManager::GetInstance()->DispatchEvents();
     DebugWindow::GetInstance()->ClearTransient();
@@ -384,6 +561,7 @@ AppWindow::Update()
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     m_test_data_provider.Update();
 #endif
+    UpdateProviderCleanups();
 }
 
 void
@@ -598,6 +776,38 @@ AppWindow::RenderEmptyState()
 }
 
 void
+AppWindow::RenderShutdownState()
+{
+    ImGui::OpenPopup(SHUTDOWN_DIALOG_NAME);
+
+    const float dpi = SettingsManager::GetInstance().GetDPI();
+    ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImGui::SetNextWindowPos(
+        ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5f,
+               viewport->WorkPos.y + viewport->WorkSize.y * 0.5f),
+        ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(360.0f * dpi, 0.0f), ImGuiCond_Always);
+
+    if(ImGui::BeginPopupModal(SHUTDOWN_DIALOG_NAME, nullptr,
+                              ImGuiWindowFlags_NoResize |
+                                  ImGuiWindowFlags_NoMove |
+                                  ImGuiWindowFlags_NoCollapse))
+    {
+        if(m_provider_cleanup_jobs.empty())
+        {
+            ImGui::TextUnformatted("Closing...");
+        }
+        else
+        {
+            ImGui::TextUnformatted("Waiting for requests to finish cleanup...");
+            ImGui::Spacing();
+            ImGui::Text("Cleanup jobs remaining: %zu", m_provider_cleanup_jobs.size());
+        }
+        ImGui::EndPopup();
+    }
+}
+
+void
 AppWindow::RenderFileDialog()
 {
     if(!ImGuiFileDialog::Instance()->IsOpened(FILE_DIALOG_NAME))
@@ -684,6 +894,11 @@ AppWindow::HandleOpenRecentFile(const std::string& file_path)
 void
 AppWindow::RenderDisableScreen()
 {
+    if(m_shutdown_requested)
+    {
+        return;
+    }
+
     if(m_disable_app_interaction)
     {
         ImGui::OpenPopup("GhostModal");
@@ -957,7 +1172,10 @@ void
 AppWindow::HandleTabClosed(std::shared_ptr<RocEvent> e)
 {
     auto tab_closed_event = std::dynamic_pointer_cast<TabEvent>(e);
-    if(tab_closed_event && m_projects.count(tab_closed_event->GetTabId()) > 0)
+    auto project_it =
+        tab_closed_event ? m_projects.find(tab_closed_event->GetTabId())
+                         : m_projects.end();
+    if(tab_closed_event && project_it != m_projects.end())
     {
         auto activeProject = GetCurrentProject();
         if(!activeProject)
@@ -978,8 +1196,10 @@ AppWindow::HandleTabClosed(std::shared_ptr<RocEvent> e)
             }
         }
         spdlog::debug("Tab closed: {}", tab_closed_event->GetTabId());
-        m_projects[tab_closed_event->GetTabId()]->Close();
-        m_projects.erase(tab_closed_event->GetTabId());
+        project_it->second->Close();
+        DetachProjectProviderCleanup(*project_it->second,
+                                     ProviderCleanupReason::kTabClose);
+        m_projects.erase(project_it);
     }
 }
 

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -561,7 +561,6 @@ AppWindow::Update()
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     m_test_data_provider.Update();
 #endif
-    UpdateProviderCleanups();
 }
 
 void

--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -13,11 +13,10 @@
 #include "widgets/rocprofvis_tab_container.h"
 
 #include <atomic>
-#ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
+#include <chrono>
 #include <future>
 #include <thread>
-#include <chrono>
-#endif
+#include <vector>
 
 namespace RocProfVis
 {
@@ -76,10 +75,25 @@ public:
     void SetFileDialogPreference(rocprofvis_view_file_dialog_preference_t pref);
 
 private:
+    enum class ProviderCleanupReason
+    {
+        kTabClose,
+        kAppShutdown
+    };
+
+    struct ProviderCleanupJob
+    {
+        std::string                            label;
+        std::string                            notification_id;
+        ProviderCleanupReason                  reason;
+        std::future<DataProviderCleanupResult> future;
+    };
+
     AppWindow();
     ~AppWindow();
 
     void RenderDisableScreen();
+    void RenderShutdownState();
     void RenderFileMenu(Project* project);
     void RenderEditMenu(Project* project);
     void RenderViewMenu(Project* project);
@@ -95,6 +109,13 @@ private:
     void HandleOpenRecentFile(const std::string& file_path);
     void HandleSaveAsFile();
     void ConfigureFileDialogBackend();
+    void BeginAppShutdown();
+    void DetachProjectProviderCleanup(Project& project, ProviderCleanupReason reason);
+    void StartProviderCleanup(DataProviderCleanupWork cleanup_work,
+                              const std::string&    label,
+                              ProviderCleanupReason reason);
+    void UpdateProviderCleanups();
+    void RequestExitIfProviderCleanupsComplete();
 
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
     void UpdateNativeFileDialog();
@@ -133,6 +154,8 @@ private:
 #endif
     bool m_open_about_dialog;
     bool m_disable_app_interaction;
+    bool m_shutdown_requested;
+    bool m_exit_notification_sent;
 
     rocprofvis_view_file_dialog_preference_t m_file_dialog_preference;
 
@@ -155,6 +178,8 @@ private:
     std::function<void(int)>         m_notification_callback;
     bool                             m_is_fullscreen;
     bool                             m_restore_fullscreen_later;
+    std::vector<ProviderCleanupJob>  m_provider_cleanup_jobs;
+    uint64_t                         m_next_provider_cleanup_id;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -66,25 +66,17 @@ DataProvider::DataProvider()
 , m_model()
 {}
 
-DataProvider::~DataProvider() { CloseController(); }
+DataProvider::~DataProvider()
+{
+    DataProviderCleanupWork cleanup_work = DetachCleanupWork();
+    CleanupDetachedResources(std::move(cleanup_work));
+}
 
 void
 DataProvider::CloseController()
 {
-    if(m_trace_timeline)
-    {
-        m_trace_timeline = nullptr;
-    }
-
-    m_model.Clear();
-    FreeRequests();
-    m_state      = ProviderState::kInit;
-
-    if(m_trace_controller)
-    {
-        rocprofvis_controller_free(m_trace_controller);
-        m_trace_controller = nullptr;
-    }
+    DataProviderCleanupWork cleanup_work = DetachCleanupWork();
+    CleanupDetachedResources(std::move(cleanup_work));
 }
 
 void
@@ -100,13 +92,47 @@ DataProvider::SetSelectedState(const std::string& id)
 void
 DataProvider::FreeRequests()
 {
-    for(auto item : m_requests)
+    DataProviderCleanupWork cleanup_work;
+    cleanup_work.trace_file_path = m_model.GetTraceFilePath();
+    cleanup_work.requests        = std::move(m_requests);
+    m_requests.clear();
+
+    CleanupDetachedResources(std::move(cleanup_work));
+}
+
+DataProviderCleanupWork
+DataProvider::DetachCleanupWork()
+{
+    DataProviderCleanupWork cleanup_work;
+    cleanup_work.trace_file_path = m_model.GetTraceFilePath();
+    cleanup_work.requests        = std::move(m_requests);
+    cleanup_work.controller      = m_trace_controller;
+
+    m_requests.clear();
+    m_trace_controller = nullptr;
+    m_trace_timeline   = nullptr;
+    m_model.Clear();
+    m_progress_mesage.clear();
+    m_progress_percent = 0;
+    m_state            = ProviderState::kInit;
+
+    return cleanup_work;
+}
+
+DataProviderCleanupResult
+DataProvider::CleanupDetachedResources(DataProviderCleanupWork cleanup_work)
+{
+    DataProviderCleanupResult cleanup_result;
+    cleanup_result.trace_file_path = cleanup_work.trace_file_path;
+    cleanup_result.request_count   = cleanup_work.requests.size();
+
+    for(auto& item : cleanup_work.requests)
     {
         RequestInfo& req = item.second;
         if(req.request_future)
         {
-            spdlog::warn("FreeRequests: cancelling request {} of type {}", req.request_id,
-                         static_cast<int>(req.request_type));
+            spdlog::warn("DataProvider cleanup: cancelling request {} of type {}",
+                         req.request_id, static_cast<int>(req.request_type));
 
             rocprofvis_result_t result =
                 rocprofvis_controller_future_cancel(req.request_future);
@@ -117,7 +143,7 @@ DataProvider::FreeRequests()
             }
         }
     }
-    for(auto item : m_requests)
+    for(auto& item : cleanup_work.requests)
     {
         RequestInfo& req = item.second;
 
@@ -151,7 +177,15 @@ DataProvider::FreeRequests()
         }
     }
 
-    m_requests.clear();
+    cleanup_work.requests.clear();
+
+    if(cleanup_work.controller)
+    {
+        rocprofvis_controller_free(cleanup_work.controller);
+        cleanup_work.controller = nullptr;
+    }
+
+    return cleanup_result;
 }
 
 const std::string&

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -33,6 +33,19 @@ enum class ProviderState
     kError
 };
 
+struct DataProviderCleanupWork
+{
+    std::string                           trace_file_path;
+    std::unordered_map<int64_t, RequestInfo> requests;
+    rocprofvis_controller_t*              controller = nullptr;
+};
+
+struct DataProviderCleanupResult
+{
+    std::string trace_file_path;
+    size_t      request_count = 0;
+};
+
 class DataProvider
 {
 public:
@@ -76,9 +89,14 @@ public:
     void SetSelectedState(const std::string& id);
 
     /*
-     *   Free all requests. This does not cancel the requests on the controller end.
+     *   Cancel, wait for, and free outstanding requests on the calling thread.
+     *   Use DetachCleanupWork() when the caller needs asynchronous cleanup.
      */
     void FreeRequests();
+
+    DataProviderCleanupWork DetachCleanupWork();
+    static DataProviderCleanupResult CleanupDetachedResources(
+        DataProviderCleanupWork cleanup_work);
 
     /*
      * Loads the trace data into the controller.

--- a/src/view/src/rocprofvis_root_view.cpp
+++ b/src/view/src/rocprofvis_root_view.cpp
@@ -26,6 +26,12 @@ void
 RootView::RenderEditMenuOptions()
 {}
 
+std::optional<DataProviderCleanupWork>
+RootView::DetachProviderCleanup()
+{
+    return std::nullopt;
+}
+
 void
 RootView::RenderLoadingScreen(const char* progress_label)
 {

--- a/src/view/src/rocprofvis_root_view.h
+++ b/src/view/src/rocprofvis_root_view.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include "rocprofvis_data_provider.h"
 #include "widgets/rocprofvis_widget.h"
 #include <memory>
+#include <optional>
 
 namespace RocProfVis
 {
@@ -22,6 +24,8 @@ public:
     virtual std::shared_ptr<RocWidget> GetToolbar();
 
     virtual void RenderEditMenuOptions();
+
+    virtual std::optional<DataProviderCleanupWork> DetachProviderCleanup();
 
 protected:
     void RenderLoadingScreen(const char* progress_label);

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -389,13 +389,13 @@ TraceView::Render()
             ImGui::End();
             popup_style.PopStyles();
         }
+    }
 
-        if(m_popup_info.show_popup)
-        {
-            m_popup_info.show_popup = false;
-            AppWindow::GetInstance()->ShowMessageDialog(m_popup_info.title,
-                                                        m_popup_info.message);
-        }
+    if(m_popup_info.show_popup)
+    {
+        m_popup_info.show_popup = false;
+        AppWindow::GetInstance()->ShowMessageDialog(m_popup_info.title,
+                                                    m_popup_info.message);
     }
 
     if(m_summary_view)
@@ -516,9 +516,26 @@ TraceView::SaveSelection(const std::string& file_path)
 bool
 TraceView::CleanupDatabase(bool rebuild, std::function<void()> on_complete)
 {
+    //show error lambda
+     auto show_error = [this](const std::string& message) {
+        m_popup_info.show_popup = true;
+        m_popup_info.title      = "Error";
+        m_popup_info.message    = message;
+    };
+
     if(m_data_provider.IsRequestPending(DataProvider::CLEANUP_DATABASE_REQUEST_ID))
     {
+        show_error("Database cleanup already in progress.");
         spdlog::debug("Database cleanup already in progress.");
+        return false;
+    }
+
+    //check if dataprovider is in a state that allows cleanup
+    auto state = m_data_provider.GetState();
+    if(state != ProviderState::kReady)
+    {
+        show_error("Cannot cleanup database while trace is loading");
+        spdlog::debug("Cannot cleanup database while trace is loading. Current state: {}", static_cast<int>(state));
         return false;
     }
 
@@ -552,6 +569,10 @@ TraceView::CleanupDatabase(bool rebuild, std::function<void()> on_complete)
             rebuild ? "Cleaning and rebuilding database..." : "Cleaning database...",
             NotificationLevel::Info);
         return true;
+    }
+    else
+    {
+        show_error("Database cleanup request failed to start.");
     }
 
     return false;

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -200,6 +200,13 @@ TraceView::~TraceView()
         m_progress_update_event_token);
 }
 
+std::optional<DataProviderCleanupWork>
+TraceView::DetachProviderCleanup()
+{
+    DataProviderCleanupWork cleanup_work = m_data_provider.DetachCleanupWork();
+    return cleanup_work;
+}
+
 void
 TraceView::Update()
 {
@@ -515,6 +522,7 @@ TraceView::CleanupDatabase(bool rebuild, std::function<void()> on_complete)
         return false;
     }
 
+    //Todo: FreeRequests() will block the UI thread.
     m_data_provider.FreeRequests();
 
     m_data_provider.SetCleanupDatabaseCallback(

--- a/src/view/src/rocprofvis_trace_view.h
+++ b/src/view/src/rocprofvis_trace_view.h
@@ -68,6 +68,7 @@ public:
     std::shared_ptr<TimelineSelection> GetTimelineSelection() const;
     std::shared_ptr<RocWidget>         GetToolbar() override;
     void                               RenderEditMenuOptions() override;
+    std::optional<DataProviderCleanupWork> DetachProviderCleanup() override;
     void                               SetAnalysisViewVisibility(bool visibility); 
     void                               SetSidebarViewVisibility(bool visibility);
     void                               SetHistogramVisibility(bool visibility);

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -184,7 +184,6 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
                        LoadingIndicatorCentering centering, float dot_radius,
                        int num_dots, float dot_spacing, float anim_speed)
 {
-    //ImVec2 pos = ImGui::GetCursorPos();
     bool   use_overlay_child = window_id && centering != kCenterNone;
 
     if(use_overlay_child)

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -180,12 +180,14 @@ RenderLoadingIndicatorDots(float dot_radius, int num_dots,
 }
 
 void
-RenderLoadingIndicator(ImU32 color, const char* window_id, float dot_radius, int num_dots,
-                       float dot_spacing, float anim_speed)
+RenderLoadingIndicator(ImU32 color, const char* window_id,
+                       LoadingIndicatorCentering centering, float dot_radius,
+                       int num_dots, float dot_spacing, float anim_speed)
 {
-    ImVec2 pos = ImGui::GetCursorPos();
+    //ImVec2 pos = ImGui::GetCursorPos();
+    bool   use_overlay_child = window_id && centering != kCenterNone;
 
-    if(window_id)
+    if(use_overlay_child)
     {
         // Create an overlay child window to display the loading indicator if requested
         ImGui::SetCursorPos(ImVec2(0, 0));
@@ -197,21 +199,29 @@ RenderLoadingIndicator(ImU32 color, const char* window_id, float dot_radius, int
     ImVec2 dot_size   = MeasureLoadingIndicatorDots(dot_radius, num_dots, dot_spacing);
     ImVec2 window_pos = ImGui::GetWindowPos();
     ImVec2 view_rect  = ImGui::GetWindowSize();
-    ImVec2 center_pos = ImVec2(window_pos.x + (view_rect.x - dot_size.x) * 0.5f,
-                               window_pos.y + (view_rect.y - dot_size.y) * 0.5f);
+    ImVec2 cursor_pos = ImGui::GetCursorScreenPos();
+    ImVec2 draw_pos   = cursor_pos;
 
-    ImGui::SetCursorScreenPos(center_pos);
+    if(centering == kCenterHorizontal || centering == kCenterBoth)
+    {
+        draw_pos.x = window_pos.x + (view_rect.x - dot_size.x) * 0.5f;
+    }
+    if(centering == kCenterVertical || centering == kCenterBoth)
+    {
+        draw_pos.y = window_pos.y + (view_rect.y - dot_size.y) * 0.5f;
+    }
+
+    if(centering != kCenterNone)
+    {
+        ImGui::SetCursorScreenPos(draw_pos);
+    }
     RenderLoadingIndicatorDots(dot_radius, num_dots, dot_spacing, color, anim_speed);
 
-    if(window_id)
+    if(use_overlay_child)
     {
         ImGui::EndChild();
         ImGui::PopStyleColor();
     }
-
-    // Zero-size Dummy avoids EndChild parent-boundary check after SetCursorPos.
-    ImGui::SetCursorPos(pos);
-    ImGui::Dummy(ImVec2(0.0f, 0.0f));
 }
 
 ImU32

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -184,9 +184,9 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
                        LoadingIndicatorCentering centering, float dot_radius,
                        int num_dots, float dot_spacing, float anim_speed)
 {
-    bool   use_overlay_child = window_id && centering != kCenterNone;
+    ImVec2 orig_pos = ImGui::GetCursorPos();
 
-    if(use_overlay_child)
+    if(window_id)
     {
         // Create an overlay child window to display the loading indicator if requested
         ImGui::SetCursorPos(ImVec2(0, 0));
@@ -198,8 +198,7 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
     ImVec2 dot_size   = MeasureLoadingIndicatorDots(dot_radius, num_dots, dot_spacing);
     ImVec2 window_pos = ImGui::GetWindowPos();
     ImVec2 view_rect  = ImGui::GetWindowSize();
-    ImVec2 cursor_pos = ImGui::GetCursorScreenPos();
-    ImVec2 draw_pos   = cursor_pos;
+    ImVec2 draw_pos   = ImGui::GetCursorScreenPos();
 
     if(centering == kCenterHorizontal || centering == kCenterBoth)
     {
@@ -216,10 +215,12 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
     }
     RenderLoadingIndicatorDots(dot_radius, num_dots, dot_spacing, color, anim_speed);
 
-    if(use_overlay_child)
+    if(window_id)
     {
         ImGui::EndChild();
         ImGui::PopStyleColor();
+        // Restore cursor position in the parent window
+        ImGui::SetCursorPos(orig_pos);
     }
 }
 

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -21,8 +21,17 @@ RenderLoadingIndicatorDots(float dot_radius, int num_dots, float spacing,
 ImVec2
 MeasureLoadingIndicatorDots(float dot_radius, int num_dots, float spacing);
 
+enum LoadingIndicatorCentering
+{
+    kCenterNone,
+    kCenterHorizontal,
+    kCenterVertical,
+    kCenterBoth,
+};
+
 void
 RenderLoadingIndicator(ImU32 color, const char* window_id = nullptr,
+                       LoadingIndicatorCentering centering = kCenterBoth,
                        float dot_radius = 5.0f, int num_dots = 3,
                        float dot_spacing = 5.0f, float anim_speed = 5.0f);
 

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -29,6 +29,20 @@ enum LoadingIndicatorCentering
     kCenterBoth,
 };
 
+/**
+ * @brief Render a loading indicator with animated dots.
+ *
+ * @param color The color of the dots (including alpha for transparency).
+ * @param window_id Optional ID for an overlay child window to render the indicator in.
+ * If null, the indicator will be rendered in the current window. The overlay window will
+ * be sized to fill the parent window.
+ * @param centering How to center the indicator within the window (horizontal, vertical,
+ * both, or none).
+ * @param dot_radius The radius of each dot in the indicator.
+ * @param num_dots The number of dots in the indicator.
+ * @param dot_spacing The spacing between each dot.
+ * @param anim_speed The speed of the dot animation.
+ */
 void
 RenderLoadingIndicator(ImU32 color, const char* window_id = nullptr,
                        LoadingIndicatorCentering centering = kCenterBoth,


### PR DESCRIPTION
## Motivation

Do not block the UI thread when tearing down the data provider.  Waiting for the backend to cancel / complete in-flight requests can take a long time, and this was done in a way that blocks the UI thread, causing the dreaded "Application not responding" message from the OS.

## Technical Details

Move DataProvider request/controller cleanup into detachable cleanup work object so tab close and app shutdown can hand long waits to AppWindow background jobs instead of blocking the UI thread.

Add shutdown cleanup polling, persistent progress notifications, and a centered modal shutdown message so the app stays responsive while outstanding requests are cancelled and freed.

Add loading-indicator centering options, including inline rendering support, to `RenderLoadingIndicator` and update the shutdown dialog to use the new inline/centered layout.

Added better feedback if Database cleanup option fails to start. (Previously no user feedback was present).

## Todo

Database cleanup will still cause UI thread to block as it causes the Dataprovider to abort requests using a different path.  This will be refactored in a separate PR.