### PR TITLE
Revert VS 2026 change

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Build, Make, and Verify Installation
         run: |
           mkdir build
-          cmake --preset "${{ inputs.cmake_config_preset }}" -G "Visual Studio 18 2026" -DROCPROFVIS_ENABLE_INTERNAL_BANNER=${{ env.ENABLE_INTERNAL_BANNER }}
+          cmake --preset "${{ inputs.cmake_config_preset }}" -DROCPROFVIS_ENABLE_INTERNAL_BANNER=${{ env.ENABLE_INTERNAL_BANNER }}
           cmake --build ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }} --preset "${{ inputs.cmake_build_preset }}" --parallel 4
           if (Test-Path "${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BINARY_DIR }}/${env:BUILD_FILE_NAME}.exe") {
             Write-Host "✅ $env:BUILD_FILE_NAME has been successfully built!"


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Revert change to generator in `ci-windows.yml` that was accidentally added in recent merge

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `ci-windows.yml` to remove the `-G "Visual Studio 18 2026"` argument provided to cmake
  - Was previously needed when GitHub windows runner was changed that removed VS 2022, no longer needed after switching to `windows-2022` runner

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure Windows CI passes

## Test Result

<!-- Briefly summarize test outcomes. -->
TBA

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
