### PR TITLE
SetCursor assert fix  [minor-improvement]

### DIFF
--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -67,15 +67,17 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
                        LoadingIndicatorCentering centering, float dot_radius,
                        int num_dots, float dot_spacing, float anim_speed)
 {
-    ImVec2 orig_pos = ImGui::GetCursorPos();
-
     if(window_id)
     {
         // Create an overlay child window to display the loading indicator if requested
-        ImGui::SetCursorPos(ImVec2(0, 0));
+        ImVec2 parent_pos = ImGui::GetWindowPos();
+        ImVec2 parent_size = ImGui::GetWindowSize();
+        ImGui::SetNextWindowPos(parent_pos);
+        ImGui::SetNextWindowSize(parent_size);
+
         // set transparent background for the overlay window
         ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0, 0, 0, 0));
-        ImGui::BeginChild(window_id, ImGui::GetWindowSize(), ImGuiChildFlags_None);
+        ImGui::BeginChild(window_id, parent_size, ImGuiChildFlags_None);
     }
 
     ImVec2 dot_size   = MeasureLoadingIndicatorDots(dot_radius, num_dots, dot_spacing);
@@ -94,7 +96,8 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
 
     if(centering != kCenterNone)
     {
-        ImGui::SetCursorScreenPos(draw_pos);
+        //needed to position dummy in RenderLoadingIndicatorDots()
+        ImGui::SetCursorScreenPos(draw_pos); 
     }
     RenderLoadingIndicatorDots(dot_radius, num_dots, dot_spacing, color, anim_speed);
 
@@ -102,10 +105,9 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
     {
         ImGui::EndChild();
         ImGui::PopStyleColor();
-        // Restore cursor position in the parent window
-        ImGui::SetCursorPos(orig_pos);
     }
 }
+ 
 
 ImU32
 ApplyAlpha(ImU32 color, float alpha)


### PR DESCRIPTION
## Motivation

Fix for the set cursor related crash / assert

```
    IM_ASSERT_USER_ERROR(0, "Code uses SetCursorPos()/SetCursorScreenPos() to extend window/parent boundaries.\nPlease submit an item e.g. Dummy() afterwards in order to grow window/parent boundaries.");
```

## Technical Details

Change RenderLoadingIndicator() implementation to not reset the cursor.  SetCursor behaviour changed as of ImGui v1.92.

Key points:

GetWindowSize() is the visible/window rectangle size. GetCursorPos() is a layout/content cursor in window-local coordinates, including scroll/content progression.  So size returned by getwindowsize can be smaller than layout, and current cursor position.  The original cursor can be outside of this view, and calling setcursor with the out-of-view position causes the assertion because of the behaviour change.  (SetCursor internally flips a flag in Imgui's state and ImGui is expecting to find an item at this new postion).

The new rule since 1.92 is basically only call setcursor if you are planning on drawing an item afterward.  Using it to reset the cursor position blindly (not knowing if another item is coming in current window) is no longer a valid use case. 

From AI:

The relevant note is in thirdparty/imgui/imgui.cpp changelog:

- 2025/06/25 (1.92.0) - Layout: commented out legacy ErrorCheckUsingSetCursorPosToExtendParentBoundaries() fallback obsoleted in 1.89 (August 2022) which allowed a SetCursorPos()/SetCursorScreenPos() call WITHOUT AN ITEM
                         to extend parent window/cell boundaries. Replaced with assert/tooltip that would already happens if previously using IMGUI_DISABLE_OBSOLETE_FUNCTIONS. (#5548, #4510, #3355, #1760, #1490, #4152)
                         - Incorrect way to make a window content size 200x200:
                              Begin(...) + SetCursorScreenPos(GetCursorScreenPos() + ImVec2(200,200)) + End();
                         - Correct ways to make a window content size 200x200:
                         - 
The setcursor behavior was already considered obsolete since 1.89, but 1.92.0 made it assert by default instead of silently applying the old fallback.

That lines up exactly with your bug: SetCursorPos()/SetCursorScreenPos() is now treated as “just move the cursor”; it no longer counts as a submitted layout item. If the moved cursor extends parent/window bounds and no item follows, ImGui asserts and tells you to submit something like Dummy() afterward.