### PR TITLE
[AIPROFVIS-65] Queue Utilization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ src/view/src/icons/rocprofvis_icon_data.h
 sqlite3.c
 
 .DS_Store
+
+CLAUDE.md
+.claude/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(VIEW_FILES
     src/view/src/model/rocprofvis_tables_model.cpp
     src/view/src/model/rocprofvis_summary_model.cpp
     src/view/src/model/rocprofvis_event_model.cpp
+    src/view/src/model/rocprofvis_analysis_model.cpp
     src/view/src/model/rocprofvis_trace_data_model.cpp
     src/view/src/rocprofvis_raw_track_data.cpp
     src/view/src/rocprofvis_events.cpp

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND rocprofvis_controller_source_files
     src/rocprofvis_controller_table.cpp    
     src/rocprofvis_controller.cpp    
     src/rocprofvis_controller_job_system.cpp	
+	src/rocprofvis_controller_analysis.cpp
     src/system/rocprofvis_controller_event.cpp
     src/system/rocprofvis_controller_graph.cpp
     src/system/rocprofvis_controller_sample.cpp

--- a/src/controller/inc/rocprofvis_controller_enums.h
+++ b/src/controller/inc/rocprofvis_controller_enums.h
@@ -638,7 +638,6 @@ typedef enum rocprofvis_controller_table_arguments_t : uint32_t
     kRPVControllerTableArgsOpTypesIndexed            = 0xE000000E,
     kRPVControllerTableArgsNumStringTableFilters     = 0xE000000F,
     kRPVControllerTableArgsStringTableFiltersIndexed = 0xE0000010,
-    kRPVControllerTableArgsSummary                   = 0xE0000011,   
 } rocprofvis_controller_table_arguments_t;
 
 typedef enum rocprofvis_controller_table_type_t

--- a/src/controller/src/rocprofvis_controller.cpp
+++ b/src/controller/src/rocprofvis_controller.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_controller.h"
+#include "rocprofvis_controller_analysis.h"
 #include "rocprofvis_controller_reference.h"
-#include "rocprofvis_controller_data.h"
 #include "rocprofvis_controller_handle.h"
 #include "rocprofvis_controller_array.h"
 #include "rocprofvis_controller_future.h"
@@ -13,7 +13,6 @@
 #include "rocprofvis_core_assert.h"
 #include "system/rocprofvis_controller_event.h"
 #include "system/rocprofvis_controller_sample.h"
-#include "system/rocprofvis_controller_sample_lod.h"
 #include "system/rocprofvis_controller_track.h"
 #include "system/rocprofvis_controller_timeline.h"
 #include "system/rocprofvis_controller_trace_system.h"

--- a/src/controller/src/rocprofvis_controller_analysis.cpp
+++ b/src/controller/src/rocprofvis_controller_analysis.cpp
@@ -1,0 +1,289 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_controller_analysis.h"
+#include "rocprofvis_controller_future.h"
+#include "rocprofvis_controller_reference.h"
+#include "system/rocprofvis_controller_trace_system.h"
+#include "system/rocprofvis_controller_track.h"
+#include "rocprofvis_core_assert.h"
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace RocProfVis
+{
+namespace Controller
+{
+
+typedef Reference<rocprofvis_controller_future_t, Future, kRPVControllerObjectTypeFuture> FutureRef;
+typedef Reference<rocprofvis_controller_t, SystemTrace, kRPVControllerObjectTypeControllerSystem> SystemTraceRef;
+typedef Reference<rocprofvis_controller_track_t, Track, kRPVControllerObjectTypeTrack> TrackRef;
+
+}  // namespace Controller
+}
+
+extern "C"
+{
+
+rocprofvis_result_t rocprofvis_controller_analysis_fetch_queue_utilization(rocprofvis_controller_t* controller, rocprofvis_controller_track_t* track, double start_time, double end_time, rocprofvis_controller_future_t* result, double* output)
+{
+    rocprofvis_result_t error = kRocProfVisResultInvalidArgument;
+    RocProfVis::Controller::SystemTraceRef trace(controller);
+    RocProfVis::Controller::TrackRef track_ref(track);
+    RocProfVis::Controller::FutureRef future(result);
+    if(trace.IsValid() && future.IsValid() && track_ref.IsValid() && output)
+    {
+        error = RocProfVis::Controller::Analysis::GetInstance().AsyncFetchQueueUtilization(trace.Get(), track_ref.Get(), start_time, end_time, output, future.Get());
+    }
+    return error;
+}
+
+}
+
+namespace RocProfVis
+{
+namespace Controller
+{
+
+Analysis& Analysis::GetInstance()
+{
+    static Analysis instance;
+    return instance;
+}
+
+Analysis::Analysis()
+{}
+
+Analysis::~Analysis()
+{}
+
+rocprofvis_result_t Analysis::AsyncFetchQueueUtilization(SystemTrace* trace, Track* track, double start, double end, double* output, Future* future) const
+{
+    rocprofvis_result_t result = kRocProfVisResultUnknownError;
+    future->Set(JobSystem::Get().IssueJob([this, trace, track, start, end, output](Future* future) -> rocprofvis_result_t {
+        rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
+        rocprofvis_handle_t* queue_handle = nullptr;
+        result = track->GetObject(kRPVControllerTrackQueue, 0, &queue_handle);
+        ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+        if(queue_handle)
+        {
+            uint64_t track_id = 0;
+            result = track->GetUInt64(kRPVControllerTrackId, 0, &track_id);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            rocprofvis_dm_database_t db = rocprofvis_dm_get_property_as_handle(trace->GetDMHandle(), kRPVDMDatabaseHandle, 0);
+            ROCPROFVIS_ASSERT(db);
+            char* query = nullptr;
+            double busy_duration = 0.0;
+            uint64_t event_count = 0;
+            rocprofvis_dm_result_t dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseAnalysis, start, end, 1, (rocprofvis_db_track_selection_t)&track_id, nullptr, nullptr,
+                                                                                "SUM(duration) AS total_duration, COUNT(*) AS event_count", "__trackId",
+                                                                                nullptr, kRPVDMSortOrderAsc, 0, nullptr, 0, 0, false, &query);
+            if(dm_result == kRocProfVisDmResultSuccess && strlen(query) > 0)
+            {
+                result = ExecuteQuery(trace, query, "Coarse queue utilization", *future, [start, end, &busy_duration, &event_count](const QueryDataStore& store) -> rocprofvis_result_t {
+                    rocprofvis_result_t result = kRocProfVisResultUnknownError;
+                    if(store.rows.size() == 1 && store.columns.count("total_duration") > 0 && store.columns.count("event_count") > 0)
+                    {
+                        const char* duration = store.rows[0][store.columns.at("total_duration")];
+                        const char* count = store.rows[0][store.columns.at("event_count")];
+                        if(duration && strlen(duration) > 0 && count && strlen(count) > 0)
+                        {
+                            busy_duration = strtod(duration, NULL);
+                            event_count = strtoull(count, NULL, 10);
+                            result = kRocProfVisResultSuccess;                        
+                        }
+                    }
+                    return result;
+                });
+            }
+            free(query);
+            if(dm_result == kRocProfVisDmResultSuccess && result == kRocProfVisResultSuccess && event_count > 0)
+            {
+                dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseAnalysis, start, end, 1, (rocprofvis_db_track_selection_t)&track_id, nullptr, nullptr, nullptr, nullptr,
+                                                                                nullptr, kRPVDMSortOrderAsc, 0, nullptr, 1, 0, false, &query);
+                if(dm_result == kRocProfVisDmResultSuccess && strlen(query) > 0)
+                {
+                    result = ExecuteQuery(trace, query, "Fine queue utilization", *future, [start, end, &busy_duration](const QueryDataStore& store) -> rocprofvis_result_t {
+                        rocprofvis_result_t result = kRocProfVisResultUnknownError;
+                        if(store.rows.size() == 1 && store.columns.count("start") > 0)
+                        {
+                            const char* data = store.rows[0][store.columns.at("start")];
+                            if(data && strlen(data) > 0)
+                            {
+                                double head = strtod(data, NULL);
+                                if(head < start)
+                                {
+                                    busy_duration -= (start - head);
+                                }
+                                result = kRocProfVisResultSuccess;                        
+                            }
+                        }
+                        return result;
+                    });
+                }
+                free(query);
+                dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseAnalysis, start, end, 1, (rocprofvis_db_track_selection_t)&track_id, nullptr, nullptr, nullptr, nullptr,
+                                                                                    nullptr, kRPVDMSortOrderAsc, 0, nullptr, 1, event_count - 1, false, &query);
+                if(dm_result == kRocProfVisDmResultSuccess && strlen(query) > 0)
+                {
+                    result = ExecuteQuery(trace, query, "Fine queue utilization", *future, [start, end, &busy_duration](const QueryDataStore& store) -> rocprofvis_result_t {
+                        rocprofvis_result_t result = kRocProfVisResultUnknownError;
+                        if(store.rows.size() == 1 && store.columns.count("end") > 0)
+                        {
+                            const char* data = store.rows[0][store.columns.at("end")];
+                            if(data && strlen(data) > 0)
+                            {
+                                double tail = strtod(data, NULL);
+                                if(end < tail)
+                                {
+                                    busy_duration -= (tail - end);
+                                }
+                                result = kRocProfVisResultSuccess;                        
+                            }
+                        }
+                        return result;
+                    });
+                }
+                free(query);
+            }
+            if(dm_result == kRocProfVisDmResultSuccess)
+            {
+                if(result == kRocProfVisResultSuccess)
+                {
+                    *output = busy_duration / (end - start) * 100.0;
+                }
+                else if(result == kRocProfVisResultNotLoaded)
+                {
+                    *output = 0.0;
+                    result = kRocProfVisResultSuccess;
+                }
+            }
+        }
+        return future->IsCancelled() ? kRocProfVisResultCancelled : result;
+    }, future));
+    if(future->IsValid())
+    {
+        result = kRocProfVisResultSuccess;
+    }
+    return result;
+}
+
+rocprofvis_result_t Analysis::ExecuteQuery(Trace* trace, const char* query, const char* description, Future& future, QueryCallback callback) const
+{
+    rocprofvis_result_t result = kRocProfVisResultUnknownError;
+    ROCPROFVIS_ASSERT(trace && query && description);
+    rocprofvis_dm_handle_t dm_handle = trace->GetDMHandle();
+    ROCPROFVIS_ASSERT(dm_handle);
+    rocprofvis_dm_database_t db = rocprofvis_dm_get_property_as_handle(dm_handle, kRPVDMDatabaseHandle, 0);
+    ROCPROFVIS_ASSERT(db);
+    rocprofvis_db_future_t object2wait = rocprofvis_db_future_alloc(nullptr);
+    if(object2wait)
+    {
+        rocprofvis_dm_table_id_t table_id = 0;
+        rocprofvis_dm_result_t dm_result = rocprofvis_db_execute_query_async(db, query, description, object2wait, &table_id);
+        if(dm_result == kRocProfVisDmResultSuccess)
+        {
+            future.AddDependentFuture(object2wait);
+            dm_result = rocprofvis_db_future_wait(object2wait, UINT64_MAX);
+            if(dm_result == kRocProfVisDmResultSuccess)
+            {
+                uint64_t num_tables = rocprofvis_dm_get_property_as_uint64(dm_handle, kRPVDMNumberOfTablesUInt64, 0);
+                if(num_tables > 0)
+                {
+                    rocprofvis_dm_table_t table = rocprofvis_dm_get_property_as_handle(dm_handle, kRPVDMTableHandleByID, table_id);
+                    if(table)
+                    {
+                        if(future.IsCancelled())
+                        {
+                            result = kRocProfVisResultCancelled;
+                        }
+                        else
+                        {
+                            const char* table_query = rocprofvis_dm_get_property_as_charptr(table, kRPVDMExtTableQueryCharPtr, 0);
+                            uint64_t num_rows = rocprofvis_dm_get_property_as_uint64(table, kRPVDMNumberOfTableRowsUInt64, 0);
+                            uint64_t num_columns = rocprofvis_dm_get_property_as_uint64(table, kRPVDMNumberOfTableColumnsUInt64, 0);
+                            if(table_query && strcmp(table_query, query) == 0)
+                            {
+                                QueryDataStore data_store;
+                                for(uint64_t c = 0; c < num_columns; c++)
+                                {
+                                    data_store.columns[rocprofvis_dm_get_property_as_charptr(table, kRPVDMExtTableColumnNameCharPtrIndexed, c)] = c;
+                                }
+                                data_store.rows.resize(num_rows);
+                                bool rows_ok = true;
+                                for(uint64_t r = 0; r < num_rows && rows_ok; r++)
+                                {
+                                    rocprofvis_dm_table_row_t table_row = rocprofvis_dm_get_property_as_handle(table, kRPVDMExtTableRowHandleIndexed, r);
+                                    if(table_row)
+                                    {
+                                        uint64_t num_cells = rocprofvis_dm_get_property_as_uint64(table_row, kRPVDMNumberOfTableRowCellsUInt64, 0);
+                                        if(num_cells == num_columns)
+                                        {
+                                            data_store.rows[r].resize(num_columns);
+                                            for(uint64_t c = 0; c < num_columns; c++)
+                                            {
+                                                data_store.rows[r][c] = rocprofvis_dm_get_property_as_charptr(table_row, kRPVDMExtTableRowCellValueCharPtrIndexed, c);
+                                            }
+                                        }
+                                        else
+                                        {
+                                            rows_ok = false;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        rows_ok = false;
+                                    }
+                                }
+                                if(rows_ok)
+                                {
+                                    result = callback(data_store);
+                                }
+                                else
+                                {
+                                    result = kRocProfVisResultUnknownError;
+                                }
+                            }
+                            else
+                            {
+                                result = kRocProfVisResultUnknownError;
+                            }
+                        }
+                        rocprofvis_dm_delete_table_at(dm_handle, table_id);
+                    }
+                    else
+                    {
+                        result = kRocProfVisResultUnknownError;
+                    }
+                }
+                else
+                {
+                    result = kRocProfVisResultUnknownError;
+                }
+            }
+            else if(dm_result == kRocProfVisDmResultDbAccessFailed)
+            {
+                result = kRocProfVisResultNotLoaded;
+            }
+            else
+            {
+                result = kRocProfVisResultUnknownError;
+            }
+            future.RemoveDependentFuture(object2wait);
+        }
+        else
+        {
+            result = kRocProfVisResultUnknownError;
+        }
+        rocprofvis_db_future_free(object2wait);
+    }
+    else
+    {
+        result = kRocProfVisResultMemoryAllocError;
+    }
+    return result;
+}
+
+}
+}

--- a/src/controller/src/rocprofvis_controller_analysis.h
+++ b/src/controller/src/rocprofvis_controller_analysis.h
@@ -1,0 +1,65 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocprofvis_controller.h"
+#include <functional>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+* Calculates the queue utilization for the specified track within the given time range.
+* @param controller The system trace controller instance.
+* @param track The handle track to analyze.
+* @param start_time The start time in ns of the analysis range.
+* @param end_time The end time in ns of the analysis range.
+* @param result The future object to store the result.
+* @param output The output value to write the queue utilization.
+* @returns kRocProfVisResultSuccess or an error code.
+*/
+rocprofvis_result_t rocprofvis_controller_analysis_fetch_queue_utilization(rocprofvis_controller_t* controller, rocprofvis_controller_track_t* track, double start_time, double end_time, rocprofvis_controller_future_t* result, double* output);
+
+#ifdef __cplusplus
+}
+#endif
+
+namespace RocProfVis
+{
+namespace Controller
+{
+
+class Trace;
+class SystemTrace;
+class Future;
+class Track;
+
+struct QueryDataStore
+{
+    std::unordered_map<std::string_view, uint64_t> columns;
+    std::vector<std::vector<const char*>> rows;
+};
+typedef std::function<rocprofvis_result_t(const QueryDataStore&)> QueryCallback;
+
+class Analysis
+{
+public:
+    static Analysis& GetInstance();
+
+    rocprofvis_result_t AsyncFetchQueueUtilization(SystemTrace* trace, Track* track, double start, double end, double* output, Future* future) const;
+
+private:
+    Analysis();
+    ~Analysis();
+
+    rocprofvis_result_t ExecuteQuery(Trace* trace, const char* query, const char* description, Future& future, QueryCallback callback) const;
+};
+
+}
+}

--- a/src/controller/src/rocprofvis_controller_trace.cpp
+++ b/src/controller/src/rocprofvis_controller_trace.cpp
@@ -25,5 +25,11 @@ Trace::~Trace()
         rocprofvis_dm_delete_trace(m_dm_handle);
 }
 
+rocprofvis_dm_handle_t
+Trace::GetDMHandle() const
+{
+    return m_dm_handle;
+}
+
 }
 }

--- a/src/controller/src/rocprofvis_controller_trace.h
+++ b/src/controller/src/rocprofvis_controller_trace.h
@@ -27,6 +27,8 @@ public:
 
     virtual rocprofvis_result_t Load(Future& future) = 0;
 
+    rocprofvis_dm_handle_t GetDMHandle() const;
+
 protected:
     uint64_t              m_id;
     rocprofvis_dm_trace_t m_dm_handle;

--- a/src/controller/src/system/rocprofvis_controller_summary.cpp
+++ b/src/controller/src/system/rocprofvis_controller_summary.cpp
@@ -386,8 +386,9 @@ rocprofvis_result_t Summary::FetchCounterAverage(rocprofvis_dm_trace_t dm_handle
                             rocprofvis_dm_result_t dm_result = kRocProfVisDmResultUnknownError;
                             rocprofvis_dm_table_id_t table_id = 0;
                             char* query = nullptr;
-                            dm_result = rocprofvis_db_build_table_query(db, m_start_ts, m_end_ts, 1, (rocprofvis_db_track_selection_t)&track_id, nullptr, nullptr, 
-                                                                        nullptr, nullptr, nullptr, kRPVDMSortOrderAsc, 0, nullptr,  0, 0, false, true, &query);
+                            dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseSampleTrackTable, m_start_ts, m_end_ts, 1, (rocprofvis_db_track_selection_t)&track_id, nullptr, nullptr, 
+                                                                        "counter, AVG(value) AS avg_value, MIN(value) AS min_value, MAX(value) AS max_value", "counter", 
+                                                                        nullptr, kRPVDMSortOrderAsc, 0, nullptr,  0, 0, false, &query);
                             if(dm_result == kRocProfVisDmResultSuccess)
                             {
                                 dm_result = rocprofvis_db_execute_query_async(db, query, "Fetch counter summary", object2wait, &table_id);
@@ -530,8 +531,9 @@ rocprofvis_result_t Summary::FetchTopKernels(rocprofvis_dm_trace_t dm_handle, No
             rocprofvis_dm_charptr_t where = where_str.empty() ? nullptr : where_str.c_str();
             std::string sort_column = "total_duration";
             char* query = nullptr;
-            dm_result = rocprofvis_db_build_table_query(db, m_start_ts, m_end_ts, 1, (rocprofvis_db_track_selection_t)op, where, nullptr, nullptr, 
-                                                        nullptr, sort_column.c_str(), kRPVDMSortOrderDesc, 0, nullptr, 0, 0, false, true, &query);
+            dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseEventTrackTable, m_start_ts, m_end_ts, 1, (rocprofvis_db_track_selection_t)op, where, nullptr, 
+                                                        "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) AS total_duration", 
+                                                        "name", sort_column.c_str(), kRPVDMSortOrderDesc, 0, nullptr, 0, 0, false, &query);
             if(dm_result == kRocProfVisDmResultSuccess)
             {
                 dm_result = rocprofvis_db_execute_query_async(db, query, "Fetch kernel summary", object2wait, &table_id);

--- a/src/controller/src/system/rocprofvis_controller_table_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_table_system.cpp
@@ -18,10 +18,9 @@ typedef Reference<rocprofvis_controller_track_t, Track, kRPVControllerObjectType
 
 SystemTable::SystemTable(uint64_t id)
 : Table(id, __kRPVControllerTablePropertiesFirst, __kRPVControllerTablePropertiesLast)
-, m_summary(false)
+, m_use_case(kRPVDMTableUseCaseEventTrackTable)
 , m_start_ts(0)
 , m_end_ts(0)
-, m_track_type(kRPVControllerTrackTypeEvents)
 {
 }
 
@@ -36,7 +35,7 @@ void SystemTable::Reset()
     m_num_items = 0;
     m_sort_column = 0;
     m_sort_order = kRPVControllerSortOrderAscending;
-    m_summary = false;
+    m_use_case = kRPVDMTableUseCaseEventTrackTable;
     m_columns.clear();
     m_rows.clear();
     m_tracks.clear();
@@ -61,9 +60,9 @@ rocprofvis_result_t SystemTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t
 
         char* fetch_query = nullptr;
         rocprofvis_dm_result_t dm_result = rocprofvis_db_build_table_query(
-            db, m_start_ts, m_end_ts, m_tracks.size(), m_tracks.data(), m_where.c_str(),  m_filter.c_str(), m_group.c_str(), m_group_cols.c_str(), sort_column,
+            db, m_use_case, m_start_ts, m_end_ts, m_tracks.size(), m_tracks.data(), m_where.c_str(),  m_filter.c_str(), m_group.c_str(), m_group_cols.c_str(), sort_column,
             (rocprofvis_dm_sort_order_t)m_sort_order, m_string_table_filters_ptr.size(), m_string_table_filters_ptr.data(), 
-            count, index, false, m_summary, &fetch_query);
+            count, index, false, &fetch_query);
         rocprofvis_dm_table_id_t table_id = 0;
         if(dm_result == kRocProfVisDmResultSuccess)
         {
@@ -221,7 +220,7 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
         if(m_tracks.size() == query_args.m_tracks.size() && m_start_ts == query_args.m_start_ts &&
            m_end_ts == query_args.m_end_ts && m_where == query_args.m_where && m_filter == query_args.m_filter && 
            m_group == query_args.m_group && m_group_cols == query_args.m_group_cols && 
-           m_string_table_filters == query_args.m_string_table_filters && m_summary == query_args.m_summary)
+           m_string_table_filters == query_args.m_string_table_filters && m_use_case == query_args.m_use_case)
         {
             bool tracks_all_same = true;
             for (int i = 0; i < query_args.m_tracks.size(); i++)
@@ -243,7 +242,6 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
         m_tracks      = query_args.m_tracks;       
         m_start_ts    = query_args.m_start_ts;
         m_end_ts      = query_args.m_end_ts;
-        m_track_type  = query_args.m_track_type;
         m_where       = query_args.m_where;
         m_filter      = query_args.m_filter;
         m_group       = query_args.m_group;
@@ -253,7 +251,7 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
         {
             m_string_table_filters_ptr.push_back(filter.c_str());
         }
-        m_summary = query_args.m_summary;
+        m_use_case = query_args.m_use_case;
 
         if(result == kRocProfVisResultSuccess)
         {
@@ -266,9 +264,9 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
 
             char*                  count_query = nullptr;
             rocprofvis_dm_result_t dm_result   = rocprofvis_db_build_table_query(
-                db, m_start_ts, m_end_ts, m_tracks.size(), m_tracks.data(), m_where.c_str(), m_filter.c_str(), m_group.c_str(), m_group_cols.c_str(), nullptr,
+                db, m_use_case, m_start_ts, m_end_ts, m_tracks.size(), m_tracks.data(), m_where.c_str(), m_filter.c_str(), m_group.c_str(), m_group_cols.c_str(), nullptr,
                 (rocprofvis_dm_sort_order_t) m_sort_order, m_string_table_filters_ptr.size(), m_string_table_filters_ptr.data(), 
-                0, 0, true, m_summary, &count_query);
+                0, 0, true, &count_query);
             rocprofvis_dm_table_id_t table_id = 0;
             if(dm_result == kRocProfVisDmResultSuccess)
             {
@@ -381,9 +379,9 @@ rocprofvis_result_t SystemTable::ExportCSV(rocprofvis_dm_trace_t dm_handle, Argu
 
             char* query = nullptr;
             rocprofvis_dm_result_t dm_result = rocprofvis_db_build_table_query(
-                db, query_args.m_start_ts, query_args.m_end_ts, (rocprofvis_db_num_of_tracks_t)query_args.m_tracks.size(), query_args.m_tracks.data(), query_args.m_where.c_str(), 
+                db, m_use_case, query_args.m_start_ts, query_args.m_end_ts, (rocprofvis_db_num_of_tracks_t)query_args.m_tracks.size(), query_args.m_tracks.data(), query_args.m_where.c_str(), 
                 query_args.m_filter.c_str(), query_args.m_group.c_str(), query_args.m_group_cols.c_str(), sort_column, (rocprofvis_dm_sort_order_t)query_args.m_sort_order, 
-                (rocprofvis_dm_num_string_table_filters_t)string_table_filters_ptr.size(), string_table_filters_ptr.data(), 0, 0, false, query_args.m_summary, &query);
+                (rocprofvis_dm_num_string_table_filters_t)string_table_filters_ptr.size(), string_table_filters_ptr.data(), 0, 0, false, &query);
             if(dm_result == kRocProfVisDmResultSuccess)
             {
                 dm_result = rocprofvis_db_export_table_csv_async(db, query, path, object2wait);
@@ -494,8 +492,8 @@ SystemTable::UnpackArguments(Arguments& args, QueryArguments& out) const
     uint64_t num_string_table_filters = 0;
     std::vector<std::string> string_table_filters;
     std::vector<const char*> string_table_filters_ptr;
-    bool summary = false;
-    rocprofvis_controller_track_type_t track_type = kRPVControllerTrackTypeSamples;
+    rocprofvis_dm_table_use_case_enum_t use_case = kRPVDMTableUseCaseEventTrackTable;
+    rocprofvis_controller_track_type_t track_type = kRPVControllerTrackTypeEvents;
     uint64_t table_type = kRPVControllerTableTypeEvents;
 
     result = args.GetUInt64(kRPVControllerTableArgsType, 0, &table_type);
@@ -508,13 +506,13 @@ SystemTable::UnpackArguments(Arguments& args, QueryArguments& out) const
             case kRPVControllerTableTypeSummaryKernelInstances:
             {
                 track_type = kRPVControllerTrackTypeEvents;
-
+                use_case = kRPVDMTableUseCaseEventTrackTable;
                 break;
             }
             case kRPVControllerTableTypeSamples:
             {
                 track_type = kRPVControllerTrackTypeSamples;
-
+                use_case = kRPVDMTableUseCaseSampleTrackTable;
                 break;
             }
             default:
@@ -665,19 +663,13 @@ SystemTable::UnpackArguments(Arguments& args, QueryArguments& out) const
                     }
                 }
             }
+            if(!string_table_filters.empty())
+            {
+                use_case = kRPVDMTableUseCaseEventSearch;
+            }
         }
     }
-    if(result == kRocProfVisResultSuccess)
-    {
-        uint64_t summary_uint64 = 0;
-        result = args.GetUInt64(kRPVControllerTableArgsSummary, 0, &summary_uint64);
-        if(result == kRocProfVisResultSuccess)
-        {
-            summary = (bool)summary_uint64;
-        }
-    }
-
-    out = {where, filter, group, group_cols, sort_column, (rocprofvis_controller_sort_order_t)sort_order, tracks, track_type, std::move(string_table_filters), summary, start_ts, end_ts};
+    out = {where, filter, group, group_cols, sort_column, (rocprofvis_controller_sort_order_t)sort_order, tracks, std::move(string_table_filters), use_case, start_ts, end_ts};
     
 	return result;
 }

--- a/src/controller/src/system/rocprofvis_controller_table_system.h
+++ b/src/controller/src/system/rocprofvis_controller_table_system.h
@@ -48,9 +48,8 @@ private:
         uint64_t m_sort_column;
         rocprofvis_controller_sort_order_t m_sort_order;
         std::vector<uint32_t> m_tracks;
-        rocprofvis_controller_track_type_t m_track_type;
         std::vector<std::string> m_string_table_filters;
-        bool m_summary;
+        rocprofvis_dm_table_use_case_enum_t m_use_case;
         double m_start_ts;
         double m_end_ts;
     };
@@ -58,10 +57,9 @@ private:
     rocprofvis_result_t UnpackArguments(Arguments& args, QueryArguments& out) const;
 
     std::vector<uint32_t> m_tracks;
-    rocprofvis_controller_track_type_t m_track_type;
     std::vector<std::string> m_string_table_filters;
     std::vector<const char*> m_string_table_filters_ptr;
-    bool m_summary;
+    rocprofvis_dm_table_use_case_enum_t m_use_case;
     double m_start_ts;
     double m_end_ts;
 };

--- a/src/controller/tests/rocprofvis_controller_system_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_system_tests.cpp
@@ -657,10 +657,6 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
             args, kRPVControllerTableArgsGroupColumns, 0, "");
         REQUIRE(result == kRocProfVisResultSuccess);
 
-        result =
-            rocprofvis_controller_set_uint64(args, kRPVControllerTableArgsSummary, 0, 0);
-        REQUIRE(result == kRocProfVisResultSuccess);
-
         const uint64_t chunk_size  = 10000;
         uint64_t       num_columns = 0;
         uint64_t       num_rows    = 0;
@@ -959,10 +955,6 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
 
         result = rocprofvis_controller_set_string(
             args, kRPVControllerTableArgsGroupColumns, 0, "");
-        REQUIRE(result == kRocProfVisResultSuccess);
-
-        result =
-            rocprofvis_controller_set_uint64(args, kRPVControllerTableArgsSummary, 0, 0);
         REQUIRE(result == kRocProfVisResultSuccess);
 
         const uint64_t chunk_size  = 10000;
@@ -3064,10 +3056,6 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
 
         result = rocprofvis_controller_set_string(
             args, kRPVControllerTableArgsGroupColumns, 0, "");
-        REQUIRE(result == kRocProfVisResultSuccess);
-
-        result =
-            rocprofvis_controller_set_uint64(args, kRPVControllerTableArgsSummary, 0, 0);
         REQUIRE(result == kRocProfVisResultSuccess);
 
         result = rocprofvis_controller_set_uint64(args, kRPVControllerTableArgsStartIndex,

--- a/src/model/inc/rocprofvis_interface.h
+++ b/src/model/inc/rocprofvis_interface.h
@@ -158,7 +158,8 @@ rocprofvis_dm_result_t rocprofvis_db_build_compute_query(
 * @note caller is responsible for freeing out_query
 * ***************************************************************************************************/
 rocprofvis_dm_result_t rocprofvis_db_build_table_query(
-    rocprofvis_dm_database_t database, 
+    rocprofvis_dm_database_t database,
+    rocprofvis_dm_table_use_case_enum_t use_case,
     rocprofvis_dm_timestamp_t start,
     rocprofvis_dm_timestamp_t end, 
     rocprofvis_db_num_of_tracks_t num,
@@ -173,8 +174,7 @@ rocprofvis_dm_result_t rocprofvis_db_build_table_query(
     rocprofvis_dm_string_table_filters_t string_table_filters,
     uint64_t max_count, 
     uint64_t offset, 
-    bool count_only, 
-    bool summary,
+    bool count_only,
     char** out_query);
 
 /****************************************************************************************************

--- a/src/model/inc/rocprofvis_interface_types.h
+++ b/src/model/inc/rocprofvis_interface_types.h
@@ -393,6 +393,14 @@ typedef enum rocprofvis_dm_table_row_property_t {
     kRPVDMExtTableRowCellValueCharPtrIndexed
 } rocprofvis_dm_table_row_property_t;
 
+// Table use cases
+typedef enum rocprofvis_dm_table_use_case_enum_t {
+    kRPVDMTableUseCaseEventTrackTable,
+    kRPVDMTableUseCaseSampleTrackTable,
+    kRPVDMTableUseCaseEventSearch,
+    kRPVDMTableUseCaseAnalysis,
+} rocprofvis_dm_table_use_case_enum_t;
+
 // Type of data can be requested per event
 typedef enum rocprofvis_dm_event_property_type_t {
     // Flow trace

--- a/src/model/src/common/rocprofvis_c_interface.cpp
+++ b/src/model/src/common/rocprofvis_c_interface.cpp
@@ -295,15 +295,14 @@ rocprofvis_dm_result_t rocprofvis_db_read_trace_slice_async(
 }
 
 rocprofvis_dm_result_t rocprofvis_db_build_table_query(
-    rocprofvis_dm_database_t database, 
+    rocprofvis_dm_database_t database, rocprofvis_dm_table_use_case_enum_t use_case,
     rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end, 
     rocprofvis_db_num_of_tracks_t num, rocprofvis_db_track_selection_t tracks, 
     rocprofvis_dm_charptr_t where, rocprofvis_dm_charptr_t filter, 
     rocprofvis_dm_charptr_t group, rocprofvis_dm_charptr_t group_cols, 
     rocprofvis_dm_charptr_t sort_column, rocprofvis_dm_sort_order_t sort_order, 
     rocprofvis_dm_num_string_table_filters_t num_string_table_filters, rocprofvis_dm_string_table_filters_t string_table_filters, 
-    uint64_t max_count, uint64_t offset, 
-    bool count_only, bool summary, 
+    uint64_t max_count, uint64_t offset, bool count_only, 
     char** out_query)
 {
     PROFILE;
@@ -314,9 +313,8 @@ rocprofvis_dm_result_t rocprofvis_db_build_table_query(
                                  kRocProfVisDmResultInvalidParameter);
     RocProfVis::DataModel::Database* db = (RocProfVis::DataModel::Database*) database;
     std::string query;
-    rocprofvis_dm_result_t result = db->BuildTableQuery(start, end, num, tracks, where, filter, group, group_cols, sort_column, sort_order, 
-                                                        num_string_table_filters, string_table_filters, max_count, offset, count_only, 
-                                                        summary, query);
+    rocprofvis_dm_result_t result = db->BuildTableQuery(use_case, start, end, num, tracks, where, filter, group, group_cols, sort_column, sort_order, 
+                                                        num_string_table_filters, string_table_filters, max_count, offset, count_only, query);
     if (result == kRocProfVisDmResultSuccess)
     {
         char* ptr = (char*) calloc(query.length() + 1, 1);

--- a/src/model/src/database/rocprofvis_db.h
+++ b/src/model/src/database/rocprofvis_db.h
@@ -183,6 +183,7 @@ class Database
                                                                rocprofvis_dm_string_t& query) = 0;
 
        virtual rocprofvis_dm_result_t BuildTableQuery(
+                                                                rocprofvis_dm_table_use_case_enum_t use_case,
                                                                 rocprofvis_dm_timestamp_t start, 
                                                                 rocprofvis_dm_timestamp_t end,
                                                                 rocprofvis_db_num_of_tracks_t num, 
@@ -198,7 +199,6 @@ class Database
                                                                 uint64_t max_count, 
                                                                 uint64_t offset,
                                                                 bool count_only,
-                                                                bool summary,
                                                                 rocprofvis_dm_string_t& query) = 0;
 
 

--- a/src/model/src/database/rocprofvis_db_compute.h
+++ b/src/model/src/database/rocprofvis_db_compute.h
@@ -206,6 +206,7 @@ namespace DataModel
         }
 
         rocprofvis_dm_result_t BuildTableQuery(
+            rocprofvis_dm_table_use_case_enum_t use_case,
             rocprofvis_dm_timestamp_t start,
             rocprofvis_dm_timestamp_t end,
             rocprofvis_db_num_of_tracks_t num,
@@ -221,7 +222,6 @@ namespace DataModel
             uint64_t max_count,
             uint64_t offset,
             bool count_only,
-            bool summary,
             rocprofvis_dm_string_t& query) override {
             ROCPROFVIS_ASSERT_ALWAYS_MSG_RETURN("Compute database does not build table query", kRocProfVisDmResultNotSupported);
         }

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1111,20 +1111,18 @@ rocprofvis_dm_result_t ProfileDatabase::BuildSliceQuery(rocprofvis_dm_timestamp_
 
 rocprofvis_dm_result_t
 ProfileDatabase::BuildTableQuery(
+    rocprofvis_dm_table_use_case_enum_t use_case,
     rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end,
     rocprofvis_db_num_of_tracks_t num, rocprofvis_db_track_selection_t tracks, 
     rocprofvis_dm_charptr_t where, rocprofvis_dm_charptr_t filter,
     rocprofvis_dm_charptr_t group, rocprofvis_dm_charptr_t group_cols, 
     rocprofvis_dm_charptr_t sort_column, rocprofvis_dm_sort_order_t sort_order, 
     rocprofvis_dm_num_string_table_filters_t num_string_table_filters, rocprofvis_dm_string_table_filters_t string_table_filters,
-    uint64_t max_count, uint64_t offset, 
-    bool count_only, bool summary, 
+    uint64_t max_count, uint64_t offset, bool count_only, 
     rocprofvis_dm_string_t& query)
 {
     std::vector<slice_query_map_t> slice_query_map_array;
     table_string_id_filter_map_t string_id_filter_map;
-    std::string group_by_select;
-    std::string group_by;
     
     bool sample_query = false;
     if(TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == 0)
@@ -1134,22 +1132,6 @@ ProfileDatabase::BuildTableQuery(
     else
     {
         sample_query = (rocprofvis_dm_event_operation_t)TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == kRocProfVisDmOperationNoOp;
-    }
-
-    if(summary)
-    {
-        BuildTableSummaryClause(sample_query, group_by_select, group_by);
-    }
-    else
-    {
-        if(group && strlen(group))
-        {
-            group_by = group;
-            if(group_cols && strlen(group_cols))
-            {
-                group_by_select = group_cols;
-            }
-        }
     }
     rocprofvis_dm_result_t string_filter_result = BuildTableStringIdFilter(num_string_table_filters, string_table_filters, string_id_filter_map);
     slice_query_map_array.resize(num);
@@ -1299,26 +1281,56 @@ ProfileDatabase::BuildTableQuery(
 
         }
     }
-
+    if(query.empty())
+    {
+        return kRocProfVisDmResultSuccess;
+    }
     query += "-- CMD: TYPE ";
-    query += string_filter_result == kRocProfVisDmResultSuccess ? "2" : event_table ? "0" : "1";
+    switch(use_case)
+    {
+        case kRPVDMTableUseCaseEventTrackTable:
+        {
+            query += std::to_string(kRPVTableDataTypeEvent);
+            break;
+        }
+        case kRPVDMTableUseCaseSampleTrackTable:
+        {
+            query += std::to_string(kRPVTableDataTypeSample);
+            break;
+        }
+        case kRPVDMTableUseCaseEventSearch:
+        {
+            query += std::to_string(kRPVTableDataTypeSearch);
+            break;
+        }
+        case kRPVDMTableUseCaseAnalysis:
+        {
+            query += std::to_string(kRPVTableDataTypeAnalysis);
+            break;
+        }
+        default:
+        {
+            return kRocProfVisDmResultInvalidParameter; 
+            break;
+        }
+    }
     query += "\n";
 
-    if (!group_by.empty())
+    if(group && strlen(group))
     {
         query += "-- CMD: GROUP ";
-        if (!group_by_select.empty())
+        if (group_cols && strlen(group_cols))
         {
-            if (!FilterExpression::StartsWithSubstring(group_by_select, group_by))
+            if (!FilterExpression::StartsWithSubstring(group, group_cols))
             {
-                query += group_by;
+                query += group_cols;
                 query += ", ";
             }
-            query += group_by_select;
+            query += group;
         }
         else
         {
-            query += group_by;
+            query += group;
             if(sample_query)
             {
                 query += ", COUNT(*) as count, AVG(value) as avg_value, MIN(value) as "
@@ -1326,8 +1338,8 @@ ProfileDatabase::BuildTableQuery(
             }
             else
             {
-            query += ", COUNT(*) as num_invocations, AVG(duration) as avg_duration, "
-                "MIN(duration) as min_duration, MAX(duration) as max_duration";
+                query += ", COUNT(*) as num_invocations, AVG(duration) as avg_duration, "
+                         "MIN(duration) as min_duration, MAX(duration) as max_duration";
             }
         }
         query += "\n";

--- a/src/model/src/database/rocprofvis_db_profile.h
+++ b/src/model/src/database/rocprofvis_db_profile.h
@@ -72,7 +72,7 @@ class ProfileDatabase : public SqliteDatabase
         // @param path - full path to database file
         ProfileDatabase( rocprofvis_db_filename_t path) : 
                         SqliteDatabase(path), 
-            m_table_processor{TableProcessor(this),TableProcessor(this),TableProcessor(this)} {};
+            m_table_processor{TableProcessor(this),TableProcessor(this),TableProcessor(this), TableProcessor(this)} {};
         // ProfileDatabase destructor, must be defined as virtual to free resources of derived classes 
         virtual ~ProfileDatabase() {}
         // worker method to read time slice
@@ -145,11 +145,6 @@ class ProfileDatabase : public SqliteDatabase
             rocprofvis_dm_string_table_filters_t string_table_filters,
             table_string_id_filter_map_t& filter) = 0;
 
-        virtual rocprofvis_dm_result_t BuildTableSummaryClause(
-            bool sample_query,
-            rocprofvis_dm_string_t& select,
-            rocprofvis_dm_string_t& group_by) = 0;
-
         std::string GetHistogramQueryPrefix(uint64_t bucket_size);
         std::string GetHistogramQuerySuffix();
 
@@ -193,6 +188,7 @@ class ProfileDatabase : public SqliteDatabase
             rocprofvis_dm_index_t track_index, 
             rocprofvis_dm_string_t& query);
         rocprofvis_dm_result_t BuildTableQuery(
+                            rocprofvis_dm_table_use_case_enum_t use_case,
                             rocprofvis_dm_timestamp_t start, 
                             rocprofvis_dm_timestamp_t end,
                             rocprofvis_db_num_of_tracks_t num,
@@ -208,7 +204,6 @@ class ProfileDatabase : public SqliteDatabase
                             uint64_t max_count, 
                             uint64_t offset,
                             bool count_only,
-                            bool summary,
                             rocprofvis_dm_string_t& query) override;
 
         rocprofvis_dm_result_t ExecuteQueryForAllTracksAsync(

--- a/src/model/src/database/rocprofvis_db_rocpd.cpp
+++ b/src/model/src/database/rocprofvis_db_rocpd.cpp
@@ -784,24 +784,6 @@ rocprofvis_dm_result_t RocpdDatabase::StringIndexToId(rocprofvis_dm_index_t inde
     return result;
 }
 
-rocprofvis_dm_result_t
-RocpdDatabase::BuildTableSummaryClause(bool sample_query,
-                                 rocprofvis_dm_string_t& select,
-                                 rocprofvis_dm_string_t& group_by)
-{
-    if(sample_query)
-    {
-        select = "counter, AVG(value) AS avg_value, MIN(value) AS min_value, MAX(value) AS max_value";
-        group_by = "counter";
-    }
-    else
-    {
-        select = "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) AS total_duration";
-        group_by = "name";
-    }
-    return kRocProfVisDmResultSuccess;
-}
-
 rocprofvis_dm_result_t  RocpdDatabase::ReadFlowTraceInfo(
         rocprofvis_dm_event_id_t event_id,
         Future* future)

--- a/src/model/src/database/rocprofvis_db_rocpd.h
+++ b/src/model/src/database/rocprofvis_db_rocpd.h
@@ -87,10 +87,6 @@ public:
 
     int ProcessTrack(rocprofvis_dm_track_params_t& track_params, rocprofvis_dm_charptr_t*  newqueries) override;
     
-    rocprofvis_dm_result_t BuildTableSummaryClause(bool sample_query,
-                                             rocprofvis_dm_string_t& select,
-                                             rocprofvis_dm_string_t& group_by) override;
-    
 private:
 
     // sqlite3_exec callback to process string list query and add string object to Trace container

--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -1863,31 +1863,6 @@ rocprofvis_dm_string_t RocprofDatabase::GetEventOperationQuery(const rocprofvis_
     }
 }
 
-rocprofvis_dm_result_t
-RocprofDatabase::BuildTableSummaryClause(bool sample_query,
-                                   rocprofvis_dm_string_t& select,
-                                   rocprofvis_dm_string_t& group_by)
-{
-    if(sample_query)
-    {
-        select += Builder::COUNTER_ID_PUBLIC_NAME;
-        select += ", AVG(";
-        select += Builder::COUNTER_VALUE_PUBLIC_NAME;
-        select += ") AS avg_value, MIN(";
-        select += Builder::COUNTER_VALUE_PUBLIC_NAME;
-        select += ") AS min_value, MAX(";
-        select += Builder::COUNTER_VALUE_PUBLIC_NAME;
-        select += ") AS max_value";
-        group_by += Builder::COUNTER_ID_PUBLIC_NAME;
-    }
-    else
-    {
-        select = "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) AS total_duration";
-        group_by = "name";
-    }
-    return kRocProfVisDmResultSuccess;
-}
-
 rocprofvis_dm_result_t  RocprofDatabase::ReadStackTraceInfo(
         rocprofvis_dm_event_id_t event_id,
         Future* future)

--- a/src/model/src/database/rocprofvis_db_rocprof.h
+++ b/src/model/src/database/rocprofvis_db_rocprof.h
@@ -133,11 +133,6 @@ public:
 
     rocprofvis_dm_result_t RemapStringId(uint64_t id, rocprofvis_db_string_type_t type, uint32_t node, uint64_t & result) override;
 
-    rocprofvis_dm_result_t BuildTableSummaryClause(
-                                        bool sample_query,
-                                        rocprofvis_dm_string_t& select,
-                                        rocprofvis_dm_string_t& group_by) override;
-
 private:
     // sqlite3_exec callback to process string list query and add string object to Trace container
     // @param data - pointer to callback caller argument

--- a/src/model/src/database/rocprofvis_db_table_processor.h
+++ b/src/model/src/database/rocprofvis_db_table_processor.h
@@ -33,6 +33,7 @@ namespace DataModel
         kRPVTableDataTypeEvent,
         kRPVTableDataTypeSample,
         kRPVTableDataTypeSearch,
+        kRPVTableDataTypeAnalysis,
         kRPVTableDataTypesNum
     } rocprofvis_db_compound_table_type;
 

--- a/src/model/src/tests/rocprofvis_dm_system_tests.cpp
+++ b/src/model/src/tests/rocprofvis_dm_system_tests.cpp
@@ -702,8 +702,8 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisDMFixture, "System Trace Data-Model Tests
                                          "Record id={0}, timestamp={1}, op={2}, "
                                          "op_str={3}, type={4}, symbol={5}, "
                                          "level={6}",
-                                         event_id, timestamp, op, op_str, type_str, symbol_str,
-                                         event_level);
+                                         event_id, timestamp, op, op_str, type_str,
+                                         symbol_str, event_level);
 
                             spdlog::info("Testing multithreaded access to "
                                          "database retrieving flow, stack and "
@@ -794,8 +794,8 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisDMFixture, "System Trace Data-Model Tests
                                                            "event_id={2}, timestamp={3}, "
                                                            "end_ts={4}, category={5}, "
                                                            "symbol={6}, level={7}",
-                                        k, endpoint_track_id, event_id_num, event_timestamp,
-                                        end_timestamp,
+                                        k, endpoint_track_id, event_id_num,
+                                        event_timestamp, end_timestamp,
                                         endpoint_category ? endpoint_category : "(null)",
                                         endpoint_symbol ? endpoint_symbol : "(null)",
                                         endpoint_level);
@@ -1077,9 +1077,13 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisDMFixture, "System Trace Data-Model Tests
         std::string sort_column             = "total_duration";
         char*       built_query             = nullptr;
         rocprofvis_dm_result_t build_result = rocprofvis_db_build_table_query(
-            m_db, m_start_time, m_end_time, 1, (rocprofvis_db_track_selection_t) op,
-            nullptr, nullptr, nullptr, nullptr, sort_column.c_str(), kRPVDMSortOrderAsc,
-            0, nullptr, 0, 0, false, true, &built_query);
+            m_db, kRPVDMTableUseCaseEventTrackTable, m_start_time, m_end_time, 1,
+            (rocprofvis_db_track_selection_t) op, nullptr, nullptr,
+            "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, "
+            "MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) "
+            "AS total_duration",
+            "name", sort_column.c_str(), kRPVDMSortOrderDesc, 0, nullptr, 0, 0, false,
+            &built_query);
         REQUIRE(kRocProfVisDmResultSuccess == build_result);
         REQUIRE(built_query != nullptr);
 
@@ -1143,9 +1147,13 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisDMFixture, "System Trace Data-Model Tests
         std::string sort_column             = "total_duration";
         char*       csv_query               = nullptr;
         rocprofvis_dm_result_t build_result = rocprofvis_db_build_table_query(
-            m_db, m_start_time, m_end_time, 1, (rocprofvis_db_track_selection_t) op,
-            nullptr, nullptr, nullptr, nullptr, sort_column.c_str(), kRPVDMSortOrderAsc,
-            0, nullptr, 0, 0, false, true, &csv_query);
+            m_db, kRPVDMTableUseCaseEventTrackTable, m_start_time, m_end_time, 1,
+            (rocprofvis_db_track_selection_t) op, nullptr, nullptr,
+            "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, "
+            "MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) "
+            "AS total_duration",
+            "name", sort_column.c_str(), kRPVDMSortOrderDesc, 0, nullptr, 0, 0, false,
+            &csv_query);
         REQUIRE(kRocProfVisDmResultSuccess == build_result);
         REQUIRE(csv_query != nullptr);
 

--- a/src/view/src/model/rocprofvis_analysis_model.cpp
+++ b/src/view/src/model/rocprofvis_analysis_model.cpp
@@ -1,0 +1,74 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_analysis_model.h"
+
+namespace RocProfVis
+{
+namespace View
+{
+
+AnalysisModel::AnalysisModel()
+: m_analysis_range_start_ns(0.0)
+, m_analysis_range_end_ns(0.0)
+{}
+void
+AnalysisModel::SetAnalysisRange(double start_ns, double end_ns)
+{
+    if(m_analysis_range_start_ns != start_ns || m_analysis_range_end_ns != end_ns)
+    {
+        m_analysis_range_start_ns = start_ns;
+        m_analysis_range_end_ns   = end_ns;
+        for(std::pair<const uint64_t, AnalysisQueueUtilization>& queue :
+            m_per_track_queue_utilization)
+        {
+            queue.second.state = AnalysisQueueUtilization::kStale;
+        }
+    }
+}
+
+const AnalysisQueueUtilization*
+AnalysisModel::GetPerTrackQueueUtilization(const TrackInfo& track)
+{
+    if(track.topology.type == TrackInfo::TrackType::Queue)
+    {
+        if(m_per_track_queue_utilization.count(track.id) == 0)
+        {
+            AnalysisQueueUtilization* queue = &m_per_track_queue_utilization[track.id];
+            m_per_track_queue_utilization[track.id].track = &track;
+            queue->util_pct                               = 0.0;
+            queue->state = AnalysisQueueUtilization::kStale;
+        }
+        return &m_per_track_queue_utilization.at(track.id);
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
+void
+AnalysisModel::SetPerTrackQueueUtilizationValue(uint64_t track_id, double util_pct)
+{
+    AnalysisQueueUtilization& data = m_per_track_queue_utilization.at(track_id);
+    if(data.state == AnalysisQueueUtilization::State::kRequested)
+    {
+        data.util_pct = util_pct;
+        data.state    = AnalysisQueueUtilization::State::kReady;
+    }
+}
+
+void
+AnalysisModel::ClearPerTrackQueueUtilization()
+{
+    m_per_track_queue_utilization.clear();
+}
+
+void
+AnalysisModel::Clear()
+{
+    ClearPerTrackQueueUtilization();
+}
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/model/rocprofvis_analysis_model.h
+++ b/src/view/src/model/rocprofvis_analysis_model.h
@@ -1,0 +1,35 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include "rocprofvis_model_types.h"
+#include <cstdint>
+#include <unordered_map>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+class AnalysisModel
+{
+public:
+    AnalysisModel();
+    ~AnalysisModel() = default;
+
+    void SetAnalysisRange(double start_ns, double end_ns);
+
+    const AnalysisQueueUtilization* GetPerTrackQueueUtilization(const TrackInfo& track);
+    void SetPerTrackQueueUtilizationValue(uint64_t track_id, double util_pct);
+
+    void ClearPerTrackQueueUtilization();
+    void Clear();
+
+private:
+    double                                                 m_analysis_range_start_ns;
+    double                                                 m_analysis_range_end_ns;
+    std::unordered_map<uint64_t, AnalysisQueueUtilization> m_per_track_queue_utilization;
+};
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/model/rocprofvis_model_types.h
+++ b/src/view/src/model/rocprofvis_model_types.h
@@ -280,5 +280,19 @@ struct TableInfo
     uint64_t                              total_row_count;
 };
 
+struct AnalysisQueueUtilization
+{
+    enum State
+    {
+        kStale,      // Invalidated by user input
+        kPending,    // Pending fetch issue
+        kRequested,  // Pending fetch completion
+        kReady,
+    };
+    const TrackInfo* track;
+    double           util_pct;
+    mutable State    state;
+};
+
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/model/rocprofvis_trace_data_model.cpp
+++ b/src/view/src/model/rocprofvis_trace_data_model.cpp
@@ -100,6 +100,7 @@ TraceDataModel::Clear()
     m_tables.ClearAllTables();
     m_summary.Clear();
     m_events.ClearEvents();
+    m_analysis.Clear();
     m_trace_file_path.clear();
 }
 

--- a/src/view/src/model/rocprofvis_trace_data_model.h
+++ b/src/view/src/model/rocprofvis_trace_data_model.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "rocprofvis_analysis_model.h"
 #include "rocprofvis_event_model.h"
 #include "rocprofvis_model_types.h"
 #include "rocprofvis_summary_model.h"
@@ -47,6 +48,9 @@ public:
     const EventModel& GetEvents() const { return m_events; }
     EventModel&       GetEvents() { return m_events; }
 
+    const AnalysisModel& GetAnalysis() const { return m_analysis; }
+    AnalysisModel&       GetAnalysis() { return m_analysis; }
+
     // Trace file metadata
     const std::string& GetTraceFilePath() const { return m_trace_file_path; }
     void SetTraceFilePath(const std::string& path) { m_trace_file_path = path; }
@@ -63,6 +67,7 @@ private:
     TablesModel       m_tables;
     SummaryModel      m_summary;
     EventModel        m_events;
+    AnalysisModel     m_analysis;
 
     std::string m_trace_file_path;
 };

--- a/src/view/src/rocprofvis_analysis_view.cpp
+++ b/src/view/src/rocprofvis_analysis_view.cpp
@@ -79,6 +79,9 @@ AnalysisView::AnalysisView(DataProvider& dp, std::shared_ptr<TrackTopology> topo
     m_timeline_track_selection_changed_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kTimelineTrackSelectionChanged),
         time_line_selection_changed_handler);
+    m_timeline_range_selection_changed_token = EventManager::GetInstance()->Subscribe(
+        static_cast<int>(RocEvents::kTimelineTimeRangeChanged),
+        time_line_selection_changed_handler);
     m_timeline_event_selection_changed_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kTimelineEventSelectionChanged),
         time_line_selection_changed_handler);
@@ -90,6 +93,9 @@ AnalysisView::~AnalysisView()
     EventManager::GetInstance()->Unsubscribe(
         static_cast<int>(RocEvents::kTimelineTrackSelectionChanged),
         m_timeline_track_selection_changed_token);
+    EventManager::GetInstance()->Unsubscribe(
+        static_cast<int>(RocEvents::kTimelineTimeRangeChanged),
+        m_timeline_range_selection_changed_token);
     EventManager::GetInstance()->Unsubscribe(
         static_cast<int>(RocEvents::kTimelineEventSelectionChanged),
         m_timeline_event_selection_changed_token);
@@ -132,6 +138,22 @@ AnalysisView::HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e)
                     m_track_details->HandleTrackSelectionChanged(
                         selection_changed_event->GetTrackID(),
                         selection_changed_event->TrackSelected());
+                }
+            }
+        }
+        else if(event_type == RocEventType::kTimelineTimeRangeChangedEvent)
+        {
+            std::shared_ptr<TimeRangeSelectionChangedEvent> selection_changed_event =
+                std::static_pointer_cast<TimeRangeSelectionChangedEvent>(e);
+            if(selection_changed_event)
+            {
+                if(m_event_table)
+                {
+                    m_event_table->HandleTrackSelectionChanged();
+                }
+                if(m_sample_table)
+                {
+                    m_sample_table->HandleTrackSelectionChanged();
                 }
             }
         }

--- a/src/view/src/rocprofvis_analysis_view.h
+++ b/src/view/src/rocprofvis_analysis_view.h
@@ -43,6 +43,7 @@ private:
     std::shared_ptr<AnnotationView> m_annotation_view;
 
     EventManager::SubscriptionToken m_timeline_track_selection_changed_token;
+    EventManager::SubscriptionToken m_timeline_range_selection_changed_token;
     EventManager::SubscriptionToken m_timeline_event_selection_changed_token;
 };
 

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -4,6 +4,7 @@
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_common_defs.h"
 #include "rocprofvis_controller.h"
+#include "rocprofvis_controller_analysis.h"
 #include "rocprofvis_core_assert.h"
 #include "rocprofvis_events.h"
 
@@ -1485,10 +1486,6 @@ DataProvider::SetupCommonTableArguments(rocprofvis_controller_arguments_t* args,
                                               0, table_params.m_group_columns.data());
     ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
 
-    result = rocprofvis_controller_set_uint64(args, kRPVControllerTableArgsSummary, 0,
-                                              table_params.m_summary ? 1 : 0);
-    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-
     if(table_params.m_start_row != -1)
     {
         result = rocprofvis_controller_set_uint64(args, kRPVControllerTableArgsStartIndex,
@@ -2102,6 +2099,57 @@ DataProvider::FetchSummary()
 }
 
 bool
+DataProvider::FetchAnalysisQueueUtilization(
+    const AnalysisQueueUtilizationRequestParams& params)
+{
+    if(m_state != ProviderState::kReady)
+    {
+        spdlog::warn("Cannot fetch, provider not ready or error, state: {}",
+                     static_cast<int>(m_state));
+        return false;
+    }
+    else
+    {
+        uint64_t request_id = RequestIdBuilder::MakeTrackDataRequestId(
+            static_cast<uint32_t>(params.m_track_id), 0, 0,
+            RequestType::kFetchAnalysisQueueUtilization);
+        auto it = m_requests.find(request_id);
+        if(it != m_requests.end())
+        {
+            spdlog::debug(
+                "Per-track queue utilization request for track {} is already pending",
+                params.m_track_id);
+            return false;
+        }
+        else
+        {
+            const TrackInfo* metadata = m_model.GetTimeline().GetTrack(params.m_track_id);
+            ROCPROFVIS_ASSERT(metadata);
+            rocprofvis_controller_track_t* track_handle = nullptr;
+            rocprofvis_result_t            result = rocprofvis_controller_get_object(
+                metadata->graph_handle, kRPVControllerGraphTrack, 0, &track_handle);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess && track_handle);
+            rocprofvis_controller_future_t* future = rocprofvis_controller_future_alloc();
+            ROCPROFVIS_ASSERT(future);
+            std::shared_ptr<AnalysisQueueUtilizationRequestParams> stored_params =
+                std::make_shared<AnalysisQueueUtilizationRequestParams>(params);
+            m_requests.emplace(request_id,
+                               RequestInfo{ request_id, future, nullptr, nullptr, nullptr,
+                                            RequestState::kLoading,
+                                            RequestType::kFetchAnalysisQueueUtilization,
+                                            stored_params });
+            result = rocprofvis_controller_analysis_fetch_queue_utilization(
+                m_trace_controller, track_handle, stored_params->m_start_ts,
+                stored_params->m_end_ts, future, &stored_params->m_result);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            spdlog::debug("Fetching per-track queue utilization for track {}",
+                          stored_params->m_track_id);
+            return true;
+        }
+    }
+}
+
+bool
 DataProvider::IsRequestPending(uint64_t request_id) const
 {
     auto it = m_requests.find(request_id);
@@ -2692,6 +2740,11 @@ DataProvider::ProcessRequest(RequestInfo& req)
             ProcessSummaryRequest(req);
             break;
         }
+        case RequestType::kFetchAnalysisQueueUtilization:
+        {
+            ProcessAnalysisQueueUtilizationRequest(req);
+            break;
+        }
 #ifdef COMPUTE_UI_SUPPORT
         case RequestType::kFetchComputeTrace:
         {
@@ -2768,6 +2821,27 @@ DataProvider::ProcessSummaryRequest(RequestInfo& req)
     if(m_summary_data_ready_callback)
     {
         m_summary_data_ready_callback();
+    }
+}
+
+void
+DataProvider::ProcessAnalysisQueueUtilizationRequest(RequestInfo& req)
+{
+    std::shared_ptr<AnalysisQueueUtilizationRequestParams> params =
+        std::dynamic_pointer_cast<AnalysisQueueUtilizationRequestParams>(req.custom_params);
+    if(!params)
+    {
+        spdlog::error("Queue utilization params missing or invalid");
+    }
+    else if(req.response_code != kRocProfVisResultSuccess)
+    {
+        spdlog::debug("Queue utilization request for track {} failed with code {}",
+                      params->m_track_id, req.response_code);
+    }
+    else
+    {
+        m_model.GetAnalysis().SetPerTrackQueueUtilizationValue(params->m_track_id,
+                                                               params->m_result);
     }
 }
 

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -184,6 +184,9 @@ public:
 
     bool FetchSummary();
 
+    bool FetchAnalysisQueueUtilization(
+        const AnalysisQueueUtilizationRequestParams& params);
+
     bool IsRequestPending(uint64_t request_id) const;
 
     /* Cancels a pending request.
@@ -283,6 +286,7 @@ private:
     void ProcessSaveTrimmedTraceRequest(RequestInfo& req);
     void ProcessCleanupDatabaseRequest(RequestInfo& req);
     void ProcessSummaryRequest(RequestInfo& req);
+    void ProcessAnalysisQueueUtilizationRequest(RequestInfo& req);
 
     bool SetupCommonTableArguments(rocprofvis_controller_arguments_t* args,
                                    const TableRequestParams&          table_params);

--- a/src/view/src/rocprofvis_events.cpp
+++ b/src/view/src/rocprofvis_events.cpp
@@ -233,6 +233,26 @@ TrackSelectionChangedEvent::TrackSelected() const
     return m_selected;
 }
 
+TimeRangeSelectionChangedEvent::TimeRangeSelectionChangedEvent(
+    double start_ns, double end_ns, const std::string& source_id)
+: RocEvent(static_cast<int>(RocEvents::kTimelineTimeRangeChanged), source_id)
+, m_start_ns(start_ns)
+, m_end_ns(end_ns)
+{
+    m_event_type = RocEventType::kTimelineTimeRangeChangedEvent;
+}
+
+double
+TimeRangeSelectionChangedEvent::GetStartNs() const
+{
+    return m_start_ns;
+}
+
+double
+TimeRangeSelectionChangedEvent::GetEndNs() const
+{
+    return m_end_ns;
+}
 
 ScrollToTrackEvent::ScrollToTrackEvent(int event_id, const uint64_t& track_id,
                                        const std::string& source_id)

--- a/src/view/src/rocprofvis_events.h
+++ b/src/view/src/rocprofvis_events.h
@@ -19,6 +19,7 @@ enum class RocEvents
     kTabClosed,
     kTabSelected,
     kTimelineTrackSelectionChanged,
+    kTimelineTimeRangeChanged,
     kTimelineEventSelectionChanged,
     kTimelineEventHighlightChanged,
     kHandleUserGraphNavigationEvent,
@@ -45,6 +46,7 @@ enum class RocEventType
     kTableDataEvent,
     kTabEvent,
     kTimelineTrackSelectionChangedEvent,
+    kTimelineTimeRangeChangedEvent,
     kTimelineEventSelectionChangedEvent,
     kTimelineEventHighlightChangedEvent,
     kScrollToTrackEvent,
@@ -256,6 +258,19 @@ public:
 private:
     uint64_t m_track_id;
     bool     m_selected;
+};
+
+class TimeRangeSelectionChangedEvent : public RocEvent
+{
+public:
+    TimeRangeSelectionChangedEvent(double start_ns, double end_ns,
+                                  const std::string& source_id);
+    double GetStartNs() const;
+    double GetEndNs() const;
+
+private:
+    double m_start_ns;
+    double m_end_ns;
 };
 
 class EventSelectionChangedEvent : public RocEvent

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -23,12 +23,13 @@ namespace RocProfVis
 namespace View
 {
 
-inline constexpr float MIN_LABEL_WIDTH          = 40.0f;
-inline constexpr float HIGHLIGHT_THICKNESS      = 4.0f;
-inline constexpr float HIGHLIGHT_THICKNESS_HALF = HIGHLIGHT_THICKNESS / 2;
-inline constexpr float TOOLTIP_OFFSET           = 16.0f;
-inline constexpr int   MAX_CHARACTERS_PER_LINE  = 40;
-inline constexpr float MAX_TABLE_HEIGHT         = 300.0f;
+inline constexpr float MIN_LABEL_WIDTH           = 40.0f;
+inline constexpr float HIGHLIGHT_THICKNESS       = 4.0f;
+inline constexpr float HIGHLIGHT_THICKNESS_HALF  = HIGHLIGHT_THICKNESS / 2;
+inline constexpr float TOOLTIP_OFFSET            = 16.0f;
+inline constexpr int   MAX_CHARACTERS_PER_LINE   = 40;
+inline constexpr float MAX_TABLE_HEIGHT          = 300.0f;
+inline constexpr float SCALE_SEPERATOR_WIDTH     = 2.0f;
 
 /*
 For IMGUI rectangle borders ANTI_ALIASING_WORKAROUND is needed to avoid anti-aliasing
@@ -61,23 +62,27 @@ FlameTrackItem::FlameTrackItem(DataProvider&                      dp,
 , m_tooltip_size(0.0f, 0.0f)
 , m_is_expanded(false)
 , m_compact_mode(false)
+, m_queue_utilization(nullptr)
 {
     if(!m_tpt)
     {
         spdlog::error("FlameTrackItem: m_tpt shared_ptr is null, cannot construct");
         return;
     }
-    const TrackInfo* track_info =
-        m_data_provider.DataModel().GetTimeline().GetTrack(m_track_id);
 
-    if(!track_info)
+    if(m_track_metadata)
     {
-        spdlog::error("FlameTrackItem: TrackInfo is null for track_id {}", m_track_id);
-        return;
-    }
+        m_min_level = static_cast<float>(m_track_metadata->min_value);
+        m_max_level = static_cast<float>(m_track_metadata->max_value);
 
-    m_min_level = static_cast<float>(track_info->min_value);
-    m_max_level = static_cast<float>(track_info->max_value);
+        if(m_track_metadata->topology.type == TrackInfo::TrackType::Queue)
+        {
+            m_meta_area_scale_width = CalculateNewMetaAreaSize();
+            m_queue_utilization =
+                m_data_provider.DataModel().GetAnalysis().GetPerTrackQueueUtilization(
+                    *m_track_metadata);
+        }
+    }
 
     auto time_line_selection_changed_handler = [this](std::shared_ptr<RocEvent> e) {
         this->HandleTimelineSelectionChanged(e);
@@ -757,7 +762,42 @@ FlameTrackItem::RenderChart(float graph_width)
 
 void
 FlameTrackItem::RenderMetaAreaScale()
-{}
+{
+    if(m_track_metadata &&
+       m_track_metadata->topology.type == TrackInfo::TrackType::Queue &&
+       m_queue_utilization)
+    {
+        ImVec2 content_region = ImGui::GetContentRegionMax();
+        ImVec2 window_pos     = ImGui::GetWindowPos();
+        ImGui::SetCursorPos(ImVec2(content_region.x - m_meta_area_scale_width +
+                                       m_metadata_padding.x + SCALE_SEPERATOR_WIDTH,
+                                   m_metadata_padding.y));
+        ImGui::BeginDisabled(m_queue_utilization->state !=
+                             AnalysisQueueUtilization::kReady);
+        ImGui::Text("%.1f%%", m_queue_utilization->util_pct);
+        ImGui::EndDisabled();
+        ImGui::GetWindowDrawList()->AddLine(
+            ImVec2(window_pos.x + content_region.x - m_meta_area_scale_width,
+                   window_pos.y),
+            ImVec2(window_pos.x + content_region.x - m_meta_area_scale_width,
+                   window_pos.y + content_region.y),
+            m_settings.GetColor(Colors::kMetaDataSeparator), SCALE_SEPERATOR_WIDTH);
+    }
+}
+
+float
+FlameTrackItem::CalculateNewMetaAreaSize()
+{
+    if(m_track_metadata && m_track_metadata->topology.type == TrackInfo::TrackType::Queue)
+    {
+        return ImGui::CalcTextSize("888.8%").x + 2.0f * m_metadata_padding.x +
+               SCALE_SEPERATOR_WIDTH;
+    }
+    else
+    {
+        return 0.0f;
+    }
+}
 
 void
 FlameTrackItem::RenderMetaAreaOptions()
@@ -792,6 +832,48 @@ FlameTrackItem::RenderMetaAreaOptions()
         {
             RecalculateTrackHeight();
         }
+    }
+}
+
+void
+FlameTrackItem::RequestAnalysis()
+{
+    if(m_track_metadata &&
+       m_track_metadata->topology.type == TrackInfo::TrackType::Queue &&
+       m_queue_utilization &&
+       (m_queue_utilization->state == AnalysisQueueUtilization::kStale ||
+        m_queue_utilization->state == AnalysisQueueUtilization::kPending))
+    {
+        uint64_t request_id = RequestIdBuilder::MakeTrackDataRequestId(
+            static_cast<uint32_t>(m_track_id), 0, 0,
+            RequestType::kFetchAnalysisQueueUtilization);
+        if(m_data_provider.IsRequestPending(request_id))
+        {
+            m_data_provider.CancelRequest(request_id);
+            m_queue_utilization->state = AnalysisQueueUtilization::kPending;
+        }
+        else
+        {
+            double start_ts;
+            double end_ts;
+            if(m_timeline_selection && m_timeline_selection->HasValidTimeRangeSelection())
+            {
+                m_timeline_selection->GetSelectedTimeRange(start_ts, end_ts);
+            }
+            else
+            {
+                start_ts = m_tpt->GetVMinX();
+                end_ts   = m_tpt->GetVMaxX();
+            }
+            m_queue_utilization->state =
+                (start_ts < end_ts &&
+                 m_data_provider.FetchAnalysisQueueUtilization(
+                     AnalysisQueueUtilizationRequestParams(m_track_id, start_ts, end_ts)))
+                    ? AnalysisQueueUtilization::kRequested
+                    : AnalysisQueueUtilization::kPending;
+        }
+        m_analysis_request_pending =
+            (m_queue_utilization->state == AnalysisQueueUtilization::kPending);
     }
 }
 

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -62,10 +62,11 @@ public:
     bool        IsCompactMode() const override { return m_compact_mode; }
 
 protected:
-    void RenderChart(float graph_width) override;
-    void RenderMetaAreaScale() override;
-    void RenderMetaAreaOptions() override;
-    void RenderMetaAreaExpand() override;
+    void  RenderChart(float graph_width) override;
+    void  RenderMetaAreaScale() override;
+    void  RenderMetaAreaOptions() override;
+    void  RenderMetaAreaExpand() override;
+    float CalculateNewMetaAreaSize() override;
 
 private:
     struct ChildEventInfo
@@ -97,6 +98,8 @@ private:
 
     void RenderTooltip(ChartItem& chart_item, int color_index);
     void RecalculateTrackHeight();
+    
+    void RequestAnalysis() override;
 
     std::vector<ChartItem>             m_chart_items;
     EventColorMode                     m_event_color_mode;
@@ -117,8 +120,10 @@ private:
 
     static float             s_max_event_label_width;
     static const std::string s_child_info_separator;
-    bool        m_is_expanded;
-    bool        m_compact_mode;
+    bool                     m_is_expanded;
+    bool                     m_compact_mode;
+
+    const AnalysisQueueUtilization* m_queue_utilization;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -58,17 +58,16 @@ LineTrackItem::~LineTrackItem() {}
 void
 LineTrackItem::UpdateMetadata()
 {
-    const TrackInfo* track_info = m_data_provider.DataModel().GetTimeline().GetTrack(m_track_id);
-    if(track_info)
+    if(m_track_metadata)
     {
-        const CounterInfo* counter =
-            m_data_provider.DataModel().GetTopology().GetCounter(track_info->topology.id.value);
+        const CounterInfo* counter = m_data_provider.DataModel().GetTopology().GetCounter(
+            m_track_metadata->topology.id.value);
         if(counter)
         {
             m_units = counter->units;
         }
         m_min_y.Init(0.0, m_units);  // Want to start at 0 by default.
-        m_max_y.Init(m_units == "%" ? 100.0 : track_info->max_value, m_units);
+        m_max_y.Init(m_units == "%" ? 100.0 : m_track_metadata->max_value, m_units);
     }
     else
     {

--- a/src/view/src/rocprofvis_requests.h
+++ b/src/view/src/rocprofvis_requests.h
@@ -35,6 +35,7 @@ enum class RequestType
     kCleanupDatabase,
     kTableExport,
     kFetchSystemTrace,
+    kFetchAnalysisQueueUtilization,
 #ifdef COMPUTE_UI_SUPPORT
     kFetchComputeTrace,
     kFetchMetrics,
@@ -167,7 +168,6 @@ public:
     std::string m_group;
     std::string m_group_columns;
     std::string m_export_to_file_path;
-    bool        m_summary;
 
     TableRequestParams(const TableRequestParams& table_params)            = default;
     TableRequestParams& operator=(const TableRequestParams& table_params) = default;
@@ -181,7 +181,7 @@ public:
         uint64_t start_row = -1, uint64_t req_row_count = -1,
         uint64_t                           sort_column_index = 0,
         rocprofvis_controller_sort_order_t sort_order = kRPVControllerSortOrderAscending,
-        std::string export_to_file_path = "", bool summary = false)
+        std::string export_to_file_path = "")
     : m_table_type(table_type)
     , m_track_ids(track_ids)
     , m_op_types(op_types)
@@ -197,7 +197,6 @@ public:
     , m_group_columns(group_cols)
     , m_string_table_filters(string_table_filters)
     , m_export_to_file_path(export_to_file_path)
-    , m_summary(summary)
     {}
 };
 
@@ -212,6 +211,26 @@ public:
 
     EventRequestParams(uint64_t event_id)
     : m_event_id(event_id)
+    {}
+};
+
+// Queue utilization analysis request parameters
+class AnalysisQueueUtilizationRequestParams : public RequestParamsBase
+{
+public:
+    uint64_t m_track_id;
+    double   m_start_ts;
+    double   m_end_ts;
+    double   m_result;
+
+    AnalysisQueueUtilizationRequestParams(const AnalysisQueueUtilizationRequestParams& other)            = default;
+    AnalysisQueueUtilizationRequestParams& operator=(const AnalysisQueueUtilizationRequestParams& other) = default;
+
+    AnalysisQueueUtilizationRequestParams(uint64_t track_id, double start, double end)
+    : m_track_id(track_id)
+    , m_start_ts(start)
+    , m_end_ts(end)
+    , m_result(0.0)
     {}
 };
 

--- a/src/view/src/rocprofvis_timeline_selection.cpp
+++ b/src/view/src/rocprofvis_timeline_selection.cpp
@@ -103,7 +103,7 @@ TimelineSelection::SelectTimeRange(double start_ts, double end_ts)
     {
         m_selected_range_start = start_ts;
         m_selected_range_end   = end_ts;
-        SendTrackSelectionChanged(INVALID_SELECTION_ID, false);
+        SendTimeRangeChanged(m_selected_range_start, m_selected_range_end);
     }
 }
 
@@ -125,7 +125,7 @@ TimelineSelection::ClearTimeRange()
 {
     m_selected_range_start = TimelineSelection::INVALID_SELECTION_TIME;
     m_selected_range_end   = TimelineSelection::INVALID_SELECTION_TIME;
-    SendTrackSelectionChanged(INVALID_SELECTION_ID, false);
+    SendTimeRangeChanged(m_selected_range_start, m_selected_range_end);
 }
 
 bool
@@ -202,6 +202,14 @@ TimelineSelection::SendTrackSelectionChanged(uint64_t track_id, bool selected)
 {
     EventManager::GetInstance()->AddEvent(std::make_shared<TrackSelectionChangedEvent>(
         track_id, selected, m_data_provider.GetTraceFilePath()));
+}
+
+void
+TimelineSelection::SendTimeRangeChanged(double start_ts, double end_ts)
+{
+    EventManager::GetInstance()->AddEvent(
+        std::make_shared<TimeRangeSelectionChangedEvent>(
+            start_ts, end_ts, m_data_provider.GetTraceFilePath()));
 }
 
 bool

--- a/src/view/src/rocprofvis_timeline_selection.h
+++ b/src/view/src/rocprofvis_timeline_selection.h
@@ -67,6 +67,7 @@ private:
     void SendEventHighlightChanged(uint64_t event_id, uint64_t track_id, bool highlighted,
                                    bool all = false);
     void SendTrackSelectionChanged(uint64_t track_id, bool selected);
+    void SendTimeRangeChanged(double start_ts, double end_ts);
 
     DataProvider& m_data_provider;
 

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -39,8 +39,6 @@ TimelineView::TimelineView(DataProvider&                       dp,
                            std::shared_ptr<TimelineSelection>  timeline_selection,
                            std::shared_ptr<AnnotationsManager> annotations)
 : m_data_provider(dp)
-, m_min_y(std::numeric_limits<double>::max())
-, m_max_y(std::numeric_limits<double>::lowest())
 , m_scroll_position_y(0.0f)
 , m_content_max_y_scroll(0.0f)
 , m_meta_map_made(false)
@@ -56,6 +54,7 @@ TimelineView::TimelineView(DataProvider&                       dp,
 , m_scroll_to_track_token(static_cast<uint64_t>(-1))
 , m_font_changed_token(static_cast<uint64_t>(-1))
 , m_set_view_range_token(static_cast<uint64_t>(-1))
+, m_timeline_time_range_changed_token(static_cast<uint64_t>(-1))
 , m_settings(SettingsManager::GetInstance())
 , m_last_data_req_v_width(0.0)
 , m_last_data_req_view_time_offset_ns(0.0)
@@ -139,6 +138,18 @@ TimelineView::TimelineView(DataProvider&                       dp,
     };
     m_navigation_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kGoToTimelineSpot), navigation_handler);
+
+    auto time_range_changed_handler = [this](std::shared_ptr<RocEvent> e) {
+        auto evt = std::dynamic_pointer_cast<TimeRangeSelectionChangedEvent>(e);
+        if(evt && evt->GetSourceId() == m_data_provider.GetTraceFilePath() &&
+           m_timeline_selection->HasValidTimeRangeSelection())
+        {
+            m_data_provider.DataModel().GetAnalysis().SetAnalysisRange(evt->GetStartNs(),
+                                                                       evt->GetEndNs());
+        }
+    };
+    m_timeline_time_range_changed_token = EventManager::GetInstance()->Subscribe(
+        static_cast<int>(RocEvents::kTimelineTimeRangeChanged), time_range_changed_handler);
 
     m_graphs = std::make_shared<std::vector<TrackGraph>>();
 
@@ -399,14 +410,15 @@ TimelineView::~TimelineView()
                                              m_set_view_range_token);
     EventManager::GetInstance()->Unsubscribe(
         static_cast<int>(RocEvents::kGoToTimelineSpot), m_navigation_token);
+    EventManager::GetInstance()->Unsubscribe(
+        static_cast<int>(RocEvents::kTimelineTimeRangeChanged),
+        m_timeline_time_range_changed_token);
 }
 
 void
 TimelineView::ResetView()
 {
     // Handles y positioning reset
-    m_min_y             = std::numeric_limits<double>::max();
-    m_max_y             = std::numeric_limits<double>::lowest();
     m_scroll_position_y = 0.0f;
 
     // Handles x positioning reset
@@ -1114,6 +1126,7 @@ TimelineView::RenderTrack(int track_index, bool request_data,
             if(is_visible || track_item->GetDistanceToView() <= m_unload_track_distance)
             {
                 RequestDataIfEmpty(track_item, request_data);
+                track_item->RequestAnalysis();
             }
         }
 
@@ -1867,6 +1880,11 @@ TimelineView::RenderTraceView()
     ImGui::PopStyleColor();
     ImGui::PopStyleVar(2);
     TimelineFocusManager::GetInstance().EvaluateFocusedLayer();
+    if(m_loading_timer.IsExpired() && !m_timeline_selection->HasValidTimeRangeSelection())
+    {
+        m_data_provider.DataModel().GetAnalysis().SetAnalysisRange(m_tpt->GetVMinX(),
+                                                                   m_tpt->GetVMaxX());
+    }
 }
 void
 TimelineView::RenderGraphPoints()

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -134,16 +134,15 @@ private:
     void                            ClearTimeRangeSelection();
     EventManager::SubscriptionToken m_scroll_to_track_token;
     EventManager::SubscriptionToken m_navigation_token;
-
     EventManager::SubscriptionToken m_new_track_token;
     EventManager::SubscriptionToken m_font_changed_token;
     EventManager::SubscriptionToken m_set_view_range_token;
-    int                             m_dragged_sticky_id;
-    const std::vector<double>*      m_histogram;
-    float                           m_ruler_height;
-    float                           m_ruler_padding;
-    double                              m_min_y;
-    double                              m_max_y;
+    EventManager::SubscriptionToken m_timeline_time_range_changed_token;
+
+    int                                 m_dragged_sticky_id;
+    const std::vector<double>*          m_histogram;
+    float                               m_ruler_height;
+    float                               m_ruler_padding;
     float                               m_sidebar_size;
     float                               m_scroll_position_y;
     float                               m_content_max_y_scroll;

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -28,6 +28,7 @@ inline constexpr uint64_t DEFAULT_CHUNK_DURATION   = TimeConstants::ns_per_s * 3
 TrackItem::TrackItem(DataProvider& dp, uint64_t id,
                      std::shared_ptr<TimePixelTransform> tpt)
 : m_data_provider(dp)
+, m_track_metadata(nullptr)
 , m_track_id(id)
 , m_track_height(DEFAULT_TRACK_HEIGHT)
 , m_track_content_height(0.0f)
@@ -49,6 +50,7 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id,
 , m_meta_area_label("")
 , m_pill("", false, false)
 , m_distance_to_view_y(0.0f)
+, m_analysis_request_pending(false)
 {
     if(m_track_project_settings.Valid())
     {
@@ -63,7 +65,7 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id,
         spdlog::error("TrackItem: failed to get TrackInfo for track_id {}", m_track_id);
         return;
     }
-
+    m_track_metadata = track_info;
     m_name = m_data_provider.DataModel().BuildTrackName(m_track_id);
     SetMetaAreaLabel(track_info);
     SetDefaultPillLabel(track_info);
@@ -468,6 +470,10 @@ TrackItem::Update()
             FetchHelper();
         }
     }
+    if(m_analysis_request_pending)
+    {
+        RequestAnalysis();
+    }
 }
 
 void
@@ -750,6 +756,12 @@ bool
 TrackItem::HasPendingRequests() const
 {
     return !m_pending_requests.empty();
+}
+
+void
+TrackItem::RequestAnalysis()
+{
+    // no op
 }
 
 TrackProjectSettings::TrackProjectSettings(const std::string& project_id,

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -98,6 +98,7 @@ public:
     virtual bool  HasData();
     virtual bool  ReleaseData();
     virtual void  RequestData(double min, double max, float width);
+    virtual void  RequestAnalysis();
     virtual bool  HandleTrackDataChanged(uint64_t request_id, uint64_t response_code);
     virtual bool  HasPendingRequests() const;
     virtual float CalculateNewMetaAreaSize();
@@ -125,23 +126,25 @@ protected:
     void SetDefaultPillLabel(const TrackInfo* track_info);
     void SetMetaAreaLabel(const TrackInfo* track_info);
 
-    uint64_t              m_track_id;
-    float                 m_track_height;
-    float                 m_track_content_height;
-    float                 m_min_track_height;
-    bool                  m_track_height_changed;
-    bool                  m_is_in_view_vertical;
-    float                 m_distance_to_view_y;
-    std::string           m_name;
-    ImVec2                m_metadata_padding;
-    float                 m_resize_grip_thickness;
-    DataProvider&         m_data_provider;
-    TrackDataRequestState m_request_state;
-    SettingsManager&      m_settings;
-    bool                  m_meta_area_clicked;
-    float                 m_meta_area_scale_width;
-    bool                  m_selected;
-    float                 m_reorder_grip_width;
+    const TrackInfo*                    m_track_metadata;
+    uint64_t                            m_track_id;
+    float                               m_track_height;
+    float                               m_track_content_height;
+    float                               m_min_track_height;
+    bool                                m_track_height_changed;
+    bool                                m_is_in_view_vertical;
+    float                               m_distance_to_view_y;
+    std::string                         m_name;
+    ImVec2                              m_metadata_padding;
+    float                               m_resize_grip_thickness;
+    DataProvider&                       m_data_provider;
+    TrackDataRequestState               m_request_state;
+    SettingsManager&                    m_settings;
+    bool                                m_meta_area_clicked;
+    float                               m_meta_area_scale_width;
+    bool                                m_selected;
+    float                               m_reorder_grip_width;
+    bool                                m_analysis_request_pending;
     std::shared_ptr<TimePixelTransform> m_tpt;
     uint64_t m_chunk_duration_ns;  // Duration of each chunk in nanoseconds
     uint8_t  m_group_id_counter;   // Counter for grouping requests


### PR DESCRIPTION
**DM**
- `rocprofvis_db_build_table_query`.
  - Removed `bool summary`. Originally this was used to override the grouping parameters with a predefined clause customized for summary that was specific to .rpd or .db. After table processor was introduced, this is no longer needed since column names are stable. Instead, callers that requested the summary flag now directly set grouping parameters.
  - Added `rocprofvis_dm_table_use_case_enum_t` parameter for specifying which `TableProcessor` instance the query will execute on. Previously this was inferred inside the function based on the query, but this will not be maintainable as more processor instances get added. Mapping between existing use cases and processors remains unchanged.
- Added 4th `TableProcessor` instance specifically for analysis related queries. Since analysis is expected to run frequently, this was done to not disturb the cache of existing processors handling event/sample/search tables.

**Controller**
- Added `GetDMHandle()` to `Trace`.
- Setup static `Analysis` object to house analysis related logic. Self-contained in its own source and header.
- Added `rocprofvis_controller_analysis_fetch_queue_utilization` to calculate queue utilization for a given `Track` from a given `Trace` between a time range.

**View**
- Added `AnalysisModel` to `TraceDataModel` for analysis related data.
- Added `TimeRangeSelectionChangedEvent` for when time range selection changes. Previously this shared `TrackSelectionChangedEvent`.
- Added placeholder UI to "meta scale area" of queue flame tracks to display queue utilization.
  -  When time range selection is active, updates when selection changes. Otherwise updates with viewport movement on TimelineView::LoadingTimer.
  - Each track updates itself, multiple tracks may update in parellel.
  - Loading indicated by value being greyed out.

**Other**
- Added Claude related files to gitignore.

**Known Issues**

- Queues with multiple event levels may exceed 100% utilization.
- "Meta scale area" of tracks with queue utilization have their own widths and do not align with the counter "meta scale area". 