### PR TITLE
Upload Test Logs on CTest Failure

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -181,7 +181,8 @@ jobs:
           cd ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}
           ctest \
             --output-on-failure \
-            --no-tests=error
+            --no-tests=error \
+            --output-junit ctest-results.xml
 
       - name: Prepare Distribution Artifacts
         run: |
@@ -218,3 +219,14 @@ jobs:
         run: |
           echo "Tests have failed!"
           exit 1
+
+      - name: Upload Test Logs (on failure)
+        if: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-mac-${{ matrix.os-version }}
+          path: |
+            ${{ env.BUILD_DIR }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/Testing/Temporary/**
+          retention-days: 1
+

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -184,6 +184,16 @@ jobs:
             --no-tests=error \
             --output-junit ctest-results.xml
 
+      - name: Upload Test Logs (on failure)
+        if: steps.run_tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-mac-${{ matrix.os-version }}
+          path: |
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/Testing/Temporary/**
+          retention-days: 7
+
       - name: Prepare Distribution Artifacts
         run: |
           mkdir ${{ env.DIST_DIR }}/
@@ -217,16 +227,6 @@ jobs:
       - name: Announce Test Failure
         if: steps.run_tests.outcome == 'failure'
         run: |
-          echo "Tests have failed!"
+          echo "Tests have failed! Please see uploaded CTest logs for more information"
           exit 1
-
-      - name: Upload Test Logs (on failure)
-        if: steps.run_tests.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-logs-mac-${{ matrix.os-version }}
-          path: |
-            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/ctest-results.xml
-            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/Testing/Temporary/**
-          retention-days: 7
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -221,12 +221,12 @@ jobs:
           exit 1
 
       - name: Upload Test Logs (on failure)
-        if: true
+        if: steps.run_tests.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: test-logs-mac-${{ matrix.os-version }}
           path: |
             ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/ctest-results.xml
             ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/Testing/Temporary/**
-          retention-days: 1
+          retention-days: 7
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -226,7 +226,7 @@ jobs:
         with:
           name: test-logs-mac-${{ matrix.os-version }}
           path: |
-            ${{ env.BUILD_DIR }}/ctest-results.xml
-            ${{ env.BUILD_DIR }}/Testing/Temporary/**
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/Testing/Temporary/**
           retention-days: 1
 

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -112,6 +112,16 @@ jobs:
             --no-tests=error \
             --output-junit ctest-results.xml
 
+      - name: Upload Test Logs (on failure)
+        if: steps.run_tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-rhel-${{ matrix.os-version }}
+          path: |
+            ${{ env.BUILD_DIR }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/Testing/Temporary/**
+          retention-days: 7
+
       - name: Prepare Distribution Artifacts
         run: |
           mkdir ${{ env.DIST_DIR }}
@@ -154,15 +164,5 @@ jobs:
       - name: Announce Test Failure
         if: steps.run_tests.outcome == 'failure'
         run: |
-          echo "Tests have failed!"
+          echo "Tests have failed! Please see uploaded CTest logs for more information"
           exit 1
-
-      - name: Upload Test Logs (on failure)
-        if: steps.run_tests.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-logs-rhel-${{ matrix.os-version }}
-          path: |
-            ${{ env.BUILD_DIR }}/ctest-results.xml
-            ${{ env.BUILD_DIR }}/Testing/Temporary/**
-          retention-days: 7

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -158,11 +158,11 @@ jobs:
           exit 1
 
       - name: Upload Test Logs (on failure)
-        if: true
+        if: steps.run_tests.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: test-logs-rhel-${{ matrix.os-version }}
           path: |
             ${{ env.BUILD_DIR }}/ctest-results.xml
             ${{ env.BUILD_DIR }}/Testing/Temporary/**
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -109,7 +109,8 @@ jobs:
           cd ${{ env.BUILD_DIR }}
           ctest \
             --output-on-failure \
-            --no-tests=error
+            --no-tests=error \
+            --output-junit ctest-results.xml
 
       - name: Prepare Distribution Artifacts
         run: |
@@ -155,3 +156,13 @@ jobs:
         run: |
           echo "Tests have failed!"
           exit 1
+
+      - name: Upload Test Logs (on failure)
+        if: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-rhel-${{ matrix.os-version }}
+          path: |
+            ${{ env.BUILD_DIR }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/Testing/Temporary/**
+          retention-days: 1

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -160,11 +160,11 @@ jobs:
           exit 1
 
       - name: Upload Test Logs (on failure)
-        if: true
+        if: steps.run_tests.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: test-logs-ubuntu-${{ matrix.os-version }}
           path: |
             ${{ env.BUILD_DIR }}/ctest-results.xml
             ${{ env.BUILD_DIR }}/Testing/Temporary/**
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -103,7 +103,8 @@ jobs:
           cd ${{ env.BUILD_DIR }}
           ctest \
             --output-on-failure \
-            --no-tests=error
+            --no-tests=error \
+            --output-junit ctest-results.xml
 
       - name: Prepare Distribution Artifacts
         run: |
@@ -157,3 +158,13 @@ jobs:
         run: |
           echo "Tests have failed!"
           exit 1
+
+      - name: Upload Test Logs (on failure)
+        if: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-ubuntu-${{ matrix.os-version }}
+          path: |
+            ${{ env.BUILD_DIR }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/Testing/Temporary/**
+          retention-days: 1

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -106,6 +106,16 @@ jobs:
             --no-tests=error \
             --output-junit ctest-results.xml
 
+      - name: Upload Test Logs (on failure)
+        if: steps.run_tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-ubuntu-${{ matrix.os-version }}
+          path: |
+            ${{ env.BUILD_DIR }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/Testing/Temporary/**
+          retention-days: 7
+
       - name: Prepare Distribution Artifacts
         run: |
           mkdir ${{ env.DIST_DIR }}
@@ -156,15 +166,5 @@ jobs:
       - name: Announce Test Failure
         if: steps.run_tests.outcome == 'failure'
         run: |
-          echo "Tests have failed!"
+          echo "Tests have failed! Please see uploaded CTest logs for more information"
           exit 1
-
-      - name: Upload Test Logs (on failure)
-        if: steps.run_tests.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-logs-ubuntu-${{ matrix.os-version }}
-          path: |
-            ${{ env.BUILD_DIR }}/ctest-results.xml
-            ${{ env.BUILD_DIR }}/Testing/Temporary/**
-          retention-days: 7

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -125,10 +125,6 @@ jobs:
           mkdir ${{ env.DIST_DIR }}
           cp ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/${{ env.BUILD_FILE_NAME }}.exe ${{ env.DIST_DIR }}/
           ls -l ${{ env.DIST_DIR }}/
-          ls -l ${{ env.BUILD_DIR }}/
-          ls -l ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/
-          ls -l ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/
-
       
       - name: Upload GitHub Artifacts
         if: ${{ inputs.upload_to_github }}
@@ -166,6 +162,6 @@ jobs:
         with:
           name: test-logs-windows-${{ matrix.os-version }}
           path: |
-            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/ctest-results.xml
-            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/Testing/Temporary/**
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/Testing/Temporary/**
           retention-days: 1

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -117,7 +117,8 @@ jobs:
           ctest `
             -C ${{ env.BINARY_DIR }} `
             --output-on-failure `
-            --no-tests=error
+            --no-tests=error `
+            --output-junit ctest-results.xml
 
       - name: Prepare Distribution Artifacts
         run: |
@@ -154,3 +155,13 @@ jobs:
         run: |
           echo "Tests have failed!"
           exit 1
+
+      - name: Upload Test Logs (on failure)
+        if: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-windows-${{ matrix.os-version }}
+          path: |
+            ${{ env.BUILD_DIR }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/Testing/Temporary/**
+          retention-days: 1

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -157,11 +157,11 @@ jobs:
           exit 1
 
       - name: Upload Test Logs (on failure)
-        if: true
+        if: steps.run_tests.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
           name: test-logs-windows-${{ matrix.os-version }}
           path: |
             ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/ctest-results.xml
             ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/Testing/Temporary/**
-          retention-days: 1
+          retention-days: 7

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -125,6 +125,10 @@ jobs:
           mkdir ${{ env.DIST_DIR }}
           cp ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/${{ env.BUILD_FILE_NAME }}.exe ${{ env.DIST_DIR }}/
           ls -l ${{ env.DIST_DIR }}/
+          ls -l ${{ env.BUILD_DIR }}/
+          ls -l ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/
+          ls -l ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/
+
       
       - name: Upload GitHub Artifacts
         if: ${{ inputs.upload_to_github }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -120,6 +120,16 @@ jobs:
             --no-tests=error `
             --output-junit ctest-results.xml
 
+      - name: Upload Test Logs (on failure)
+        if: steps.run_tests.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-windows-${{ matrix.os-version }}
+          path: |
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/Testing/Temporary/**
+          retention-days: 7
+
       - name: Prepare Distribution Artifacts
         run: |
           mkdir ${{ env.DIST_DIR }}
@@ -153,15 +163,5 @@ jobs:
       - name: Announce Test Failure
         if: steps.run_tests.outcome == 'failure'
         run: |
-          echo "Tests have failed!"
+          echo "Tests have failed! Please see uploaded CTest logs for more information"
           exit 1
-
-      - name: Upload Test Logs (on failure)
-        if: steps.run_tests.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-logs-windows-${{ matrix.os-version }}
-          path: |
-            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/ctest-results.xml
-            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/Testing/Temporary/**
-          retention-days: 7

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -162,6 +162,6 @@ jobs:
         with:
           name: test-logs-windows-${{ matrix.os-version }}
           path: |
-            ${{ env.BUILD_DIR }}/ctest-results.xml
-            ${{ env.BUILD_DIR }}/Testing/Temporary/**
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/ctest-results.xml
+            ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/Testing/Temporary/**
           retention-days: 1


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
These changes will enable uploading of CTest log files when the CTests have failed.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated all of the `ci-*.yml` workflow files to include test log upload support
  - New step `Upload Test Logs (on failure)` that uploads an artifact of the test logs for runs where the CTests have failed
    - 7 Day Retention, open to changing if desired
  - Updated echo statement in ` Announce Test Failure` step to reference uploaded log files

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Test out all OS distro combinations to ensure logs are successfully uploaded (temp change to always run upload)
  - https://github.com/ROCm/roc-optiq/actions/runs/25742568544

## Test Result

<!-- Briefly summarize test outcomes. -->
Test logs were uploaded successfully.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
