### PR TITLE
Add Open Remote Database feature (libssh2/SFTP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ set(VIEW_FILES
     src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
     src/view/src/widgets/rocprofvis_dialog.cpp
     src/view/src/widgets/rocprofvis_notification_manager.cpp
+    src/view/src/widgets/rocprofvis_ssh_auth_modal.cpp
     )
 
 if(COMPUTE_UI_SUPPORT) 
@@ -214,6 +215,7 @@ target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/sr
 target_include_directories(${TARGET_NAME} PRIVATE ${Vulkan_INCLUDE_DIRS})
 target_include_directories(${TARGET_NAME} PRIVATE ${Vulkan_INCLUDE_DIR})
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/model/inc)
+target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/model/src/database)
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/core/inc)
 target_link_libraries(${TARGET_NAME} PRIVATE imgui)
 target_link_libraries(${TARGET_NAME} PRIVATE implot)

--- a/src/model/CMakeLists.txt
+++ b/src/model/CMakeLists.txt
@@ -44,6 +44,37 @@ target_link_libraries(${PROJECT_NAME} spdlog)
 target_link_libraries(${PROJECT_NAME} yaml-cpp)
 target_link_libraries(${PROJECT_NAME} json)
 
+# libssh2 — required for the SFTP-backed "Open Remote Database" feature.
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(LIBSSH2 QUIET libssh2)
+endif()
+if(LIBSSH2_FOUND)
+    target_include_directories(${PROJECT_NAME} PRIVATE ${LIBSSH2_INCLUDE_DIRS})
+    target_link_directories(${PROJECT_NAME} PRIVATE ${LIBSSH2_LIBRARY_DIRS})
+    target_link_libraries(${PROJECT_NAME} ${LIBSSH2_LIBRARIES})
+else()
+    find_path(LIBSSH2_INCLUDE_DIR libssh2.h
+        HINTS ${LIBSSH2_DIR}/include ${LIBSSH2_DIR}
+              $ENV{LIBSSH2_DIR}/include $ENV{LIBSSH2_DIR}
+              /usr/include /usr/local/include /opt/homebrew/include
+              "C:/msys64/mingw64/include" "C:/Program Files/libssh2/include")
+    find_library(LIBSSH2_LIBRARY NAMES ssh2 libssh2
+        HINTS ${LIBSSH2_DIR}/lib ${LIBSSH2_DIR}
+              $ENV{LIBSSH2_DIR}/lib $ENV{LIBSSH2_DIR}
+              /usr/lib /usr/local/lib /opt/homebrew/lib
+              "C:/msys64/mingw64/lib" "C:/Program Files/libssh2/lib")
+    if(LIBSSH2_INCLUDE_DIR AND LIBSSH2_LIBRARY)
+        target_include_directories(${PROJECT_NAME} PRIVATE ${LIBSSH2_INCLUDE_DIR})
+        target_link_libraries(${PROJECT_NAME} ${LIBSSH2_LIBRARY})
+    else()
+        message(FATAL_ERROR "libssh2 not found. Install libssh2-1-dev (Linux) or set LIBSSH2_DIR.")
+    endif()
+endif()
+if(WIN32)
+    target_link_libraries(${PROJECT_NAME} ws2_32)
+endif()
+
 # TBB is conditionally required on Linux when libtbb-dev is installed
 # - Windows MSVC: Has its own parallel backend, doesn't need TBB
 # - macOS: Parallel execution not yet supported in libc++

--- a/src/model/src/database/rocprofvis_remote_fetch.cpp
+++ b/src/model/src/database/rocprofvis_remote_fetch.cpp
@@ -1,0 +1,166 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_remote_fetch.h"
+
+#include "rocprofvis_ssh_auth_bridge.h"
+
+#include <spdlog/spdlog.h>
+
+#include <cctype>
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+namespace
+{
+// FNV-1a 64-bit. Adequate for naming local cache directories.
+uint64_t Fnv1a64(const std::string& s)
+{
+    uint64_t h = 0xcbf29ce484222325ull;
+    for(unsigned char c : s)
+    {
+        h ^= c;
+        h *= 0x100000001b3ull;
+    }
+    return h;
+}
+
+std::string ToHex(uint64_t v)
+{
+    char buf[17];
+    std::snprintf(buf, sizeof(buf), "%016llx", static_cast<unsigned long long>(v));
+    return buf;
+}
+
+bool IsSafeChar(char c)
+{
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-' ||
+           c == '.';
+}
+
+std::string Sanitize(const std::string& s)
+{
+    std::string out;
+    out.reserve(s.size());
+    for(char c : s) out.push_back(IsSafeChar(c) ? c : '_');
+    return out;
+}
+
+SshAuthResult FromConnect(ConnectResult r)
+{
+    switch(r)
+    {
+        case ConnectResult::Ok:               return SshAuthResult::Ok;
+        case ConnectResult::NeedsPassword:    return SshAuthResult::NeedsPassword;
+        case ConnectResult::AuthFailed:       return SshAuthResult::AuthFailed;
+        case ConnectResult::HostKeyMismatch:  return SshAuthResult::HostKeyMismatch;
+        case ConnectResult::HostKeyRejected:  return SshAuthResult::HostKeyRejected;
+        case ConnectResult::ConnectionError:  return SshAuthResult::ConnectionError;
+        case ConnectResult::Cancelled:        return SshAuthResult::Cancelled;
+    }
+    return SshAuthResult::ConnectionError;
+}
+}  // namespace
+
+std::string RemoteCacheKey(const RemoteUri& u)
+{
+    std::string canon = u.user + "@" + u.host + ":" + std::to_string(u.port) + u.path;
+    return ToHex(Fnv1a64(canon));
+}
+
+std::string RemoteBasenameForCache(const RemoteUri& u)
+{
+    auto pos = u.path.find_last_of('/');
+    std::string base = (pos == std::string::npos) ? u.path : u.path.substr(pos + 1);
+    if(base.empty()) base = "remote";
+    base = Sanitize(base);
+    if(base.size() < 3 || base.substr(base.size() - 3) != ".db") base += ".db";
+    return base;
+}
+
+SshAuthResult TestSshConnection(const RemoteUri& u, AuthBridge& bridge,
+                                std::string& err)
+{
+    SshSession   s;
+    AuthOptions  opts;
+    opts.password      = u.password;
+    opts.identity_file = u.identity_file;
+    return FromConnect(s.Connect(u.host, u.port, u.user, opts, bridge, err));
+}
+
+SshAuthResult FetchRemoteFile(const RemoteUri& u,
+                              const std::filesystem::path& dest_path,
+                              AuthBridge& bridge, ProgressSink& sink,
+                              std::string& err)
+{
+    spdlog::info("[ssh] FetchRemoteFile uri=ssh://{}@{}:{}{} dest={}",
+                 u.user, u.host, u.port, u.path, dest_path.string());
+
+    SshSession  s;
+    AuthOptions opts;
+    opts.password      = u.password;
+    opts.identity_file = u.identity_file;
+    opts.passphrase    = u.key_passphrase;
+
+    auto r = s.Connect(u.host, u.port, u.user, opts, bridge, err);
+    if(r != ConnectResult::Ok)
+    {
+        spdlog::warn("[ssh] FetchRemoteFile aborting: Connect returned {}",
+                     static_cast<int>(r));
+        return FromConnect(r);
+    }
+
+    uint64_t mtime = 0;
+    std::string stat_err;
+    uint64_t    remote_size = s.StatFileSize(u.path, mtime, stat_err);
+    if(remote_size == 0 && !stat_err.empty())
+    {
+        err = stat_err;
+        return SshAuthResult::ConnectionError;
+    }
+
+    auto meta_path = std::filesystem::path(dest_path).concat(".meta");
+
+    // Cache hit: dest exists and meta matches remote (size, mtime).
+    {
+        std::error_code ec;
+        if(std::filesystem::exists(dest_path, ec) &&
+           std::filesystem::exists(meta_path, ec))
+        {
+            std::ifstream m(meta_path);
+            uint64_t      cached_size = 0, cached_mtime = 0;
+            if(m >> cached_size >> cached_mtime &&
+               cached_size == remote_size && cached_mtime == mtime)
+            {
+                sink.total      = remote_size;
+                sink.bytes_read = remote_size;
+                spdlog::info("Remote cache hit: {}", dest_path.string());
+                return SshAuthResult::Ok;
+            }
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(dest_path.parent_path(), ec);
+
+    if(!s.DownloadTo(u.path, dest_path.string(), sink, err))
+    {
+        return SshAuthResult::ConnectionError;
+    }
+
+    {
+        std::ofstream m(meta_path, std::ios::trunc);
+        if(m) m << remote_size << ' ' << mtime << '\n';
+    }
+    spdlog::info("Fetched remote file to {}", dest_path.string());
+    return SshAuthResult::Ok;
+}
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_remote_fetch.h
+++ b/src/model/src/database/rocprofvis_remote_fetch.h
@@ -1,0 +1,53 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocprofvis_remote_uri.h"
+#include "rocprofvis_ssh_session.h"
+
+#include <filesystem>
+#include <string>
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+class AuthBridge;
+
+enum class SshAuthResult
+{
+    Ok,
+    NeedsPassword,
+    AuthFailed,
+    HostKeyMismatch,
+    HostKeyRejected,
+    ConnectionError,
+    Cancelled
+};
+
+// Stable, filesystem-safe key derived from host+port+user+remote_path.
+// Same URI -> same key across runs. Not collision-resistant by design;
+// suitable for a per-user local cache only.
+std::string RemoteCacheKey(const RemoteUri& u);
+
+// Last path component of u.path; sanitized to be filesystem-safe and
+// always end in `.db`.
+std::string RemoteBasenameForCache(const RemoteUri& u);
+
+// Probe-only Connect()+Disconnect().
+SshAuthResult TestSshConnection(const RemoteUri& u, AuthBridge& bridge,
+                                std::string& err);
+
+// Fetch the remote file to `dest_path`. Honors a per-file sidecar
+// `<dest_path>.meta` to skip the download if the remote size+mtime
+// haven't changed. Returns Ok on success (cache hit or fresh download).
+SshAuthResult FetchRemoteFile(const RemoteUri&             u,
+                              const std::filesystem::path& dest_path,
+                              AuthBridge&                  bridge,
+                              ProgressSink&                sink,
+                              std::string&                 err);
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_remote_uri.cpp
+++ b/src/model/src/database/rocprofvis_remote_uri.cpp
@@ -1,0 +1,165 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_remote_uri.h"
+
+#include <cctype>
+#include <cstdlib>
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+namespace
+{
+constexpr const char* kSchemePrefix = "ssh://";
+constexpr size_t      kSchemeLen    = 6;
+
+bool IsValidPort(int p) { return p > 0 && p < 65536; }
+}  // namespace
+
+bool IsSshUri(const std::string& s)
+{
+    return s.size() >= kSchemeLen &&
+           std::equal(s.begin(), s.begin() + kSchemeLen, kSchemePrefix);
+}
+
+std::optional<RemoteUri> ParseRemoteUri(const std::string& uri)
+{
+    if(!IsSshUri(uri)) return std::nullopt;
+
+    std::string rest = uri.substr(kSchemeLen);
+
+    // Split off ?key=... query suffix first; key path may contain '/' but not '?' or '#'.
+    std::string identity;
+    auto        qpos = rest.find('?');
+    if(qpos != std::string::npos)
+    {
+        std::string query = rest.substr(qpos + 1);
+        rest.resize(qpos);
+        // Single supported key: key=...
+        constexpr const char* kKeyEq = "key=";
+        if(query.compare(0, 4, kKeyEq) == 0)
+        {
+            identity = query.substr(4);
+        }
+        else
+        {
+            return std::nullopt;
+        }
+    }
+
+    // Split userinfo from authority+path on first '@' (if any).
+    std::string userinfo;
+    std::string authority_path = rest;
+    auto        atp            = rest.find('@');
+    if(atp != std::string::npos)
+    {
+        userinfo       = rest.substr(0, atp);
+        authority_path = rest.substr(atp + 1);
+    }
+
+    // Split authority (host[:port]) from path on first '/'.
+    // The first '/' is the URI separator and is consumed; what remains is
+    // the path. A leading '/' in the *remaining* characters means the
+    // original URI had a double slash and the path is absolute. Otherwise
+    // it's relative to the user's home directory.
+    auto slash = authority_path.find('/');
+    if(slash == std::string::npos) return std::nullopt;  // path required
+
+    std::string authority = authority_path.substr(0, slash);
+    std::string path      = authority_path.substr(slash + 1);  // strip URI separator
+
+    if(authority.empty() || path.empty()) return std::nullopt;
+
+    // userinfo := user[:password]
+    std::string user;
+    std::string password;
+    if(!userinfo.empty())
+    {
+        auto colon = userinfo.find(':');
+        if(colon == std::string::npos)
+        {
+            user = userinfo;
+        }
+        else
+        {
+            user     = userinfo.substr(0, colon);
+            password = userinfo.substr(colon + 1);
+        }
+    }
+
+    // authority := host[:port]
+    std::string host;
+    int         port  = 22;
+    auto        pcol  = authority.rfind(':');
+    if(pcol == std::string::npos)
+    {
+        host = authority;
+    }
+    else
+    {
+        host                     = authority.substr(0, pcol);
+        const std::string portstr = authority.substr(pcol + 1);
+        if(portstr.empty()) return std::nullopt;
+        char* end = nullptr;
+        long  p   = std::strtol(portstr.c_str(), &end, 10);
+        if(end != portstr.c_str() + portstr.size() || !IsValidPort(static_cast<int>(p)))
+        {
+            return std::nullopt;
+        }
+        port = static_cast<int>(p);
+    }
+    if(host.empty()) return std::nullopt;
+
+    RemoteUri out;
+    out.host          = std::move(host);
+    out.user          = std::move(user);
+    out.password      = std::move(password);
+    out.port          = port;
+    out.path          = std::move(path);
+    out.identity_file = std::move(identity);
+    return out;
+}
+
+std::string SanitizeForRecent(const RemoteUri& u)
+{
+    return SerializeRemoteUri(u, /*include_password=*/false);
+}
+
+std::string SerializeRemoteUri(const RemoteUri& u, bool include_password)
+{
+    std::string out = "ssh://";
+    if(!u.user.empty())
+    {
+        out += u.user;
+        if(include_password && !u.password.empty())
+        {
+            out += ":";
+            out += u.password;
+        }
+        out += "@";
+    }
+    out += u.host;
+    if(u.port != 22)
+    {
+        out += ":";
+        out += std::to_string(u.port);
+    }
+    // Always emit the URI separator '/' between authority and path. Absolute
+    // paths (already starting with '/') therefore appear as '//path' — the
+    // standard SCP-style convention for distinguishing absolute from
+    // home-relative SSH paths.
+    out += "/";
+    out += u.path;
+    if(!u.identity_file.empty())
+    {
+        out += "?key=";
+        out += u.identity_file;
+    }
+    return out;
+}
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_remote_uri.h
+++ b/src/model/src/database/rocprofvis_remote_uri.h
@@ -1,0 +1,40 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+struct RemoteUri
+{
+    std::string host;
+    std::string user;
+    std::string password;
+    int         port = 22;
+    std::string path;
+    std::string identity_file;
+    // Passphrase for an encrypted private key. Memory-only; never parsed
+    // from or written to a URI string.
+    std::string key_passphrase;
+};
+
+bool IsSshUri(const std::string& s);
+
+// Strict ssh://[user[:password]@]host[:port]/abs/path[?key=/path/to/id]
+std::optional<RemoteUri> ParseRemoteUri(const std::string& uri);
+
+// URI suitable for Recent-files: omits password.
+std::string SanitizeForRecent(const RemoteUri& u);
+
+// Re-serialize a RemoteUri (includes password if present). Used by callers
+// that want a single string to log or to display.
+std::string SerializeRemoteUri(const RemoteUri& u, bool include_password);
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_ssh_auth_bridge.cpp
+++ b/src/model/src/database/rocprofvis_ssh_auth_bridge.cpp
@@ -1,0 +1,90 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_ssh_auth_bridge.h"
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+AuthBridge::Pending AuthBridge::Peek()
+{
+    std::lock_guard<std::mutex> lk(m_mutex);
+    return m_pending;
+}
+
+std::optional<std::vector<std::string>>
+AuthBridge::AskPrompts(const PromptRequest& req)
+{
+    std::unique_lock<std::mutex> lk(m_mutex);
+    m_pending          = req;
+    m_prompt_responses.reset();
+    m_worker_cv.wait(lk, [&] { return m_prompt_responses.has_value() || m_cancelled; });
+    m_pending = std::monostate{};
+    if(m_cancelled)
+    {
+        return std::nullopt;
+    }
+    auto out = std::move(*m_prompt_responses);
+    m_prompt_responses.reset();
+    return out;
+}
+
+std::optional<HostKeyDecision>
+AuthBridge::AskHostKey(const HostKeyRequest& req)
+{
+    std::unique_lock<std::mutex> lk(m_mutex);
+    m_pending = req;
+    m_hostkey_decision.reset();
+    m_worker_cv.wait(lk, [&] { return m_hostkey_decision.has_value() || m_cancelled; });
+    m_pending = std::monostate{};
+    if(m_cancelled)
+    {
+        return std::nullopt;
+    }
+    auto d = *m_hostkey_decision;
+    m_hostkey_decision.reset();
+    return d;
+}
+
+void AuthBridge::SubmitPromptResponses(std::vector<std::string> responses)
+{
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        if(!std::holds_alternative<PromptRequest>(m_pending)) return;
+        m_prompt_responses = std::move(responses);
+    }
+    m_worker_cv.notify_all();
+}
+
+void AuthBridge::SubmitHostKeyDecision(HostKeyDecision decision)
+{
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        if(!std::holds_alternative<HostKeyRequest>(m_pending)) return;
+        m_hostkey_decision = decision;
+    }
+    m_worker_cv.notify_all();
+}
+
+void AuthBridge::Cancel()
+{
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        m_cancelled = true;
+    }
+    m_worker_cv.notify_all();
+}
+
+void AuthBridge::Reset()
+{
+    std::lock_guard<std::mutex> lk(m_mutex);
+    m_pending = std::monostate{};
+    m_cancelled = false;
+    m_prompt_responses.reset();
+    m_hostkey_decision.reset();
+}
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_ssh_auth_bridge.h
+++ b/src/model/src/database/rocprofvis_ssh_auth_bridge.h
@@ -1,0 +1,90 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+struct PromptItem
+{
+    std::string text;
+    bool        echo = true;  // false => password-style
+};
+
+struct PromptRequest
+{
+    std::string             name;
+    std::string             instruction;
+    std::vector<PromptItem> prompts;
+};
+
+enum class HostKeyState
+{
+    NotFound,
+    Mismatch
+};
+
+struct HostKeyRequest
+{
+    std::string  host;
+    int          port = 22;
+    std::string  fingerprint_sha256_b64;  // user-friendly display
+    std::string  key_type;                // "ssh-rsa", "ssh-ed25519", ...
+    HostKeyState state = HostKeyState::NotFound;
+};
+
+enum class HostKeyDecision
+{
+    Reject,
+    TrustOnce,
+    TrustPermanently
+};
+
+// Thread-safe round-trip channel between a worker thread (libssh2 Connect)
+// and the UI main thread. Worker calls AskPrompts() / AskHostKey() and
+// blocks. UI polls Pending() each frame; if a request is pending it draws a
+// modal and eventually calls Submit*() or Cancel().
+class AuthBridge
+{
+public:
+    using Pending =
+        std::variant<std::monostate, PromptRequest, HostKeyRequest>;
+
+    Pending Peek();
+
+    // Worker-side: blocking. Returns nullopt if the user cancelled.
+    std::optional<std::vector<std::string>> AskPrompts(const PromptRequest& req);
+    std::optional<HostKeyDecision>          AskHostKey(const HostKeyRequest& req);
+
+    // UI-side. No-op if no matching request is pending.
+    void SubmitPromptResponses(std::vector<std::string> responses);
+    void SubmitHostKeyDecision(HostKeyDecision decision);
+
+    // UI-side. Wakes any blocked worker call with a cancellation result.
+    void Cancel();
+
+    // Reset state for a new attempt. Should only be called when no worker
+    // is blocked.
+    void Reset();
+
+private:
+    std::mutex                              m_mutex;
+    std::condition_variable                 m_worker_cv;
+    Pending                                 m_pending;
+    bool                                    m_cancelled = false;
+    std::optional<std::vector<std::string>> m_prompt_responses;
+    std::optional<HostKeyDecision>          m_hostkey_decision;
+};
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_ssh_known_hosts.cpp
+++ b/src/model/src/database/rocprofvis_ssh_known_hosts.cpp
@@ -1,0 +1,173 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_ssh_known_hosts.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+namespace
+{
+std::string DefaultKnownHostsPath()
+{
+#ifdef _WIN32
+    const char* home = std::getenv("USERPROFILE");
+    if(!home) return {};
+    return std::string(home) + "\\.ssh\\known_hosts";
+#else
+    const char* home = std::getenv("HOME");
+    if(!home) return {};
+    return std::string(home) + "/.ssh/known_hosts";
+#endif
+}
+
+std::string Base64Encode(const unsigned char* data, size_t n)
+{
+    static const char* alphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string out;
+    out.reserve(((n + 2) / 3) * 4);
+    for(size_t i = 0; i < n; i += 3)
+    {
+        unsigned v = data[i] << 16;
+        if(i + 1 < n) v |= data[i + 1] << 8;
+        if(i + 2 < n) v |= data[i + 2];
+        out.push_back(alphabet[(v >> 18) & 0x3F]);
+        out.push_back(alphabet[(v >> 12) & 0x3F]);
+        out.push_back(i + 1 < n ? alphabet[(v >> 6) & 0x3F] : '=');
+        out.push_back(i + 2 < n ? alphabet[v & 0x3F] : '=');
+    }
+    return out;
+}
+}  // namespace
+
+KnownHosts::KnownHosts(LIBSSH2_SESSION* session)
+    : m_session(session), m_path(DefaultKnownHostsPath())
+{
+    m_kh = libssh2_knownhost_init(m_session);
+}
+
+KnownHosts::~KnownHosts()
+{
+    if(m_kh) libssh2_knownhost_free(m_kh);
+}
+
+bool KnownHosts::Load()
+{
+    if(!m_kh || m_path.empty()) return false;
+    int rc = libssh2_knownhost_readfile(m_kh, m_path.c_str(),
+                                        LIBSSH2_KNOWNHOST_FILE_OPENSSH);
+    return rc >= 0;
+}
+
+KnownHostMatch KnownHosts::Check(const std::string& host, int port) const
+{
+    if(!m_kh) return KnownHostMatch::Failure;
+
+    size_t      key_len  = 0;
+    int         key_type = 0;
+    const char* key      = libssh2_session_hostkey(m_session, &key_len, &key_type);
+    if(!key) return KnownHostMatch::Failure;
+
+    int kh_type_mask = LIBSSH2_KNOWNHOST_TYPE_PLAIN | LIBSSH2_KNOWNHOST_KEYENC_RAW;
+    switch(key_type)
+    {
+        case LIBSSH2_HOSTKEY_TYPE_RSA:     kh_type_mask |= LIBSSH2_KNOWNHOST_KEY_SSHRSA; break;
+        case LIBSSH2_HOSTKEY_TYPE_DSS:     kh_type_mask |= LIBSSH2_KNOWNHOST_KEY_SSHDSS; break;
+#ifdef LIBSSH2_HOSTKEY_TYPE_ECDSA_256
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_256: kh_type_mask |= LIBSSH2_KNOWNHOST_KEY_ECDSA_256; break;
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_384: kh_type_mask |= LIBSSH2_KNOWNHOST_KEY_ECDSA_384; break;
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_521: kh_type_mask |= LIBSSH2_KNOWNHOST_KEY_ECDSA_521; break;
+#endif
+#ifdef LIBSSH2_HOSTKEY_TYPE_ED25519
+        case LIBSSH2_HOSTKEY_TYPE_ED25519: kh_type_mask |= LIBSSH2_KNOWNHOST_KEY_ED25519; break;
+#endif
+        default: break;
+    }
+
+    struct libssh2_knownhost* match = nullptr;
+    int rc = libssh2_knownhost_checkp(m_kh, host.c_str(), port, key, key_len,
+                                      kh_type_mask, &match);
+    switch(rc)
+    {
+        case LIBSSH2_KNOWNHOST_CHECK_MATCH:    return KnownHostMatch::Match;
+        case LIBSSH2_KNOWNHOST_CHECK_MISMATCH: return KnownHostMatch::Mismatch;
+        case LIBSSH2_KNOWNHOST_CHECK_NOTFOUND: return KnownHostMatch::NotFound;
+        default:                               return KnownHostMatch::Failure;
+    }
+}
+
+bool KnownHosts::Add(const std::string& host, int port)
+{
+    if(!m_kh) return false;
+    size_t      key_len  = 0;
+    int         key_type = 0;
+    const char* key      = libssh2_session_hostkey(m_session, &key_len, &key_type);
+    if(!key) return false;
+
+    int type_mask = LIBSSH2_KNOWNHOST_TYPE_PLAIN | LIBSSH2_KNOWNHOST_KEYENC_RAW;
+    switch(key_type)
+    {
+        case LIBSSH2_HOSTKEY_TYPE_RSA:     type_mask |= LIBSSH2_KNOWNHOST_KEY_SSHRSA; break;
+        case LIBSSH2_HOSTKEY_TYPE_DSS:     type_mask |= LIBSSH2_KNOWNHOST_KEY_SSHDSS; break;
+#ifdef LIBSSH2_HOSTKEY_TYPE_ECDSA_256
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_256: type_mask |= LIBSSH2_KNOWNHOST_KEY_ECDSA_256; break;
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_384: type_mask |= LIBSSH2_KNOWNHOST_KEY_ECDSA_384; break;
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_521: type_mask |= LIBSSH2_KNOWNHOST_KEY_ECDSA_521; break;
+#endif
+#ifdef LIBSSH2_HOSTKEY_TYPE_ED25519
+        case LIBSSH2_HOSTKEY_TYPE_ED25519: type_mask |= LIBSSH2_KNOWNHOST_KEY_ED25519; break;
+#endif
+        default: return false;
+    }
+
+    return libssh2_knownhost_addc(m_kh, host.c_str(), nullptr, key, key_len,
+                                  "added by roc-optiq", strlen("added by roc-optiq"),
+                                  type_mask, nullptr) == 0;
+}
+
+bool KnownHosts::Save() const
+{
+    if(!m_kh || m_path.empty()) return false;
+    return libssh2_knownhost_writefile(m_kh, m_path.c_str(),
+                                       LIBSSH2_KNOWNHOST_FILE_OPENSSH) == 0;
+}
+
+std::string FormatHostKeyFingerprint(LIBSSH2_SESSION* session)
+{
+    const char* sha = libssh2_hostkey_hash(session, LIBSSH2_HOSTKEY_HASH_SHA256);
+    if(!sha) return {};
+    std::string b64 =
+        Base64Encode(reinterpret_cast<const unsigned char*>(sha), 32);
+    while(!b64.empty() && b64.back() == '=') b64.pop_back();  // OpenSSH strips '='
+    return "SHA256:" + b64;
+}
+
+std::string HostKeyTypeName(LIBSSH2_SESSION* session)
+{
+    size_t len  = 0;
+    int    type = 0;
+    if(!libssh2_session_hostkey(session, &len, &type)) return {};
+    switch(type)
+    {
+        case LIBSSH2_HOSTKEY_TYPE_RSA: return "ssh-rsa";
+        case LIBSSH2_HOSTKEY_TYPE_DSS: return "ssh-dss";
+#ifdef LIBSSH2_HOSTKEY_TYPE_ECDSA_256
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_256: return "ecdsa-sha2-nistp256";
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_384: return "ecdsa-sha2-nistp384";
+        case LIBSSH2_HOSTKEY_TYPE_ECDSA_521: return "ecdsa-sha2-nistp521";
+#endif
+#ifdef LIBSSH2_HOSTKEY_TYPE_ED25519
+        case LIBSSH2_HOSTKEY_TYPE_ED25519: return "ssh-ed25519";
+#endif
+        default: return "unknown";
+    }
+}
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_ssh_known_hosts.h
+++ b/src/model/src/database/rocprofvis_ssh_known_hosts.h
@@ -1,0 +1,64 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <libssh2.h>
+#include <string>
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+enum class KnownHostMatch
+{
+    Match,
+    Mismatch,
+    NotFound,
+    Failure
+};
+
+// Thin RAII wrapper around libssh2_knownhost_*. Loads (and writes) the
+// per-user OpenSSH known_hosts file.
+class KnownHosts
+{
+public:
+    explicit KnownHosts(LIBSSH2_SESSION* session);
+    ~KnownHosts();
+
+    KnownHosts(const KnownHosts&) = delete;
+    KnownHosts& operator=(const KnownHosts&) = delete;
+
+    // Loads the user's known_hosts file. Returns true if the file was
+    // present and parseable, false otherwise (still safe to use Check()).
+    bool Load();
+
+    // Compares the live server key for `host`/`port` against the loaded
+    // known_hosts entries.
+    KnownHostMatch Check(const std::string& host, int port) const;
+
+    // Adds the live server key for `host`/`port` to the in-memory store.
+    bool Add(const std::string& host, int port);
+
+    // Persists the in-memory store back to disk.
+    bool Save() const;
+
+    // Returns the path that Load/Save use (resolved at construction time).
+    const std::string& Path() const { return m_path; }
+
+private:
+    LIBSSH2_SESSION*    m_session = nullptr;
+    LIBSSH2_KNOWNHOSTS* m_kh      = nullptr;
+    std::string         m_path;
+};
+
+// Returns base64(SHA256(host_key_bytes)) — matches `ssh-keygen -lf` output.
+std::string FormatHostKeyFingerprint(LIBSSH2_SESSION* session);
+
+// Returns the OpenSSH key-type label (e.g. "ssh-ed25519") for the live
+// server key on `session`, or "" if unavailable.
+std::string HostKeyTypeName(LIBSSH2_SESSION* session);
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_ssh_session.cpp
+++ b/src/model/src/database/rocprofvis_ssh_session.cpp
@@ -1,0 +1,729 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_ssh_session.h"
+
+#include "rocprofvis_ssh_auth_bridge.h"
+#include "rocprofvis_ssh_known_hosts.h"
+
+#include <spdlog/spdlog.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <vector>
+
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+#define CLOSE_SOCKET(s) closesocket(s)
+#else
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#define CLOSE_SOCKET(s) ::close(s)
+#endif
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+namespace
+{
+std::once_flag g_libssh2_init_once;
+std::atomic<bool> g_libssh2_inited{false};
+}  // namespace
+
+void EnsureLibssh2Inited()
+{
+    std::call_once(g_libssh2_init_once, [] {
+#ifdef _WIN32
+        WSADATA wsa;
+        WSAStartup(MAKEWORD(2, 2), &wsa);
+#endif
+        if(libssh2_init(0) == 0)
+        {
+            g_libssh2_inited = true;
+        }
+        else
+        {
+            spdlog::error("libssh2_init failed");
+        }
+    });
+}
+
+void Libssh2GlobalShutdown()
+{
+    if(g_libssh2_inited.exchange(false))
+    {
+        libssh2_exit();
+#ifdef _WIN32
+        WSACleanup();
+#endif
+    }
+}
+
+SshSession::SshSession() = default;
+
+SshSession::~SshSession() { Disconnect(); }
+
+namespace
+{
+// kbdint trampoline. The libssh2 callback signature gives us only an
+// `abstract` void**, which we set to the AuthBridge before kicking auth.
+struct KbdintCtx
+{
+    AuthBridge*           bridge        = nullptr;
+    bool                  was_cancelled = false;
+};
+
+void KbdIntCallback(const char* name, int name_len,
+                    const char* instruction, int instruction_len,
+                    int num_prompts,
+                    const LIBSSH2_USERAUTH_KBDINT_PROMPT* prompts,
+                    LIBSSH2_USERAUTH_KBDINT_RESPONSE* responses,
+                    void** abstract)
+{
+    auto* ctx = static_cast<KbdintCtx*>(*abstract);
+    spdlog::info("[ssh] kbdint callback fired: name_len={} instr_len={} num_prompts={} ctx={}",
+                 name_len, instruction_len, num_prompts,
+                 static_cast<void*>(ctx));
+    if(!ctx || !ctx->bridge) return;
+
+    // libssh2 fires this callback for every kbdint round, including "info"
+    // rounds (banner / status messages with no input). If there are no
+    // prompts, there is nothing to ask the user — just acknowledge and
+    // continue without touching the UI.
+    if(num_prompts == 0)
+    {
+        spdlog::info("[ssh] kbdint callback: zero-prompt round (info/banner), auto-acking");
+        return;
+    }
+
+    PromptRequest req;
+    if(name_len > 0) req.name.assign(name, name_len);
+    if(instruction_len > 0) req.instruction.assign(instruction, instruction_len);
+    req.prompts.reserve(num_prompts);
+    for(int i = 0; i < num_prompts; i++)
+    {
+        PromptItem p;
+        p.text.assign(reinterpret_cast<const char*>(prompts[i].text),
+                      prompts[i].length);
+        p.echo = prompts[i].echo != 0;
+        req.prompts.push_back(std::move(p));
+    }
+
+    spdlog::info("[ssh] kbdint callback: posting {} prompt(s) to UI bridge, blocking...",
+                 num_prompts);
+    auto answer = ctx->bridge->AskPrompts(req);
+    spdlog::info("[ssh] kbdint callback: bridge returned (cancelled={})", !answer.has_value());
+    if(!answer)
+    {
+        ctx->was_cancelled = true;
+        for(int i = 0; i < num_prompts; i++)
+        {
+            responses[i].text   = nullptr;
+            responses[i].length = 0;
+        }
+        return;
+    }
+
+    const auto& vec = *answer;
+    for(int i = 0; i < num_prompts; i++)
+    {
+        const std::string& s = (i < (int) vec.size()) ? vec[i] : std::string{};
+        responses[i].text   = static_cast<char*>(malloc(s.size() + 1));
+        if(responses[i].text)
+        {
+            std::memcpy(responses[i].text, s.data(), s.size());
+            responses[i].text[s.size()] = '\0';
+            responses[i].length         = static_cast<unsigned int>(s.size());
+        }
+        else
+        {
+            responses[i].length = 0;
+        }
+    }
+}
+
+std::string ExpandTilde(const std::string& p)
+{
+    if(p.empty() || p[0] != '~') return p;
+    if(p.size() == 1 || p[1] == '/' || p[1] == '\\')
+    {
+#ifdef _WIN32
+        const char* home = std::getenv("USERPROFILE");
+#else
+        const char* home = std::getenv("HOME");
+#endif
+        if(home) return std::string(home) + p.substr(1);
+    }
+    // ~user/... is not expanded (would require getpwnam); pass through.
+    return p;
+}
+
+bool TryPublicKey(LIBSSH2_SESSION* session, const std::string& user,
+                  const std::string& priv_path_in, const std::string& passphrase)
+{
+    std::string priv_path = ExpandTilde(priv_path_in);
+    if(!std::filesystem::exists(priv_path))
+    {
+        spdlog::warn("[ssh] publickey: private key not found: '{}' (expanded from '{}')",
+                     priv_path, priv_path_in);
+        return false;
+    }
+    std::string pub_path = priv_path + ".pub";
+    bool        have_pub = std::filesystem::exists(pub_path);
+    const char* pub      = have_pub ? pub_path.c_str() : nullptr;
+    spdlog::info("[ssh] trying publickey: priv={} pub={} have_passphrase={}",
+                 priv_path, have_pub ? pub_path : std::string("(derived from priv)"),
+                 !passphrase.empty());
+    int rc = libssh2_userauth_publickey_fromfile(
+        session, user.c_str(), pub, priv_path.c_str(),
+        passphrase.empty() ? nullptr : passphrase.c_str());
+    if(rc == 0)
+    {
+        spdlog::info("[ssh] publickey auth OK ({})", priv_path);
+        return true;
+    }
+    char* msg = nullptr;
+    libssh2_session_last_error(session, &msg, nullptr, 0);
+    const char* hint = "";
+    switch(rc)
+    {
+        case LIBSSH2_ERROR_FILE:
+            hint = " [file unreadable or unsupported format]"; break;
+        case LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED:
+            hint = " [server rejected the key — possibly encrypted (passphrase needed) or not in authorized_keys]"; break;
+        case LIBSSH2_ERROR_AUTHENTICATION_FAILED:
+            hint = " [auth rejected by server]"; break;
+        case LIBSSH2_ERROR_METHOD_NOT_SUPPORTED:
+            hint = " [server does not support this key type]"; break;
+        default: break;
+    }
+    spdlog::warn("[ssh] publickey auth failed (rc={}): {}{}", rc,
+                 msg ? msg : "(no message)", hint);
+    return false;
+}
+
+// Try every identity loaded into ssh-agent. Returns true on first success.
+bool TryAgent(LIBSSH2_SESSION* session, const std::string& user)
+{
+    LIBSSH2_AGENT* agent = libssh2_agent_init(session);
+    if(!agent)
+    {
+        spdlog::info("[ssh] agent: init failed (libssh2 built without agent support?)");
+        return false;
+    }
+    if(libssh2_agent_connect(agent) != 0)
+    {
+        spdlog::info("[ssh] agent: connect failed (no $SSH_AUTH_SOCK or agent not running)");
+        libssh2_agent_free(agent);
+        return false;
+    }
+    if(libssh2_agent_list_identities(agent) != 0)
+    {
+        spdlog::warn("[ssh] agent: list_identities failed");
+        libssh2_agent_disconnect(agent);
+        libssh2_agent_free(agent);
+        return false;
+    }
+
+    bool ok = false;
+    struct libssh2_agent_publickey* identity = nullptr;
+    struct libssh2_agent_publickey* prev     = nullptr;
+    int  identity_count                      = 0;
+    while(true)
+    {
+        int rc = libssh2_agent_get_identity(agent, &identity, prev);
+        if(rc == 1) break;       // end of list
+        if(rc < 0)
+        {
+            spdlog::warn("[ssh] agent: get_identity rc={}", rc);
+            break;
+        }
+        identity_count++;
+        spdlog::info("[ssh] agent: trying identity '{}'",
+                     identity->comment ? identity->comment : "(no comment)");
+        if(libssh2_agent_userauth(agent, user.c_str(), identity) == 0)
+        {
+            spdlog::info("[ssh] agent: auth OK with '{}'",
+                         identity->comment ? identity->comment : "(no comment)");
+            ok = true;
+            break;
+        }
+        char* msg = nullptr;
+        libssh2_session_last_error(session, &msg, nullptr, 0);
+        spdlog::info("[ssh] agent: identity rejected: {}", msg ? msg : "(no message)");
+        prev = identity;
+    }
+    if(!ok && identity_count == 0)
+    {
+        spdlog::info("[ssh] agent: connected but no identities loaded (run 'ssh-add')");
+    }
+
+    libssh2_agent_disconnect(agent);
+    libssh2_agent_free(agent);
+    return ok;
+}
+
+std::vector<std::string> DefaultKeyPaths()
+{
+    std::string home;
+#ifdef _WIN32
+    if(const char* h = std::getenv("USERPROFILE")) home = h;
+    std::string sep = "\\";
+    std::string sub = "\\.ssh\\";
+#else
+    if(const char* h = std::getenv("HOME")) home = h;
+    std::string sep = "/";
+    (void) sep;
+    std::string sub = "/.ssh/";
+#endif
+    if(home.empty()) return {};
+    return {home + sub + "id_ed25519",
+            home + sub + "id_rsa",
+            home + sub + "id_ecdsa",
+            home + sub + "id_dsa"};
+}
+
+bool MethodListed(const char* methods, const char* needle)
+{
+    return methods && std::strstr(methods, needle) != nullptr;
+}
+}  // namespace
+
+ConnectResult SshSession::Connect(const std::string& host, int port,
+                                  const std::string& user,
+                                  const AuthOptions& auth, AuthBridge& bridge,
+                                  std::string& err)
+{
+    spdlog::info("[ssh] Connect host={} port={} user={} have_password={} identity={}",
+                 host, port, user, !auth.password.empty(),
+                 auth.identity_file.empty() ? std::string("(defaults)")
+                                            : auth.identity_file);
+
+    EnsureLibssh2Inited();
+    if(!g_libssh2_inited)
+    {
+        err = "libssh2 init failed";
+        spdlog::error("[ssh] {}", err);
+        return ConnectResult::ConnectionError;
+    }
+
+    Disconnect();
+
+    // Resolve hostname (use getaddrinfo for IPv6 readiness; for now we keep
+    // it simple with hostent which is what the reference uses).
+    addrinfo hints{};
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo* res = nullptr;
+    std::string portstr = std::to_string(port);
+    int gai = getaddrinfo(host.c_str(), portstr.c_str(), &hints, &res);
+    if(gai != 0 || !res)
+    {
+        err = std::string("DNS resolution failed: ") + gai_strerror(gai);
+        spdlog::error("[ssh] {}", err);
+        return ConnectResult::ConnectionError;
+    }
+
+    bool connected = false;
+    for(addrinfo* p = res; p; p = p->ai_next)
+    {
+        m_sock = ::socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+        if(m_sock == kInvalidSocket) continue;
+        if(::connect(m_sock, p->ai_addr, static_cast<socklen_t>(p->ai_addrlen)) == 0)
+        {
+            connected = true;
+            break;
+        }
+        CLOSE_SOCKET(m_sock);
+        m_sock = kInvalidSocket;
+    }
+    freeaddrinfo(res);
+    if(!connected)
+    {
+        err = "TCP connect failed";
+        spdlog::error("[ssh] {}", err);
+        return ConnectResult::ConnectionError;
+    }
+    spdlog::info("[ssh] TCP connected");
+
+    m_session = libssh2_session_init();
+    if(!m_session)
+    {
+        err = "libssh2_session_init failed";
+        spdlog::error("[ssh] {}", err);
+        Disconnect();
+        return ConnectResult::ConnectionError;
+    }
+    libssh2_session_set_blocking(m_session, 1);
+
+    if(libssh2_session_handshake(m_session, m_sock) != 0)
+    {
+        char* msg = nullptr;
+        libssh2_session_last_error(m_session, &msg, nullptr, 0);
+        err = std::string("SSH handshake failed: ") + (msg ? msg : "");
+        spdlog::error("[ssh] {}", err);
+        Disconnect();
+        return ConnectResult::ConnectionError;
+    }
+    spdlog::info("[ssh] handshake ok");
+
+    // ---- host key check ----
+    {
+        KnownHosts kh(m_session);
+        bool       loaded = kh.Load();
+        spdlog::info("[ssh] known_hosts loaded={} path={} fingerprint={}",
+                     loaded, kh.Path(), FormatHostKeyFingerprint(m_session));
+        KnownHostMatch m = kh.Check(host, port);
+        const char* mstr = m == KnownHostMatch::Match    ? "Match"
+                         : m == KnownHostMatch::Mismatch ? "Mismatch"
+                         : m == KnownHostMatch::NotFound ? "NotFound"
+                                                         : "Failure";
+        spdlog::info("[ssh] host key check: {}", mstr);
+        if(m == KnownHostMatch::NotFound || m == KnownHostMatch::Mismatch)
+        {
+            HostKeyRequest req;
+            req.host                   = host;
+            req.port                   = port;
+            req.fingerprint_sha256_b64 = FormatHostKeyFingerprint(m_session);
+            req.key_type               = HostKeyTypeName(m_session);
+            req.state = (m == KnownHostMatch::Mismatch) ? HostKeyState::Mismatch
+                                                        : HostKeyState::NotFound;
+            auto decision = bridge.AskHostKey(req);
+            if(!decision)
+            {
+                Disconnect();
+                return ConnectResult::Cancelled;
+            }
+            if(*decision == HostKeyDecision::Reject)
+            {
+                Disconnect();
+                err = (m == KnownHostMatch::Mismatch)
+                          ? "Host key mismatch — connection rejected."
+                          : "Host key not trusted.";
+                return (m == KnownHostMatch::Mismatch)
+                           ? ConnectResult::HostKeyMismatch
+                           : ConnectResult::HostKeyRejected;
+            }
+            if(*decision == HostKeyDecision::TrustPermanently)
+            {
+                kh.Add(host, port);
+                if(!kh.Save())
+                {
+                    spdlog::warn("Could not persist known_hosts at {}", kh.Path());
+                }
+            }
+            // TrustOnce: continue without saving.
+        }
+        else if(m == KnownHostMatch::Failure)
+        {
+            err = "Host key check failed";
+            Disconnect();
+            return ConnectResult::ConnectionError;
+        }
+    }
+
+    // ---- auth ----
+    char* methods = libssh2_userauth_list(m_session, user.c_str(),
+                                          static_cast<unsigned int>(user.size()));
+    spdlog::info("[ssh] server auth methods: {}", methods ? methods : "(none)");
+
+    bool tried_password = false;
+    bool tried_kbdint   = false;
+    int  auth_rc        = LIBSSH2_ERROR_AUTHENTICATION_FAILED;
+
+    // 1) publickey
+    if(MethodListed(methods, "publickey"))
+    {
+        // 1a) explicit identity_file from the dialog
+        if(!auth.identity_file.empty())
+        {
+            if(TryPublicKey(m_session, user, auth.identity_file, auth.passphrase))
+                auth_rc = 0;
+        }
+        // 1b) ssh-agent — handles encrypted keys without us needing a passphrase.
+        if(auth_rc != 0)
+        {
+            spdlog::info("[ssh] trying ssh-agent");
+            if(TryAgent(m_session, user)) auth_rc = 0;
+        }
+        // 1c) default on-disk identity files
+        if(auth_rc != 0)
+        {
+            spdlog::info("[ssh] trying default identity files");
+            for(const auto& p : DefaultKeyPaths())
+            {
+                if(!std::filesystem::exists(p))
+                {
+                    spdlog::info("[ssh]   default key absent: {}", p);
+                    continue;
+                }
+                if(TryPublicKey(m_session, user, p, auth.passphrase))
+                {
+                    auth_rc = 0;
+                    break;
+                }
+            }
+        }
+    }
+    else
+    {
+        spdlog::info("[ssh] server does not advertise publickey");
+    }
+
+    // 2) password
+    if(auth_rc != 0 && MethodListed(methods, "password") && !auth.password.empty())
+    {
+        spdlog::info("[ssh] trying password auth");
+        tried_password = true;
+        auth_rc = libssh2_userauth_password(m_session, user.c_str(),
+                                            auth.password.c_str());
+        if(auth_rc == 0)
+        {
+            spdlog::info("[ssh] password auth OK");
+        }
+        else
+        {
+            char* msg = nullptr;
+            libssh2_session_last_error(m_session, &msg, nullptr, 0);
+            spdlog::warn("[ssh] password auth failed (rc={}): {}", auth_rc,
+                         msg ? msg : "(no message)");
+        }
+    }
+    else if(auth_rc != 0)
+    {
+        spdlog::info("[ssh] skipping password auth (server_lists={} have_password={})",
+                     MethodListed(methods, "password"), !auth.password.empty());
+    }
+
+    // 3) keyboard-interactive
+    KbdintCtx kbd_ctx{&bridge, false};
+    if(auth_rc != 0 && MethodListed(methods, "keyboard-interactive"))
+    {
+        spdlog::info("[ssh] trying keyboard-interactive auth (will route prompts to UI)");
+        tried_kbdint = true;
+        // libssh2's session abstract slot: stash kbd_ctx so the C callback can find it.
+        void** abstract = libssh2_session_abstract(m_session);
+        if(abstract) *abstract = &kbd_ctx;
+        auth_rc = libssh2_userauth_keyboard_interactive(m_session, user.c_str(),
+                                                        &KbdIntCallback);
+        if(abstract) *abstract = nullptr;
+        if(kbd_ctx.was_cancelled)
+        {
+            spdlog::info("[ssh] kbdint cancelled by user");
+            Disconnect();
+            return ConnectResult::Cancelled;
+        }
+        if(auth_rc == 0)
+        {
+            spdlog::info("[ssh] kbdint auth OK");
+        }
+        else
+        {
+            char* msg = nullptr;
+            libssh2_session_last_error(m_session, &msg, nullptr, 0);
+            spdlog::warn("[ssh] kbdint auth failed (rc={}): {}", auth_rc,
+                         msg ? msg : "(no message)");
+        }
+    }
+    else if(auth_rc != 0)
+    {
+        spdlog::info("[ssh] skipping kbdint (server_lists={})",
+                     MethodListed(methods, "keyboard-interactive"));
+    }
+
+    if(auth_rc != 0)
+    {
+        char* msg = nullptr;
+        libssh2_session_last_error(m_session, &msg, nullptr, 0);
+        err = std::string("Authentication failed: ") + (msg ? msg : "");
+        spdlog::error("[ssh] auth failed (final rc={}, last_err={}): tried_password={} tried_kbdint={}",
+                      auth_rc, msg ? msg : "", tried_password, tried_kbdint);
+        Disconnect();
+        // Distinguish "no password tried" from "password tried and wrong"
+        // so the dialog can prompt.
+        if(auth.password.empty() && MethodListed(methods, "password"))
+        {
+            spdlog::info("[ssh] mapping result -> NeedsPassword (server lists password, none provided)");
+            return ConnectResult::NeedsPassword;
+        }
+        // If the only remaining option is keyboard-interactive and we
+        // never had any input to give it, treat as NeedsPassword too.
+        if(auth.password.empty() && MethodListed(methods, "keyboard-interactive") &&
+           !MethodListed(methods, "publickey"))
+        {
+            spdlog::info("[ssh] mapping result -> NeedsPassword (kbdint only, none provided)");
+            return ConnectResult::NeedsPassword;
+        }
+        spdlog::info("[ssh] mapping result -> AuthFailed");
+        return ConnectResult::AuthFailed;
+    }
+
+    // ---- SFTP ----
+    m_sftp = libssh2_sftp_init(m_session);
+    if(!m_sftp)
+    {
+        char* msg = nullptr;
+        libssh2_session_last_error(m_session, &msg, nullptr, 0);
+        err = std::string("SFTP init failed: ") + (msg ? msg : "");
+        spdlog::error("[ssh] {}", err);
+        Disconnect();
+        return ConnectResult::ConnectionError;
+    }
+
+    spdlog::info("[ssh] SFTP session initialized; ready");
+    return ConnectResult::Ok;
+}
+
+uint64_t SshSession::StatFileSize(const std::string& remote_path,
+                                  uint64_t& mtime_out, std::string& err)
+{
+    if(!IsConnected()) { err = "not connected"; return 0; }
+    LIBSSH2_SFTP_ATTRIBUTES attrs{};
+    spdlog::info("[ssh] sftp_stat path='{}'", remote_path);
+    int rc = libssh2_sftp_stat(m_sftp, remote_path.c_str(), &attrs);
+    if(rc != 0)
+    {
+        unsigned long sftp_err = libssh2_sftp_last_error(m_sftp);
+        char*         lib_msg  = nullptr;
+        int           lib_rc   = libssh2_session_last_error(m_session, &lib_msg, nullptr, 0);
+        const char*   sftp_str = "unknown";
+        switch(sftp_err)
+        {
+            case LIBSSH2_FX_OK:                  sftp_str = "OK"; break;
+            case LIBSSH2_FX_EOF:                 sftp_str = "EOF"; break;
+            case LIBSSH2_FX_NO_SUCH_FILE:        sftp_str = "NO_SUCH_FILE"; break;
+            case LIBSSH2_FX_PERMISSION_DENIED:   sftp_str = "PERMISSION_DENIED"; break;
+            case LIBSSH2_FX_FAILURE:             sftp_str = "FAILURE"; break;
+            case LIBSSH2_FX_BAD_MESSAGE:         sftp_str = "BAD_MESSAGE"; break;
+            case LIBSSH2_FX_NO_CONNECTION:       sftp_str = "NO_CONNECTION"; break;
+            case LIBSSH2_FX_CONNECTION_LOST:     sftp_str = "CONNECTION_LOST"; break;
+            case LIBSSH2_FX_OP_UNSUPPORTED:      sftp_str = "OP_UNSUPPORTED"; break;
+            case LIBSSH2_FX_INVALID_HANDLE:      sftp_str = "INVALID_HANDLE"; break;
+            case LIBSSH2_FX_NO_SUCH_PATH:        sftp_str = "NO_SUCH_PATH"; break;
+            case LIBSSH2_FX_FILE_ALREADY_EXISTS: sftp_str = "FILE_ALREADY_EXISTS"; break;
+            case LIBSSH2_FX_WRITE_PROTECT:       sftp_str = "WRITE_PROTECT"; break;
+            case LIBSSH2_FX_NO_MEDIA:            sftp_str = "NO_MEDIA"; break;
+            default: break;
+        }
+        err = "sftp stat failed for '" + remote_path + "': " + sftp_str +
+              " (sftp_err=" + std::to_string(sftp_err) +
+              ", libssh2_rc=" + std::to_string(lib_rc) +
+              ", msg=" + (lib_msg ? lib_msg : "") + ")";
+        spdlog::error("[ssh] {}", err);
+        return 0;
+    }
+    mtime_out = attrs.mtime;
+    spdlog::info("[ssh] sftp_stat ok: size={} mtime={}", attrs.filesize, attrs.mtime);
+    return attrs.filesize;
+}
+
+bool SshSession::DownloadTo(const std::string& remote_path,
+                            const std::string& local_path, ProgressSink& sink,
+                            std::string& err)
+{
+    if(!IsConnected()) { err = "not connected"; return false; }
+
+    LIBSSH2_SFTP_HANDLE* handle = libssh2_sftp_open(m_sftp, remote_path.c_str(),
+                                                    LIBSSH2_FXF_READ, 0);
+    if(!handle)
+    {
+        err = "sftp open failed: " + remote_path;
+        return false;
+    }
+
+    LIBSSH2_SFTP_ATTRIBUTES attrs{};
+    if(libssh2_sftp_fstat(handle, &attrs) == 0)
+    {
+        sink.total = attrs.filesize;
+    }
+
+    std::string part_path = local_path + ".part";
+    {
+        std::ofstream out(part_path, std::ios::binary | std::ios::trunc);
+        if(!out)
+        {
+            err = "cannot open " + part_path + " for writing";
+            libssh2_sftp_close(handle);
+            return false;
+        }
+
+        constexpr size_t kBuf = 32 * 1024;
+        std::vector<char> buf(kBuf);
+        while(true)
+        {
+            ssize_t n = libssh2_sftp_read(handle, buf.data(), buf.size());
+            if(n == 0) break;
+            if(n < 0)
+            {
+                err = "sftp read failed";
+                out.close();
+                std::error_code ec;
+                std::filesystem::remove(part_path, ec);
+                libssh2_sftp_close(handle);
+                return false;
+            }
+            out.write(buf.data(), n);
+            if(!out)
+            {
+                err = "local write failed";
+                out.close();
+                std::error_code ec;
+                std::filesystem::remove(part_path, ec);
+                libssh2_sftp_close(handle);
+                return false;
+            }
+            sink.bytes_read.fetch_add(static_cast<uint64_t>(n),
+                                      std::memory_order_relaxed);
+        }
+    }
+    libssh2_sftp_close(handle);
+
+    std::error_code ec;
+    std::filesystem::rename(part_path, local_path, ec);
+    if(ec)
+    {
+        // Fallback: copy + remove (e.g. across mount points).
+        std::filesystem::copy_file(part_path, local_path,
+                                   std::filesystem::copy_options::overwrite_existing,
+                                   ec);
+        if(ec)
+        {
+            err = "rename to " + local_path + " failed: " + ec.message();
+            return false;
+        }
+        std::filesystem::remove(part_path, ec);
+    }
+    return true;
+}
+
+void SshSession::Disconnect()
+{
+    if(m_sftp)
+    {
+        libssh2_sftp_shutdown(m_sftp);
+        m_sftp = nullptr;
+    }
+    if(m_session)
+    {
+        libssh2_session_disconnect(m_session, "normal shutdown");
+        libssh2_session_free(m_session);
+        m_session = nullptr;
+    }
+    if(m_sock != kInvalidSocket)
+    {
+        CLOSE_SOCKET(m_sock);
+        m_sock = kInvalidSocket;
+    }
+}
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/model/src/database/rocprofvis_ssh_session.h
+++ b/src/model/src/database/rocprofvis_ssh_session.h
@@ -1,0 +1,95 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <libssh2.h>
+#include <libssh2_sftp.h>
+#include <string>
+
+#ifdef _WIN32
+#include <winsock2.h>
+using socket_t                          = SOCKET;
+constexpr socket_t kInvalidSocket       = INVALID_SOCKET;
+#else
+using socket_t                          = int;
+constexpr socket_t kInvalidSocket       = -1;
+#endif
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+
+class AuthBridge;
+
+struct AuthOptions
+{
+    std::string password;        // empty => not provided
+    std::string identity_file;   // empty => try defaults
+    std::string passphrase;      // empty => key assumed unencrypted
+};
+
+enum class ConnectResult
+{
+    Ok,
+    NeedsPassword,
+    AuthFailed,
+    HostKeyMismatch,
+    HostKeyRejected,
+    ConnectionError,
+    Cancelled
+};
+
+struct ProgressSink
+{
+    std::atomic<uint64_t> bytes_read{0};
+    uint64_t              total = 0;
+};
+
+// RAII libssh2 session + SFTP wrapper. Single-threaded; meant to live on a
+// worker thread for the duration of one Connect()+DownloadTo()+Disconnect().
+class SshSession
+{
+public:
+    SshSession();
+    ~SshSession();
+
+    SshSession(const SshSession&)            = delete;
+    SshSession& operator=(const SshSession&) = delete;
+
+    ConnectResult Connect(const std::string& host,
+                          int                port,
+                          const std::string& user,
+                          const AuthOptions& auth,
+                          AuthBridge&        bridge,
+                          std::string&       err);
+
+    // SFTP-stat the file. Returns 0 on failure.
+    uint64_t StatFileSize(const std::string& remote_path,
+                          uint64_t&          mtime_out,
+                          std::string&       err);
+
+    bool DownloadTo(const std::string& remote_path,
+                    const std::string& local_path,
+                    ProgressSink&      sink,
+                    std::string&       err);
+
+    void Disconnect();
+
+    bool IsConnected() const { return m_session != nullptr && m_sftp != nullptr; }
+
+private:
+    socket_t         m_sock    = kInvalidSocket;
+    LIBSSH2_SESSION* m_session = nullptr;
+    LIBSSH2_SFTP*    m_sftp    = nullptr;
+};
+
+// Process-wide one-shot init/exit for libssh2.
+void EnsureLibssh2Inited();
+void Libssh2GlobalShutdown();
+
+}  // namespace DataModel
+}  // namespace RocProfVis

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -26,6 +26,13 @@
 #include "widgets/rocprofvis_gui_helpers.h"
 #include "widgets/rocprofvis_widget.h"
 #include "widgets/rocprofvis_notification_manager.h"
+#include "widgets/rocprofvis_ssh_auth_modal.h"
+#include "rocprofvis_remote_fetch.h"
+#include "rocprofvis_remote_uri.h"
+#include "rocprofvis_ssh_auth_bridge.h"
+#include "rocprofvis_ssh_session.h"
+#include <cfloat>
+#include <cstring>
 #include <filesystem>
 #include <sstream>
 
@@ -85,6 +92,7 @@ AppWindow::AppWindow()
 , m_default_padding(0.0f, 0.0f)
 , m_default_spacing(0.0f, 0.0f)
 , m_open_about_dialog(false)
+, m_ssh_auth_bridge(std::make_unique<DataModel::AuthBridge>())
 , m_tabclosed_event_token(static_cast<EventManager::SubscriptionToken>(-1))
 , m_tabselected_event_token(static_cast<EventManager::SubscriptionToken>(-1))
 #ifdef ROCPROFVIS_DEVELOPER_MODE
@@ -440,6 +448,18 @@ AppWindow::Render()
         m_open_about_dialog = false;  // Reset the flag after opening the dialog
     }
     RenderAboutDialog();  // Popup dialogs need to be rendered as part of the main window
+    if(m_open_remote_dialog)
+    {
+        ImGui::OpenPopup("Open Remote Database");
+        m_open_remote_dialog = false;
+    }
+    RenderRemoteOpenDialog();
+    // Render the auth modal before the progress modal. ImGui can't stack a
+    // popup opened from outside the currently-active modal, so the auth
+    // request must "win" the OpenPopup race.
+    RenderSshAuthModal(*m_ssh_auth_bridge);
+    RenderRemoteProgressDialog();
+    PollRemoteFetch();
     m_confirmation_dialog->Render();
     m_message_dialog->Render();
     m_settings_panel->Render();
@@ -670,6 +690,20 @@ AppWindow::OpenFile(std::string file_path)
 void
 AppWindow::HandleOpenRecentFile(const std::string& file_path)
 {
+    if(DataModel::IsSshUri(file_path))
+    {
+        auto parsed = DataModel::ParseRemoteUri(file_path);
+        if(!parsed)
+        {
+            SettingsManager::GetInstance().RemoveRecentFile(file_path);
+            ShowMessageDialog("Recent File",
+                              "This recent ssh:// URI is malformed and was removed:\n\n" +
+                                  file_path);
+            return;
+        }
+        OpenRemoteFile(*parsed);
+        return;
+    }
     if(!std::filesystem::exists(file_path))
     {
         SettingsManager::GetInstance().RemoveRecentFile(file_path);
@@ -722,6 +756,11 @@ AppWindow::RenderFileMenu(Project* project)
         if(ImGui::MenuItem("Open", nullptr, false, !is_open_file_dialog_open))
         {
             HandleOpenFile();
+        }
+        if(ImGui::MenuItem("Open Remote...", nullptr, false,
+                           !is_open_file_dialog_open && !m_remote_fetch))
+        {
+            HandleOpenRemote();
         }
         if(ImGui::MenuItem("Save", nullptr, false,
                            !is_open_file_dialog_open && (project && project->IsProject())))
@@ -932,6 +971,345 @@ AppWindow::HandleOpenFile()
     ShowOpenFileDialog(
         "Choose File", file_filters, "",
         [this](std::string file_path) -> void { this->OpenFile(file_path); });
+}
+
+// ============================================================================
+// "Open Remote Database" feature
+// ============================================================================
+
+namespace
+{
+void CopyToBuf(char* dst, size_t dst_size, const std::string& src)
+{
+    if(dst_size == 0) return;
+    size_t n = std::min(src.size(), dst_size - 1);
+    std::memcpy(dst, src.data(), n);
+    dst[n] = '\0';
+}
+
+DataModel::RemoteUri RemoteUriFromForm(const char* host, const char* port,
+                                       const char* user, const char* password,
+                                       const char* path, const char* key,
+                                       const char* key_passphrase)
+{
+    DataModel::RemoteUri u;
+    u.host           = host;
+    u.user           = user;
+    u.password       = password;
+    u.path           = path;
+    u.identity_file  = key;
+    u.key_passphrase = key_passphrase ? key_passphrase : "";
+    if(port && port[0] != '\0')
+    {
+        try { u.port = std::stoi(port); } catch(...) { u.port = 22; }
+    }
+    // Path is stored exactly as the user typed it. A leading '/' means
+    // absolute on the remote server; no leading '/' means relative to the
+    // user's home directory (SFTP interprets relative paths that way).
+    return u;
+}
+}  // namespace
+
+AppWindow::RemoteFetchInProgress::~RemoteFetchInProgress()
+{
+    if(worker.joinable()) worker.join();
+}
+
+void
+AppWindow::HandleOpenRemote()
+{
+    m_open_remote_dialog       = true;
+    m_remote_password_required = false;
+    m_remote_status_msg.clear();
+    m_ssh_auth_bridge->Reset();
+}
+
+void
+AppWindow::RenderRemoteOpenDialog()
+{
+    PopUpStyle popup_style;
+    popup_style.PushPopupStyles();
+    popup_style.PushTitlebarColors();
+    popup_style.CenterPopup();
+
+    ImGui::SetNextWindowSize(ImVec2(580, 0));
+
+    if(ImGui::BeginPopupModal("Open Remote Database", nullptr,
+                              ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+    {
+        ImGui::TextWrapped("Open a SQLite database on a remote host over SSH (SFTP). "
+                           "The full file is materialized into a local cache on first open.");
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        ImGui::TextUnformatted("Paste ssh:// URI");
+        ImGui::SetNextItemWidth(-FLT_MIN - 90.0f);
+        ImGui::InputTextWithHint(
+            "##rpasteuri",
+            "ssh://[user[:password]@]host[:port]/relative/or//absolute/path.db[?key=/path/to/id]",
+            m_remote_uri_paste, sizeof(m_remote_uri_paste));
+        ImGui::SameLine();
+        if(ImGui::Button("Parse", ImVec2(80, 0)))
+        {
+            auto parsed = DataModel::ParseRemoteUri(m_remote_uri_paste);
+            if(parsed)
+            {
+                CopyToBuf(m_remote_host, sizeof(m_remote_host), parsed->host);
+                CopyToBuf(m_remote_user, sizeof(m_remote_user), parsed->user);
+                CopyToBuf(m_remote_password, sizeof(m_remote_password), parsed->password);
+                CopyToBuf(m_remote_path, sizeof(m_remote_path), parsed->path);
+                CopyToBuf(m_remote_key, sizeof(m_remote_key), parsed->identity_file);
+                if(parsed->port != 22)
+                    CopyToBuf(m_remote_port, sizeof(m_remote_port), std::to_string(parsed->port));
+                else
+                    m_remote_port[0] = '\0';
+                m_remote_status_msg        = "Parsed.";
+                m_remote_password_required = false;
+            }
+            else
+            {
+                m_remote_status_msg = "Malformed ssh:// URI.";
+            }
+        }
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        const float label_w = 110.0f;
+        ImGui::AlignTextToFramePadding(); ImGui::Text("Host"); ImGui::SameLine(label_w);
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        ImGui::InputText("##rhost", m_remote_host, sizeof(m_remote_host));
+
+        ImGui::AlignTextToFramePadding(); ImGui::Text("Port"); ImGui::SameLine(label_w);
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        ImGui::InputTextWithHint("##rport", "22", m_remote_port, sizeof(m_remote_port));
+
+        ImGui::AlignTextToFramePadding(); ImGui::Text("User"); ImGui::SameLine(label_w);
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        ImGui::InputText("##ruser", m_remote_user, sizeof(m_remote_user));
+
+        const char* pwd_label = m_remote_password_required ? "Password*" : "Password";
+        ImGui::AlignTextToFramePadding(); ImGui::Text("%s", pwd_label); ImGui::SameLine(label_w);
+        ImGuiInputTextFlags pwd_flags = m_remote_show_password ? 0 : ImGuiInputTextFlags_Password;
+        ImGui::SetNextItemWidth(-FLT_MIN - 90.0f);
+        ImGui::InputText("##rpass", m_remote_password, sizeof(m_remote_password), pwd_flags);
+        ImGui::SameLine();
+        ImGui::Checkbox("Show", &m_remote_show_password);
+
+        ImGui::AlignTextToFramePadding(); ImGui::Text("Remote Path"); ImGui::SameLine(label_w);
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        ImGui::InputTextWithHint(
+            "##rpath",
+            "relative/to/home.db  or  /absolute/path.db",
+            m_remote_path, sizeof(m_remote_path));
+
+        ImGui::AlignTextToFramePadding(); ImGui::Text("SSH Key"); ImGui::SameLine(label_w);
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        ImGui::InputTextWithHint(
+            "##rkey",
+            "Optional private key (e.g. ~/.ssh/id_ed25519). "
+            "Leave blank for default keys, agent, or password.",
+            m_remote_key, sizeof(m_remote_key));
+
+        ImGui::AlignTextToFramePadding(); ImGui::Text("Key Passphrase"); ImGui::SameLine(label_w);
+        ImGuiInputTextFlags pass_flags =
+            m_remote_show_passphrase ? 0 : ImGuiInputTextFlags_Password;
+        ImGui::SetNextItemWidth(-FLT_MIN - 90.0f);
+        ImGui::InputTextWithHint(
+            "##rkeypass", "Leave blank if key is unencrypted or loaded in ssh-agent",
+            m_remote_key_passphrase, sizeof(m_remote_key_passphrase), pass_flags);
+        ImGui::SameLine();
+        ImGui::Checkbox("Show##kpshow", &m_remote_show_passphrase);
+
+        ImGui::Spacing();
+
+        DataModel::RemoteUri preview_uri =
+            RemoteUriFromForm(m_remote_host, m_remote_port, m_remote_user,
+                              m_remote_password, m_remote_path, m_remote_key,
+                              m_remote_key_passphrase);
+        std::string preview = "ssh://";
+        if(!preview_uri.user.empty())
+        {
+            preview += preview_uri.user;
+            if(!preview_uri.password.empty())
+                preview += ":" + std::string(preview_uri.password.size(), '*');
+            preview += "@";
+        }
+        preview += preview_uri.host;
+        if(preview_uri.port != 22) preview += ":" + std::to_string(preview_uri.port);
+        // Always emit the URI separator '/'; absolute paths therefore show
+        // as '//path' (SCP-style convention).
+        preview += "/";
+        preview += preview_uri.path;
+        if(!preview_uri.identity_file.empty())
+            preview += "?key=" + preview_uri.identity_file;
+        ImGui::TextDisabled("URI: %s", preview.c_str());
+
+        if(!m_remote_status_msg.empty())
+        {
+            ImVec4 color = m_remote_password_required ? ImVec4(1.0f, 0.5f, 0.3f, 1.0f)
+                                                       : ImVec4(0.6f, 0.8f, 0.6f, 1.0f);
+            ImGui::TextColored(color, "%s", m_remote_status_msg.c_str());
+        }
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        bool can_open = m_remote_host[0] != '\0' && m_remote_path[0] != '\0';
+        if(!can_open) ImGui::BeginDisabled();
+        if(ImGui::Button("Open", ImVec2(110, 0)))
+        {
+            DataModel::RemoteUri uri = RemoteUriFromForm(
+                m_remote_host, m_remote_port, m_remote_user, m_remote_password,
+                m_remote_path, m_remote_key, m_remote_key_passphrase);
+            ImGui::CloseCurrentPopup();
+            OpenRemoteFile(uri);
+        }
+        if(!can_open) ImGui::EndDisabled();
+
+        ImGui::SameLine();
+        if(ImGui::Button("Cancel", ImVec2(110, 0)))
+        {
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::EndPopup();
+    }
+    popup_style.PopStyles();
+}
+
+void
+AppWindow::OpenRemoteFile(const DataModel::RemoteUri& uri)
+{
+    if(m_remote_fetch)
+    {
+        ShowMessageDialog("Open Remote", "A remote download is already in progress.");
+        return;
+    }
+
+    std::filesystem::path config_root = get_application_config_path(true);
+    std::filesystem::path cache_root  = config_root / "remote_cache";
+    std::filesystem::path cache_dir   = cache_root / DataModel::RemoteCacheKey(uri);
+    std::filesystem::path cache_path  = cache_dir / DataModel::RemoteBasenameForCache(uri);
+
+    auto fetch         = std::make_unique<RemoteFetchInProgress>();
+    fetch->cache_path  = cache_path;
+    fetch->display_name = DataModel::RemoteBasenameForCache(uri);
+    fetch->sanitized_uri = DataModel::SanitizeForRecent(uri);
+    fetch->sink         = std::make_unique<DataModel::ProgressSink>();
+
+    DataModel::AuthBridge* bridge = m_ssh_auth_bridge.get();
+    bridge->Reset();
+
+    auto* sink_ptr   = fetch->sink.get();
+    auto* err_ptr    = &fetch->err;
+    auto* result_ptr = &fetch->result_code;
+    auto* done_ptr   = &fetch->done;
+    DataModel::RemoteUri uri_copy = uri;
+
+    fetch->worker = std::thread([uri_copy, cache_path, bridge, sink_ptr,
+                                 err_ptr, result_ptr, done_ptr]() {
+        DataModel::SshAuthResult r =
+            DataModel::FetchRemoteFile(uri_copy, cache_path, *bridge, *sink_ptr, *err_ptr);
+        *result_ptr = static_cast<int>(r);
+        done_ptr->store(true, std::memory_order_release);
+    });
+
+    m_remote_fetch = std::move(fetch);
+}
+
+void
+AppWindow::PollRemoteFetch()
+{
+    if(!m_remote_fetch) return;
+    if(!m_remote_fetch->done.load(std::memory_order_acquire)) return;
+
+    auto fetch     = std::move(m_remote_fetch);  // resets the member
+    if(fetch->worker.joinable()) fetch->worker.join();
+
+    auto result = static_cast<DataModel::SshAuthResult>(fetch->result_code);
+    spdlog::info("[ssh] PollRemoteFetch: result={} err='{}' cache_path={}",
+                 fetch->result_code, fetch->err, fetch->cache_path.string());
+    switch(result)
+    {
+        case DataModel::SshAuthResult::Ok:
+        {
+            OpenFile(fetch->cache_path.string());
+            SettingsManager::GetInstance().AddRecentFile(fetch->sanitized_uri);
+            break;
+        }
+        case DataModel::SshAuthResult::NeedsPassword:
+        {
+            m_open_remote_dialog       = true;
+            m_remote_password_required = true;
+            m_remote_status_msg =
+                "Server requires a password. Enter it and click Open again.";
+            break;
+        }
+        case DataModel::SshAuthResult::Cancelled:
+        {
+            m_remote_status_msg = "Cancelled.";
+            break;
+        }
+        default:
+        {
+            std::string msg = fetch->err.empty() ? "Unknown error" : fetch->err;
+            ShowMessageDialog("Remote Open Failed", msg);
+            break;
+        }
+    }
+}
+
+void
+AppWindow::RenderRemoteProgressDialog()
+{
+    if(!m_remote_fetch) return;
+
+    // Step aside while an auth modal is pending — ImGui won't stack a second
+    // modal opened from outside the first one, and the progress bar is
+    // meaningless until auth completes anyway. Just don't open ours.
+    bool auth_pending =
+        !std::holds_alternative<std::monostate>(m_ssh_auth_bridge->Peek());
+    if(auth_pending) return;
+
+    if(!ImGui::IsPopupOpen("Remote Download"))
+    {
+        ImGui::OpenPopup("Remote Download");
+    }
+
+    PopUpStyle popup_style;
+    popup_style.PushPopupStyles();
+    popup_style.PushTitlebarColors();
+    popup_style.CenterPopup();
+    ImGui::SetNextWindowSize(ImVec2(440, 0));
+
+    if(ImGui::BeginPopupModal("Remote Download", nullptr,
+                              ImGuiWindowFlags_AlwaysAutoResize |
+                                  ImGuiWindowFlags_NoMove |
+                                  ImGuiWindowFlags_NoTitleBar))
+    {
+        ImGui::Text("Downloading: %s", m_remote_fetch->display_name.c_str());
+        uint64_t done  = m_remote_fetch->sink->bytes_read.load(std::memory_order_relaxed);
+        uint64_t total = m_remote_fetch->sink->total;
+        if(total > 0)
+        {
+            float frac = static_cast<float>(done) / static_cast<float>(total);
+            ImGui::ProgressBar(frac, ImVec2(-FLT_MIN, 0),
+                               (std::to_string(done / 1024) + " / " +
+                                std::to_string(total / 1024) + " KiB").c_str());
+        }
+        else
+        {
+            ImGui::Text("Connecting...");
+        }
+        // Modal closes when the fetch completes (PollRemoteFetch resets member).
+        if(!m_remote_fetch) ImGui::CloseCurrentPopup();
+        ImGui::EndPopup();
+    }
+    popup_style.PopStyles();
 }
 
 void

--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -13,14 +13,24 @@
 #include "widgets/rocprofvis_tab_container.h"
 
 #include <atomic>
+#include <filesystem>
+#include <thread>
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
 #include <future>
-#include <thread>
 #include <chrono>
 #endif
 
 namespace RocProfVis
 {
+
+namespace DataModel
+{
+class AuthBridge;
+struct ProgressSink;
+struct RemoteUri;
+enum class SshAuthResult;
+}  // namespace DataModel
+
 namespace View
 {
 
@@ -87,13 +97,18 @@ private:
 
     void RenderFileDialog();
     void RenderAboutDialog();
+    void RenderRemoteOpenDialog();
+    void RenderRemoteProgressDialog();
     void RenderEmptyState();
 
     void HandleTabClosed(std::shared_ptr<RocEvent> e);
     void HandleTabSelectionChanged(std::shared_ptr<RocEvent> e);
     void HandleOpenFile();
+    void HandleOpenRemote();
     void HandleOpenRecentFile(const std::string& file_path);
     void HandleSaveAsFile();
+    void OpenRemoteFile(const DataModel::RemoteUri& uri);
+    void PollRemoteFetch();
     void ConfigureFileDialogBackend();
 
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
@@ -133,6 +148,39 @@ private:
 #endif
     bool m_open_about_dialog;
     bool m_disable_app_interaction;
+
+    // ---- "Open Remote" feature ----
+    bool m_open_remote_dialog          = false;
+    bool m_remote_show_password        = false;
+    bool m_remote_show_passphrase      = false;
+    bool m_remote_password_required    = false;
+    char m_remote_uri_paste[1024]      = {};
+    char m_remote_host[256]            = {};
+    char m_remote_port[16]             = {};
+    char m_remote_user[128]            = {};
+    char m_remote_password[256]        = {};
+    char m_remote_path[512]            = {};
+    char m_remote_key[512]             = {};
+    char m_remote_key_passphrase[256]  = {};
+    std::string m_remote_status_msg;
+
+    std::unique_ptr<DataModel::AuthBridge> m_ssh_auth_bridge;
+
+    struct RemoteFetchInProgress
+    {
+        std::thread                            worker;
+        std::atomic<bool>                      done{false};
+        std::filesystem::path                  cache_path;
+        std::string                            display_name;
+        std::string                            sanitized_uri;
+        std::string                            err;
+        // SshAuthResult is incomplete here; the cpp owns the actual value
+        // through this small int wrapper.
+        int                                    result_code = 0;
+        std::unique_ptr<DataModel::ProgressSink> sink;
+        ~RemoteFetchInProgress();
+    };
+    std::unique_ptr<RemoteFetchInProgress> m_remote_fetch;
 
     rocprofvis_view_file_dialog_preference_t m_file_dialog_preference;
 

--- a/src/view/src/widgets/rocprofvis_ssh_auth_modal.cpp
+++ b/src/view/src/widgets/rocprofvis_ssh_auth_modal.cpp
@@ -1,0 +1,172 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_ssh_auth_modal.h"
+
+#include "rocprofvis_ssh_auth_bridge.h"
+#include "rocprofvis_widget.h"
+
+#include "imgui.h"
+#include <spdlog/spdlog.h>
+
+#include <cstring>
+#include <vector>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+namespace
+{
+// Per-frame buffers backing the kbdint inputs. Sized once, reused.
+struct KbdintState
+{
+    std::vector<std::string> answers;
+    bool                     opened = false;
+};
+
+KbdintState& KbdintForFrame() { static KbdintState s; return s; }
+}  // namespace
+
+void RenderSshAuthModal(DataModel::AuthBridge& bridge)
+{
+    using namespace DataModel;
+    auto pending = bridge.Peek();
+
+    // ---- kbdint ----
+    if(auto* req = std::get_if<PromptRequest>(&pending))
+    {
+        auto& st = KbdintForFrame();
+        if(!st.opened)
+        {
+            st.answers.assign(req->prompts.size(), "");
+            st.opened = true;
+            spdlog::info("[ssh-ui] kbdint pending: {} prompt(s); calling OpenPopup",
+                         req->prompts.size());
+            ImGui::OpenPopup("SSH Authentication");
+        }
+
+        PopUpStyle popup_style;
+        popup_style.PushPopupStyles();
+        popup_style.PushTitlebarColors();
+        popup_style.CenterPopup();
+        ImGui::SetNextWindowSize(ImVec2(480, 0));
+
+        if(ImGui::BeginPopupModal("SSH Authentication", nullptr,
+                                  ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+        {
+            if(!req->name.empty())        ImGui::TextWrapped("%s", req->name.c_str());
+            if(!req->instruction.empty()) ImGui::TextWrapped("%s", req->instruction.c_str());
+            ImGui::Spacing();
+
+            for(size_t i = 0; i < req->prompts.size(); i++)
+            {
+                ImGui::TextUnformatted(req->prompts[i].text.c_str());
+                ImGui::SetNextItemWidth(-FLT_MIN);
+                ImGuiInputTextFlags flags =
+                    req->prompts[i].echo ? 0 : ImGuiInputTextFlags_Password;
+                char buf[256];
+                std::strncpy(buf, st.answers[i].c_str(), sizeof(buf));
+                buf[sizeof(buf) - 1] = '\0';
+                std::string id = "##kbd" + std::to_string(i);
+                if(ImGui::InputText(id.c_str(), buf, sizeof(buf), flags))
+                {
+                    st.answers[i] = buf;
+                }
+            }
+
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+
+            if(ImGui::Button("Submit", ImVec2(110, 0)))
+            {
+                std::vector<std::string> resp = st.answers;
+                bridge.SubmitPromptResponses(std::move(resp));
+                st = {};
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SameLine();
+            if(ImGui::Button("Cancel", ImVec2(110, 0)))
+            {
+                bridge.Cancel();
+                st = {};
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        }
+        popup_style.PopStyles();
+        return;
+    }
+
+    // ---- host key confirmation ----
+    if(auto* req = std::get_if<HostKeyRequest>(&pending))
+    {
+        static bool opened = false;
+        if(!opened) { ImGui::OpenPopup("SSH Host Key"); opened = true; }
+
+        PopUpStyle popup_style;
+        popup_style.PushPopupStyles();
+        popup_style.PushTitlebarColors();
+        popup_style.CenterPopup();
+        ImGui::SetNextWindowSize(ImVec2(520, 0));
+
+        if(ImGui::BeginPopupModal("SSH Host Key", nullptr,
+                                  ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+        {
+            if(req->state == HostKeyState::Mismatch)
+            {
+                ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f),
+                                   "WARNING: server host key has CHANGED");
+                ImGui::TextWrapped("Someone could be eavesdropping on you right now "
+                                   "(man-in-the-middle attack), or the server's key was "
+                                   "rotated. Continue only if you know this is expected.");
+            }
+            else
+            {
+                ImGui::TextWrapped("This is the first time you are connecting to this host. "
+                                   "Verify the fingerprint matches what the server administrator "
+                                   "expects before continuing.");
+            }
+            ImGui::Spacing();
+            ImGui::Text("Host:        %s:%d", req->host.c_str(), req->port);
+            ImGui::Text("Key type:    %s", req->key_type.c_str());
+            ImGui::Text("Fingerprint: %s", req->fingerprint_sha256_b64.c_str());
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+
+            if(ImGui::Button("Trust permanently", ImVec2(160, 0)))
+            {
+                bridge.SubmitHostKeyDecision(HostKeyDecision::TrustPermanently);
+                opened = false;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SameLine();
+            if(ImGui::Button("Trust once", ImVec2(110, 0)))
+            {
+                bridge.SubmitHostKeyDecision(HostKeyDecision::TrustOnce);
+                opened = false;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SameLine();
+            if(ImGui::Button("Reject", ImVec2(110, 0)))
+            {
+                bridge.SubmitHostKeyDecision(HostKeyDecision::Reject);
+                opened = false;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
+        }
+        popup_style.PopStyles();
+        return;
+    }
+
+    // No pending request; reset latched modal state in case a previous
+    // one was just dismissed.
+    KbdintForFrame() = {};
+}
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/widgets/rocprofvis_ssh_auth_modal.h
+++ b/src/view/src/widgets/rocprofvis_ssh_auth_modal.h
@@ -1,0 +1,25 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+namespace RocProfVis
+{
+namespace DataModel
+{
+class AuthBridge;
+}
+
+namespace View
+{
+
+// Polls the bridge each frame; if a kbdint prompt or host-key request is
+// pending, opens the corresponding modal popup. Submits the user's response
+// (or Cancel) back to the bridge.
+//
+// Must be called every frame from AppWindow::Render(), after any user-
+// initiated SSH connection has been started.
+void RenderSshAuthModal(DataModel::AuthBridge& bridge);
+
+}  // namespace View
+}  // namespace RocProfVis


### PR DESCRIPTION
## Summary

- Adds **File → Open Remote…** menu entry. The dialog accepts an `ssh://` URI (paste-and-Parse, or fill in the Host/Port/User/Password/Path/Key/Passphrase fields). The remote SQLite database is fetched over SFTP into a per-user cache (`~/.config/rocm-optiq/remote_cache/<hash>/<name>.db`) and then handed off to the existing `OpenFile()` path. Subsequent opens of the same URI hit the cache when remote `size`+`mtime` match a sidecar `.meta` file.
- All SSH transport runs through **libssh2 in-process** — no shelling out to `ssh`/`sshpass`/`cat`/`ControlMaster`. Adds libssh2 1.11+ as a build dependency (linux-deb / vcpkg / msys2 / homebrew probed via pkg-config + find_library fallback).
- Multiple auth methods, tried in order: explicit identity file (with passphrase) → ssh-agent (OpenSSH agent or Pageant) → default keys (`~/.ssh/id_ed25519`, `id_rsa`, `id_ecdsa`, `id_dsa`) → password → keyboard-interactive (PAM/OTP). Tilde paths in the SSH Key field are expanded.
- Host keys are validated against `~/.ssh/known_hosts` via `libssh2_knownhost_*`. Unknown / mismatched keys pop a fingerprint confirmation modal (Trust permanently / Trust once / Reject).
- Worker thread + `AuthBridge` round-trips kbdint prompts and host-key confirmations to ImGui modals so the UI never blocks. A non-cancelable progress modal shows byte progress during the SFTP transfer.
- Path semantics follow the SCP convention: `ssh://host/relative/path` is home-relative on the remote; `ssh://host//absolute/path` is absolute. The dialog's path field accepts the same convention (no leading `/` ⇒ home-relative).
- **Credentials are kept in memory only.** Recent files entries persist the URI without the password and route back through the remote-fetch flow.

### New files
- `src/model/src/database/rocprofvis_remote_uri.{h,cpp}` — URI parser/serializer.
- `src/model/src/database/rocprofvis_ssh_session.{h,cpp}` — RAII libssh2 wrapper (handshake, host-key, auth fallback, SFTP).
- `src/model/src/database/rocprofvis_ssh_known_hosts.{h,cpp}` — `libssh2_knownhost_*` wrapper + SHA-256 fingerprint formatter.
- `src/model/src/database/rocprofvis_ssh_auth_bridge.{h,cpp}` — worker↔UI channel for kbdint + host-key prompts.
- `src/model/src/database/rocprofvis_remote_fetch.{h,cpp}` — high-level fetch + cache logic.
- `src/view/src/widgets/rocprofvis_ssh_auth_modal.{h,cpp}` — kbdint and host-key ImGui modals.

### Modified files
- `src/view/src/rocprofvis_appwindow.{h,cpp}` — menu item, dialog, fetch orchestration, recent-files dispatch for `ssh://`.
- `src/model/CMakeLists.txt`, top-level `CMakeLists.txt` — libssh2 link + view include path for new model headers.

## Test plan

- [ ] Build on Linux (`cmake --build build -j`) — succeeds with system `libssh2-1-dev`.
- [ ] Build on Windows (vcpkg or msys2) — no platform-specific calls outside the existing `_WIN32` branches; `ws2_32` linked.
- [ ] Default-key auth, known host: silent success, tab opens, file cached.
- [ ] Identity-file auth with `~/.ssh/id_*` (tilde expansion).
- [ ] Encrypted private key + Key Passphrase field — decrypts and authenticates.
- [ ] ssh-agent: `ssh-add` a key, leave Key field blank — agent path picks it up (log line `[ssh] agent: auth OK`).
- [ ] Password auth: Password field populated, succeeds.
- [ ] Keyboard-interactive (PAM/OTP): kbdint modal pops with prompts; submit → auth succeeds. Zero-prompt info rounds are auto-acknowledged without showing the modal.
- [ ] Unknown host: SHA-256 fingerprint confirmation modal; "Trust permanently" appends to `~/.ssh/known_hosts`.
- [ ] Host-key mismatch: red mismatch modal; reject → `HostKeyMismatch` surfaced.
- [ ] Wrong password: `NeedsPassword` reopens the dialog with `Password*` required marker.
- [ ] DNS / refused / timeout: each yields `ConnectionError` with a distinct status string.
- [ ] Cache hit: re-open same URI → SFTP-stat matches sidecar metadata → instant open.
- [ ] Recent files: `ssh://user@host/path` (no password) appears; selecting it re-runs the fetch flow.
- [ ] Verify cache contents do not contain plaintext password (`grep -r '<test-pw>' ~/.config/rocm-optiq/remote_cache/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)