### PR TITLE
Fix annotation scroll interactions

### DIFF
--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -103,7 +103,7 @@ StickyNote::SetTitle(std::string title)
 {
     m_title = title;
 }
-void
+bool
 StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
                    std::shared_ptr<TimePixelTransform> tpt)
 {
@@ -111,7 +111,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     {
         spdlog::error(
             "StickyNote::Render: conversion_manager shared_ptr is null, cannot render");
-        return;
+        return false;
     }
     SettingsManager& settings      = SettingsManager::GetInstance();
     const bool       use_dark_mode = settings.GetUserSettings().display_settings.use_dark_mode;
@@ -184,7 +184,8 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         ImGui::PopStyleColor(4);
         ImGui::PopFont();
 
-        if(ImGui::IsMouseHoveringRect(sticky_pos, btn_max))
+        bool blocks_timeline_input = ImGui::IsMouseHoveringRect(sticky_pos, btn_max);
+        if(blocks_timeline_input)
         {
             TimelineFocusManager::GetInstance().RequestLayerFocus(
                 Layer::kInteractiveLayer);
@@ -195,6 +196,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         }
 
         ImGui::EndChild();
+        return blocks_timeline_input;
     }
     else
     {
@@ -336,8 +338,10 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         // Cover hover case for input control
         ImVec2 sticky_max =
             ImVec2(sticky_pos.x + sticky_size.x, sticky_pos.y + sticky_size.y);
-        if(ImGui::IsMouseHoveringRect(sticky_pos, sticky_max) &&
-           !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
+        bool blocks_timeline_input =
+            ImGui::IsMouseHoveringRect(sticky_pos, sticky_max) &&
+            !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect);
+        if(blocks_timeline_input)
         {
             TimelineFocusManager::GetInstance().RequestLayerFocus(Layer::kInteractiveLayer);
         }
@@ -348,6 +352,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
         ImGui::PopStyleColor(2);
         ImGui::PopStyleVar(3);
+        return blocks_timeline_input;
     }
 }
 
@@ -398,8 +403,10 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         {
             drag_pos = ImVec2(window_position.x + x, window_position.y + y);
         }
+        // Expanded notes drag by the header so the scrollable body can own
+        // scrollbar/body interactions.
         drag_w   = m_size.x;
-        drag_h   = m_size.y;
+        drag_h   = 36.0f;
         drag_max = ImVec2(drag_pos.x + drag_w, drag_pos.y + drag_h);
     }
 
@@ -410,8 +417,10 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     if(!m_is_minimized)
     {
         const float handle_size = 12.0f;
-        ImVec2      handle_pos  = ImVec2(drag_max.x - handle_size, drag_max.y - handle_size);
-        if(ImGui::IsMouseHoveringRect(handle_pos, drag_max))
+        ImVec2      sticky_max  = ImVec2(drag_pos.x + m_size.x, drag_pos.y + m_size.y);
+        ImVec2      handle_pos  = ImVec2(sticky_max.x - handle_size,
+                                         sticky_max.y - handle_size);
+        if(ImGui::IsMouseHoveringRect(handle_pos, sticky_max))
             return false;
     }
 

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -18,6 +18,11 @@ namespace RocProfVis
 namespace View
 {
 
+namespace
+{
+constexpr float kExpandedHeaderHeight = 36.0f;
+}  // namespace
+
 static int s_unique_id_counter = 0;
 StickyNote::StickyNote(double time_ns, float y_offset, const ImVec2& size,
                        const std::string& text, const std::string& title,
@@ -136,7 +141,6 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
     const float rounding      = settings.GetDefaultStyle().ChildRounding;
     const float margin        = 14.0f;
-    const float header_height = 36.0f;
     const float icon_btn_gap  = 8.0f;
 
     float  x           = tpt->TimeToPixel(m_time_ns);
@@ -256,7 +260,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         const ImVec2 note_min      = ImGui::GetWindowPos();
         const ImVec2 header_min    = note_min;
         const ImVec2 header_max    = ImVec2(note_min.x + sticky_size.x,
-                                            note_min.y + header_height);
+                                            note_min.y + kExpandedHeaderHeight);
         note_draw_list->AddRectFilled(header_min, header_max, header_color, rounding,
                                       ImDrawFlags_RoundCornersTop);
         note_draw_list->AddRectFilled(header_min,
@@ -269,7 +273,8 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
         // Title (left)
         ImGui::SetCursorPos(
-            ImVec2(margin, (header_height - ImGui::GetTextLineHeight()) * 0.5f));
+            ImVec2(margin,
+                   (kExpandedHeaderHeight - ImGui::GetTextLineHeight()) * 0.5f));
         ImGui::PushStyleColor(ImGuiCol_Text, text_color);
         ImGui::TextUnformatted(m_title.c_str());
         ImGui::PopStyleColor();
@@ -282,7 +287,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         ImVec2 close_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
         const float action_btn_size =
             std::max({34.0f, edit_icon_size.x + 14.0f, close_icon_size.x + 14.0f});
-        const float action_btn_y = (header_height - action_btn_size) * 0.5f;
+        const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
 
         ImGui::SetCursorPos(ImVec2(sticky_size.x - action_btn_size * 2.0f - margin -
                                        icon_btn_gap,
@@ -318,7 +323,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         ImGui::PopFont();
 
         // Scroll only the note body; the header/actions stay pinned.
-        const float body_y      = header_height + margin;
+        const float body_y      = kExpandedHeaderHeight + margin;
         const float body_height = std::max(0.0f, sticky_size.y - body_y - margin);
         ImGui::SetCursorPos(ImVec2(margin, body_y));
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
@@ -406,8 +411,8 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         // Expanded notes drag by the header so the scrollable body can own
         // scrollbar/body interactions.
         drag_w   = m_size.x;
-        drag_h   = 36.0f;
-        drag_max = ImVec2(drag_pos.x + drag_w, drag_pos.y + drag_h);
+        drag_max = ImVec2(drag_pos.x + drag_w,
+                          drag_pos.y + kExpandedHeaderHeight);
     }
 
     ImVec2 mouse_pos      = ImGui::GetMousePos();
@@ -441,7 +446,9 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         float  new_y       = mouse_pos.y - window_position.y - m_drag_offset.y;
         ImVec2 window_size = ImGui::GetWindowSize();
         new_x = std::clamp(new_x, 0.0f, window_size.x - drag_w);
-        new_y = std::clamp(new_y, 0.0f, window_size.y - drag_h);
+        new_y = std::clamp(new_y, 0.0f,
+                           window_size.y -
+                               (m_is_minimized ? drag_h : kExpandedHeaderHeight));
 
         if(m_is_minimized)
         {

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -21,7 +21,7 @@ public:
                const std::string& text, const std::string& title,
                const std::string& project_id, double v_min, double v_max, bool is_minimized = true);
 
-    void Render(ImDrawList* draw_list, const ImVec2& window_position,
+    bool Render(ImDrawList* draw_list, const ImVec2& window_position,
                 std::shared_ptr<TimePixelTransform> conversion_manager);
     bool HandleResize(const ImVec2&       window_position,
                       std::shared_ptr<TimePixelTransform> conversion_manager);

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -205,13 +205,18 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
                 m_annotations->GetStickyNotes()[i].HandleResize(window_position, m_tpt);
         }
 
+        bool annotation_blocks_timeline_input = false;
+
         // Rendering --> based on added order (old bottom new on top)
         for(size_t i = 0; i < m_annotations->GetStickyNotes().size(); ++i)
         {
             if(!m_annotations->GetStickyNotes()[i].IsVisible()) continue;
 
-            m_annotations->GetStickyNotes()[i].Render(draw_list, window_position, m_tpt);
+            annotation_blocks_timeline_input |=
+                m_annotations->GetStickyNotes()[i].Render(draw_list, window_position,
+                                                          m_tpt);
         }
+        m_stop_user_interaction |= annotation_blocks_timeline_input;
     }
     m_stop_user_interaction |= movement_drag || movement_resize;
 


### PR DESCRIPTION
-Fixed annotation scrollbar interactions so mouse wheel/scrollbar input inside an expanded annotation no longer also drives timeline scrolling or zooming.
-Updated sticky notes to report when they are consuming timeline input, allowing the timeline to ignore those interactions while the annotation is hovered.
-Limited expanded annotation dragging to the header area so grabbing the note body scrollbar scrolls the annotation content instead of moving the annotation.