### PR TITLE
Update Nightly Builds S3 Path, Add Initial POC Release Controller

### DIFF
--- a/.github/workflows/ci-controller.yml
+++ b/.github/workflows/ci-controller.yml
@@ -95,6 +95,7 @@ jobs:
       os_version: ${{ needs.setup.outputs.redhat-os-versions }}
       upload_to_github: ${{ github.event_name == 'schedule' || github.event.inputs.upload_to_github == 'true' }}
       upload_to_s3: ${{ github.event_name == 'schedule' || github.event.inputs.upload_to_s3 == 'true' }}
+      s3_root_directory: ${{ github.event_name == 'schedule' && 'nightly' || 'test' }}
 
   ci-ubuntu:
     name: Ubuntu CI
@@ -106,6 +107,7 @@ jobs:
       os_version: ${{ needs.setup.outputs.ubuntu-os-versions }}
       upload_to_github: ${{ github.event_name == 'schedule' || github.event.inputs.upload_to_github == 'true' }}
       upload_to_s3: ${{ github.event_name == 'schedule' || github.event.inputs.upload_to_s3 == 'true' }}
+      s3_root_directory: ${{ github.event_name == 'schedule' && 'nightly' || 'test' }}
 
   ci-windows:
     name: Windows CI
@@ -117,6 +119,7 @@ jobs:
       os_version: ${{ needs.setup.outputs.windows-os-versions }}
       upload_to_github: ${{ github.event_name == 'schedule' || github.event.inputs.upload_to_github == 'true' }}
       upload_to_s3: ${{ github.event_name == 'schedule' || github.event.inputs.upload_to_s3 == 'true' }}
+      s3_root_directory: ${{ github.event_name == 'schedule' && 'nightly' || 'test' }}
 
   ci-mac:
     name: macOS CI
@@ -128,3 +131,4 @@ jobs:
       os_version: ${{ needs.setup.outputs.mac-os-versions }}
       upload_to_github: ${{ github.event_name == 'schedule' || github.event.inputs.upload_to_github == 'true' }}
       upload_to_s3: ${{ github.event_name == 'schedule' || github.event.inputs.upload_to_s3 == 'true' }}
+      s3_root_directory: ${{ github.event_name == 'schedule' && 'nightly' || 'test' }}

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -74,6 +74,7 @@ env:
   BUILD_FILE_NAME: "roc-optiq"
   VULKAN_SDK_VERSION: "1.4.328.1"
   ENABLE_INTERNAL_BANNER: ${{ inputs.enable_internal_banner == 'true' && 'ON' || 'OFF' }}
+  S3_ROOT_DIRECTORY: ${{ inputs.s3_root_directory }}
 
 jobs:
   mac:
@@ -233,7 +234,7 @@ jobs:
         run: |
           ditto -c -k --keepParent ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip
           TIMESTAMP=$(date +%Y_%m_%d)
-          aws s3 cp ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip s3://${{ secrets.AWS_S3_BUCKET }}/${{ inputs.s3_root_directory }}}/$TIMESTAMP/mac/${{ matrix.os-version }}/ \
+          aws s3 cp ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.S3_ROOT_DIRECTORY }}/$TIMESTAMP/mac/${{ matrix.os-version }}/ \
             --no-progress
       
       - name: Announce Test Failure

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -28,6 +28,15 @@ on:
         description: 'Upload built artifacts to the roc-optiq S3 bucket?'
         type: boolean
         default: false
+      s3_root_directory:
+        description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
+        type: choice
+        default: 'test'
+        options: 
+          - test
+          - nightly
+          - rc
+          - release
   workflow_call:
     inputs:
       os_version:
@@ -54,6 +63,10 @@ on:
         description: 'Upload built artifacts to the roc-optiq S3 bucket?'
         type: boolean
         default: false
+      s3_root_directory:
+        description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
+        type: string
+        default: 'test'
 
 env:
   BUILD_DIR: "build"
@@ -61,7 +74,6 @@ env:
   BUILD_FILE_NAME: "roc-optiq"
   VULKAN_SDK_VERSION: "1.4.328.1"
   ENABLE_INTERNAL_BANNER: ${{ inputs.enable_internal_banner == 'true' && 'ON' || 'OFF' }}
-  AWS_S3_BUCKET_BASE_PATH: "test"
 
 jobs:
   mac:
@@ -221,7 +233,7 @@ jobs:
         run: |
           ditto -c -k --keepParent ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip
           TIMESTAMP=$(date +%Y_%m_%d)
-          aws s3 cp ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.AWS_S3_BUCKET_BASE_PATH }}/$TIMESTAMP/mac/${{ matrix.os-version }}/ \
+          aws s3 cp ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip s3://${{ secrets.AWS_S3_BUCKET }}/${{ inputs.s3_root_directory }}}/$TIMESTAMP/mac/${{ matrix.os-version }}/ \
             --no-progress
       
       - name: Announce Test Failure

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -37,6 +37,10 @@ on:
           - nightly
           - rc
           - release
+      release_version:
+        description: 'Manually specify a release version to use in the S3 bucket path. Defaults to YYYY_MM_DD timestamp if left empty.'
+        type: string
+        default: ''
   workflow_call:
     inputs:
       os_version:
@@ -67,6 +71,10 @@ on:
         description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
         type: string
         default: 'test'
+      release_version:
+        description: 'Manually specify a release version to use in the S3 bucket path. Defaults to YYYY_MM_DD timestamp if left empty.'
+        type: string
+        default: ''
 
 env:
   BUILD_DIR: "build"
@@ -75,6 +83,7 @@ env:
   VULKAN_SDK_VERSION: "1.4.328.1"
   ENABLE_INTERNAL_BANNER: ${{ inputs.enable_internal_banner == 'true' && 'ON' || 'OFF' }}
   S3_ROOT_DIRECTORY: ${{ inputs.s3_root_directory }}
+  RELEASE_VERSION: ${{ inputs.release_version }}
 
 jobs:
   mac:
@@ -233,8 +242,14 @@ jobs:
         if: ${{ inputs.upload_to_s3 }}
         run: |
           ditto -c -k --keepParent ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip
-          TIMESTAMP=$(date +%Y_%m_%d)
-          aws s3 cp ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.S3_ROOT_DIRECTORY }}/$TIMESTAMP/mac/${{ matrix.os-version }}/ \
+          if [ -z "${{ env.RELEASE_VERSION }}" ]; then
+            echo "No release version provided, defaulting to using TIMESTAMP as S3_SECONDARY_DIRECTORY"
+            S3_SECONDARY_DIRECTORY=$(date +%Y_%m_%d)
+          else
+            echo "Release Version ${{ env.RELEASE_VERSION }} provided, using ${{ env.RELEASE_VERSION }} as S3_SECONDARY_DIRECTORY"
+            S3_SECONDARY_DIRECTORY="${{ env.RELEASE_VERSION }}"
+          fi
+          aws s3 cp ${{ env.DIST_DIR }}/${{ env.BUILD_FILE_NAME }}.app.zip s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.S3_ROOT_DIRECTORY }}/$S3_SECONDARY_DIRECTORY/mac/${{ matrix.os-version }}/ \
             --no-progress
       
       - name: Announce Test Failure

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -89,6 +89,9 @@ jobs:
   mac:
     name: macOS ${{ matrix.os-version }} • Optiq CI • GitHub Artifacts (${{ inputs.upload_to_github }}) • S3 Artifacts (${{ inputs.upload_to_s3 }})
     runs-on: macos-${{ matrix.os-version }}
+    defaults:
+      run:
+        shell: bash
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -28,6 +28,19 @@ on:
         description: 'Upload built artifacts to the roc-optiq S3 bucket?'
         type: boolean
         default: false
+      s3_root_directory:
+        description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
+        type: choice
+        default: 'test'
+        options: 
+          - test
+          - nightly
+          - rc
+          - release
+      release_version:
+        description: 'Manually specify a release version to use in the S3 bucket path. Defaults to YYYY_MM_DD timestamp if left empty.'
+        type: string
+        default: ''
   workflow_call:
     inputs:
       os_version:
@@ -54,18 +67,30 @@ on:
         description: 'Upload built artifacts to the roc-optiq S3 bucket?'
         type: boolean
         default: false
+      s3_root_directory:
+        description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
+        type: string
+        default: 'test'
+      release_version:
+        description: 'Manually specify a release version to use in the S3 bucket path. Defaults to YYYY_MM_DD timestamp if left empty.'
+        type: string
+        default: ''
 
 env:
   BUILD_DIR: "build"
   DIST_DIR: "dist"
   BUILD_FILE_NAME: "roc-optiq"
   ENABLE_INTERNAL_BANNER: ${{ inputs.enable_internal_banner == 'true' && 'ON' || 'OFF' }}
-  AWS_S3_BUCKET_BASE_PATH: "test"
+  S3_ROOT_DIRECTORY: ${{ inputs.s3_root_directory }}
+  RELEASE_VERSION: ${{ inputs.release_version }}
 
 jobs:
   rocky-linux:
     name: RedHat ${{ matrix.os-version }} • Optiq CI • GitHub Artifacts (${{ inputs.upload_to_github }}) • S3 Artifacts (${{ inputs.upload_to_s3 }})
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     permissions:
       id-token: write
       contents: read
@@ -83,7 +108,6 @@ jobs:
           submodules: true
 
       - name: Build, Make, and Verify Installation
-        shell: bash
         run: |
           source /opt/vulkan/**/setup-env.sh
           if [ "${{ matrix.os-version }}" = "8" ]; then
@@ -148,17 +172,21 @@ jobs:
 
       - name: Generate Metadata for S3
         if: ${{ inputs.upload_to_s3 }}
-        shell: bash
         working-directory: ${{ env.DIST_DIR }}
         run: |
           createrepo .
 
       - name: Upload Build to S3
         if: ${{ inputs.upload_to_s3 }}
-        shell: bash
         run: |
-          TIMESTAMP=$(date +%Y_%m_%d)
-          aws s3 cp --recursive ${{ env.DIST_DIR }} s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.AWS_S3_BUCKET_BASE_PATH }}/$TIMESTAMP/rhel/${{ matrix.os-version }}/ \
+          if [ -z "${{ env.RELEASE_VERSION }}" ]; then
+            echo "No release version provided, defaulting to using TIMESTAMP as S3_SECONDARY_DIRECTORY"
+            S3_SECONDARY_DIRECTORY=$(date +%Y_%m_%d)
+          else
+            echo "Release Version ${{ env.RELEASE_VERSION }} provided, using ${{ env.RELEASE_VERSION }} as S3_SECONDARY_DIRECTORY"
+            S3_SECONDARY_DIRECTORY="${{ env.RELEASE_VERSION }}"
+          fi
+          aws s3 cp --recursive ${{ env.DIST_DIR }} s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.S3_ROOT_DIRECTORY }}/$S3_SECONDARY_DIRECTORY/rhel/${{ matrix.os-version }}/ \
             --no-progress
 
       - name: Announce Test Failure

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -28,6 +28,19 @@ on:
         description: 'Upload built artifacts to the roc-optiq S3 bucket?'
         type: boolean
         default: false
+      s3_root_directory:
+        description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
+        type: choice
+        default: 'test'
+        options: 
+          - test
+          - nightly
+          - rc
+          - release
+      release_version:
+        description: 'Manually specify a release version to use in the S3 bucket path. Defaults to YYYY_MM_DD timestamp if left empty.'
+        type: string
+        default: ''
   workflow_call:
     inputs:
       os_version:
@@ -54,18 +67,30 @@ on:
         description: 'Upload built artifacts to the roc-optiq S3 bucket?'
         type: boolean
         default: false
+      s3_root_directory:
+        description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
+        type: string
+        default: 'test'
+      release_version:
+        description: 'Manually specify a release version to use in the S3 bucket path. Defaults to YYYY_MM_DD timestamp if left empty.'
+        type: string
+        default: ''
 
 env:
   BUILD_DIR: "build"
   DIST_DIR: "dist"
   BUILD_FILE_NAME: "roc-optiq"
   ENABLE_INTERNAL_BANNER: ${{ inputs.enable_internal_banner == 'true' && 'ON' || 'OFF' }}
-  AWS_S3_BUCKET_BASE_PATH: "test"
+  S3_ROOT_DIRECTORY: ${{ inputs.s3_root_directory }}
+  RELEASE_VERSION: ${{ inputs.release_version }}
 
 jobs:
   ubuntu:
     name: Ubuntu ${{ matrix.os-version }} • Optiq CI • GitHub Artifacts (${{ inputs.upload_to_github }}) • S3 Artifacts (${{ inputs.upload_to_s3 }})
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     permissions:
       id-token: write
       contents: read
@@ -83,7 +108,6 @@ jobs:
           submodules: true
 
       - name: Build, Make, and Verify Installation
-        shell: bash
         run: |
           source /opt/vulkan/**/setup-env.sh
           cmake -B ${{ env.BUILD_DIR }} --preset ${{ inputs.cmake_config_preset }} -DROCPROFVIS_ENABLE_INTERNAL_BANNER=${{ env.ENABLE_INTERNAL_BANNER }}
@@ -142,7 +166,6 @@ jobs:
 
       - name: Generate Metadata for S3
         if: ${{ inputs.upload_to_s3 }}
-        shell: bash
         working-directory: ${{ env.DIST_DIR }}
         run: |
           dpkg-scanpackages . /dev/null > Packages
@@ -157,10 +180,15 @@ jobs:
 
       - name: Upload Build to S3
         if: ${{ inputs.upload_to_s3 }}
-        shell: bash
         run: |
-          TIMESTAMP=$(date +%Y_%m_%d)
-          aws s3 cp --recursive ${{ env.DIST_DIR }} s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.AWS_S3_BUCKET_BASE_PATH }}/$TIMESTAMP/ubuntu/${{ matrix.os-version }}/ \
+          if [ -z "${{ env.RELEASE_VERSION }}" ]; then
+            echo "No release version provided, defaulting to using TIMESTAMP as S3_SECONDARY_DIRECTORY"
+            S3_SECONDARY_DIRECTORY=$(date +%Y_%m_%d)
+          else
+            echo "Release Version ${{ env.RELEASE_VERSION }} provided, using ${{ env.RELEASE_VERSION }} as S3_SECONDARY_DIRECTORY"
+            S3_SECONDARY_DIRECTORY="${{ env.RELEASE_VERSION }}"
+          fi
+          aws s3 cp --recursive ${{ env.DIST_DIR }} s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.S3_ROOT_DIRECTORY }}/$S3_SECONDARY_DIRECTORY/ubuntu/${{ matrix.os-version }}/ \
             --no-progress
 
       - name: Announce Test Failure

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -28,6 +28,19 @@ on:
         description: 'Upload built artifacts to the roc-optiq S3 bucket?'
         type: boolean
         default: false
+      s3_root_directory:
+        description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
+        type: choice
+        default: 'test'
+        options: 
+          - test
+          - nightly
+          - rc
+          - release
+      release_version:
+        description: 'Manually specify a release version to use in the S3 bucket path. Defaults to YYYY_MM_DD timestamp if left empty.'
+        type: string
+        default: ''
   workflow_call:
     inputs:
       os_version:
@@ -54,6 +67,14 @@ on:
         description: 'Upload built artifacts to the roc-optiq S3 bucket?'
         type: boolean
         default: false
+      s3_root_directory:
+        description: 'The root directory to use when uploading to the roc-optiq S3 bucket'
+        type: string
+        default: 'test'
+      release_version:
+        description: 'Manually specify a release version to use in the S3 bucket path. Defaults to YYYY_MM_DD timestamp if left empty.'
+        type: string
+        default: ''
 
 env:
   BUILD_DIR: "build"
@@ -61,12 +82,16 @@ env:
   BINARY_DIR: ${{ inputs.cmake_config_preset == 'x64-debug' && 'Debug' || 'Release' }}
   BUILD_FILE_NAME: "roc-optiq"
   ENABLE_INTERNAL_BANNER: ${{ inputs.enable_internal_banner == 'true' && 'ON' || 'OFF' }}
-  AWS_S3_BUCKET_BASE_PATH: "test"
+  S3_ROOT_DIRECTORY: ${{ inputs.s3_root_directory }}
+  RELEASE_VERSION: ${{ inputs.release_version }}
 
 jobs:
   windows:
     name: Windows ${{ matrix.os-version }} • Optiq CI • GitHub Artifacts (${{ inputs.upload_to_github }}) • S3 Artifacts (${{ inputs.upload_to_s3 }})
     runs-on: windows-${{ matrix.os-version }}
+    defaults:
+      run:
+        shell: pwsh
     permissions:
       id-token: write
       contents: read
@@ -88,7 +113,6 @@ jobs:
           ./vulkan_sdk.exe --accept-licenses --default-answer --confirm-command install
 
       - name: Set Vulkan SDK environment variables
-        shell: pwsh
         run: |
           $vulkanRoot = Get-ChildItem -Directory "C:\VulkanSDK" | Sort-Object Name -Descending | Select-Object -First 1
           if (-not $vulkanRoot) { Write-Host "Vulkan SDK not found!"; exit 1 }
@@ -154,10 +178,16 @@ jobs:
 
       - name: Upload Build to S3
         if: ${{ inputs.upload_to_s3 }}
-        shell: pwsh
         run: |
           $timestamp = Get-Date -Format "yyyy_MM_dd"
-          aws s3 cp --recursive ${{ env.DIST_DIR }} s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.AWS_S3_BUCKET_BASE_PATH }}/$timeStamp/windows/ `
+          if (-not $env:RELEASE_VERSION) {
+              Write-Host "No release version provided, defaulting to using TIMESTAMP as S3_SECONDARY_DIRECTORY"
+              $S3_SECONDARY_DIRECTORY = Get-Date -Format "yyyy_MM_dd"
+          } else {
+              Write-Host "Release Version $env:RELEASE_VERSION provided, using $env:RELEASE_VERSION as S3_SECONDARY_DIRECTORY"
+              $S3_SECONDARY_DIRECTORY = $env:RELEASE_VERSION
+          }
+          aws s3 cp --recursive ${{ env.DIST_DIR }} s3://${{ secrets.AWS_S3_BUCKET }}/${{ env.S3_ROOT_DIRECTORY }}/$S3_SECONDARY_DIRECTORY/windows/ `
             --no-progress
       
       - name: Announce Test Failure

--- a/.github/workflows/release-controller.yml
+++ b/.github/workflows/release-controller.yml
@@ -1,0 +1,59 @@
+name: Release Controller
+run-name: roc-optiq-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'WARNING: This is enabled by default. Only uncheck this if you are planning on triggering a release!'
+        type: boolean
+        default: true
+      release_version:
+        description: 'Specify the release version. This will be used in the S3 file path: /release/<RELEASE_VERSION/'
+        type: string
+        default: ''
+
+jobs:
+  ci-redhat:
+    name: RedHat Release
+    uses: ./.github/workflows/ci-redhat.yml
+    secrets: inherit
+    with:
+      os_version: '[ "8", "9", "10" ]'
+      upload_to_github: ${{ !inputs.dry_run }}
+      upload_to_s3: ${{ !inputs.dry_run }}
+      s3_root_directory: release
+      release_version: ${{ inputs.release_version }}
+
+  ci-ubuntu:
+    name: Ubuntu Release
+    uses: ./.github/workflows/ci-ubuntu.yml
+    secrets: inherit
+    with:
+      os_version: '[ "22.04", "24.04", "26.04" ]'
+      upload_to_github: ${{ !inputs.dry_run }}
+      upload_to_s3: ${{ !inputs.dry_run }}
+      s3_root_directory: release
+      release_version: ${{ inputs.release_version }}
+
+  ci-windows:
+    name: Windows Release
+    uses: ./.github/workflows/ci-windows.yml
+    secrets: inherit
+    with:
+      os_version: '[ "2022" ]'
+      upload_to_github: ${{ !inputs.dry_run }}
+      upload_to_s3: ${{ !inputs.dry_run }}
+      s3_root_directory: release
+      release_version: ${{ inputs.release_version }}
+
+  ci-mac:
+    name: macOS CI
+    uses: ./.github/workflows/ci-mac.yml
+    secrets: inherit
+    with:
+      os_version: '[ "14", "15", "26" ]'
+      upload_to_github: ${{ !inputs.dry_run }}
+      upload_to_s3: ${{ !inputs.dry_run }}
+      s3_root_directory: release
+      release_version: ${{ inputs.release_version }}

--- a/.github/workflows/release-controller.yml
+++ b/.github/workflows/release-controller.yml
@@ -14,7 +14,7 @@ on:
         default: ''
 
 jobs:
-  ci-redhat:
+  release-redhat:
     name: RedHat Release
     uses: ./.github/workflows/ci-redhat.yml
     secrets: inherit
@@ -25,7 +25,7 @@ jobs:
       s3_root_directory: release
       release_version: ${{ inputs.release_version }}
 
-  ci-ubuntu:
+  release-ubuntu:
     name: Ubuntu Release
     uses: ./.github/workflows/ci-ubuntu.yml
     secrets: inherit
@@ -36,7 +36,7 @@ jobs:
       s3_root_directory: release
       release_version: ${{ inputs.release_version }}
 
-  ci-windows:
+  release-windows:
     name: Windows Release
     uses: ./.github/workflows/ci-windows.yml
     secrets: inherit
@@ -47,8 +47,8 @@ jobs:
       s3_root_directory: release
       release_version: ${{ inputs.release_version }}
 
-  ci-mac:
-    name: macOS CI
+  release-mac:
+    name: macOS Release
     uses: ./.github/workflows/ci-mac.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Enable nightly scheduled runs to upload to the `nightly` directory in S3, along with improvements to support release workflows that will post to a `release` directory in S3

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `ci-*.yml` workflows to include two new inputs
  - `s3_root_directory`: allows support for future options, defaults to `test` for testing out uploads
  - `release_version`: allows the secondary s3 directory to be named after the input, if provided. Meant to support releases. Defaults to empty string which will make the secondary s3 directory default to `YYYY_MM_DD` timestamp instead.
- Updated `ci-controller.yml` to provide `s3_root_directory` as `nightly` for all scheduled runs, otherwise defaults to `test`
- Added `release-controller.yml` proof-of-concept template that will be used for releases to S3
  - Simpler version of `ci-controller.yml` that is designed to only support releases and provide the appropriate release data to the workflow calls
  - Added `dry_run` option to disable S3/GitHub uploads to ensure proper functionality and builds for testing

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure no regression issues with changes to `ci-*.yml` workflows
- Ensure all workflows pass in PR

## Test Result

<!-- Briefly summarize test outcomes. -->
- Tested out each `ci-*.yml` file and verified default values are respected and that no release options are included unless manually overwritten via workflow_dispatch

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
