### PR TITLE
Top Events UI + Misc

### DIFF
--- a/src/controller/inc/rocprofvis_controller_enums.h
+++ b/src/controller/inc/rocprofvis_controller_enums.h
@@ -288,11 +288,11 @@ typedef enum rocprofvis_controller_track_properties_t : uint32_t
     // Entries are actually loaded via an async call to prepare for RPC
     kRPVControllerTrackEntry,
     // Category of the track
-    kRPVControllerCategory,
+    kRPVControllerTrackCategory,
     // Track main process string (PID, GPUID, etc)
-    kRPVControllerMainName,
+    kRPVControllerTrackMainName,
     // Track sub process string (TID, QueueID, PMC name)
-    kRPVControllerSubName,
+    kRPVControllerTrackSubName,
     // Description
     kRPVControllerTrackDescription,
     // Min value for sample tracks
@@ -327,6 +327,10 @@ typedef enum rocprofvis_controller_track_properties_t : uint32_t
     kRPVControllerTrackAgentIdOrPid,
     // Get track queue id or TID
     kRPVControllerTrackQueueIdOrTid,
+    // Number of event operation types supported by the track
+    kRPVControllerTrackNumberOfOperationTypes,
+    // Event operation type at the given index, see rocprofvis_dm_event_operation_t
+    kRPVControllerTrackOperationTypeIndexed,
     __kRPVControllerTrackPropertiesLast
 } rocprofvis_controller_track_properties_t;
 /* JSON: RPVTrack

--- a/src/controller/src/rocprofvis_controller_analysis.cpp
+++ b/src/controller/src/rocprofvis_controller_analysis.cpp
@@ -393,11 +393,13 @@ rocprofvis_result_t Analysis::EventsTable::UnpackArguments(Arguments& args, Quer
             }
         }
     }
+    const char* group = (m_op == kRocProfVisDmOperationLaunchSample) ? "name, COUNT(*) AS Invocations, SUM(duration) AS DurationTotal" :
+        "name, COUNT(*) AS Invocations, SUM(duration) AS DurationTotal, AVG(duration) AS DurationAvg, MIN(duration) AS DurationMin, MAX(duration) AS DurationMax";
     ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
     result = args.GetUInt64(kRPVControllerTableArgsSortColumn, 0, &sort_column_index);
     ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
     result = args.GetUInt64(kRPVControllerTableArgsSortOrder, 0, &sort_order);
-    out = {"", "__op = " + std::to_string(m_op), "name, COUNT(*) AS Invocations, SUM(duration) AS DurationTotal, AVG(duration) AS DurationAvg, MIN(duration) AS DurationMin, MAX(duration) AS DurationMax", "name", sort_column_index, (rocprofvis_controller_sort_order_t)sort_order, tracks, {}, use_case, start_ts, end_ts};
+    out = {"", "__op = " + std::to_string(m_op), group, "name", sort_column_index, (rocprofvis_controller_sort_order_t)sort_order, tracks, {}, use_case, start_ts, end_ts};
     return result;
 }
 

--- a/src/controller/src/system/rocprofvis_controller_table_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_table_system.cpp
@@ -706,7 +706,6 @@ SystemTable::UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t&
         switch (table_type)
         {
             case kRPVControllerTableTypeEvents:
-            case kRPVControllerTableTypeSearchResults:
             case kRPVControllerTableTypeSummaryKernelInstances:
             {
                 out = kRPVDMTableUseCaseEventTrackTable;

--- a/src/controller/src/system/rocprofvis_controller_trace_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_trace_system.cpp
@@ -199,21 +199,21 @@ rocprofvis_result_t SystemTrace::LoadRocpd(Future* future) {
                                                 dm_track_handle,
                                                 kRPVDMTrackCategoryEnumCharPtr, 0);
 
-                                        track->SetString(kRPVControllerCategory, 0,
+                                        track->SetString(kRPVControllerTrackCategory, 0,
                                                          category.c_str());
 
                                         std::string main_name =
                                             rocprofvis_dm_get_property_as_charptr(
                                                 dm_track_handle,
                                                 kRPVDMTrackMainProcessNameCharPtr, 0);
-                                        track->SetString(kRPVControllerMainName, 0,
+                                        track->SetString(kRPVControllerTrackMainName, 0,
                                                          main_name.c_str());
 
                                         std::string sub_name =
                                             rocprofvis_dm_get_property_as_charptr(
                                                 dm_track_handle,
                                                 kRPVDMTrackSubProcessNameCharPtr, 0);
-                                        track->SetString(kRPVControllerSubName, 0,
+                                        track->SetString(kRPVControllerTrackSubName, 0,
                                                          sub_name.c_str());
 
                                         uint64_t num_records =
@@ -360,6 +360,69 @@ rocprofvis_result_t SystemTrace::LoadRocpd(Future* future) {
                                                          name.c_str(), value.c_str());
                                         }
 
+                                        switch((rocprofvis_dm_track_category_t)dm_track_type)
+                                        {
+                                            case kRocProfVisDmPmcTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationNoOp);
+                                                break;
+                                            }
+                                            case kRocProfVisDmRegionTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 2);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationLaunch);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 1, kRocProfVisDmOperationLaunchSample);
+                                                break;
+                                            }
+                                            case kRocProfVisDmKernelDispatchTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationDispatch);
+                                                break;
+                                            }
+                                            case kRocProfVisDmMemoryAllocationTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationMemoryAllocate);
+                                                break;
+                                            }
+                                            case kRocProfVisDmMemoryCopyTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationMemoryCopy);
+                                                break;
+                                            }
+                                            case kRocProfVisDmStreamTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 5);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationLaunch);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 1, kRocProfVisDmOperationDispatch);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 2, kRocProfVisDmOperationMemoryAllocate);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 3, kRocProfVisDmOperationMemoryCopy);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 4, kRocProfVisDmOperationLaunchSample);
+                                                break;
+                                            }
+                                            case kRocProfVisDmRegionMainTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationLaunch);
+                                                break;
+                                            }
+                                            case kRocProfVisDmRegionSampleTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationLaunchSample);
+                                                break;
+                                            }
+                                            default:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmMultipleOperations);
+                                                break;
+                                            }
+                                        }
+                                        
                                         uint32_t index = static_cast<uint32_t>(m_tracks.size());
                                         m_tracks.push_back(track);
                                         if(m_tracks.size() != (index + 1))

--- a/src/controller/src/system/rocprofvis_controller_track.cpp
+++ b/src/controller/src/system/rocprofvis_controller_track.cpp
@@ -552,7 +552,26 @@ rocprofvis_result_t Track::GetUInt64(rocprofvis_property_t property, uint64_t in
                 *value = m_queue_id_or_tid;
                 result = kRocProfVisResultSuccess;
                 break;
-            }  
+            }
+            case kRPVControllerTrackNumberOfOperationTypes:
+            {
+                *value = m_operation_types.size();
+                result = kRocProfVisResultSuccess;
+                break;
+            }
+            case kRPVControllerTrackOperationTypeIndexed:
+            {
+                if(index < m_operation_types.size())
+                {
+                    *value = m_operation_types[index];
+                    result = kRocProfVisResultSuccess;
+                }
+                else
+                {
+                    result = kRocProfVisResultOutOfRange;
+                }
+                break;
+            }
             default:
             {
                 result = UnhandledProperty(property);
@@ -669,17 +688,17 @@ rocprofvis_result_t Track::GetString(rocprofvis_property_t property, uint64_t in
     rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
     switch(property)
     {
-        case kRPVControllerCategory:
+        case kRPVControllerTrackCategory:
         {
             result = GetStdStringImpl(value, length, m_category);
             break;
         }
-        case kRPVControllerMainName:
+        case kRPVControllerTrackMainName:
         {
             result = GetStdStringImpl(value, length, m_main_name);
             break;
         }
-        case kRPVControllerSubName:
+        case kRPVControllerTrackSubName:
         {
             result = GetStdStringImpl(value, length, m_sub_name);
             break;
@@ -752,6 +771,25 @@ rocprofvis_result_t Track::SetUInt64(rocprofvis_property_t property, uint64_t in
         {
             m_queue_id_or_tid = value;
             result = kRocProfVisResultSuccess;
+            break;
+        }
+        case kRPVControllerTrackNumberOfOperationTypes:
+        {
+            m_operation_types.resize(value);
+            result = kRocProfVisResultSuccess;
+            break;
+        }
+        case kRPVControllerTrackOperationTypeIndexed:
+        {
+            if(index < m_operation_types.size())
+            {
+                m_operation_types[index] = (rocprofvis_dm_event_operation_t)value;
+                result = kRocProfVisResultSuccess;
+            }
+            else
+            {
+                result = kRocProfVisResultOutOfRange;
+            }
             break;
         }
         default:
@@ -987,19 +1025,19 @@ rocprofvis_result_t Track::SetString(rocprofvis_property_t property, uint64_t in
     {
         switch(property)
         {
-            case kRPVControllerCategory:
+            case kRPVControllerTrackCategory:
             {
                 m_category = value;
                 result = kRocProfVisResultSuccess;
                 break;
             }
-            case kRPVControllerMainName:
+            case kRPVControllerTrackMainName:
             {
                 m_main_name = value;
                 result = kRocProfVisResultSuccess;
                 break;
             }
-            case kRPVControllerSubName:
+            case kRPVControllerTrackSubName:
             {
                 m_sub_name = value;
                 result = kRocProfVisResultSuccess;

--- a/src/controller/src/system/rocprofvis_controller_track.h
+++ b/src/controller/src/system/rocprofvis_controller_track.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <string>
 #include <memory>
+#include <vector>
 
 namespace RocProfVis
 {
@@ -66,6 +67,7 @@ private:
     std::string m_category;
     std::string m_main_name;
     std::string m_sub_name;
+    std::vector<rocprofvis_dm_event_operation_t> m_operation_types;
     rocprofvis_dm_track_t m_dm_handle;
     Thread* m_thread;
     Queue* m_queue;

--- a/src/controller/tests/rocprofvis_controller_system_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_system_tests.cpp
@@ -1957,34 +1957,34 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
 
             uint32_t len = 0;
             result       = rocprofvis_controller_get_string(
-                track_handle, kRPVControllerCategory, 0, nullptr, &len);
+                track_handle, kRPVControllerTrackCategory, 0, nullptr, &len);
             REQUIRE(result == kRocProfVisResultSuccess);
             std::string category;
             category.resize(len);
             result = rocprofvis_controller_get_string(
-                track_handle, kRPVControllerCategory, 0,
+                track_handle, kRPVControllerTrackCategory, 0,
                 const_cast<char*>(category.c_str()), &len);
             REQUIRE(result == kRocProfVisResultSuccess);
 
             len    = 0;
             result = rocprofvis_controller_get_string(
-                track_handle, kRPVControllerMainName, 0, nullptr, &len);
+                track_handle, kRPVControllerTrackMainName, 0, nullptr, &len);
             REQUIRE(result == kRocProfVisResultSuccess);
             std::string main_name;
             main_name.resize(len);
             result = rocprofvis_controller_get_string(
-                track_handle, kRPVControllerMainName, 0,
+                track_handle, kRPVControllerTrackMainName, 0,
                 const_cast<char*>(main_name.c_str()), &len);
             REQUIRE(result == kRocProfVisResultSuccess);
 
             len    = 0;
-            result = rocprofvis_controller_get_string(track_handle, kRPVControllerSubName,
+            result = rocprofvis_controller_get_string(track_handle, kRPVControllerTrackSubName,
                                                       0, nullptr, &len);
             REQUIRE(result == kRocProfVisResultSuccess);
             std::string sub_name;
             sub_name.resize(len);
             result = rocprofvis_controller_get_string(
-                track_handle, kRPVControllerSubName, 0,
+                track_handle, kRPVControllerTrackSubName, 0,
                 const_cast<char*>(sub_name.c_str()), &len);
             REQUIRE(result == kRocProfVisResultSuccess);
 

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -823,6 +823,12 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
             {
                 empty = false;
                 ImGui::PushID(i);
+                ImGui::PushStyleColor(ImGuiCol_Header,
+                                      m_settings.GetColor(Colors::kSelection));
+                ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
+                                      m_settings.GetColor(Colors::kHighlightChart));
+                ImGui::PushStyleColor(ImGuiCol_HeaderActive,
+                                      m_settings.GetColor(Colors::kHighlightChart));
                 ImVec2 pos         = ImGui::GetCursorPos();
                 bool   row_clicked = ImGui::Selectable(
                     "", false,
@@ -887,6 +893,7 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                         m_options_changed  = true;
                     }
                 }
+                ImGui::PopStyleColor(3);
                 ImGui::PopID();
             }
         }

--- a/src/view/src/compute/rocprofvis_compute_summary.cpp
+++ b/src/view/src/compute/rocprofvis_compute_summary.cpp
@@ -42,19 +42,14 @@ void
 PushPlotChrome(SettingsManager& settings)
 {
     ImPlot::PushStyleColor(ImPlotCol_FrameBg, ThemeColor(settings, Colors::kTransparent));
-    ImPlot::PushStyleColor(ImPlotCol_PlotBg, ThemeColor(settings, Colors::kTransparent));
+    ImPlot::PushStyleColor(ImPlotCol_PlotBg, ThemeColor(settings, Colors::kBgFrame));
     ImPlot::PushStyleColor(ImPlotCol_PlotBorder,
-                           ThemeColor(settings, Colors::kTransparent));
+                           ThemeColor(settings, Colors::kBorderColor, 0.85f));
     ImPlot::PushStyleColor(ImPlotCol_AxisText, ThemeColor(settings, Colors::kTextMain));
     ImPlot::PushStyleColor(ImPlotCol_AxisGrid,
                            ThemeColor(settings, Colors::kBorderColor, 0.7f));
     ImPlot::PushStyleColor(ImPlotCol_AxisTick,
                            ThemeColor(settings, Colors::kTextDim, 0.56f));
-    ImPlot::PushStyleColor(ImPlotCol_LegendBg,
-                           ThemeColor(settings, Colors::kBgPanel, 0.96f));
-    ImPlot::PushStyleColor(ImPlotCol_LegendBorder,
-                           ThemeColor(settings, Colors::kBorderColor, 0.85f));
-    ImPlot::PushStyleColor(ImPlotCol_LegendText, ThemeColor(settings, Colors::kTextMain));
 }
 
 }  // namespace
@@ -607,7 +602,7 @@ ComputeTopKernels::RenderPieChart(const ImPlotStyle& plot_style, TimeFormat time
         ImPlot::EndPlot();
     }
     ImGui::PopID();
-    ImPlot::PopStyleColor(9);
+    ImPlot::PopStyleColor(6);
     ImPlot::PopStyleVar();
 }
 
@@ -704,7 +699,7 @@ ComputeTopKernels::RenderBarChart(const ImPlotStyle& plot_style, TimeFormat time
         }
         ImPlot::EndPlot();
     }
-    ImPlot::PopStyleColor(9);
+    ImPlot::PopStyleColor(6);
     ImPlot::PopStyleVar();
     ImGui::EndChild();
 }
@@ -750,6 +745,12 @@ ComputeTopKernels::RenderTable(const ImPlotStyle& plot_style, TimeFormat time_fo
         for(size_t i = 0; i < m_kernels.size(); i++)
         {
             ImGui::PushID(i);
+            ImGui::PushStyleColor(ImGuiCol_Header,
+                                  m_settings.GetColor(Colors::kSelection));
+            ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
+                                  m_settings.GetColor(Colors::kHighlightChart));
+            ImGui::PushStyleColor(ImGuiCol_HeaderActive,
+                                  m_settings.GetColor(Colors::kHighlightChart));
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);
             ImGui::GetWindowDrawList()->AddRectFilled(
@@ -808,6 +809,7 @@ ComputeTopKernels::RenderTable(const ImPlotStyle& plot_style, TimeFormat time_fo
                     }
                 }
             }
+            ImGui::PopStyleColor(3);
             ImGui::PopID();
         }
         ImGui::EndTable();

--- a/src/view/src/model/rocprofvis_model_types.h
+++ b/src/view/src/model/rocprofvis_model_types.h
@@ -5,10 +5,12 @@
 
 #include "rocprofvis_controller_enums.h"
 #include "rocprofvis_controller_types.h"
+#include "rocprofvis_c_interface_types.h"
 
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace RocProfVis
@@ -74,6 +76,8 @@ struct TrackInfo
     std::string category;  // Category of the track
     std::string main_name; // Track main process string (PID, GPUID, etc)
     std::string sub_name;  // Track sub process string (TID, QueueID, PMC name)
+    std::unordered_set<rocprofvis_dm_event_operation_t>
+        operation_types;  // Operation types supported by the track
     struct Topology
     {
         uint64_t node_id;     // ID of track's parent node

--- a/src/view/src/rocprofvis_analysis_view.cpp
+++ b/src/view/src/rocprofvis_analysis_view.cpp
@@ -7,9 +7,7 @@
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_events_view.h"
 #include "rocprofvis_multi_track_table.h"
-#ifdef ROCPROFVIS_DEVELOPER_MODE
 #include "rocprofvis_top_events_view.h"
-#endif
 #include "rocprofvis_track_details.h"
 
 namespace RocProfVis
@@ -36,9 +34,7 @@ AnalysisView::AnalysisView(DataProvider& dp, std::shared_ptr<TrackTopology> topo
 , m_events_view(std::make_shared<EventsView>(dp, timeline_selection))
 , m_annotation_view(std::make_shared<AnnotationView>(dp, annotation_manager))
 , m_track_details(std::make_shared<TrackDetails>(dp, topology, timeline_selection))
-#ifdef ROCPROFVIS_DEVELOPER_MODE
 , m_top_events_view(std::make_shared<TopEventsView>(dp, timeline_selection))
-#endif
 {
     m_widget_name = GenUniqueName("Analysis View");
 
@@ -70,19 +66,19 @@ AnalysisView::AnalysisView(DataProvider& dp, std::shared_ptr<TrackTopology> topo
     tab_item.m_widget    = m_track_details;
     m_tab_container->AddTab(tab_item);
 
+    tab_item.m_label     = "Top Events";
+    tab_item.m_id        = "top_events";
+    tab_item.m_can_close = false;
+    tab_item.m_widget    = m_top_events_view;
+    m_tab_container->AddTab(tab_item);
+
     // Add Annotation View Tab
     tab_item.m_label     = "Annotations";
     tab_item.m_id        = "annotation_view";
     tab_item.m_can_close = false;
     tab_item.m_widget    = m_annotation_view;
     m_tab_container->AddTab(tab_item);
-#ifdef ROCPROFVIS_DEVELOPER_MODE
-    tab_item.m_label     = "Top Events";
-    tab_item.m_id        = "top_events";
-    tab_item.m_can_close = false;
-    tab_item.m_widget    = m_top_events_view;
-    m_tab_container->AddTab(tab_item);
-#endif
+
     m_tab_container->SetAllowToolTips(false);
     m_tab_container->SetActiveTab(0);
 
@@ -142,11 +138,15 @@ AnalysisView::HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e)
             {
                 if(m_event_table)
                 {
-                    m_event_table->HandleTrackSelectionChanged();
+                    m_event_table->HandleTrackSelectionChanged(
+                        selection_changed_event->GetTrackID(),
+                        selection_changed_event->TrackSelected());
                 }
                 if(m_sample_table)
                 {
-                    m_sample_table->HandleTrackSelectionChanged();
+                    m_sample_table->HandleTrackSelectionChanged(
+                        selection_changed_event->GetTrackID(),
+                        selection_changed_event->TrackSelected());
                 }
                 if(m_track_details)
                 {
@@ -154,12 +154,12 @@ AnalysisView::HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e)
                         selection_changed_event->GetTrackID(),
                         selection_changed_event->TrackSelected());
                 }
-#ifdef ROCPROFVIS_DEVELOPER_MODE
                 if(m_top_events_view)
                 {
-                    m_top_events_view->HandleTrackSelectionChanged();
+                    m_top_events_view->HandleTrackSelectionChanged(
+                        selection_changed_event->GetTrackID(),
+                        selection_changed_event->TrackSelected());
                 }
-#endif
             }
         }
         else if(event_type == RocEventType::kTimelineTimeRangeChangedEvent)
@@ -170,18 +170,22 @@ AnalysisView::HandleTimelineSelectionChanged(std::shared_ptr<RocEvent> e)
             {
                 if(m_event_table)
                 {
-                    m_event_table->HandleTrackSelectionChanged();
+                    m_event_table->HandleTimeRangeSelectionChanged(
+                        selection_changed_event->GetStartNs(),
+                        selection_changed_event->GetEndNs());
                 }
                 if(m_sample_table)
                 {
-                    m_sample_table->HandleTrackSelectionChanged();
+                    m_sample_table->HandleTimeRangeSelectionChanged(
+                        selection_changed_event->GetStartNs(),
+                        selection_changed_event->GetEndNs());
                 }
-#ifdef ROCPROFVIS_DEVELOPER_MODE
                 if(m_top_events_view)
                 {
-                    m_top_events_view->HandleTrackSelectionChanged();
+                    m_top_events_view->HandleTimeRangeSelectionChanged(
+                        selection_changed_event->GetStartNs(),
+                        selection_changed_event->GetEndNs());
                 }
-#endif
             }
         }
         else if(event_type == RocEventType::kTimelineEventSelectionChangedEvent)

--- a/src/view/src/rocprofvis_analysis_view.h
+++ b/src/view/src/rocprofvis_analysis_view.h
@@ -15,9 +15,7 @@ namespace View
 class DataProvider;
 class EventsView;
 class MultiTrackTable;
-#ifdef ROCPROFVIS_DEVELOPER_MODE
 class TopEventsView;
-#endif
 class TrackTopology;
 class TrackDetails;
 class TimelineSelection;
@@ -44,9 +42,7 @@ private:
     std::shared_ptr<EventsView>     m_events_view;
     std::shared_ptr<TrackDetails>   m_track_details;
     std::shared_ptr<AnnotationView> m_annotation_view;
-#ifdef ROCPROFVIS_DEVELOPER_MODE
     std::shared_ptr<TopEventsView>  m_top_events_view;
-#endif
 
     EventManager::SubscriptionToken m_timeline_track_selection_changed_token;
     EventManager::SubscriptionToken m_timeline_range_selection_changed_token;

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -1022,14 +1022,29 @@ DataProvider::HandleLoadTrackMetaData()
                                         ? kRPVControllerTrackTypeSamples
                                         : kRPVControllerTrackTypeEvents;
 
-            result = GetString(track, kRPVControllerCategory, 0, track_info.category);
+            result = GetString(track, kRPVControllerTrackCategory, 0, track_info.category);
             ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
 
-            result = GetString(track, kRPVControllerMainName, 0,
+            uint64_t operation_type_count = 0;
+            result = rocprofvis_controller_get_uint64(
+                track, kRPVControllerTrackNumberOfOperationTypes, 0,
+                &operation_type_count);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            for(uint64_t i = 0; i < operation_type_count; i++)
+            {
+                uint64_t operation_type = 0;
+                result = rocprofvis_controller_get_uint64(
+                    track, kRPVControllerTrackOperationTypeIndexed, i, &operation_type);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                track_info.operation_types.insert(
+                    (rocprofvis_dm_event_operation_t)operation_type);
+            }
+
+            result = GetString(track, kRPVControllerTrackMainName, 0,
                                track_info.main_name);
             ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
             
-            result = GetString(track, kRPVControllerSubName, 0,
+            result = GetString(track, kRPVControllerTrackSubName, 0,
                                track_info.sub_name);
             ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
 

--- a/src/view/src/rocprofvis_event_search.cpp
+++ b/src/view/src/rocprofvis_event_search.cpp
@@ -20,16 +20,16 @@ constexpr const char* ID_COLUMN_NAME        = "__uuid";
 constexpr const char* EVENT_ID_COLUMN_NAME  = "id";
 constexpr const char* NAME_COLUMN_NAME      = "name";
 
-EventSearch::EventSearch(DataProvider& dp)
+EventSearch::EventSearch(DataProvider&                      dp,
+                         std::shared_ptr<TimelineSelection> timeline_selection)
 : InfiniteScrollTable(
       dp, TableType::kEventSearchTable, kRPVControllerTableTypeSearchResults,
       DataProvider::EVENT_SEARCH_REQUEST_ID,
       [&dp]() -> const TablesModel& { return dp.DataModel().GetTables(); },
-      [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); }, nullptr, 1,
-      kRPVControllerSortOrderAscending, "Event Search Table", "")
+      [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); }, timeline_selection,
+      1, kRPVControllerSortOrderAscending, "Event Search Table", "")
 , m_should_open(false)
 , m_should_close(false)
-, m_open_context_menu(false)
 , m_focus_text_input(false)
 , m_search_deferred(false)
 , m_searched(false)
@@ -94,7 +94,6 @@ EventSearch::Render()
                 ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
                 InfiniteScrollTable::Render();
                 ImGui::PopStyleVar();
-                RenderContextMenu();
             }
             auto table_params = tm.GetTableParams(m_table_type);
             if(table_params)
@@ -318,46 +317,9 @@ EventSearch::RowSelected(const ImGuiMouseButton mouse_button)
     }
     else if(mouse_button == ImGuiMouseButton_Right)
     {
-        m_open_context_menu = true;
+        SelectedRowContextMenu();
     }
     InfiniteScrollTable::RowSelected(mouse_button);
-}
-
-void
-EventSearch::RenderContextMenu()
-{
-    if(m_open_context_menu)
-    {
-        ImGui::OpenPopup("");
-        m_open_context_menu = false;
-    }
-
-    const ImGuiStyle& style = m_settings.GetDefaultStyle();
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-    if(ImGui::BeginPopup(""))
-    {
-        uint64_t target_track_id = SelectedRowToTrackID(
-            m_important_column_idxs[kTrackId], m_important_column_idxs[kStreamId]);
-        if(ImGui::MenuItem("Copy Row Data", nullptr, false))
-        {
-            SelectedRowToClipboard();
-        }
-        else if(ImGui::MenuItem("Go To Event", nullptr, false,
-                                target_track_id != INVALID_UINT64_INDEX))
-        {
-            SelectedRowNavigateEvent(m_important_column_idxs[kTrackId],
-                                     m_important_column_idxs[kStreamId]);
-        }
-        else if(ImGui::MenuItem("Export To File", nullptr, false,
-                                !m_data_provider.IsRequestPending(
-                                    DataProvider::TABLE_EXPORT_REQUEST_ID)))
-        {
-            ExportToFile();
-        }
-        ImGui::EndPopup();
-    }
-    ImGui::PopStyleVar(2);
 }
 
 float

--- a/src/view/src/rocprofvis_event_search.h
+++ b/src/view/src/rocprofvis_event_search.h
@@ -15,7 +15,7 @@ namespace View
 class EventSearch : public InfiniteScrollTable
 {
 public:
-    EventSearch(DataProvider& dp);
+    EventSearch(DataProvider& dp, std::shared_ptr<TimelineSelection> timeline_selection);
     void Update() override;
     void Render() override;
 
@@ -34,14 +34,12 @@ private:
     void FormatData() const override;
     void IndexColumns() override;
     void RowSelected(const ImGuiMouseButton mouse_button) override;
-    void RenderContextMenu();
 
     bool  Open() const;
     float Height() const;
 
     bool  m_should_open;
     bool  m_should_close;
-    bool  m_open_context_menu;
     bool  m_focus_text_input;
     bool  m_search_deferred;
     bool  m_searched;

--- a/src/view/src/rocprofvis_multi_track_table.cpp
+++ b/src/view/src/rocprofvis_multi_track_table.cpp
@@ -7,16 +7,13 @@
 #include "widgets/rocprofvis_gui_helpers.h"
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_timeline_selection.h"
-#include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
-#include "widgets/rocprofvis_notification_manager.h"
 
 namespace RocProfVis
 {
 namespace View
 {
 
-constexpr const char* ROWCONTEXTMENU_POPUP_NAME = "RowContextMenu";
 constexpr const char* NO_DATA_TEXT =
     "No data available for the selected tracks or filters.";
 constexpr const char* TRACK_ID_COLUMN_NAME  = "__trackId";
@@ -40,9 +37,8 @@ MultiTrackTable::MultiTrackTable(DataProvider& dp, TableType table_type,
 : InfiniteScrollTable(dp, table_type, request_table_type, request_id, table_model,
                       table_model_mutable, timeline_selection, default_sort_column_index,
                       default_sort_order, friendly_name, NO_DATA_TEXT)
-, m_defer_track_selection_changed(false)
+, m_retry_selection_fetch(false)
 , m_display_filters(display_filters)
-, m_open_context_menu(false)
 , m_group_by_selection_index(0)
 {
     m_filter_store[0] = '\0';
@@ -51,68 +47,21 @@ MultiTrackTable::MultiTrackTable(DataProvider& dp, TableType table_type,
 MultiTrackTable::~MultiTrackTable() {}
 
 void
-MultiTrackTable::HandleTrackSelectionChanged()
+MultiTrackTable::HandleTrackSelectionChanged(uint64_t track_id, bool selected)
 {
-    std::vector<uint64_t> tracks;
-    double                start_ns;
-    double                end_ns;
-    m_timeline_selection->GetSelectedTracks(tracks);
+    if(IncludeTrack(track_id) ||
+       (track_id == TimelineSelection::INVALID_SELECTION_ID && !selected))
+    {
+        FetchSelectionData();
+    }
+}
 
-    const TimelineModel& tlm = m_data_provider.DataModel().GetTimeline();
-    // If no valid time range is provided, use the full trace range
-    if(m_timeline_selection->HasValidTimeRangeSelection())
-    {
-        m_timeline_selection->GetSelectedTimeRange(start_ns, end_ns);
-    }
-    else
-    {
-        start_ns = tlm.GetStartTime();
-        end_ns   = tlm.GetEndTime();
-    }
-
-    std::vector<uint64_t> filtered_tracks;
-    FilterSelectedTracksForTableType(tracks, filtered_tracks);
-
-    bool fetch_result = false;
-
-    // Cancel pending requests.
-    if(m_data_provider.IsRequestPending(m_request_id))
-    {
-        m_data_provider.CancelRequest(m_request_id);
-    }
-    // if no tracks match the table type, clear the table
-    if(filtered_tracks.empty())
-    {
-        m_table_model_mutable().ClearTable(m_table_type);
-        fetch_result = true;
-    }
-    else
-    {
-        // Fetch table data for the selected tracks
-        TableRequestParams table_params(
-            m_request_table_type, filtered_tracks, {}, start_ns, end_ns,
-            m_filter_options.where, m_filter_options.filter,
-            m_filter_options.group_by.c_str(), m_filter_options.group_columns, {}, 0,
-            m_fetch_chunk_size, m_sort_column_index, m_sort_order);
-
-        fetch_result = m_data_provider.FetchTable(table_params);
-    }
-
-    if(!fetch_result)
-    {
-        spdlog::error("Failed to queue table request for tracks: {}",
-                      filtered_tracks.size());
-        // save this selection event to reprocess it later (it's ok to replace the
-        // previous one as the new one reflects the current selection)
-        m_defer_track_selection_changed = true;
-    }
-    else
-    {
-        // clear any pending track selection event
-        m_defer_track_selection_changed = false;
-    }
-    // Update the selected tracks for this table type
-    m_selected_tracks = std::move(filtered_tracks);
+void
+MultiTrackTable::HandleTimeRangeSelectionChanged(double start_ns, double end_ns)
+{
+    (void) start_ns;
+    (void) end_ns;
+    FetchSelectionData();
 }
 
 void
@@ -331,7 +280,6 @@ MultiTrackTable::Render()
     }
 
     InfiniteScrollTable::Render();
-    RenderContextMenu();
 
     ImGui::EndChild();
 }
@@ -340,7 +288,7 @@ void
 MultiTrackTable::Update()
 {
     // Handle track selection changed event
-    if(m_defer_track_selection_changed)
+    if(m_retry_selection_fetch)
     {
         if(!m_data_provider.IsRequestPending(m_request_id))
         {
@@ -348,7 +296,7 @@ MultiTrackTable::Update()
             spdlog::debug(
                 "Reprocessing deferred track selection changed event for table: {}",
                 m_widget_name);
-            HandleTrackSelectionChanged();
+            FetchSelectionData();
         }
     }
 
@@ -400,6 +348,22 @@ MultiTrackTable::Update()
     }
 
     InfiniteScrollTable::Update();
+}
+
+bool
+MultiTrackTable::IncludeTrack(uint64_t track_id) const
+{
+    bool             include = false;
+    const TrackInfo* track_info =
+        m_data_provider.DataModel().GetTimeline().GetTrack(track_id);
+    if(track_info)
+    {
+        include = (track_info->track_type == kRPVControllerTrackTypeSamples &&
+                   m_table_type == TableType::kSampleTable) ||
+                  (track_info->track_type == kRPVControllerTrackTypeEvents &&
+                   m_table_type == TableType::kEventTable);
+    }
+    return include;
 }
 
 void
@@ -457,31 +421,80 @@ MultiTrackTable::RowSelected(const ImGuiMouseButton mouse_button)
 {
     if(mouse_button == ImGuiMouseButton_Right)
     {
-        m_open_context_menu = true;
+        InfiniteScrollTable::SelectedRowContextMenu();
     }
     InfiniteScrollTable::RowSelected(mouse_button);
 }
 
 void
-MultiTrackTable::FilterSelectedTracksForTableType(
-    const std::vector<uint64_t>& selected_track_ids,
-    std::vector<uint64_t>&       filtered_track_ids) const
+MultiTrackTable::FetchSelectionData()
 {
+    std::vector<uint64_t> tracks;
+    double                start_ns;
+    double                end_ns;
+    m_timeline_selection->GetSelectedTracks(tracks);
+
     const TimelineModel& tlm = m_data_provider.DataModel().GetTimeline();
-    for(uint64_t track_id : selected_track_ids)
+    // If no valid time range is provided, use the full trace range
+    if(m_timeline_selection->HasValidTimeRangeSelection())
     {
-        const TrackInfo* track_info = tlm.GetTrack(track_id);
-        if(track_info)
+        m_timeline_selection->GetSelectedTimeRange(start_ns, end_ns);
+    }
+    else
+    {
+        start_ns = tlm.GetStartTime();
+        end_ns   = tlm.GetEndTime();
+    }
+
+    std::vector<uint64_t> included_tracks;
+    for(uint64_t& track_id : tracks)
+    {
+        if(IncludeTrack(track_id))
         {
-            if((track_info->track_type == kRPVControllerTrackTypeSamples &&
-                m_table_type == TableType::kSampleTable) ||
-               (track_info->track_type == kRPVControllerTrackTypeEvents &&
-                m_table_type == TableType::kEventTable))
-            {
-                filtered_track_ids.push_back(track_id);
-            }
+            included_tracks.push_back(track_id);
         }
     }
+
+    bool fetch_result = false;
+
+    // Cancel pending requests.
+    if(m_data_provider.IsRequestPending(m_request_id))
+    {
+        m_data_provider.CancelRequest(m_request_id);
+    }
+    // if no tracks match the table type, clear the table
+    if(included_tracks.empty())
+    {
+        m_table_model_mutable().ClearTable(m_table_type);
+        fetch_result = true;
+    }
+    else
+    {
+        // Fetch table data for the selected tracks
+        TableRequestParams table_params(
+            m_request_table_type, included_tracks, {}, start_ns, end_ns,
+            m_filter_options.where, m_filter_options.filter,
+            m_filter_options.group_by.c_str(), m_filter_options.group_columns, {}, 0,
+            m_fetch_chunk_size, m_sort_column_index, m_sort_order);
+
+        fetch_result = m_data_provider.FetchTable(table_params);
+    }
+
+    if(!fetch_result)
+    {
+        spdlog::error("Failed to queue table request for tracks: {}",
+                      included_tracks.size());
+        // save this selection event to reprocess it later (it's ok to replace the
+        // previous one as the new one reflects the current selection)
+        m_retry_selection_fetch = true;
+    }
+    else
+    {
+        // clear any pending selection fetch
+        m_retry_selection_fetch = false;
+    }
+    // Update the included tracks for this table type
+    m_included_tracks = std::move(included_tracks);
 }
 
 bool
@@ -489,126 +502,6 @@ MultiTrackTable::XButton(const char* id) const
 {
     bool clicked = RocProfVis::View::XButton(id, "Clear", &m_settings);
     return clicked;
-}
-
-void
-MultiTrackTable::RenderContextMenu()
-{
-    if(m_open_context_menu)
-    {
-        ImGui::OpenPopup(ROWCONTEXTMENU_POPUP_NAME);
-        m_open_context_menu = false;
-    }
-
-    auto style = m_settings.GetDefaultStyle();
-
-    // Render context menu for row actions
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-    if(ImGui::BeginPopup(ROWCONTEXTMENU_POPUP_NAME))
-    {
-        uint64_t target_track_id = SelectedRowToTrackID(
-            m_important_column_idxs[kTrackId], m_important_column_idxs[kStreamId]);
-        if(ImGui::MenuItem(m_table_type == TableType::kSampleTable ? "Go To Sample"
-                                                                        : "Go To Event",
-                                nullptr, false, target_track_id != INVALID_UINT64_INDEX))
-        {
-            SelectedRowNavigateEvent(m_important_column_idxs[kTrackId],
-                                     m_important_column_idxs[kStreamId]);
-        } 
-        ImGui::Separator();
-        if(ImGui::MenuItem("Copy Row Data", nullptr, false))
-        {
-            SelectedRowToClipboard();
-        }
-        else if(ImGui::MenuItem("Copy Cell Data", nullptr, false))
-        {
-            CopyCellToClipboard(true);
-        }
-
-        // Only show option to copy unformatted cell data if 
-        // column has formatting applied to it. 
-        bool show_copy_unformatted = false;
-        if(m_selected_column >= 0 &&
-           m_selected_column < (int) m_table_model().GetTableHeader(m_table_type).size())
-        {
-            const auto&                             table_model = m_table_model();
-            const std::vector<FormattedColumnInfo>& formatted_table_data =
-                table_model.GetFormattedTableData(m_table_type);
-            const auto& col_format_info = formatted_table_data[m_selected_column];
-            show_copy_unformatted = col_format_info.needs_formatting;
-        }
-        if(show_copy_unformatted) 
-        {         
-            if(ImGui::MenuItem("Copy Unformatted Cell Data", nullptr, false))
-            {
-                CopyCellToClipboard(false);
-            }
-        }
-        ImGui::Separator();
-        if(ImGui::MenuItem("Export To File", nullptr, false,
-                                !m_data_provider.IsRequestPending(
-                                    DataProvider::TABLE_EXPORT_REQUEST_ID)))
-        {
-            ExportToFile();
-        }        
-        // TODO handle event selection
-        // else if(ImGui::MenuItem("Select event", nullptr, false))
-        // {
-        //     uint64_t event_id = INVALID_UINT64_INDEX;
-
-        //     if(m_important_columns[kUUId] != INVALID_COLUMN_INDEX &&
-        //        m_important_columns[kUUId] < table_data[m_selected_row].size())
-        //     {
-        //         event_id =
-        //             std::stoull(table_data[m_selected_row][m_important_columns[kUUId]]);
-        //     }
-        // }
-
-        ImGui::EndPopup();
-    }
-    // Pop the style vars for window padding and item spacing
-    ImGui::PopStyleVar(2);
-}
-
-void
-MultiTrackTable::CopyCellToClipboard(bool use_formatted_data)
-{
-    const std::vector<std::vector<std::string>>& table_data =
-        m_table_model().GetTableData(m_table_type);
-
-    if(m_selected_row < 0 || m_selected_row >= (int) table_data.size())
-    {
-        spdlog::warn("Selected row index out of bounds: {}", m_selected_row);
-        return;
-    }
-
-    if(m_selected_column < 0 ||
-       m_selected_column >= (int) table_data[m_selected_row].size())
-    {
-        spdlog::warn("Selected column index out of bounds: {}", m_selected_column);
-        return;
-    }
-
-    std::string cell_text = table_data[m_selected_row][m_selected_column];
-
-    if(use_formatted_data)
-    {
-        const auto&                             table_model = m_table_model();
-        const std::vector<FormattedColumnInfo>& formatted_table_data =
-            table_model.GetFormattedTableData(m_table_type);
-
-        const auto& col_format_info = formatted_table_data[m_selected_column];
-        if(col_format_info.needs_formatting &&
-           m_selected_row < col_format_info.formatted_row_value.size())
-        {
-            cell_text = col_format_info.formatted_row_value[m_selected_row];
-        }
-    }
-
-    ImGui::SetClipboardText(cell_text.c_str());
-    NotificationManager::GetInstance().Show("Cell data was copied",
-                                            NotificationLevel::Info);
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_multi_track_table.h
+++ b/src/view/src/rocprofvis_multi_track_table.h
@@ -34,32 +34,29 @@ public:
     void Render() override;
     void Update() override;
 
-    void HandleTrackSelectionChanged();
+    virtual void HandleTrackSelectionChanged(uint64_t track_id, bool selected);
+    virtual void HandleTimeRangeSelectionChanged(double start_ns, double end_ns);
 
 protected:
+    virtual bool IncludeTrack(uint64_t track_id) const;
     void         FormatData() const override;
     void         IndexColumns() override;
     void         RowSelected(const ImGuiMouseButton mouse_button) override;
-    virtual void FilterSelectedTracksForTableType(
-        const std::vector<uint64_t>& selected_track_ids,
-        std::vector<uint64_t>&       filtered_track_ids) const;
+
+    // Subset of selected tracks applicable to this table type
+    std::vector<uint64_t> m_included_tracks;
 
 private:
-    void RenderContextMenu();
+    void FetchSelectionData();
     bool XButton(const char* id) const;
-    void CopyCellToClipboard(bool use_formatted_data);
 
-    bool m_defer_track_selection_changed;
+    bool m_retry_selection_fetch;
     bool m_display_filters;
-
-    // Keep track of currently selected tracks for this table type
-    std::vector<uint64_t> m_selected_tracks;
 
     std::vector<std::string> m_group_by_choices;
     std::vector<const char*> m_group_by_choices_ptr;
     int                      m_group_by_selection_index;
 
-    bool m_open_context_menu;
     char m_filter_store[FILTER_SIZE];
 };
 

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -141,6 +141,8 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
 
     ImGui::PushID(static_cast<int>(graph.chart->GetID()));
     ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, m_settings.GetColor(Colors::kHighlightChart));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, m_settings.GetColor(Colors::kHighlightChart));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(2, 0));
 
     bool display = graph.display;
@@ -173,17 +175,15 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     }
 
     ImGui::PopStyleVar();
-    ImGui::PopStyleColor();
+    ImGui::PopStyleColor(3);
     if(show_eye_button)
     {
         ImGui::SameLine();
     }
 
-    bool highlight = graph.selected;
-    if(!highlight)
-    {
-        ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
-    }
+    ImGui::PushStyleColor(
+        ImGuiCol_Button,
+        m_settings.GetColor(graph.selected ? Colors::kSelection : Colors::kTransparent));
     if(!display)
     {
         ImGui::PushStyleColor(ImGuiCol_Text,
@@ -197,10 +197,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     {
         ImGui::PopStyleColor();
     }
-    if(!highlight)
-    {
-        ImGui::PopStyleColor();
-    }
+    ImGui::PopStyleColor();
 
     ImGui::PopID();
 }

--- a/src/view/src/rocprofvis_summary_view.cpp
+++ b/src/view/src/rocprofvis_summary_view.cpp
@@ -4,6 +4,7 @@
 #include "rocprofvis_summary_view.h"
 #include "icons/rocprovfis_icon_defines.h"
 #include "implot/implot.h"
+#include "model/rocprofvis_common_defs.h"
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_utils.h"
@@ -18,13 +19,18 @@ namespace RocProfVis
 namespace View
 {
 
-constexpr float  IMPLOT_LEGEND_ICON_SHRINK       = 2.0f;  // Implot_internal.h
-constexpr double PIE_CHART_RADIUS                = 1.0;
-constexpr double BAR_CHART_THICKNESS             = 0.67;
-constexpr ImVec2 CHART_FIT_PADDING               = ImVec2(0.1f, 0.1f);
-constexpr float  FILTER_COMBO_RELATIVE_MIN_WIDTH = 17.0f;
-constexpr ImVec2 INITIAL_RELATIVE_POS            = ImVec2(0.1f, 0.2f);
-constexpr float  INITIAL_RELATIVE_SIZE           = 0.8f;
+constexpr float       IMPLOT_LEGEND_ICON_SHRINK       = 2.0f;  // Implot_internal.h
+constexpr double      PIE_CHART_RADIUS                = 1.0;
+constexpr double      BAR_CHART_THICKNESS             = 0.67;
+constexpr ImVec2      CHART_FIT_PADDING               = ImVec2(0.1f, 0.1f);
+constexpr float       FILTER_COMBO_RELATIVE_MIN_WIDTH = 17.0f;
+constexpr ImVec2      INITIAL_RELATIVE_POS            = ImVec2(0.1f, 0.2f);
+constexpr float       INITIAL_RELATIVE_SIZE           = 0.8f;
+constexpr const char* TRACK_ID_COLUMN_NAME            = "__trackId";
+constexpr const char* STREAM_ID_COLUMN_NAME           = "__streamTrackId";
+constexpr const char* ID_COLUMN_NAME                  = "__uuid";
+constexpr const char* EVENT_ID_COLUMN_NAME            = "id";
+constexpr const char* NAME_COLUMN_NAME                = "name";
 
 namespace
 {
@@ -41,16 +47,12 @@ PushPlotChrome(SettingsManager& settings)
                            ThemeColor(settings, Colors::kBorderColor, 0.7f));
     ImPlot::PushStyleColor(ImPlotCol_AxisTick,
                            ThemeColor(settings, Colors::kTextDim, 0.56f));
-    ImPlot::PushStyleColor(ImPlotCol_LegendBg,
-                           ThemeColor(settings, Colors::kBgPanel, 0.96f));
-    ImPlot::PushStyleColor(ImPlotCol_LegendBorder,
-                           ThemeColor(settings, Colors::kBorderColor, 0.85f));
-    ImPlot::PushStyleColor(ImPlotCol_LegendText, ThemeColor(settings, Colors::kTextMain));
 }
 
 }  // namespace
 
-SummaryView::SummaryView(DataProvider& dp)
+SummaryView::SummaryView(DataProvider&                      dp,
+                         std::shared_ptr<TimelineSelection> timeline_selection)
 : m_data_provider(dp)
 , m_settings(SettingsManager::GetInstance())
 , m_h_container(nullptr)
@@ -58,11 +60,15 @@ SummaryView::SummaryView(DataProvider& dp)
 , m_kernel_instance_table(nullptr)
 , m_top_kernels(nullptr)
 , m_hw_utilization(nullptr)
+, m_hw_utilization_item(nullptr)
+, m_top_kernels_item(nullptr)
+, m_kernel_instance_table_item(nullptr)
 , m_open(SettingsManager::GetInstance().GetAppWindowSettings().show_summary)
 , m_fetched(false)
 {
-    m_kernel_instance_table = std::make_shared<KernelInstanceTable>(m_data_provider);
-    m_top_kernels           = std::make_shared<TopKernels>(
+    m_kernel_instance_table =
+        std::make_shared<KernelInstanceTable>(m_data_provider, timeline_selection);
+    m_top_kernels = std::make_shared<TopKernels>(
         m_data_provider,
         [this](const char* kernel_name, const uint64_t* node_id,
                const uint64_t* device_id) {
@@ -70,18 +76,19 @@ SummaryView::SummaryView(DataProvider& dp)
         },
         [this]() { m_kernel_instance_table->Clear(); });
     m_hw_utilization = std::make_shared<HWUtilization>(m_data_provider);
-    m_v_container    = std::make_shared<VSplitContainer>(
-        LayoutItem::CreateFromWidget(m_top_kernels),
-        LayoutItem::CreateFromWidget(m_kernel_instance_table));
-    m_v_container->SetSplit(0.5f);
 
-    auto hw_utilization_item = LayoutItem::CreateFromWidget(m_hw_utilization);
-    m_h_container =
-        std::make_unique<HSplitContainer>(hw_utilization_item,
-                                          LayoutItem::CreateFromWidget(m_v_container));
+    m_top_kernels_item           = LayoutItem::CreateFromWidget(m_top_kernels);
+    m_kernel_instance_table_item = LayoutItem::CreateFromWidget(m_kernel_instance_table);
+    m_hw_utilization_item        = LayoutItem::CreateFromWidget(m_hw_utilization);
+
+    m_v_container = std::make_shared<VSplitContainer>(m_top_kernels_item,
+                                                      m_kernel_instance_table_item);
+    m_v_container->SetSplit(0.5f);
+    m_h_container = std::make_unique<HSplitContainer>(
+        m_hw_utilization_item, LayoutItem::CreateFromWidget(m_v_container));
     m_h_container->SetSplit(0.25f);
     // Hide HW utilization for now as the data is not yet reliable
-    hw_utilization_item->m_visible = false;
+    m_hw_utilization_item->m_visible = false;
 }
 
 void
@@ -118,6 +125,9 @@ SummaryView::Render()
         m_v_container->SetMinBottomHeight(m_kernel_instance_table->MinHeight());
         m_h_container->SetMinLeftWidth(m_hw_utilization->MinWidth());
         m_h_container->SetMinRightWidth(m_top_kernels->MinWidth());
+        m_top_kernels_item->m_bg_color           = m_settings.GetColor(Colors::kBgPanel);
+        m_kernel_instance_table_item->m_bg_color = m_settings.GetColor(Colors::kBgPanel);
+        m_hw_utilization_item->m_bg_color        = m_settings.GetColor(Colors::kBgPanel);
         ImGui::SetNextWindowPos(ImGui::GetWindowSize() * INITIAL_RELATIVE_POS,
                                 ImGuiCond_FirstUseEver);
         ImGui::SetNextWindowSize(ImGui::GetWindowSize() * INITIAL_RELATIVE_SIZE,
@@ -720,7 +730,7 @@ TopKernels::RenderPieChart(const ImVec2 region, const ImPlotStyle& plot_style,
         }
         ImPlot::EndPlot();
     }
-    ImPlot::PopStyleColor(9);
+    ImPlot::PopStyleColor(6);
     ImPlot::PopStyleVar();
     PlotInputHandler();
 }
@@ -779,7 +789,7 @@ TopKernels::RenderBarChart(const ImVec2 region, const ImPlotStyle& plot_style,
         }
         ImPlot::EndPlot();
     }
-    ImPlot::PopStyleColor(9);
+    ImPlot::PopStyleColor(6);
     ImPlot::PopStyleVar();
     PlotInputHandler();
 }
@@ -791,14 +801,21 @@ TopKernels::RenderTable(const ImPlotStyle& plot_style, TimeFormat time_format)
                                ImGui::GetFontSize() + plot_style.PlotBorderSize +
                                    plot_style.PlotPadding.y +
                                    2 * plot_style.LabelPadding.y));
-    if(ImGui::BeginTable(
-           "Table", 5,
-           ImGuiTableFlags_ScrollY | ImGuiTableFlags_Borders | ImGuiTableFlags_Resizable,
-           ImGui::GetContentRegionAvail() -
-               ImVec2(plot_style.PlotBorderSize + plot_style.PlotPadding.x,
-                      ImGui::GetFrameHeightWithSpacing() + 2 * plot_style.PlotPadding.y +
-                          plot_style.PlotBorderSize)))
+    if(ImGui::BeginTable("Table", 5,
+                         ImGuiTableFlags_ScrollY | ImGuiTableFlags_RowBg |
+                             ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV |
+                             ImGuiTableFlags_Resizable,
+                         ImGui::GetContentRegionAvail() -
+                             ImVec2(plot_style.PlotBorderSize + plot_style.PlotPadding.x,
+                                    ImGui::GetFrameHeightWithSpacing() +
+                                        2 * plot_style.PlotPadding.y +
+                                        plot_style.PlotBorderSize)))
     {
+        ImGui::PushStyleColor(ImGuiCol_Header, m_settings.GetColor(Colors::kSelection));
+        ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
+                              m_settings.GetColor(Colors::kHighlightChart));
+        ImGui::PushStyleColor(ImGuiCol_HeaderActive,
+                              m_settings.GetColor(Colors::kHighlightChart));
         ImGui::TableSetupScrollFreeze(0, 1);
         ImGui::TableSetupColumn("Name");
         ImGui::TableSetupColumn("Invocations");
@@ -841,6 +858,7 @@ TopKernels::RenderTable(const ImPlotStyle& plot_style, TimeFormat time_format)
                                              (*m_kernels)[i].exec_time_min, time_format)
                                              .c_str());
         }
+        ImGui::PopStyleColor(3);
         ImGui::EndTable();
     }
 }
@@ -882,10 +900,15 @@ TopKernels::RenderLegend(const ImVec2 region, const ImGuiStyle& style,
                        3 * plot_style.PlotPadding.y - plot_style.PlotBorderSize));
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, plot_style.LegendInnerPadding);
         ImGui::PushStyleColor(ImGuiCol_ChildBg, style.Colors[ImGuiCol_WindowBg]);
+        ImGui::PushStyleColor(ImGuiCol_Header, m_settings.GetColor(Colors::kSelection));
+        ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
+                              m_settings.GetColor(Colors::kHighlightChart));
+        ImGui::PushStyleColor(ImGuiCol_HeaderActive,
+                              m_settings.GetColor(Colors::kHighlightChart));
         ImGui::BeginChild("legend", ImVec2(region.x * 0.25f, 0),
                           ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
-        float legend_width = ImGui::GetWindowWidth() - 2 * style.WindowPadding.x;
-        float icon_width   = ImGui::GetFontSize();
+        float legend_width     = ImGui::GetWindowWidth() - 2 * style.WindowPadding.x;
+        float icon_width       = ImGui::GetFontSize();
         float scroll_bar_width = ImGui::GetScrollMaxY() ? style.ScrollbarSize : 0.0f;
         ImGui::BeginChild(
             "legend_scroll_view", ImVec2(legend_width - scroll_bar_width, 0),
@@ -926,7 +949,7 @@ TopKernels::RenderLegend(const ImVec2 region, const ImGuiStyle& style,
         }
         ImGui::EndChild();
         ImGui::EndChild();
-        ImGui::PopStyleColor();
+        ImGui::PopStyleColor(4);
         ImGui::PopStyleVar();
         ImGui::SetItemKeyOwner(ImGuiKey_MouseWheelX);
     }
@@ -1042,12 +1065,13 @@ TopKernels::ToggleSelectKernel(const size_t& idx)
     }
 }
 
-KernelInstanceTable::KernelInstanceTable(DataProvider& dp)
+KernelInstanceTable::KernelInstanceTable(
+    DataProvider& dp, std::shared_ptr<TimelineSelection> timeline_selection)
 : InfiniteScrollTable(
       dp, TableType::kSummaryKernelTable, kRPVControllerTableTypeSummaryKernelInstances,
       DataProvider::SUMMARY_KERNEL_INSTANCE_TABLE_REQUEST_ID,
       [&dp]() -> const TablesModel& { return dp.DataModel().GetTables(); },
-      [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); })
+      [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); }, timeline_selection)
 , m_fetched(false)
 , m_fetch_deferred(false)
 {
@@ -1125,6 +1149,54 @@ KernelInstanceTable::FormatData() const
     formatted_column_data.clear();
     formatted_column_data.resize(m_table_model().GetTableHeader(m_table_type).size());
     InfiniteScrollTable::FormatTimeColumns();
+}
+
+void
+KernelInstanceTable::IndexColumns()
+{
+    const std::vector<std::string>& column_names =
+        m_table_model().GetTableHeader(m_table_type);
+    // remember column index positions
+    m_important_column_idxs =
+        std::vector<size_t>(kNumImportantColumns, INVALID_UINT64_INDEX);
+    for(size_t i = 0; i < column_names.size(); i++)
+    {
+        const auto& col = column_names[i];
+        if(!col.empty())
+        {
+            if(col == TRACK_ID_COLUMN_NAME)
+            {
+                m_important_column_idxs[kTrackId] = i;
+            }
+            else if(col == STREAM_ID_COLUMN_NAME)
+            {
+                m_important_column_idxs[kStreamId] = i;
+            }
+            else if(col == ID_COLUMN_NAME)
+            {
+                m_important_column_idxs[kUUId] = i;
+            }
+            else if(col == EVENT_ID_COLUMN_NAME)
+            {
+                m_important_column_idxs[kDbEventId] = i;
+            }
+            else if(col == NAME_COLUMN_NAME)
+            {
+                m_important_column_idxs[kName] = i;
+            }
+        }
+    }
+    InfiniteScrollTable::IndexColumns();
+}
+
+void
+KernelInstanceTable::RowSelected(const ImGuiMouseButton mouse_button)
+{
+    if(mouse_button == ImGuiMouseButton_Right)
+    {
+        InfiniteScrollTable::SelectedRowContextMenu();
+    }
+    InfiniteScrollTable::RowSelected(mouse_button);
 }
 
 void

--- a/src/view/src/rocprofvis_summary_view.h
+++ b/src/view/src/rocprofvis_summary_view.h
@@ -19,12 +19,13 @@ class SettingsManager;
 class KernelInstanceTable;
 class HWUtilization;
 class TopKernels;
+class TimelineSelection;
 enum class TimeFormat;
 
 class SummaryView : public RocWidget
 {
 public:
-    SummaryView(DataProvider& dp);
+    SummaryView(DataProvider& dp, std::shared_ptr<TimelineSelection> timeline_selection);
     void Update() override;
     void Render() override;
 
@@ -37,6 +38,10 @@ private:
     std::shared_ptr<KernelInstanceTable> m_kernel_instance_table;
     std::shared_ptr<HWUtilization>       m_hw_utilization;
     std::shared_ptr<TopKernels>          m_top_kernels;
+
+    LayoutItem::Ptr m_hw_utilization_item;
+    LayoutItem::Ptr m_top_kernels_item;
+    LayoutItem::Ptr m_kernel_instance_table_item;
 
     bool m_open;
     bool m_fetched;
@@ -155,7 +160,8 @@ private:
 class KernelInstanceTable : public InfiniteScrollTable
 {
 public:
-    KernelInstanceTable(DataProvider& dp);
+    KernelInstanceTable(DataProvider&                      dp,
+                        std::shared_ptr<TimelineSelection> timeline_selection);
     void Update() override;
     void Render() override;
 
@@ -166,6 +172,9 @@ public:
 
 private:
     void FormatData() const override;
+    void IndexColumns() override;
+    void RowSelected(const ImGuiMouseButton mouse_button) override;
+
     void Fetch();
 
     std::string m_kernel_name;

--- a/src/view/src/rocprofvis_top_events_view.cpp
+++ b/src/view/src/rocprofvis_top_events_view.cpp
@@ -19,45 +19,40 @@ constexpr const char* TOP_EVENTS_DURATION_TOTAL_COLUMN = "DurationTotal";
 constexpr const char* TOP_EVENTS_DURATION_AVG_COLUMN   = "DurationAvg";
 constexpr const char* TOP_EVENTS_DURATION_MIN_COLUMN   = "DurationMin";
 constexpr const char* TOP_EVENTS_DURATION_MAX_COLUMN   = "DurationMax";
-constexpr uint8_t     TABLE_MAX_ROWS                   = 6;
 
 TopEventsView::TopEventsView(DataProvider&                      data_provider,
                              std::shared_ptr<TimelineSelection> timeline_selection)
-: m_data_provider(data_provider)
+: m_tables(
+      { std::make_unique<TopEventsTable>(
+            data_provider, TableType::kAnalysisTopInstrumentedEventsTable,
+            kRPVControllerTableTypeInstrumentedEvents,
+            DataProvider::ANALYSIS_TOP_INSTRUMENTED_EVENTS_TABLE_REQUEST_ID,
+            timeline_selection, kRocProfVisDmOperationLaunch,
+            "Top Instrumented Thread Events"),
+        std::make_unique<TopEventsTable>(
+            data_provider, TableType::kAnalysisTopDispatchEventsTable,
+            kRPVControllerTableTypeDispatchEvents,
+            DataProvider::ANALYSIS_TOP_DISPATCH_EVENTS_TABLE_REQUEST_ID,
+            timeline_selection, kRocProfVisDmOperationDispatch, "Top Dispatch Events"),
+        std::make_unique<TopEventsTable>(
+            data_provider, TableType::kAnalysisTopMemoryAllocationEventsTable,
+            kRPVControllerTableTypeMemoryAllocationEvents,
+            DataProvider::ANALYSIS_TOP_MEMORY_ALLOCATION_EVENTS_TABLE_REQUEST_ID,
+            timeline_selection, kRocProfVisDmOperationMemoryAllocate,
+            "Top Memory Allocation Events"),
+        std::make_unique<TopEventsTable>(
+            data_provider, TableType::kAnalysisTopMemoryCopyEventsTable,
+            kRPVControllerTableTypeMemoryCopyEvents,
+            DataProvider::ANALYSIS_TOP_MEMORY_COPY_EVENTS_TABLE_REQUEST_ID,
+            timeline_selection, kRocProfVisDmOperationMemoryCopy,
+            "Top Memory Copy Events"),
+        std::make_unique<TopEventsTable>(
+            data_provider, TableType::kAnalysisTopSampledEventsTable,
+            kRPVControllerTableTypeSampledEvents,
+            DataProvider::ANALYSIS_TOP_LAUNCH_SAMPLED_TABLE_REQUEST_ID,
+            timeline_selection, kRocProfVisDmOperationLaunchSample,
+            "Top Sampled Thread Events") })
 {
-    m_sections[0].heading = "Top Instrumented Thread Events";
-    m_sections[0].table   = std::make_unique<TopEventsTable>(
-        m_data_provider, TableType::kAnalysisTopInstrumentedEventsTable,
-        kRPVControllerTableTypeInstrumentedEvents,
-        DataProvider::ANALYSIS_TOP_INSTRUMENTED_EVENTS_TABLE_REQUEST_ID,
-        timeline_selection);
-
-    m_sections[1].heading = "Top Dispatch Events";
-    m_sections[1].table   = std::make_unique<TopEventsTable>(
-        m_data_provider, TableType::kAnalysisTopDispatchEventsTable,
-        kRPVControllerTableTypeDispatchEvents,
-        DataProvider::ANALYSIS_TOP_DISPATCH_EVENTS_TABLE_REQUEST_ID, timeline_selection);
-
-    m_sections[2].heading = "Top Memory Allocation Events";
-    m_sections[2].table   = std::make_unique<TopEventsTable>(
-        m_data_provider, TableType::kAnalysisTopMemoryAllocationEventsTable,
-        kRPVControllerTableTypeMemoryAllocationEvents,
-        DataProvider::ANALYSIS_TOP_MEMORY_ALLOCATION_EVENTS_TABLE_REQUEST_ID,
-        timeline_selection);
-
-    m_sections[3].heading = "Top Memory Copy Events";
-    m_sections[3].table   = std::make_unique<TopEventsTable>(
-        m_data_provider, TableType::kAnalysisTopMemoryCopyEventsTable,
-        kRPVControllerTableTypeMemoryCopyEvents,
-        DataProvider::ANALYSIS_TOP_MEMORY_COPY_EVENTS_TABLE_REQUEST_ID,
-        timeline_selection);
-
-    m_sections[4].heading = "Top Launch Sample Events";
-    m_sections[4].table   = std::make_unique<TopEventsTable>(
-        m_data_provider, TableType::kAnalysisTopSampledEventsTable,
-        kRPVControllerTableTypeSampledEvents,
-        DataProvider::ANALYSIS_TOP_LAUNCH_SAMPLED_TABLE_REQUEST_ID, timeline_selection);
-
     m_widget_name = GenUniqueName("Top Events View");
 }
 
@@ -66,23 +61,11 @@ TopEventsView::~TopEventsView() {}
 void
 TopEventsView::Update()
 {
-    for(Section& section : m_sections)
+    for(std::unique_ptr<TopEventsTable>& table : m_tables)
     {
-        if(section.table)
+        if(table)
         {
-            section.table->Update();
-        }
-    }
-}
-
-void
-TopEventsView::HandleTrackSelectionChanged()
-{
-    for(Section& section : m_sections)
-    {
-        if(section.table)
-        {
-            section.table->HandleTrackSelectionChanged();
+            table->Update();
         }
     }
 }
@@ -90,31 +73,63 @@ TopEventsView::HandleTrackSelectionChanged()
 void
 TopEventsView::Render()
 {
+    const SettingsManager& settings = SettingsManager::GetInstance();
+    const ImGuiStyle&      style    = settings.GetDefaultStyle();
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, style.ChildRounding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
+    ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kBorderColor));
     ImGui::BeginChild("top_events", ImVec2(0, 0), ImGuiChildFlags_Borders);
-    for(size_t i = 0; i < m_sections.size(); i++)
+    bool no_data = true;
+    for(std::unique_ptr<TopEventsTable>& table : m_tables)
     {
-        Section& section = m_sections[i];
-        ImGui::TextUnformatted(section.heading);
-        ImGui::Separator();
-        if(section.table)
+        if(table)
         {
-            ImGui::PushID(static_cast<int>(i));
-            ImGui::BeginChild("section",
-                              ImVec2(0, (TABLE_MAX_ROWS + 1) * TableRowHeight()),
-                              ImGuiChildFlags_None);
-            section.table->Render();
-            ImGui::EndChild();
-            ImGui::PopID();
+            table->Render();
+            no_data &= !table->Visible();
         }
-        ImGui::Spacing();
+    }
+    if(no_data)
+    {
+        CenterNextTextItem("No data available for the selected tracks.");
+        ImGui::SetCursorPosY((ImGui::GetWindowHeight() - ImGui::GetTextLineHeight()) *
+                             0.5f);
+        ImGui::TextDisabled("No data available for the selected tracks.");
     }
     ImGui::EndChild();
+    ImGui::PopStyleColor(2);
+    ImGui::PopStyleVar(2);
+}
+
+void
+TopEventsView::HandleTrackSelectionChanged(uint64_t track_id, bool selected)
+{
+    for(std::unique_ptr<TopEventsTable>& table : m_tables)
+    {
+        if(table)
+        {
+            table->HandleTrackSelectionChanged(track_id, selected);
+        }
+    }
+}
+
+void
+TopEventsView::HandleTimeRangeSelectionChanged(double start_ns, double end_ns)
+{
+    for(std::unique_ptr<TopEventsTable>& table : m_tables)
+    {
+        if(table)
+        {
+            table->HandleTimeRangeSelectionChanged(start_ns, end_ns);
+        }
+    }
 }
 
 TopEventsView::TopEventsTable::TopEventsTable(
     DataProvider& dp, TableType table_type,
     rocprofvis_controller_table_type_t request_table_type, uint64_t request_id,
-    std::shared_ptr<TimelineSelection> timeline_selection)
+    std::shared_ptr<TimelineSelection> timeline_selection,
+    rocprofvis_dm_event_operation_t op, const char* header)
 : MultiTrackTable(
       dp, table_type, request_table_type, request_id,
       [&dp]() -> const TablesModel& { return dp.DataModel().GetAnalysis().GetTables(); },
@@ -122,6 +137,9 @@ TopEventsView::TopEventsTable::TopEventsTable(
       timeline_selection, 2, kRPVControllerSortOrderDescending)
 , m_duration_column_indices({ INVALID_UINT64_INDEX, INVALID_UINT64_INDEX,
                               INVALID_UINT64_INDEX, INVALID_UINT64_INDEX })
+, m_op(op)
+, m_header(header)
+, m_visible(false)
 {
     m_widget_name = GenUniqueName("Top Events Table");
 }
@@ -129,19 +147,54 @@ TopEventsView::TopEventsTable::TopEventsTable(
 TopEventsView::TopEventsTable::~TopEventsTable() {}
 
 void
-TopEventsView::TopEventsTable::FilterSelectedTracksForTableType(
-    const std::vector<uint64_t>& selected_track_ids,
-    std::vector<uint64_t>&       filtered_track_ids) const
+TopEventsView::TopEventsTable::Render()
 {
-    const TimelineModel& tlm = m_data_provider.DataModel().GetTimeline();
-    for(uint64_t track_id : selected_track_ids)
+    if(m_visible)
     {
-        const TrackInfo* track_info = tlm.GetTrack(track_id);
-        if(track_info && track_info->track_type == kRPVControllerTrackTypeEvents)
+        const ImGuiStyle& style = ImGui::GetStyle();
+        ImGui::PushID(static_cast<int>(m_op));
+        ImVec2 region_avail =
+            ImVec2(ImGui::GetContentRegionAvail().x,
+                   ImGui::GetWindowHeight() - 2.0f * style.WindowPadding.y);
+        if(ImGui::CollapsingHeader(m_header, ImGuiTreeNodeFlags_DefaultOpen))
         {
-            filtered_track_ids.push_back(track_id);
+            ImGui::SetNextWindowSize(
+                ImVec2(region_avail.x,
+                       std::min(region_avail.y - ImGui::GetFrameHeightWithSpacing(),
+                                (Rows() + 1) * TableRowHeight() +
+                                    ImGui::GetFrameHeightWithSpacing() +
+                                    2.0f * style.WindowPadding.y)));
+            MultiTrackTable::Render();
         }
+        ImGui::PopID();
     }
+}
+
+void
+TopEventsView::TopEventsTable::HandleTrackSelectionChanged(uint64_t track_id,
+                                                           bool     selected)
+{
+    MultiTrackTable::HandleTrackSelectionChanged(track_id, selected);
+    m_visible = !m_included_tracks.empty();
+}
+
+bool
+TopEventsView::TopEventsTable::Visible() const
+{
+    return m_visible;
+}
+
+bool
+TopEventsView::TopEventsTable::IncludeTrack(uint64_t track_id) const
+{
+    bool             include = false;
+    const TrackInfo* track_info =
+        m_data_provider.DataModel().GetTimeline().GetTrack(track_id);
+    if(track_info)
+    {
+        include = track_info->operation_types.count(m_op) > 0;
+    }
+    return include;
 }
 
 void
@@ -207,6 +260,12 @@ TopEventsView::TopEventsTable::FormatData() const
             }
         }
     }
+}
+
+size_t
+TopEventsView::TopEventsTable::Rows() const
+{
+    return m_table_model().GetTableTotalRowCount(m_table_type);
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_top_events_view.h
+++ b/src/view/src/rocprofvis_top_events_view.h
@@ -27,7 +27,8 @@ public:
     void Update() override;
     void Render() override;
 
-    void HandleTrackSelectionChanged();
+    void HandleTrackSelectionChanged(uint64_t track_id, bool selected);
+    void HandleTimeRangeSelectionChanged(double start_ns, double end_ns);
 
 private:
     class TopEventsTable : public MultiTrackTable
@@ -36,8 +37,14 @@ private:
         TopEventsTable(DataProvider& dp, TableType table_type,
                        rocprofvis_controller_table_type_t request_table_type,
                        uint64_t                           request_id,
-                       std::shared_ptr<TimelineSelection> timeline_selection);
+                       std::shared_ptr<TimelineSelection> timeline_selection,
+                       rocprofvis_dm_event_operation_t op, const char* header);
         ~TopEventsTable();
+
+        void Render() override;
+        void HandleTrackSelectionChanged(uint64_t track_id, bool selected) override;
+
+        bool Visible() const;
 
     private:
         enum DurationColumns
@@ -49,22 +56,19 @@ private:
             kNumDurationColumns
         };
 
+        bool IncludeTrack(uint64_t track_id) const override;
         void IndexColumns() override;
         void FormatData() const override;
-        void FilterSelectedTracksForTableType(
-            const std::vector<uint64_t>& selected_track_ids,
-            std::vector<uint64_t>&       filtered_track_ids) const override;
+
+        size_t Rows() const;
 
         std::array<size_t, kNumDurationColumns> m_duration_column_indices;
-    };
-    struct Section
-    {
-        const char*                     heading;
-        std::unique_ptr<TopEventsTable> table;
+        rocprofvis_dm_event_operation_t         m_op;
+        const char*                             m_header;
+        bool                                    m_visible;
     };
 
-    std::array<Section, 5> m_sections;
-    DataProvider&          m_data_provider;
+    std::array<std::unique_ptr<TopEventsTable>, 5> m_tables;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -282,8 +282,8 @@ TraceView::CreateView()
     m_timeline_view         = std::make_shared<TimelineView>(m_data_provider,
                                                              m_timeline_selection,
                                                              m_measurement, m_annotations);
-    m_event_search          = std::make_shared<EventSearch>(m_data_provider);
-    m_summary_view          = std::make_shared<SummaryView>(m_data_provider);
+    m_summary_view = std::make_shared<SummaryView>(m_data_provider, m_timeline_selection);
+    m_event_search = std::make_shared<EventSearch>(m_data_provider, m_timeline_selection);
     m_minimap               = std::make_shared<Minimap>(m_data_provider, m_timeline_view.get());
     auto m_histogram_widget = std::make_shared<RocCustomWidget>(
         [this]() { m_timeline_view->RenderHistogram(); });

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_infinite_scroll_table.h"
-#include "icons/rocprovfis_icon_defines.h"
 #include "rocprofvis_appwindow.h"
 #include "rocprofvis_common_defs.h"
-#include "rocprofvis_font_manager.h"
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_timeline_selection.h"
 #include "rocprofvis_utils.h"
@@ -20,10 +18,11 @@ namespace RocProfVis
 namespace View
 {
 
-constexpr uint64_t    FETCH_CHUNK_SIZE     = 1000;
-constexpr const char* START_TS_COLUMN_NAME = "start";
-constexpr const char* END_TS_COLUMN_NAME   = "end";
-constexpr const char* DURATION_COLUMN_NAME = "duration";
+constexpr const char* ROWCONTEXTMENU_POPUP_NAME = "RowContextMenu";
+constexpr uint64_t    FETCH_CHUNK_SIZE          = 1000;
+constexpr const char* START_TS_COLUMN_NAME      = "start";
+constexpr const char* END_TS_COLUMN_NAME        = "end";
+constexpr const char* DURATION_COLUMN_NAME      = "duration";
 
 InfiniteScrollTable::InfiniteScrollTable(
     DataProvider& dp, TableType table_type,
@@ -35,6 +34,7 @@ InfiniteScrollTable::InfiniteScrollTable(
     rocprofvis_controller_sort_order_t        default_sort_order,
     const std::string& friendly_name, const std::string& no_data_text)
 : m_data_provider(dp)
+, m_open_context_menu(false)
 , m_skip_data_fetch(false)
 , m_table_type(table_type)
 , m_request_table_type(request_table_type)
@@ -245,7 +245,7 @@ InfiniteScrollTable::Render()
                               m_settings.GetColor(Colors::kFillerColor));
         if(!table_data.empty())
         {
-            if(ImGui::BeginTable("Event Data Table",
+            if(ImGui::BeginTable("infinite_scroll_table",
                                  static_cast<int>(column_names.size()), table_flags,
                                  outer_size))
             {
@@ -504,6 +504,7 @@ InfiniteScrollTable::Render()
                 }
                 ImGui::EndTable();  // End BeginTable
             }
+            RenderContextMenu();
         }
         else if(!m_no_data_text.empty() && !show_loading_indicator &&
                 ImGui::GetContentRegionAvail().y > ImGui::GetTextLineHeight())
@@ -560,6 +561,89 @@ InfiniteScrollTable::RenderCell(const std::string* cell_text, int row, int colum
     {
         m_hovered_row = row;
     }
+}
+
+void
+InfiniteScrollTable::RenderContextMenu()
+{
+    if(m_open_context_menu)
+    {
+        ImGui::OpenPopup(ROWCONTEXTMENU_POPUP_NAME);
+        m_open_context_menu = false;
+    }
+
+    auto style = m_settings.GetDefaultStyle();
+
+    // Render context menu for row actions
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+    if(ImGui::BeginPopup(ROWCONTEXTMENU_POPUP_NAME))
+    {
+        uint64_t target_track_id = SelectedRowToTrackID(
+            m_important_column_idxs[kTrackId], m_important_column_idxs[kStreamId]);
+        if(target_track_id != INVALID_UINT64_INDEX)
+        {
+            if(ImGui::MenuItem(m_table_type == TableType::kSampleTable ? "Go To Sample"
+                                                                       : "Go To Event",
+                               nullptr, false, target_track_id != INVALID_UINT64_INDEX))
+            {
+                SelectedRowNavigateEvent(m_important_column_idxs[kTrackId],
+                                         m_important_column_idxs[kStreamId]);
+            }
+            ImGui::Separator();
+        }        
+        if(ImGui::MenuItem("Copy Row Data", nullptr, false))
+        {
+            SelectedRowToClipboard();
+        }
+        else if(ImGui::MenuItem("Copy Cell Data", nullptr, false))
+        {
+            SelectedCellToClipboard(true);
+        }
+
+        // Only show option to copy unformatted cell data if
+        // column has formatting applied to it.
+        bool show_copy_unformatted = false;
+        if(m_selected_column >= 0 &&
+           m_selected_column < (int) m_table_model().GetTableHeader(m_table_type).size())
+        {
+            const auto&                             table_model = m_table_model();
+            const std::vector<FormattedColumnInfo>& formatted_table_data =
+                table_model.GetFormattedTableData(m_table_type);
+            const auto& col_format_info = formatted_table_data[m_selected_column];
+            show_copy_unformatted       = col_format_info.needs_formatting;
+        }
+        if(show_copy_unformatted)
+        {
+            if(ImGui::MenuItem("Copy Unformatted Cell Data", nullptr, false))
+            {
+                SelectedCellToClipboard(false);
+            }
+        }
+        ImGui::Separator();
+        if(ImGui::MenuItem(
+               "Export To File", nullptr, false,
+               !m_data_provider.IsRequestPending(DataProvider::TABLE_EXPORT_REQUEST_ID)))
+        {
+            ExportToFile();
+        }
+        // TODO handle event selection
+        // else if(ImGui::MenuItem("Select event", nullptr, false))
+        // {
+        //     uint64_t event_id = INVALID_UINT64_INDEX;
+
+        //     if(m_important_columns[kUUId] != INVALID_COLUMN_INDEX &&
+        //        m_important_columns[kUUId] < table_data[m_selected_row].size())
+        //     {
+        //         event_id =
+        //             std::stoull(table_data[m_selected_row][m_important_columns[kUUId]]);
+        //     }
+        // }
+
+        ImGui::EndPopup();
+    }
+    // Pop the style vars for window padding and item spacing
+    ImGui::PopStyleVar(2);
 }
 
 void
@@ -740,6 +824,46 @@ InfiniteScrollTable::SelectedRowToClipboard() const
 }
 
 void
+InfiniteScrollTable::SelectedCellToClipboard(bool use_formatted_data) const
+{
+    const std::vector<std::vector<std::string>>& table_data =
+        m_table_model().GetTableData(m_table_type);
+
+    if(m_selected_row < 0 || m_selected_row >= (int) table_data.size())
+    {
+        spdlog::warn("Selected row index out of bounds: {}", m_selected_row);
+        return;
+    }
+
+    if(m_selected_column < 0 ||
+       m_selected_column >= (int) table_data[m_selected_row].size())
+    {
+        spdlog::warn("Selected column index out of bounds: {}", m_selected_column);
+        return;
+    }
+
+    std::string cell_text = table_data[m_selected_row][m_selected_column];
+
+    if(use_formatted_data)
+    {
+        const auto&                             table_model = m_table_model();
+        const std::vector<FormattedColumnInfo>& formatted_table_data =
+            table_model.GetFormattedTableData(m_table_type);
+
+        const auto& col_format_info = formatted_table_data[m_selected_column];
+        if(col_format_info.needs_formatting &&
+           m_selected_row < col_format_info.formatted_row_value.size())
+        {
+            cell_text = col_format_info.formatted_row_value[m_selected_row];
+        }
+    }
+
+    ImGui::SetClipboardText(cell_text.c_str());
+    NotificationManager::GetInstance().Show("Cell data was copied",
+                                            NotificationLevel::Info);
+}
+
+void
 InfiniteScrollTable::SelectedRowNavigateEvent(size_t track_id_column_index,
                                               size_t stream_id_column_index) const
 {
@@ -783,6 +907,12 @@ InfiniteScrollTable::SelectedRowNavigateEvent(size_t track_id_column_index,
             spdlog::warn("No valid track or stream ID found for row: {}", m_selected_row);
         }
     }
+}
+
+void
+InfiniteScrollTable::SelectedRowContextMenu()
+{
+    m_open_context_menu = true;
 }
 
 void

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -80,10 +80,13 @@ protected:
                                                        size_t stream_id_column_index) const;
     std::pair<uint64_t, uint64_t> SelectedRowToTimeRange() const;
     void                          SelectedRowToClipboard() const;
-    void                          FormatTimeColumns() const;
+    void                          SelectedCellToClipboard(bool use_formatted_data) const;
     void                          SelectedRowNavigateEvent(size_t track_id_column_index,
                                                            size_t stream_id_column_index) const;
-    void                          ExportToFile() const;
+    void                          SelectedRowContextMenu();
+
+    void FormatTimeColumns() const;
+    void ExportToFile() const;
 
     FilterOptions                      m_filter_options;
     FilterOptions                      m_pending_filter_options;
@@ -119,13 +122,15 @@ protected:
 
 private:
     void RenderCell(const std::string* cell_text, int row, int column);
+    void RenderContextMenu();
     void ProcessSortOrFilterRequest(rocprofvis_controller_sort_order_t sort_order,
-                            uint64_t sort_column_index, uint64_t frame_count);
+                                    uint64_t sort_column_index, uint64_t frame_count);
 
     int m_fetch_pad_items;
     int m_fetch_threshold_items;
 
     // Internal state flags below
+    bool     m_open_context_menu;
     bool     m_skip_data_fetch;
     uint64_t m_last_total_row_count;
     ImVec2   m_last_table_size;


### PR DESCRIPTION
  ## Controller
  - Added operation type indexed property (`kRPVControllerTrackOperationTypeIndexed`) to `Track`. Mapping from track type to operation type done in controller in the interim.
  - Removed `DurationAvg`/`DurationMin`/`DurationMax` columns from `kAnalysisTopSampledEventsTable`.
  - Renamed track property enums that did not conform to naming scheme.

  ## View
  - Polished and exposed `TopEventsView` tab outside of developer mode.
  - Optimized `MultiTrackTable` track selection filtering such that only instances appropriate for the selection request new data.
  - Moved `MultiTrackTable`'s context menu into `InfiniteScrollTable` such that all instances have option to display a common context menu.
  - Enabled context menu functionality for `SummaryView`'s `KernelInstanceTable`.
  - Updated various lists to use a consistent color scheme for active/hovered state. These had poor contrast vs their base state and now use the `InfiniteScrollTable` scheme:
    - Compute: `Roofline` legend, `TopKernels` table.
    - Systems: `SideBar`, `TopKernels` legends and table