### PR TITLE
Make use of status bar area [minor-improvement]

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_view.h
+++ b/src/view/src/compute/rocprofvis_compute_view.h
@@ -28,6 +28,8 @@ public:
     void CreateView();
     void DestroyView();
 
+    DataProvider* GetDataProvider() override { return &m_data_provider; }
+
     std::shared_ptr<RocWidget> GetToolbar() override;
     std::optional<DataProviderCleanupWork> DetachProviderCleanup() override;
 

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -1565,7 +1565,7 @@ AppWindow::UpdateStatusBar()
             }
             if(clean_up_jobs > 0)
             {
-                m_status_message += (pending_requests > 0 ? " | " : "") +
+                m_status_message = (pending_requests > 0 ? m_status_message + " | " : "") +
                                     ("Cleaning up... (" + std::to_string(clean_up_jobs) +
                                      " pending jobs)");
             }

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -202,13 +202,13 @@ AppWindow::Init()
     m_default_spacing = ImGui::GetStyle().ItemSpacing;
 
     auto new_tab_closed_handler = [this](std::shared_ptr<RocEvent> e) {
-        this->HandleTabClosed(e);
+        HandleTabClosed(e);
     };
     m_tabclosed_event_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kTabClosed), new_tab_closed_handler);
 
     auto new_tab_selected_handler = [this](std::shared_ptr<RocEvent> e) {
-        this->HandleTabSelectionChanged(e);
+        HandleTabSelectionChanged(e);
     };
 
     m_tabselected_event_token = EventManager::GetInstance()->Subscribe(
@@ -1600,14 +1600,14 @@ AppWindow::UpdateStatusBar()
         {
             if(pending_requests > 0)
             {
-                m_status_message = "Working... (" + std::to_string(pending_requests) +
-                                   " pending requests)";
+                m_status_message = "Working: " + std::to_string(pending_requests) +
+                                   " pending request(s)";
             }
             if(clean_up_jobs > 0)
             {
                 m_status_message = (pending_requests > 0 ? m_status_message + " | " : "") +
-                                    ("Cleaning up... (" + std::to_string(clean_up_jobs) +
-                                     " pending jobs)");
+                                    ("Cleaning up: " + std::to_string(clean_up_jobs) +
+                                     " pending job(s)");
             }
             m_status_show_busy_indicator = true;
         }

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -52,8 +52,6 @@ const std::vector<std::string> PROJECT_EXTENSIONS = { "rpv" };
 const std::vector<std::string> ALL_EXTENSIONS     = { "db", "rpd", "yaml", "rpv" };
 constexpr const char* SUPPORTED_FILE_TYPES_HINT   = "Supported types: .db, .rpd, .yaml, .rpv";
 
-constexpr float STATUS_BAR_HEIGHT = 30.0f;
-
 constexpr const char* CLEANUP_MESSAGE = "Waiting for requests to finish cleanup...";
 constexpr const char* CLOSING_MESSAGE = "Closing...";
 
@@ -97,6 +95,7 @@ AppWindow::AppWindow()
 , m_open_about_dialog(false)
 , m_tabclosed_event_token(static_cast<EventManager::SubscriptionToken>(-1))
 , m_tabselected_event_token(static_cast<EventManager::SubscriptionToken>(-1))
+, m_font_changed_token(static_cast<EventManager::SubscriptionToken>(-1))
 #ifdef ROCPROFVIS_DEVELOPER_MODE
 , m_show_debug_window(false)
 , m_show_provider_test_widow(false)
@@ -127,6 +126,9 @@ AppWindow::~AppWindow()
                                              m_tabclosed_event_token);
     EventManager::GetInstance()->Unsubscribe(static_cast<int>(RocEvents::kTabSelected),
                                              m_tabselected_event_token);
+    EventManager::GetInstance()->Unsubscribe(static_cast<int>(RocEvents::kFontSizeChanged),
+                                             m_font_changed_token);
+
     for(auto& job : m_provider_cleanup_jobs)
     {
         if(job.future.valid())
@@ -161,10 +163,11 @@ AppWindow::Init()
         spdlog::warn("Failed to initialize SettingsManager");
     }
 
-    LayoutItem status_bar_item(-1, STATUS_BAR_HEIGHT);
+    constexpr float initial_status_bar_height = 30.0f;
+    LayoutItem status_bar_item(-1, initial_status_bar_height);
     status_bar_item.m_item =
         std::make_shared<RocCustomWidget>([this]() { RenderStatusBar(); });
-    LayoutItem main_area_item(-1, -STATUS_BAR_HEIGHT);
+    LayoutItem main_area_item(-1, -initial_status_bar_height);
     LayoutItem tool_bar_item(-1, 0);
     tool_bar_item.m_child_flags = ImGuiChildFlags_AutoResizeY;
 
@@ -211,8 +214,16 @@ AppWindow::Init()
     m_tabselected_event_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kTabSelected), new_tab_selected_handler);
 
-    ConfigureFileDialogBackend();
+    auto font_changed_handler = [this](std::shared_ptr<RocEvent> e) {
+        (void)e;
+        HandleFontChanged();
+    };
 
+    m_font_changed_token = EventManager::GetInstance()->Subscribe(
+        static_cast<int>(RocEvents::kFontSizeChanged), font_changed_handler);
+
+    ConfigureFileDialogBackend();
+    HandleFontChanged();
     return result;
 }
 
@@ -1257,6 +1268,35 @@ AppWindow::HandleTabSelectionChanged(std::shared_ptr<RocEvent> e)
 }
 
 void
+AppWindow::HandleFontChanged()
+{
+    // Update status bar height based on new font size
+    int count = static_cast<int>(m_main_view->ItemCount());
+
+    // status bar (assume as the last item)
+    auto status_bar_item = m_main_view->GetMutableAt(count - 1);
+    if(!status_bar_item)
+    {
+        return;
+    }
+
+    // Calculate status bar height based on font size, with some padding.
+    ImGuiStyle& style     = ImGui::GetStyle();
+    float       line_pad  = style.CellPadding.y * 2.0f;
+    float       line_size = ImGui::GetTextLineHeight() + line_pad;
+
+    status_bar_item->m_height = line_size;
+
+    // adjust main view's size to account for new status bar height
+    auto main_view_item = m_main_view->GetMutableAt(count - 2);
+    if(!main_view_item)
+    {
+        return;
+    }
+    main_view_item->m_height = -status_bar_item->m_height;
+}
+
+void
 AppWindow::RenderAboutDialog()
 {
     static constexpr const char* NAME_LABEL = "ROCm (TM) Optiq";
@@ -1593,8 +1633,9 @@ AppWindow::RenderStatusBar()
     ImGui::SameLine();
     if(m_status_show_busy_indicator)
     {
+        float radius = ImGui::GetTextLineHeight() * 0.25f;
         RenderLoadingIndicator(settings.GetColor(Colors::kTextDim), nullptr,
-                               kCenterVertical);
+                               kCenterVertical, radius);
         ImGui::SameLine(0.f, style.ItemSpacing.x);
     }
     ImGui::TextUnformatted(m_status_message.c_str());

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -118,6 +118,7 @@ AppWindow::AppWindow()
 , m_exit_notification_sent(false)
 , m_restore_fullscreen_later(false)
 , m_next_provider_cleanup_id(0)
+, m_status_show_busy_indicator(false)
 {}
 
 AppWindow::~AppWindow()
@@ -161,7 +162,8 @@ AppWindow::Init()
     }
 
     LayoutItem status_bar_item(-1, STATUS_BAR_HEIGHT);
-    status_bar_item.m_item = std::make_shared<RocWidget>();
+    status_bar_item.m_item =
+        std::make_shared<RocCustomWidget>([this]() { RenderStatusBar(); });
     LayoutItem main_area_item(-1, -STATUS_BAR_HEIGHT);
     LayoutItem tool_bar_item(-1, 0);
     tool_bar_item.m_child_flags = ImGuiChildFlags_AutoResizeY;
@@ -565,6 +567,7 @@ AppWindow::Update()
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     m_test_data_provider.Update();
 #endif
+    UpdateStatusBar();
 }
 
 void
@@ -1530,6 +1533,74 @@ AppWindow::ShowImGuiFileDialog(const std::string& title, const std::vector<FileF
                                             filter_stream.str().c_str(), config);
 }
 
+void
+AppWindow::UpdateStatusBar()
+{
+    // Update status message every N frames
+    const int UPDATE_STEP = 4;
+    if(ImGui::GetFrameCount() % UPDATE_STEP == 0)
+    {
+        // Get number of pending requests from data provider
+        size_t pending_requests = 0;
+        for(const auto& [id, project] : m_projects)
+        {
+            auto root_view = dynamic_cast<RootView*>(project->GetView().get());
+            if(root_view)
+            {
+                auto data_provider = root_view->GetDataProvider();
+                if(data_provider)
+                {
+                    pending_requests += data_provider->GetPendingRequestCount();
+                }
+            }
+        }
+        // also check if there are any cleanup jobs pending
+        size_t clean_up_jobs = m_provider_cleanup_jobs.size();
+        if(pending_requests > 0 || clean_up_jobs > 0)
+        {
+            if(pending_requests > 0)
+            {
+                m_status_message = "Working... (" + std::to_string(pending_requests) +
+                                   " pending requests)";
+            }
+            if(clean_up_jobs > 0)
+            {
+                m_status_message += (pending_requests > 0 ? " | " : "") +
+                                    ("Cleaning up... (" + std::to_string(clean_up_jobs) +
+                                     " pending jobs)");
+            }
+            m_status_show_busy_indicator = true;
+        }
+        else
+        {
+            m_status_message             = "";
+            m_status_show_busy_indicator = false;
+        }
+    }
+}
+
+void
+AppWindow::RenderStatusBar()
+{
+    SettingsManager&  settings = SettingsManager::GetInstance();
+    const ImGuiStyle& style    = settings.GetDefaultStyle();
+
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, style.FramePadding);
+
+    ImGui::AlignTextToFramePadding();
+    ImGui::Dummy(ImVec2(style.WindowPadding.x, ImGui::GetFrameHeight()));
+    ImGui::SameLine();
+    if(m_status_show_busy_indicator)
+    {
+        RenderLoadingIndicator(settings.GetColor(Colors::kTextDim), nullptr,
+                               kCenterVertical);
+        ImGui::SameLine(0.f, style.ItemSpacing.x);
+    }
+    ImGui::TextUnformatted(m_status_message.c_str());
+    ImGui::PopStyleVar(2);
+}
+
 #ifdef ROCPROFVIS_DEVELOPER_MODE
 void
 AppWindow::RenderDeveloperMenu()
@@ -1718,3 +1789,4 @@ AppWindow::RenderDebugOuput()
 
 }  // namespace View
 }  // namespace RocProfVis
+

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -1613,7 +1613,7 @@ AppWindow::UpdateStatusBar()
         }
         else
         {
-            m_status_message             = "";
+            m_status_message             = "Ready";
             m_status_show_busy_indicator = false;
         }
     }
@@ -1629,7 +1629,7 @@ AppWindow::RenderStatusBar()
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, style.FramePadding);
 
     ImGui::AlignTextToFramePadding();
-    ImGui::Dummy(ImVec2(style.WindowPadding.x, ImGui::GetFrameHeight()));
+    ImGui::Dummy(ImVec2(0.f, ImGui::GetFrameHeight()));
     ImGui::SameLine();
     if(m_status_show_busy_indicator)
     {

--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -108,6 +108,7 @@ private:
 
     void HandleTabClosed(std::shared_ptr<RocEvent> e);
     void HandleTabSelectionChanged(std::shared_ptr<RocEvent> e);
+    void HandleFontChanged();
     void HandleOpenFile();
     void HandleOpenRecentFile(const std::string& file_path);
     void HandleSaveAsFile();
@@ -146,6 +147,7 @@ private:
 
     EventManager::SubscriptionToken m_tabclosed_event_token;
     EventManager::SubscriptionToken m_tabselected_event_token;
+    EventManager::SubscriptionToken m_font_changed_token;
 
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     void RenderDebugOuput();

--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -103,6 +103,8 @@ private:
     void RenderFileDialog();
     void RenderAboutDialog();
     void RenderEmptyState();
+    void RenderStatusBar();
+    void UpdateStatusBar();
 
     void HandleTabClosed(std::shared_ptr<RocEvent> e);
     void HandleTabSelectionChanged(std::shared_ptr<RocEvent> e);
@@ -182,6 +184,9 @@ private:
     bool                             m_restore_fullscreen_later;
     std::vector<ProviderCleanupJob>  m_provider_cleanup_jobs;
     uint64_t                         m_next_provider_cleanup_id;
+
+    std::string m_status_message;
+    bool        m_status_show_busy_indicator;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -100,6 +100,12 @@ DataProvider::FreeRequests()
     CleanupDetachedResources(std::move(cleanup_work));
 }
 
+size_t
+DataProvider::GetPendingRequestCount() const
+{
+    return m_requests.size();
+}
+
 DataProviderCleanupWork
 DataProvider::DetachCleanupWork()
 {

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -94,6 +94,11 @@ public:
      */
     void FreeRequests();
 
+    /*
+     *   Get the number of pending requests.
+     */
+    size_t GetPendingRequestCount() const;
+
     DataProviderCleanupWork DetachCleanupWork();
     static DataProviderCleanupResult CleanupDetachedResources(
         DataProviderCleanupWork cleanup_work);

--- a/src/view/src/rocprofvis_root_view.h
+++ b/src/view/src/rocprofvis_root_view.h
@@ -27,6 +27,8 @@ public:
 
     virtual std::optional<DataProviderCleanupWork> DetachProviderCleanup();
 
+    virtual DataProvider* GetDataProvider() { return nullptr; };
+
 protected:
     void RenderLoadingScreen(const char* progress_label);
 

--- a/src/view/src/rocprofvis_trace_view.h
+++ b/src/view/src/rocprofvis_trace_view.h
@@ -58,6 +58,8 @@ public:
     void CreateView();
     void DestroyView();
 
+    DataProvider* GetDataProvider() override { return &m_data_provider; }
+
     bool HasTrimActiveTrimSelection() const;
     bool IsTrimSaveAllowed() const;
 

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -67,15 +67,17 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
                        LoadingIndicatorCentering centering, float dot_radius,
                        int num_dots, float dot_spacing, float anim_speed)
 {
-    ImVec2 orig_pos = ImGui::GetCursorPos();
-
     if(window_id)
     {
         // Create an overlay child window to display the loading indicator if requested
-        ImGui::SetCursorPos(ImVec2(0, 0));
+        ImVec2 parent_pos = ImGui::GetWindowPos();
+        ImVec2 parent_size = ImGui::GetWindowSize();
+        ImGui::SetNextWindowPos(parent_pos);
+        ImGui::SetNextWindowSize(parent_size);
+
         // set transparent background for the overlay window
         ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0, 0, 0, 0));
-        ImGui::BeginChild(window_id, ImGui::GetWindowSize(), ImGuiChildFlags_None);
+        ImGui::BeginChild(window_id, parent_size, ImGuiChildFlags_None);
     }
 
     ImVec2 dot_size   = MeasureLoadingIndicatorDots(dot_radius, num_dots, dot_spacing);
@@ -94,7 +96,8 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
 
     if(centering != kCenterNone)
     {
-        ImGui::SetCursorScreenPos(draw_pos);
+        //needed to position dummy in RenderLoadingIndicatorDots()
+        ImGui::SetCursorScreenPos(draw_pos); 
     }
     RenderLoadingIndicatorDots(dot_radius, num_dots, dot_spacing, color, anim_speed);
 
@@ -102,10 +105,9 @@ RenderLoadingIndicator(ImU32 color, const char* window_id,
     {
         ImGui::EndChild();
         ImGui::PopStyleColor();
-        // Restore cursor position in the parent window
-        ImGui::SetCursorPos(orig_pos);
     }
 }
+ 
 
 ImU32
 ApplyAlpha(ImU32 color, float alpha)


### PR DESCRIPTION
## Motivation

Make use of status bar area.  Show active requests to the controller.

## Technical Details

Update root view(s) to return dataprovider pointer.  On update check all views (dataproviders) for pending requests.  Render counts in status bar area.