### PR TITLE
Selection Optimization 

### DIFF
--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -327,7 +327,7 @@ FlameTrackItem::HandleTimelineHighlightChanged(std::shared_ptr<RocEvent> e)
 
 void
 FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart_item,
-                        float duration, ImDrawList* draw_list)
+                        float duration, ImDrawList* draw_list, bool use_highlight_color)
 {
     ImVec2 cursor_position = ImGui::GetCursorScreenPos();
     ImVec2 content_size    = ImGui::GetContentRegionAvail();
@@ -337,7 +337,12 @@ FlameTrackItem::DrawBox(ImVec2 start_position, int color_index, ChartItem& chart
                             start_position.y + m_level_height + cursor_position.y);
 
     ImU32 rectColor;
-    if(m_event_color_mode == EventColorMode::kNone)
+    if(use_highlight_color)
+    {
+        const auto& highlight_wheel = m_settings.GetHighlightedEventColorWheel();
+        rectColor = highlight_wheel[color_index % highlight_wheel.size()];
+    }
+    else if(m_event_color_mode == EventColorMode::kNone)
     {
         rectColor = m_settings.GetColor(Colors::kFlameChartColor);
     }
@@ -633,6 +638,12 @@ FlameTrackItem::RenderChart(float graph_width)
 
     int color_index      = 0;
     m_has_drawn_tool_tip = false;
+
+    double     range_start_ns           = TimelineSelection::INVALID_SELECTION_TIME;
+    double     range_end_ns             = TimelineSelection::INVALID_SELECTION_TIME;
+    const bool has_time_range_selection =
+        m_timeline_selection->GetSelectedTimeRange(range_start_ns, range_end_ns);
+
     for(ChartItem& item : m_chart_items)
     {
         ImVec2 container_pos = ImGui::GetWindowPos();
@@ -672,8 +683,13 @@ FlameTrackItem::RenderChart(float graph_width)
             normalized_duration = std::numeric_limits<float>::max();
         }
 
+        const bool use_highlight_color =
+            has_time_range_selection &&
+            item.event.m_start_ts <= range_end_ns &&
+            item.event.m_start_ts + item.event.m_duration >= range_start_ns;
+
         DrawBox(start_position, color_index, item,
-                static_cast<float>(normalized_duration), draw_list);
+                static_cast<float>(normalized_duration), draw_list, use_highlight_color);
     }
 
     for(ChartItem& item : m_selected_chart_items)

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -89,7 +89,7 @@ private:
     void HandleTimelineHighlightChanged(std::shared_ptr<RocEvent> e);
 
     void DrawBox(ImVec2 start_position, int boxplot_box_id, ChartItem& flame,
-                 float duration, ImDrawList* draw_list);
+                 float duration, ImDrawList* draw_list, bool use_highlight_color);
 
     bool ExtractPointsFromData();
     bool ExtractChildInfo(ChartItem& item);

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -191,6 +191,20 @@ const std::vector<ImU32> LIGHT_FLAME_COLORS = {
     IM_COL32(94, 178, 138, 200),  IM_COL32(212, 168, 102, 200),
     IM_COL32(158, 160, 222, 200), IM_COL32(220, 156, 118, 200)
 };
+const std::vector<ImU32> DARK_HIGHLIGHTED_EVENT_COLORS = {
+    IM_COL32(50, 145, 210, 215),  IM_COL32(0, 158, 115, 215),
+    IM_COL32(240, 228, 66, 215),  IM_COL32(204, 121, 167, 215),
+    IM_COL32(86, 180, 233, 215),  IM_COL32(235, 130, 45, 215),
+    IM_COL32(0, 204, 102, 215),   IM_COL32(230, 159, 0, 215),
+    IM_COL32(153, 153, 255, 215), IM_COL32(255, 153, 51, 215)
+};
+const std::vector<ImU32> LIGHT_HIGHLIGHTED_EVENT_COLORS = {
+    IM_COL32(50, 145, 210, 220),  IM_COL32(0, 158, 115, 220),
+    IM_COL32(240, 228, 66, 220),  IM_COL32(204, 121, 167, 220),
+    IM_COL32(86, 180, 233, 220),  IM_COL32(235, 130, 45, 220),
+    IM_COL32(0, 204, 102, 220),   IM_COL32(230, 159, 0, 220),
+    IM_COL32(153, 153, 255, 220), IM_COL32(255, 153, 51, 220)
+};
 inline constexpr const char* FLAME_DARK_COLORMAP_NAME    = "flame_dark";
 inline constexpr const char* FLAME_LIGHT_COLORMAP_NAME   = "flame_light";
 inline constexpr const char* CONTRAST_DARK_COLORMAP_NAME = "contrast_dark";
@@ -484,6 +498,13 @@ SettingsManager::GetColorWheel() const
 {
     return m_usersettings.display_settings.use_dark_mode ? DARK_FLAME_COLORS
                                                          : LIGHT_FLAME_COLORS;
+}
+
+const std::vector<ImU32>&
+SettingsManager::GetHighlightedEventColorWheel() const
+{
+    return m_usersettings.display_settings.use_dark_mode ? DARK_HIGHLIGHTED_EVENT_COLORS
+                                                         : LIGHT_HIGHLIGHTED_EVENT_COLORS;
 }
 
 const char*

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -178,6 +178,7 @@ public:
     // Styling
     ImU32                     GetColor(Colors color) const;
     const std::vector<ImU32>& GetColorWheel() const;
+    const std::vector<ImU32>& GetHighlightedEventColorWheel() const;
     const char*               GetFlameColormapName() const;
     const char*               GetContrastColormapName() const;
     /**

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -825,28 +825,6 @@ TimelineView::RenderScrubber(ImVec2 screen_pos)
             m_settings.GetColor(Colors::kSelectionBorder), 3.0f);
     }
 
-    if(m_highlighted_region.first != TimelineSelection::INVALID_SELECTION_TIME &&
-       m_highlighted_region.second != TimelineSelection::INVALID_SELECTION_TIME)
-    {
-        float normalized_start_box_highlighted =
-            window_position.x + m_tpt->TimeToPixel(m_highlighted_region.first);
-
-        float normalized_start_box_highlighted_end =
-            window_position.x + m_tpt->TimeToPixel(m_highlighted_region.second);
-
-        // Clamp to not overlap scrollbar
-        float min_x         = window_position.x;
-        float max_x         = window_position.x + m_tpt->GetGraphSizeX();
-        float clamped_start = std::clamp(normalized_start_box_highlighted, min_x, max_x);
-        float clamped_end =
-            std::clamp(normalized_start_box_highlighted_end, min_x, max_x);
-
-        draw_list->AddRectFilled(
-            ImVec2(clamped_start, cursor_position.y),
-            ImVec2(clamped_end, cursor_position.y + container_size.y - m_ruler_height),
-            m_settings.GetColor(Colors::kSelection));
-    }
-
     // IsMouseHoveringRect check in screen coordinates
     if(ImGui::IsMouseHoveringRect(window_position,
                                   ImVec2(window_position.x + m_tpt->GetGraphSizeX(),
@@ -1232,6 +1210,8 @@ TimelineView::RenderNormalTrack(TrackGraph& track_graph, int track_index,
         }
     }
 
+    RenderTimeRangeSelectionFill(lane_dl, lane_min, lane_max);
+
     if(track_graph.selected)
     {
         // Mark the selected lane without covering the track contents.
@@ -1324,6 +1304,35 @@ TimelineView::RenderNormalTrack(TrackGraph& track_graph, int track_index,
         ImVec2(p_min.x, p_max.y - 0.5f),
         ImVec2(p_max.x, p_max.y - 0.5f),
         m_settings.GetColor(Colors::kTableBorderLight), 1.0f);
+}
+
+void
+TimelineView::RenderTimeRangeSelectionFill(ImDrawList* draw_list, ImVec2 lane_min,
+                                           ImVec2 lane_max)
+{
+    if(m_highlighted_region.first == TimelineSelection::INVALID_SELECTION_TIME ||
+       m_highlighted_region.second == TimelineSelection::INVALID_SELECTION_TIME)
+    {
+        return;
+    }
+
+    const float  graph_min_x = lane_min.x + m_sidebar_size;
+    const float  graph_max_x = graph_min_x + m_tpt->GetGraphSizeX();
+    const double range_min_ns =
+        std::min(m_highlighted_region.first, m_highlighted_region.second);
+    const double range_max_ns =
+        std::max(m_highlighted_region.first, m_highlighted_region.second);
+
+    const float fill_start = std::clamp(graph_min_x + m_tpt->TimeToPixel(range_min_ns),
+                                        graph_min_x, graph_max_x);
+    const float fill_end   = std::clamp(graph_min_x + m_tpt->TimeToPixel(range_max_ns),
+                                        graph_min_x, graph_max_x);
+
+    if(fill_start >= fill_end) return;
+
+    draw_list->AddRectFilled(ImVec2(fill_start, lane_min.y),
+                             ImVec2(fill_end, lane_max.y),
+                             m_settings.GetColor(Colors::kSelection));
 }
 
 void

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -126,6 +126,8 @@ private:
     void RequestDataIfEmpty(TrackItem* track_item, bool request_data);
     void RenderNormalTrack(TrackGraph& track_graph, int track_index, ImGuiWindowFlags window_flags,
                    bool is_reordering);
+    void RenderTimeRangeSelectionFill(ImDrawList* draw_list, ImVec2 lane_min,
+                                      ImVec2 lane_max);
     void RenderEmptyTrack(TrackItem* track_item);
     void RenderReorderingTrack(TrackItem* track_item, ImVec2 container_size);
 


### PR DESCRIPTION
-Recolored timeline events that overlap the active time-range selection using the original flame color ramp from main.
-Moved the translucent time-range selection fill behind track events by drawing it per lane before event rendering.
-Kept the selection boundary bars on the scrubber overlay so they remain visible and interactive above events.

<img width="1643" height="1001" alt="image" src="https://github.com/user-attachments/assets/80e84e9e-b75c-487d-81b4-00fad6c212c1" />
