### PR TITLE
Amokichev/get back icons to context menu

### DIFF
--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -29,6 +29,7 @@ constexpr ImWchar icon_ranges[] = {
     0xF472, 0xF472,
     0xF484, 0xF484,
     0xF41B, 0xF41B,
+    0xF30F, 0xF30F,
     0
 };
 
@@ -59,6 +60,7 @@ inline constexpr const char* ICON_LIST          = u8"\uF454";
 inline constexpr const char* ICON_STICKY_NOTE   = u8"\uF472";
 inline constexpr const char* ICON_CHART_PIE     = u8"\uF484";
 inline constexpr const char* ICON_COPY          = u8"\uF41B";
+inline constexpr const char* ICON_ARROW_FORWARD = u8"\uF30F";
 
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -28,6 +28,7 @@ constexpr ImWchar icon_ranges[] = {
     0xF454, 0xF454,
     0xF472, 0xF472,
     0xF484, 0xF484,
+    0xF41B, 0xF41B,
     0
 };
 
@@ -57,6 +58,7 @@ inline constexpr const char* ICON_EYE_THIN      = u8"\uF424";
 inline constexpr const char* ICON_LIST          = u8"\uF454";
 inline constexpr const char* ICON_STICKY_NOTE   = u8"\uF472";
 inline constexpr const char* ICON_CHART_PIE     = u8"\uF484";
+inline constexpr const char* ICON_COPY          = u8"\uF41B";
 
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/widgets/rocprofvis_compute_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_compute_widget.cpp
@@ -10,6 +10,7 @@
 #include "rocprofvis_requests.h"
 #include "rocprofvis_settings_manager.h"
 #include "widgets/rocprofvis_notification_manager.h"
+#include "icons/rocprovfis_icon_defines.h"
 
 namespace RocProfVis
 {
@@ -366,7 +367,7 @@ MetricTable::ContextMenu(const char* value_to_copy, uint32_t column_index,
 {
     if(ImGui::BeginPopupContextItem())
     {
-        if(ImGui::MenuItem("Copy"))
+        if(IconMenuItem(ICON_COPY, "Copy"))
         {
             ImGui::SetClipboardText(value_to_copy);
             NotificationManager::GetInstance().Show(COPY_DATA_NOTIFICATION.data(),
@@ -376,7 +377,7 @@ MetricTable::ContextMenu(const char* value_to_copy, uint32_t column_index,
         // not equal pin column, MetricId, Metric Name and Metric Unit
         {
             if(!m_event_source_id.empty() &&
-               ImGui::MenuItem("Send metric to kernel details"))
+               IconMenuItem(ICON_ARROW_FORWARD, "Send metric to kernel details"))
             {
                 AddMetricToKernelDetails(row.first, m_columns[column_index]);
             }
@@ -523,7 +524,7 @@ PinnedMetricTable::ContextMenu(const char* value_to_copy, uint32_t column_index,
     {
         if(value_to_copy && std::string_view(value_to_copy) != "N/A")
         {
-            if(ImGui::MenuItem("Copy"))
+            if(IconMenuItem(ICON_COPY, "Copy"))
             {
                 ImGui::SetClipboardText(value_to_copy);
                 NotificationManager::GetInstance().Show(COPY_DATA_NOTIFICATION.data(),
@@ -534,7 +535,7 @@ PinnedMetricTable::ContextMenu(const char* value_to_copy, uint32_t column_index,
         if(IsValueColumn(column_index))
         {
             if(!m_event_source_id.empty() &&
-               ImGui::MenuItem("Send metric to kernel details"))
+               IconMenuItem(ICON_ARROW_FORWARD, "Send metric to kernel details"))
             {
                 AddMetricToKernelDetails(row.first, m_columns[column_index]);
             }

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -102,6 +102,21 @@ WithPadding(float left, float right, float top, float bottom,
 }
 
 bool
+IconMenuItem(const char* icon, const char* label)
+{
+    ImVec2 item_pos    = ImGui::GetCursorPos();
+    bool   clicked     = ImGui::Selectable(std::string("##icon_menu_item_").append(label).c_str());
+    ImGui::SetCursorPos(item_pos);
+    ImGui::PushFont(
+        SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault));
+    ImGui::TextUnformatted(icon);
+    ImGui::PopFont();
+    ImGui::SameLine(0.f, ImGui::GetStyle().ItemSpacing.x);
+    ImGui::TextUnformatted(label);
+    return clicked;
+}
+
+bool
 CopyableTextUnformatted(
     const char* text, std::string_view unique_id, std::string_view notification,
     bool one_click_copy, bool context_menu,
@@ -141,7 +156,7 @@ CopyableTextUnformatted(
         }
         else if(ImGui::BeginPopupContextItem())
         {
-            if(ImGui::MenuItem("Copy"))
+            if(IconMenuItem(ICON_COPY, "Copy"))
             {
                 ImGui::SetClipboardText(text);
                 if(!notification.empty())

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -104,15 +104,19 @@ WithPadding(float left, float right, float top, float bottom,
 bool
 IconMenuItem(const char* icon, const char* label)
 {
-    ImVec2 item_pos    = ImGui::GetCursorPos();
-    bool   clicked     = ImGui::Selectable(std::string("##icon_menu_item_").append(label).c_str());
-    ImGui::SetCursorPos(item_pos);
-    ImGui::PushFont(
-        SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault));
+    ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault);
+
+    ImGui::BeginGroup();
+    ImGui::PushFont(icon_font);
     ImGui::TextUnformatted(icon);
     ImGui::PopFont();
     ImGui::SameLine(0.f, ImGui::GetStyle().ItemSpacing.x);
     ImGui::TextUnformatted(label);
+    ImGui::EndGroup();
+
+    bool clicked = ImGui::IsItemClicked();
+    if(clicked)
+        ImGui::CloseCurrentPopup();
     return clicked;
 }
 

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -105,11 +105,12 @@ bool
 IconMenuItem(const char* icon, const char* label)
 {
     ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-    bool clicked =
-        ImGui::Selectable(("##copy_row" + std::string(label)).c_str(), false, ImGuiSelectableFlags_SpanAllColumns,
-                          ImVec2(0, ImGui::GetTextLineHeightWithSpacing()));
+
+    bool clicked = ImGui::Selectable(("##menu_item" + std::string(label)).c_str(), false,
+                                     ImGuiSelectableFlags_SpanAllColumns,
+                                     ImVec2(0, ImGui::GetTextLineHeightWithSpacing()));
     ImGui::SameLine(0.0f, 0.0f);
-    
+
     ImGui::BeginGroup();
     ImGui::PushFont(icon_font);
     ImGui::TextUnformatted(icon);
@@ -118,7 +119,6 @@ IconMenuItem(const char* icon, const char* label)
     ImGui::TextUnformatted(label);
     ImGui::EndGroup();
 
-    bool clicked = ImGui::IsItemClicked();
     if(clicked)
         ImGui::CloseCurrentPopup();
     return clicked;

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -104,7 +104,7 @@ WithPadding(float left, float right, float top, float bottom,
 bool
 IconMenuItem(const char* icon, const char* label)
 {
-    ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetIconFont(FontType::kDefault);
+    ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
 
     ImGui::BeginGroup();
     ImGui::PushFont(icon_font);

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -105,7 +105,11 @@ bool
 IconMenuItem(const char* icon, const char* label)
 {
     ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-
+    bool clicked =
+        ImGui::Selectable(("##copy_row" + std::string(label)).c_str(), false, ImGuiSelectableFlags_SpanAllColumns,
+                          ImVec2(0, ImGui::GetTextLineHeightWithSpacing()));
+    ImGui::SameLine(0.0f, 0.0f);
+    
     ImGui::BeginGroup();
     ImGui::PushFont(icon_font);
     ImGui::TextUnformatted(icon);

--- a/src/view/src/widgets/rocprofvis_widget.h
+++ b/src/view/src/widgets/rocprofvis_widget.h
@@ -96,6 +96,10 @@ CopyableTextUnformatted(
     std::function<void(const char* value_to_copy)> menu_func = nullptr);
 
 
+// Renders a selectable menu item with an icon (from the icon font) followed by a text label.
+// Returns true when clicked. Intended for use inside BeginPopup/BeginPopupContextItem blocks.
+bool IconMenuItem(const char* icon, const char* label);
+
 inline constexpr std::string_view COPY_DATA_NOTIFICATION = "Cell data was copied";
 
 class PopUpStyle


### PR DESCRIPTION
## Motivation
Get back possibility to render menu item with icon and text together
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Added function that cover font switch and draw together icon and text
<img width="195" height="108" alt="image" src="https://github.com/user-attachments/assets/649adf80-ea54-4813-a922-7cf85df02c32" />

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
