### PR TITLE
Remove roc-optiq application from dist artifacts in linux workflows

### DIFF
--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -149,7 +149,6 @@ jobs:
       - name: Prepare Distribution Artifacts
         run: |
           mkdir ${{ env.DIST_DIR }}
-          cp ${{ env.BUILD_DIR }}/${{ env.BUILD_FILE_NAME }} ${{ env.DIST_DIR }}/
           cp ${{ env.BUILD_DIR }}/*.tar.gz ${{ env.DIST_DIR }}/
           cp ${{ env.BUILD_DIR }}/*.rpm ${{ env.DIST_DIR }}/
           ls -l ${{ env.DIST_DIR }}/

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -143,7 +143,6 @@ jobs:
       - name: Prepare Distribution Artifacts
         run: |
           mkdir ${{ env.DIST_DIR }}
-          cp ${{ env.BUILD_DIR }}/${{ env.BUILD_FILE_NAME }} ${{ env.DIST_DIR }}/
           cp ${{ env.BUILD_DIR }}/*.tar.gz ${{ env.DIST_DIR }}/
           cp ${{ env.BUILD_DIR }}/*.deb ${{ env.DIST_DIR }}/
           ls -l ${{ env.DIST_DIR }}/


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
We don't need to include the roc-optiq application in the distribution artifacts for Linux, since we already have .deb/.rpm packages and a tarball.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Remove the copying of roc-optiq application to the distribution directory in `ci-redhat.yml` and `ci-ubuntu.yml`
  - Will ensure they are no longer included in both S3 and GitHub artifacts

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure workflows still pass, no roc-optiq application present for Linux packages

## Test Result

<!-- Briefly summarize test outcomes. -->
TBA

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
