### PR TITLE
Fix reopening .rpv with missing source .db

### DIFF
--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1601,9 +1601,7 @@ rocprofvis_db_type_t ProfileDatabase::Detect(rocprofvis_db_filename_t filename, 
     {
         return rocprofvis_db_type_t::kRocprofMultinodeSqlite;
     }
-    // Open without SQLITE_OPEN_CREATE so probing a missing file does not create
-    // an empty (0-byte) database at that path. sqlite3_close handles the handle
-    // sqlite allocates even when the open fails (and is a no-op on nullptr).
+    // Avoid SQLITE_OPEN_CREATE so detecting a missing file doesn't create one.
     if (sqlite3_open_v2(filename, &db, SQLITE_OPEN_READWRITE, nullptr) != SQLITE_OK)
     {
         sqlite3_close(db);

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1601,7 +1601,14 @@ rocprofvis_db_type_t ProfileDatabase::Detect(rocprofvis_db_filename_t filename, 
     {
         return rocprofvis_db_type_t::kRocprofMultinodeSqlite;
     }
-    if( sqlite3_open(filename, &db) != SQLITE_OK) return rocprofvis_db_type_t::kAutodetect;
+    // Open without SQLITE_OPEN_CREATE so probing a missing file does not create
+    // an empty (0-byte) database at that path. sqlite3_close handles the handle
+    // sqlite allocates even when the open fails (and is a no-op on nullptr).
+    if (sqlite3_open_v2(filename, &db, SQLITE_OPEN_READWRITE, nullptr) != SQLITE_OK)
+    {
+        sqlite3_close(db);
+        return rocprofvis_db_type_t::kAutodetect;
+    }
 
     if (DetectTable(db, "rocpd_event") == SQLITE_OK) {
         sqlite3_close(db);

--- a/src/view/src/rocprofvis_project.cpp
+++ b/src/view/src/rocprofvis_project.cpp
@@ -73,9 +73,7 @@ Project::Open(std::string& file_path)
 
         if(result == Failed)
         {
-            // OpenProject/OpenTrace may set a specific message (e.g. naming a
-            // missing trace file referenced by the project). Fall back to the
-            // generic message only when no specific one was provided.
+            // Use the specific failure message if one was set, else a generic one.
             AppWindow::GetInstance()->ShowMessageDialog(
                 "Error",
                 m_open_error_message.empty()
@@ -159,10 +157,8 @@ Project::OpenProject(std::string& file_path)
             }
             else
             {
-                // The project references a trace file that is no longer present.
-                // Name the missing trace (not the project) and skip the open
-                // attempt, which would otherwise create an empty database file
-                // at the trace's original path.
+                // Referenced trace is gone: name it and don't open it, which would
+                // create an empty database at its original path.
                 m_open_error_message =
                     "The trace file referenced by this project could not be "
                     "found:\n\n" +

--- a/src/view/src/rocprofvis_project.cpp
+++ b/src/view/src/rocprofvis_project.cpp
@@ -58,6 +58,7 @@ Project::OpenResult
 Project::Open(std::string& file_path)
 {
     OpenResult result = Failed;
+    m_open_error_message.clear();
     if(std::filesystem::exists(file_path))
     {
         std::string file_ext = std::filesystem::path(file_path).extension().string();
@@ -72,12 +73,16 @@ Project::Open(std::string& file_path)
 
         if(result == Failed)
         {
-            // show error dialog
+            // OpenProject/OpenTrace may set a specific message (e.g. naming a
+            // missing trace file referenced by the project). Fall back to the
+            // generic message only when no specific one was provided.
             AppWindow::GetInstance()->ShowMessageDialog(
                 "Error",
-                "The file could not be opened:\n\n" + file_path +
-                    "\n\nPlease make sure the file is a valid trace or project file.");
-            spdlog::error("Failed to open file: {}, invalid trace or project file", file_path);                    
+                m_open_error_message.empty()
+                    ? "The file could not be opened:\n\n" + file_path +
+                          "\n\nPlease make sure the file is a valid trace or project file."
+                    : m_open_error_message);
+            spdlog::error("Failed to open file: {}", file_path);
         }
     }
     else
@@ -144,16 +149,35 @@ Project::OpenProject(std::string& file_path)
                                                          [JSON_KEY_GENERAL_TRACE_PATH]
                                                              .getString()))
                     .string();
-            result = OpenTrace(trace_path);
-            if(result == Duplicate)
+            if(std::filesystem::exists(trace_path))
             {
-                file_path = trace_path;
+                result = OpenTrace(trace_path);
+                if(result == Duplicate)
+                {
+                    file_path = trace_path;
+                }
+            }
+            else
+            {
+                // The project references a trace file that is no longer present.
+                // Name the missing trace (not the project) and skip the open
+                // attempt, which would otherwise create an empty database file
+                // at the trace's original path.
+                m_open_error_message =
+                    "The trace file referenced by this project could not be "
+                    "found:\n\n" +
+                    trace_path +
+                    "\n\nIt may have been moved or deleted. Restore it and try "
+                    "again.";
+                spdlog::error("Failed to open project {}: referenced trace file "
+                              "does not exist: {}",
+                              file_path, trace_path);
             }
         }
         else
         {
-            AppWindow::GetInstance()->ShowMessageDialog(
-                "Error", "Failed to load project: " + file_path);
+            m_open_error_message = "Failed to load project:\n\n" + file_path +
+                                   "\n\nThe project file is invalid or corrupted.";
         }
         file.close();
     }

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -122,6 +122,9 @@ private:
     std::shared_ptr<RocWidget> m_view;
     std::list<ProjectSetting*> m_settings;
     jt::Json                   m_settings_json;
+    // Specific failure message set by OpenProject/OpenTrace and surfaced by
+    // Open(). Empty means "use the generic could-not-be-opened message".
+    std::string                m_open_error_message;
 };
 
 constexpr const char* JSON_KEY_GROUP_GENERAL  = "general";

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -122,8 +122,7 @@ private:
     std::shared_ptr<RocWidget> m_view;
     std::list<ProjectSetting*> m_settings;
     jt::Json                   m_settings_json;
-    // Specific failure message set by OpenProject/OpenTrace and surfaced by
-    // Open(). Empty means "use the generic could-not-be-opened message".
+    // Specific open-failure message; empty falls back to the generic one.
     std::string                m_open_error_message;
 };
 


### PR DESCRIPTION
When a project's referenced trace file was moved or deleted, opening the .rpv named the .rpv as invalid instead of the missing .db, and created an empty 0-byte database at the trace's original path.

Project: :OpenProject now verifies the resolved trace path exists before opening it, reports the missing trace file by name, and skips the open attempt. ProfileDatabase::Detect opens via sqlite3_open_v2 without SQLITE_OPEN_CREATE so probing a missing path no longer creates a 0-byte database (and closes the handle on failure).
