### PR TITLE
TableProcessor Desync

### DIFF
--- a/src/controller/src/rocprofvis_controller_analysis.cpp
+++ b/src/controller/src/rocprofvis_controller_analysis.cpp
@@ -207,7 +207,11 @@ rocprofvis_result_t Analysis::AsyncFetchQueueUtilization(SystemTrace* trace, Tra
             {
                 result = ExecuteQuery(trace, query, "Coarse queue utilization", *future, [start, end, &busy_duration, &event_count](const QueryDataStore& store) -> rocprofvis_result_t {
                     rocprofvis_result_t result = kRocProfVisResultUnknownError;
-                    if(store.rows.size() == 1 && store.columns.count("total_duration") > 0 && store.columns.count("event_count") > 0)
+                    if(store.rows.empty())
+                    {
+                        result = kRocProfVisResultSuccess;
+                    }
+                    else if(store.rows.size() == 1 && store.columns.count("total_duration") > 0 && store.columns.count("event_count") > 0)
                     {
                         const char* duration = store.rows[0][store.columns.at("total_duration")];
                         const char* count = store.rows[0][store.columns.at("event_count")];
@@ -271,17 +275,20 @@ rocprofvis_result_t Analysis::AsyncFetchQueueUtilization(SystemTrace* trace, Tra
                 }
                 free(query);
             }
-            if(dm_result == kRocProfVisDmResultSuccess)
+            if(dm_result == kRocProfVisDmResultSuccess && result == kRocProfVisResultSuccess)
             {
-                if(result == kRocProfVisResultSuccess)
-                {
-                    *output = busy_duration / (end - start) * 100.0;
-                }
-                else if(result == kRocProfVisResultNotLoaded)
+                if(busy_duration == 0.0)
                 {
                     *output = 0.0;
-                    result = kRocProfVisResultSuccess;
                 }
+                else if(end == start)
+                {
+                    *output = 100.0;
+                }
+                else
+                {
+                    *output = busy_duration / (end - start) * 100.0;
+                }                
             }
         }
         return future->IsCancelled() ? kRocProfVisResultCancelled : result;
@@ -515,10 +522,6 @@ rocprofvis_result_t Analysis::ExecuteQuery(Trace* trace, const char* query, cons
                 {
                     result = kRocProfVisResultUnknownError;
                 }
-            }
-            else if(dm_result == kRocProfVisDmResultDbAccessFailed)
-            {
-                result = kRocProfVisResultNotLoaded;
             }
             else
             {

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -5,7 +5,6 @@
 #include "rocprofvis_db_expression_filter.h"
 #include "rocprofvis_c_interface.h"
 #include <sstream>
-#include <unordered_set>
 #include <cfloat>
 #include <yaml-cpp/yaml.h>
 #include "json.h"
@@ -1272,7 +1271,7 @@ ProfileDatabase::BuildTableQuery(
                         query += where;
                     }
                     query += ";";
-                    query += std::to_string(track);
+                    query += std::to_string(tracks[i]);
                     query += ";";
                     query += std::to_string(it_instance->first);
                     query += "\n";
@@ -1522,10 +1521,9 @@ rocprofvis_dm_result_t  ProfileDatabase::ExecuteQuery(
         ROCPROFVIS_ASSERT_MSG_BREAK(BindObject()->trace_properties->metadata_loaded, ERROR_METADATA_IS_NOT_LOADED);
         rocprofvis_dm_table_t table = BindObject()->FuncAddTable(BindObject()->trace_object, query, description);
         ROCPROFVIS_ASSERT_MSG_RETURN(table, ERROR_TABLE_CANNOT_BE_NULL, kRocProfVisDmResultUnknownError);
-        std::vector<rocprofvis_db_compound_query> queries;
+        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>> queries;
         std::vector<rocprofvis_db_compound_query_command> commands;
         std::set<uint32_t> tracks;
-        std::string query_without_commands = TableProcessor::QueryWithoutCommands(query);
         if (TableProcessor::IsCompoundQuery(query, queries, tracks,  commands))
         {
             auto it = std::find_if(commands.begin(), commands.end(), [](rocprofvis_db_compound_query_command& cmd) { return cmd.name == "TYPE"; });
@@ -1534,9 +1532,9 @@ rocprofvis_dm_result_t  ProfileDatabase::ExecuteQuery(
             {
                 data_type = (rocprofvis_db_compound_table_type)std::atol(it->parameter.c_str());
             }
-            bool query_updated = !m_table_processor[data_type].IsCurrentQuery(query_without_commands.c_str());
-            m_table_processor[data_type].SaveCurrentQuery(query_without_commands.c_str());
-            if (kRocProfVisDmResultSuccess != m_table_processor[data_type].ExecuteCompoundQuery(future, queries, tracks, commands, table, data_type, query_updated)) break;
+            bool query_updated = !m_table_processor[data_type].IsCurrentQuery(queries);
+            m_table_processor[data_type].SaveCurrentQuery(queries);
+            if (kRocProfVisDmResultSuccess != m_table_processor[data_type].ExecuteCompoundQuery(future, queries, tracks, commands, table, query_updated)) break;
         }
         else
         {
@@ -1630,27 +1628,20 @@ rocprofvis_dm_result_t ProfileDatabase::ExportTableCSV(rocprofvis_dm_charptr_t q
     ROCPROFVIS_ASSERT_MSG_RETURN(future, ERROR_FUTURE_CANNOT_BE_NULL, kRocProfVisDmResultInvalidParameter);
     ROCPROFVIS_ASSERT_MSG_RETURN(BindObject()->trace_object, ERROR_TRACE_CANNOT_BE_NULL, kRocProfVisDmResultInvalidParameter);
     rocprofvis_dm_result_t result = kRocProfVisDmResultInvalidParameter;
-
-    rocprofvis_db_compound_table_type data_type = kRPVTableDataTypeEvent;
-    std::vector<rocprofvis_db_compound_query> queries;
-    std::vector<rocprofvis_db_compound_query_command> commands;
-    std::set<uint32_t> tracks;
-    if (TableProcessor::IsCompoundQuery(query, queries, tracks,  commands))
+    Future* internal_future = future->AddSubFuture();
+    result = ExecuteQuery(query, "ExportTableCSV", internal_future);
+    future->WaitAndDeleteSubFuture(internal_future);
+    if (result == kRocProfVisDmResultSuccess)
     {
+        rocprofvis_db_compound_table_type data_type = kRPVTableDataTypeEvent;
+        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>> queries;
+        std::vector<rocprofvis_db_compound_query_command> commands;
+        std::set<uint32_t> tracks;
+        TableProcessor::IsCompoundQuery(query, queries, tracks,  commands);
         auto it = std::find_if(commands.begin(), commands.end(), [](rocprofvis_db_compound_query_command& cmd) { return cmd.name == "TYPE"; });
         if (it != commands.end())
         {
             data_type = (rocprofvis_db_compound_table_type)std::atol(it->parameter.c_str());
-            result = kRocProfVisDmResultSuccess;
-        }            
-    }
-    if (result == kRocProfVisDmResultSuccess)
-    {
-        Future* internal_future = future->AddSubFuture();
-        result = ExecuteQuery(query, "ExportTableCSV", internal_future);
-        future->WaitAndDeleteSubFuture(internal_future);
-        if (result == kRocProfVisDmResultSuccess)
-        {
             result = m_table_processor[data_type].ExportToCSV(file_path);
             if (result == kRocProfVisDmResultSuccess)
             {

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1521,7 +1521,7 @@ rocprofvis_dm_result_t  ProfileDatabase::ExecuteQuery(
         ROCPROFVIS_ASSERT_MSG_BREAK(BindObject()->trace_properties->metadata_loaded, ERROR_METADATA_IS_NOT_LOADED);
         rocprofvis_dm_table_t table = BindObject()->FuncAddTable(BindObject()->trace_object, query, description);
         ROCPROFVIS_ASSERT_MSG_RETURN(table, ERROR_TABLE_CANNOT_BE_NULL, kRocProfVisDmResultUnknownError);
-        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>> queries;
+        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>> queries;
         std::vector<rocprofvis_db_compound_query_command> commands;
         std::set<uint32_t> tracks;
         if (TableProcessor::IsCompoundQuery(query, queries, tracks,  commands))
@@ -1634,7 +1634,7 @@ rocprofvis_dm_result_t ProfileDatabase::ExportTableCSV(rocprofvis_dm_charptr_t q
     if (result == kRocProfVisDmResultSuccess)
     {
         rocprofvis_db_compound_table_type data_type = kRPVTableDataTypeEvent;
-        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>> queries;
+        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>> queries;
         std::vector<rocprofvis_db_compound_query_command> commands;
         std::set<uint32_t> tracks;
         TableProcessor::IsCompoundQuery(query, queries, tracks,  commands);

--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -60,13 +60,12 @@ namespace DataModel
         return column;
     }
 
-    rocprofvis_dm_result_t TableProcessor::ExecuteCompoundQuery(Future* future, 
-        std::vector<rocprofvis_db_compound_query>& queries, 
+    rocprofvis_dm_result_t TableProcessor::ExecuteCompoundQuery(Future* future,
+        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries,
         std::set<uint32_t>& tracks,
-        std::vector<rocprofvis_db_compound_query_command> commands, 
-        rocprofvis_dm_handle_t handle, 
-        rocprofvis_db_compound_table_type type,
-        bool query_updated) 
+        std::vector<rocprofvis_db_compound_query_command> commands,
+        rocprofvis_dm_handle_t handle,
+        bool query_updated)
     {
         m_timer.pause();
         rocprofvis_dm_result_t result = kRocProfVisDmResultInvalidParameter;
@@ -89,31 +88,31 @@ namespace DataModel
                 m_tracks.begin(), m_tracks.end(),
                 std::inserter(added_tracks, added_tracks.end())
             );
-            bool sametracks = (removed_tracks.size() == 0) && (added_tracks.size() == 0);
-            if (sametracks && query_updated)
+
+            if (query_updated)
             {
                 removed_tracks = m_tracks;
                 added_tracks = tracks;
             }
 
             result = kRocProfVisDmResultSuccess;
-            bool same_queries = (removed_tracks.size() == 0) && (added_tracks.size() == 0);
+            bool same_queries = removed_tracks.empty() && added_tracks.empty();
             if (!same_queries)
             {
                 m_tables.clear();
                 std::vector<std::pair<DbInstance*, std::string>> new_queries;
-                for (int i = 0; i < queries.size(); i++)
+                for (const std::pair<const uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& track : queries)
                 {
-                    if (added_tracks.find(queries[i].track) != added_tracks.end())
+                    for (const std::pair<const std::string, rocprofvis_db_compound_query>& compound_query : track.second)
                     {
                         m_tables.push_back(std::make_unique<PackedTable>());
-                        DbInstance* db_instance = m_db->DbInstancePtrAt(queries[i].guid_id);
-                        new_queries.push_back({ db_instance, queries[i].query });
+                        DbInstance* db_instance = m_db->DbInstancePtrAt(compound_query.second.guid_id);
+                        new_queries.push_back({ db_instance, compound_query.second.query });
                     }
                     
                 }
 
-                m_merged_table.RemoveRowsForSetOfTracks(tracks, removed_tracks, sametracks && query_updated);
+                m_merged_table.RemoveRowsForSetOfTracks(tracks, removed_tracks, query_updated);
 
                 if (new_queries.size())
                 {
@@ -148,18 +147,19 @@ namespace DataModel
                 m_merged_table.CreateSortOrderArray();
                 if (m_merged_table.RowCount() == 0)
                 {
-                    result = kRocProfVisDmResultNotLoaded;
+                    result = (kRocProfVisDmResultSuccess == result) ? kRocProfVisDmResultSuccess : kRocProfVisDmResultNotLoaded;
                 }
             }
 
 
-            if (kRocProfVisDmResultSuccess == result)
+            if (kRocProfVisDmResultSuccess == result && m_merged_table.RowCount() > 0)
             {
                 result = ProcessCompoundQuery(handle, commands, !same_queries);
                 m_tracks = tracks;
             }
             else
             {
+                m_tracks.clear();
                 m_tables.clear();
             }
         }
@@ -177,7 +177,7 @@ namespace DataModel
         return query_without_commands;
     }
 
-    bool TableProcessor::IsCompoundQuery(const char* query, std::vector<rocprofvis_db_compound_query>& queries, std::set<uint32_t>& tracks, std::vector<rocprofvis_db_compound_query_command>& commands)
+    bool TableProcessor::IsCompoundQuery(const char* query, std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries, std::set<uint32_t>& tracks, std::vector<rocprofvis_db_compound_query_command>& commands)
     {
         std::istringstream stream(query);
         std::string line;
@@ -212,7 +212,7 @@ namespace DataModel
                                 uint32_t track = std::atol(s_track.c_str());
                                 uint32_t guid_id = std::atoll(s_guid_id.c_str());
                                 tracks.insert(track);
-                                queries.push_back({ stmt,track,guid_id });
+                                queries[track][stmt] = { stmt, track, guid_id };
                             }
                            
                         }
@@ -229,6 +229,21 @@ namespace DataModel
         return false;
     }
 
+    bool TableProcessor::IsCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries)
+    {
+        if(m_current_queries.size() && (*m_current_queries.begin()).second.size() && TABLE_QUERY_UNPACK_OP_TYPE((*(*m_current_queries.begin()).second.begin()).second.track))
+        {
+            return false;
+        }
+        for(std::pair<const uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& track : queries)
+        {
+            if(m_current_queries.count(track.first) && track.second.size())
+            {
+                return m_current_queries.at(track.first).count((*track.second.begin()).first);
+            }
+        }
+        return true;
+    }
 
     rocprofvis_dm_result_t TableProcessor::AddTableCells(bool to_file, rocprofvis_dm_handle_t handle, uint32_t row_index)
     {
@@ -950,7 +965,8 @@ namespace DataModel
         return 0;
     }
 
-    rocprofvis_dm_result_t TableProcessor::ExportToCSV(rocprofvis_dm_charptr_t file_path) {
+    rocprofvis_dm_result_t TableProcessor::ExportToCSV(rocprofvis_dm_charptr_t file_path)
+    {
         rocprofvis_dm_result_t result = kRocProfVisDmResultNotLoaded;
         std::ofstream file(file_path);
         if (file.is_open())

--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -61,7 +61,7 @@ namespace DataModel
     }
 
     rocprofvis_dm_result_t TableProcessor::ExecuteCompoundQuery(Future* future,
-        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries,
+        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& queries,
         std::set<uint32_t>& tracks,
         std::vector<rocprofvis_db_compound_query_command> commands,
         rocprofvis_dm_handle_t handle,
@@ -101,13 +101,13 @@ namespace DataModel
             {
                 m_tables.clear();
                 std::vector<std::pair<DbInstance*, std::string>> new_queries;
-                for (const std::pair<const uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& track : queries)
+                for (const std::pair<const uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& track : queries)
                 {
-                    for (const std::pair<const std::string, rocprofvis_db_compound_query>& compound_query : track.second)
+                    for (const std::pair<const std::string, rocprofvis_db_compound_query_info>& compound_query : track.second)
                     {
                         m_tables.push_back(std::make_unique<PackedTable>());
                         DbInstance* db_instance = m_db->DbInstancePtrAt(compound_query.second.guid_id);
-                        new_queries.push_back({ db_instance, compound_query.second.query });
+                        new_queries.push_back({ db_instance, compound_query.first });
                     }
                     
                 }
@@ -177,7 +177,7 @@ namespace DataModel
         return query_without_commands;
     }
 
-    bool TableProcessor::IsCompoundQuery(const char* query, std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries, std::set<uint32_t>& tracks, std::vector<rocprofvis_db_compound_query_command>& commands)
+    bool TableProcessor::IsCompoundQuery(const char* query, std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& queries, std::set<uint32_t>& tracks, std::vector<rocprofvis_db_compound_query_command>& commands)
     {
         std::istringstream stream(query);
         std::string line;
@@ -212,7 +212,7 @@ namespace DataModel
                                 uint32_t track = std::atol(s_track.c_str());
                                 uint32_t guid_id = std::atoll(s_guid_id.c_str());
                                 tracks.insert(track);
-                                queries[track][stmt] = { stmt, track, guid_id };
+                                queries[track][stmt] = { track, guid_id };
                             }
                            
                         }
@@ -229,13 +229,13 @@ namespace DataModel
         return false;
     }
 
-    bool TableProcessor::IsCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries)
+    bool TableProcessor::IsCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& queries)
     {
         if(m_current_queries.size() && (*m_current_queries.begin()).second.size() && TABLE_QUERY_UNPACK_OP_TYPE((*(*m_current_queries.begin()).second.begin()).second.track))
         {
             return false;
         }
-        for(std::pair<const uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& track : queries)
+        for(std::pair<const uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& track : queries)
         {
             if(m_current_queries.count(track.first) && track.second.size())
             {

--- a/src/model/src/database/rocprofvis_db_table_processor.h
+++ b/src/model/src/database/rocprofvis_db_table_processor.h
@@ -152,19 +152,18 @@ namespace DataModel
 
         };
 
-        static bool IsCompoundQuery(const char* query, std::vector<rocprofvis_db_compound_query>& queries, std::set<uint32_t>& tracks, 
+        static bool IsCompoundQuery(const char* query, std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries, std::set<uint32_t>& tracks,
             std::vector<rocprofvis_db_compound_query_command>& commands);
-        static std::string QueryWithoutCommands(const char* query);
-        rocprofvis_dm_result_t ExecuteCompoundQuery(Future* future, 
-            std::vector<rocprofvis_db_compound_query>& queries, 
+        static std::string QueryWithoutCommands(const char* query); // Unused
+        rocprofvis_dm_result_t ExecuteCompoundQuery(Future* future,
+            std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries,
             std::set<uint32_t>& tracks,
-            std::vector<rocprofvis_db_compound_query_command> commands, 
-            rocprofvis_dm_handle_t handle, 
-            rocprofvis_db_compound_table_type type,
+            std::vector<rocprofvis_db_compound_query_command> commands,
+            rocprofvis_dm_handle_t handle,
             bool query_updated);
         std::string ParseSortCommand(std::string param, bool& order);
-        void SaveCurrentQuery(rocprofvis_dm_charptr_t query) { m_current_query = query; };
-        bool IsCurrentQuery(rocprofvis_dm_charptr_t query) { return m_current_query == query; };
+        void SaveCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries) { m_current_queries = queries; };
+        bool IsCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries);
         rocprofvis_dm_result_t ExportToCSV(rocprofvis_dm_charptr_t file_path);
 
     private:
@@ -188,7 +187,7 @@ namespace DataModel
         bool m_sort_order = true;
         std::string m_sort_column;
         std::mutex m_lock;
-        std::string m_current_query;
+        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>> m_current_queries;
 
         static constexpr const char* QUERY_COMMAND_TAG = "-- CMD:";
     };

--- a/src/model/src/database/rocprofvis_db_table_processor.h
+++ b/src/model/src/database/rocprofvis_db_table_processor.h
@@ -42,11 +42,10 @@ namespace DataModel
         std::string parameter;
     } rocprofvis_db_compound_query_command;
 
-    typedef struct rocprofvis_db_compound_query {
-        std::string query;
+    typedef struct rocprofvis_db_compound_query_info {
         uint32_t track;
         uint32_t guid_id;
-    } rocprofvis_db_compound_query;
+    } rocprofvis_db_compound_query_info;
 
     class RestartableTimer {
     public:
@@ -152,18 +151,18 @@ namespace DataModel
 
         };
 
-        static bool IsCompoundQuery(const char* query, std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries, std::set<uint32_t>& tracks,
+        static bool IsCompoundQuery(const char* query, std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& queries, std::set<uint32_t>& tracks,
             std::vector<rocprofvis_db_compound_query_command>& commands);
         static std::string QueryWithoutCommands(const char* query); // Unused
         rocprofvis_dm_result_t ExecuteCompoundQuery(Future* future,
-            std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries,
+            std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& queries,
             std::set<uint32_t>& tracks,
             std::vector<rocprofvis_db_compound_query_command> commands,
             rocprofvis_dm_handle_t handle,
             bool query_updated);
         std::string ParseSortCommand(std::string param, bool& order);
-        void SaveCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries) { m_current_queries = queries; };
-        bool IsCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>>& queries);
+        void SaveCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& queries) { m_current_queries = queries; };
+        bool IsCurrentQuery(std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>>& queries);
         rocprofvis_dm_result_t ExportToCSV(rocprofvis_dm_charptr_t file_path);
 
     private:
@@ -187,7 +186,8 @@ namespace DataModel
         bool m_sort_order = true;
         std::string m_sort_column;
         std::mutex m_lock;
-        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query>> m_current_queries;
+        // track id, query string, query info.
+        std::unordered_map<uint32_t, std::unordered_map<std::string, rocprofvis_db_compound_query_info>> m_current_queries;
 
         static constexpr const char* QUERY_COMMAND_TAG = "-- CMD:";
     };


### PR DESCRIPTION
Fix various desyncs between timeline selection and `TableProcessor`.

Running two back-to-back queries with different track selection and range filter will break `TableProcessor`'s internal bookkeeping, which causes `TableProcessor` to return stale/incomplete data. 

Issues occurs only in specific scenarios because UI will never run two back-to-back queries with both different track selection and range filter, it will only change one or the other. The problem comes from possibility of `BuildTableQuery` dropping a track UI asked for if it detected said track is empty in the requested range, such as:
1. When multiple tracks are selected, followed by a filter to a range where some of tracks are empty.
2. When op type queries and track type queries are interleaved on same `TableProcessor`, like summary. 

Also makes `TableProcessor` consider a result of 0 rows as `ResultSuccess` instead of `ResultNotLoaded` provided there are no errors. To go with this, code that compensated for this in `Analysis` was removed.

