### PR TITLE
Add Ubuntu 26.04 Support

### DIFF
--- a/.github/workflows/ci-controller.yml
+++ b/.github/workflows/ci-controller.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Full OS Coverage (default for scheduled runs)
-      UBUNTU_FULL_OS_VERSIONS: '[ "22.04", "24.04" ]'
+      UBUNTU_FULL_OS_VERSIONS: '[ "22.04", "24.04", "26.04" ]'
       REDHAT_FULL_OS_VERSIONS: '[ "8", "9", "10" ]'
       WINDOWS_FULL_OS_VERSIONS: '[ "2022" ]'
       MAC_FULL_OS_VERSIONS: '[ "14", "15", "26" ]'

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -7,7 +7,7 @@ on:
       os_version:
         description: 'JSON array of OS version(s) to test'
         type: string
-        default: '[ "9", "10" ]'
+        default: '[ "8", "9", "10" ]'
       cmake_config_preset:
         description: 'CMake Config Preset to Use'
         type: string

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -7,7 +7,7 @@ on:
       os_version:
         description: 'JSON array of OS versions to test'
         type: string
-        default: '[ "22.04", "24.04" ]'
+        default: '[ "22.04", "24.04", "26.04" ]'
       cmake_config_preset:
         description: 'CMake Config Preset to Use'
         type: string
@@ -33,7 +33,7 @@ on:
       os_version:
         description: 'JSON array of OS versions to test'
         type: string
-        default: '[ "22.04", "24.04" ]'
+        default: '[ "22.04", "24.04", "26.04" ]'
       cmake_config_preset:
         description: 'CMake Config Preset to Use'
         type: string

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os-release: [ 'ubuntu-22.04', 'ubuntu-24.04', 'rhel-8', 'rhel-9', 'rhel-10' ]
+        os-release: [ 'ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04', 'rhel-8', 'rhel-9', 'rhel-10' ]
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Add Ubuntu 26.04 as a build/release option in CI/CD workflows

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `ci-controller.yml`, `ci-ubuntu.yml`, and `docker-ghcr.yml` to include Ubuntu 26.04 support
- Fixed default value of `os_version` in `ci-redhat.yml` to include RHEL8 for `workflow_dispatch` option

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure Optiq can build, pass tests, and upload artifacts with Ubuntu 26.04 as the distro

## Test Result

<!-- Briefly summarize test outcomes. -->
https://github.com/ROCm/roc-optiq/actions/runs/25693592899

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
