### PR TITLE
Add copy menu to Call Stack table and fix cell right-click hitboxes

### DIFF
--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -21,6 +21,9 @@ constexpr ImGuiTableFlags TABLE_FLAGS = ImGuiTableFlags_BordersOuter |
                                         ImGuiTableFlags_Resizable |
                                         ImGuiTableFlags_SizingStretchProp;
 
+constexpr int kFlowColumnCount      = 6;
+constexpr int kCallStackColumnCount = 5;
+
 namespace
 {
 
@@ -327,7 +330,7 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
         }
         else
         {
-            if(ImGui::BeginTable("FlowInfoTable", 6, TABLE_FLAGS))
+            if(ImGui::BeginTable("FlowInfoTable", kFlowColumnCount, TABLE_FLAGS))
             {
                 ImGui::TableSetupColumn("ID");
                 ImGui::TableSetupColumn("Name");
@@ -406,7 +409,9 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                             m_context_menu_flow_index = i;
                             int hovered_col           = ImGui::TableGetHoveredColumn();
                             m_context_menu_flow_column =
-                                (hovered_col >= 0 && hovered_col < 6) ? hovered_col : 0;
+                                (hovered_col >= 0 && hovered_col < kFlowColumnCount)
+                                    ? hovered_col
+                                    : 0;
                             ImGui::OpenPopup("##FlowContextMenu");
                         }
                         ImGui::PopStyleColor(3);
@@ -482,7 +487,7 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                         if(ImGui::MenuItem("Copy Row Data"))
                         {
                             std::string row_text;
-                            for(int c = 0; c < 6; c++)
+                            for(int c = 0; c < kFlowColumnCount; c++)
                             {
                                 if(c > 0) row_text += '\t';
                                 row_text += cells[c];
@@ -492,7 +497,7 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                         if(ImGui::MenuItem("Copy Cell Data"))
                         {
                             int col = m_context_menu_flow_column;
-                            if(col >= 0 && col < 6)
+                            if(col >= 0 && col < kFlowColumnCount)
                                 ImGui::SetClipboardText(cells[col].c_str());
                         }
                     }
@@ -526,7 +531,7 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
         }
         else
         {
-            if(ImGui::BeginTable("CallStackTable", 5, TABLE_FLAGS))
+            if(ImGui::BeginTable("CallStackTable", kCallStackColumnCount, TABLE_FLAGS))
             {
                 ImGui::TableSetupColumn("ID");
                 ImGui::TableSetupColumn("Address");
@@ -624,7 +629,9 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                             m_context_menu_callstack_index = i;
                             int hovered_col                = ImGui::TableGetHoveredColumn();
                             m_context_menu_callstack_column =
-                                (hovered_col >= 0 && hovered_col < 5) ? hovered_col : 0;
+                                (hovered_col >= 0 && hovered_col < kCallStackColumnCount)
+                                    ? hovered_col
+                                    : 0;
                             open_callstack_context_menu = true;
                         }
                         ImGui::PopStyleColor(3);
@@ -687,7 +694,7 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                         if(ImGui::MenuItem("Copy Row Data"))
                         {
                             std::string row_text;
-                            for(int c = 0; c < 5; c++)
+                            for(int c = 0; c < kCallStackColumnCount; c++)
                             {
                                 if(c > 0) row_text += '\t';
                                 row_text += cells[c];
@@ -697,7 +704,7 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                         if(ImGui::MenuItem("Copy Cell Data"))
                         {
                             int col = m_context_menu_callstack_column;
-                            if(col >= 0 && col < 5)
+                            if(col >= 0 && col < kCallStackColumnCount)
                                 ImGui::SetClipboardText(cells[col].c_str());
                         }
                     }

--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -59,6 +59,7 @@ EventsView::EventsView(DataProvider&                      dp,
 , m_context_menu_flow_index(-1)
 , m_context_menu_flow_column(-1)
 , m_context_menu_callstack_index(-1)
+, m_context_menu_callstack_column(-1)
 {
     static_assert(CallStackHoverState::kInvalidId ==
                       TimelineSelection::INVALID_SELECTION_ID,
@@ -402,8 +403,10 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                                 ImGuiHoveredFlags_AllowWhenOverlappedByItem);
                         if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
                         {
-                            m_context_menu_flow_index  = i;
-                            m_context_menu_flow_column = 0;
+                            m_context_menu_flow_index = i;
+                            int hovered_col           = ImGui::TableGetHoveredColumn();
+                            m_context_menu_flow_column =
+                                (hovered_col >= 0 && hovered_col < 6) ? hovered_col : 0;
                             ImGui::OpenPopup("##FlowContextMenu");
                         }
                         ImGui::PopStyleColor(3);
@@ -558,8 +561,9 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
 
                     if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
                     {
-                        m_context_menu_callstack_index = row;
-                        open_callstack_context_menu    = true;
+                        m_context_menu_callstack_index  = row;
+                        m_context_menu_callstack_column = col;
+                        open_callstack_context_menu     = true;
                     }
                 };
 
@@ -618,7 +622,10 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                         if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
                         {
                             m_context_menu_callstack_index = i;
-                            open_callstack_context_menu    = true;
+                            int hovered_col                = ImGui::TableGetHoveredColumn();
+                            m_context_menu_callstack_column =
+                                (hovered_col >= 0 && hovered_col < 5) ? hovered_col : 0;
+                            open_callstack_context_menu = true;
                         }
                         ImGui::PopStyleColor(3);
 
@@ -670,6 +677,28 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                         if(ImGui::MenuItem("Go To Event"))
                         {
                             navigate_to_frame(ctx_frame.id.uuid);
+                        }
+
+                        std::string cells[] = {
+                            std::to_string(ctx_frame.id.bitfield.event_id),
+                            ctx_frame.address, ctx_frame.name, ctx_frame.file,
+                            ctx_frame.pc};
+
+                        if(ImGui::MenuItem("Copy Row Data"))
+                        {
+                            std::string row_text;
+                            for(int c = 0; c < 5; c++)
+                            {
+                                if(c > 0) row_text += '\t';
+                                row_text += cells[c];
+                            }
+                            ImGui::SetClipboardText(row_text.c_str());
+                        }
+                        if(ImGui::MenuItem("Copy Cell Data"))
+                        {
+                            int col = m_context_menu_callstack_column;
+                            if(col >= 0 && col < 5)
+                                ImGui::SetClipboardText(cells[col].c_str());
                         }
                     }
                     ImGui::EndPopup();

--- a/src/view/src/rocprofvis_events_view.h
+++ b/src/view/src/rocprofvis_events_view.h
@@ -79,6 +79,7 @@ private:
     int                                      m_context_menu_flow_index;
     int                                      m_context_menu_flow_column;
     int                                      m_context_menu_callstack_index;
+    int                                      m_context_menu_callstack_column;
     FlowHighlightState                       m_flow_hover;
     FlowHighlightState                       m_frame_flow_hover;
     CallStackHoverState                      m_callstack_hover;


### PR DESCRIPTION
## Motivation
The Flow table in the Event Details tab has a right-click "Copy Row Data" / "Copy Cell Data" menu, but the Call Stack table did not. Also, in both tables, Copy Cell would often grab the wrong column when right-clicking inside the cell — making the feature unreliable.
## Technical Details
- Added "Copy Row Data" and "Copy Cell Data" entries to the Call Stack table's right-click context menu, mirroring the existing Flow table behavior. Tracks the clicked column via a new `m_context_menu_callstack_column` member.
- Fixed the cell hitbox bug in both tables: cell text only covers as much width as the string, so right-clicks on the surrounding padding fell through to the row-spanning `Selectable` and were hardcoded to column 0. Now uses `ImGui::TableGetHoveredColumn()` to record the actual column under the cursor.