### PR TITLE
Add hover tooltip and copy menu to track meta area, fix per-track table count off-by-one

### DIFF
--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1264,10 +1264,6 @@ ProfileDatabase::BuildTableQuery(
                     query += std::to_string(fetch_start);
                     query += " and ";
                     query += Builder::START_SERVICE_NAME;
-                    // Internal chunk seams use strict '<' so a row whose
-                    // START lands on a seam is counted exactly once. The
-                    // final chunk uses '<=' so the global upper bound is
-                    // inclusive, matching the trace-wide record count.
                     query += (j == divider - 1) ? " <= " : " < ";
                     query += std::to_string(fetch_end);
                     if (where && strlen(where))

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1819,6 +1819,9 @@ rocprofvis_dm_result_t ProfileDatabase::SaveTrackProperties(Future* future) {
     std::string table_name = GetMetadataVersionControl()->GetTrackInfoTableName();
     for (int i = 0; i < NumTracks(); i++)
     {
+        // Write a merged track's total on one load_id row only; the loader
+        // re-sums rows, so repeating it per row would multiply it on reload.
+        bool first_load_id = true;
         for (auto load_id : TrackPropertiesAt(i)->load_id)
         {
             DbInstance* db_instance = (DbInstance*)TrackPropertiesAt(i)->track_indentifiers.db_instance;
@@ -1829,7 +1832,8 @@ rocprofvis_dm_result_t ProfileDatabase::SaveTrackProperties(Future* future) {
             p.track_id = TrackPropertiesAt(i)->track_indentifiers.track_id;
             p.category = TrackPropertiesAt(i)->track_indentifiers.category;
             p.op = TrackPropertiesAt(i)->op;
-            p.record_count = TrackPropertiesAt(i)->record_count;
+            p.record_count = first_load_id ? TrackPropertiesAt(i)->record_count : 0;
+            first_load_id = false;
             p.min_ts = TrackPropertiesAt(i)->min_ts;
             p.max_ts = TrackPropertiesAt(i)->max_ts;
             p.min_val = TrackPropertiesAt(i)->min_value;

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1264,7 +1264,11 @@ ProfileDatabase::BuildTableQuery(
                     query += std::to_string(fetch_start);
                     query += " and ";
                     query += Builder::START_SERVICE_NAME;
-                    query += " < ";
+                    // Internal chunk seams use strict '<' so a row whose
+                    // START lands on a seam is counted exactly once. The
+                    // final chunk uses '<=' so the global upper bound is
+                    // inclusive, matching the trace-wide record count.
+                    query += (j == divider - 1) ? " <= " : " < ";
                     query += std::to_string(fetch_end);
                     if (where && strlen(where))
                     {

--- a/src/model/src/database/rocprofvis_db_rocpd.cpp
+++ b/src/model/src/database/rocprofvis_db_rocpd.cpp
@@ -146,6 +146,8 @@ int RocpdDatabase::ProcessTrack(rocprofvis_dm_track_params_t& track_params, rocp
     }
     else
     {
+        // Streams merge several per-operation queries into one track; sum the counts.
+        it->get()->record_count += track_params.record_count;
         it->get()->load_id.insert(*track_params.load_id.begin());
     }
     return 0;

--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -177,6 +177,8 @@ int RocprofDatabase::ProcessTrack(rocprofvis_dm_track_params_t& track_params, ro
     }
     else
     {
+        // Streams merge several per-operation queries into one track; sum the counts.
+        it->get()->record_count += track_params.record_count;
         it->get()->load_id.insert(*track_params.load_id.begin());
         track_params.track_indentifiers.track_id = it->get()->track_indentifiers.track_id;
     }

--- a/src/model/src/database/rocprofvis_db_version.cpp
+++ b/src/model/src/database/rocprofvis_db_version.cpp
@@ -97,7 +97,7 @@ namespace DataModel
             kRocOptiqTablePerFile,
             kRocOptiqTableDisposeWhenTrimmed,
             kRocOptiqTableDependentOnNoDependency, 
-            kRocOptiqTableVersionMemoryCopyLevel, 
+            kRocOptiqTableVersionTrackInfo, 
             db->GetHistogramQueryAndSchemaHash()
         };
         m_roc_optiq_table_properties[kRocOptiqTableKernelDispatchLevel] = {

--- a/src/model/src/database/rocprofvis_db_version.h
+++ b/src/model/src/database/rocprofvis_db_version.h
@@ -64,7 +64,7 @@ namespace DataModel
             kRocOptiqTableVersionMemoryAllocLevel = kRocOptiqTableVersionForLevelCalculation,
             kRocOptiqTableVersionMemoryCopyLevel = kRocOptiqTableVersionForLevelCalculation,
             kRocOptiqTableVersionHistogram = 0x0001,
-            kRocOptiqTableVersionTrackInfo = 0x0002,
+            kRocOptiqTableVersionTrackInfo = 0x0003,
         };
 
         struct roc_optiq_metadata_t

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -8,6 +8,8 @@
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_gui_helpers.h"
+#include "widgets/rocprofvis_notification_manager.h"
+#include "widgets/rocprofvis_widget.h"
 #include <memory>
 #include <algorithm>
 
@@ -18,6 +20,8 @@ namespace View
 
 constexpr float kMinTooltipWrapWidth = 200.0f;
 constexpr float kMaxTooltipWrapWidth = 600.0f;
+
+inline constexpr uint64_t kCompactCountThreshold = 1000;
 
 float TrackItem::s_metadata_width = 400.0f;
 
@@ -306,23 +310,6 @@ TrackItem::RenderMetaArea()
         ImGui::PopStyleColor();
         ImGui::EndGroup();
 
-        if(!m_meta_area_tooltip.empty() && ImGui::IsItemHovered())
-        {
-            const float tooltip_max_width = std::max(
-                kMinTooltipWrapWidth,
-                std::min(kMaxTooltipWrapWidth, s_metadata_width - m_reorder_grip_width -
-                                                   2.0f * m_metadata_padding.x));
-
-            // Constrain tooltip window width (height auto-fits)
-            ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),
-                                                ImVec2(tooltip_max_width, FLT_MAX));
-            BeginTooltipStyled();
-            ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + tooltip_max_width);
-            ImGui::TextUnformatted(m_meta_area_tooltip.c_str());
-            ImGui::PopTextWrapPos();
-            EndTooltipStyled();
-        }
-
         ImGui::SetCursorPos(ImVec2(m_metadata_padding.x + content_size.x -
                                        m_meta_area_scale_width - menu_button_width,
                                    m_metadata_padding.y));
@@ -369,6 +356,61 @@ TrackItem::RenderMetaArea()
     {
         m_meta_area_clicked = false;
     }
+
+    ImVec2 pill_min, pill_max;
+    const bool over_pill = m_pill.GetLastScreenRect(pill_min, pill_max) &&
+                           ImGui::IsMouseHoveringRect(pill_min, pill_max);
+    const bool meta_area_hovered =
+        ImGui::IsMouseHoveringRect(meta_min, meta_max) &&
+        !ImGui::IsAnyItemHovered() && !over_pill &&
+        !ImGui::IsPopupOpen(nullptr,
+            ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel);
+
+    if(meta_area_hovered && !m_meta_area_tooltip.empty())
+    {
+        const float tooltip_max_width = std::max(
+            kMinTooltipWrapWidth,
+            std::min(kMaxTooltipWrapWidth, s_metadata_width - m_reorder_grip_width -
+                                               2.0f * m_metadata_padding.x));
+
+        ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),
+                                            ImVec2(tooltip_max_width, FLT_MAX));
+        BeginTooltipStyled();
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + tooltip_max_width);
+        ImGui::TextUnformatted(m_meta_area_tooltip.c_str());
+        ImGui::PopTextWrapPos();
+        EndTooltipStyled();
+    }
+
+    const std::string copy_popup_id =
+        "##track_copy_menu_" + std::to_string(m_track_id);
+    if(meta_area_hovered &&
+       ImGui::IsMouseClicked(ImGuiMouseButton_Right))
+    {
+        ImGui::OpenPopup(copy_popup_id.c_str());
+    }
+    const ImGuiStyle& popup_style = m_settings.GetDefaultStyle();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, popup_style.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, popup_style.ItemSpacing);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, popup_style.FramePadding);
+    if(ImGui::BeginPopup(copy_popup_id.c_str()))
+    {
+        if(ImGui::MenuItem("Copy track name"))
+        {
+            ImGui::SetClipboardText(m_meta_area_label.c_str());
+            NotificationManager::GetInstance().Show(
+                COPY_DATA_NOTIFICATION.data(), NotificationLevel::Info);
+        }
+        if(ImGui::MenuItem("Copy track ID"))
+        {
+            std::string id_str = std::to_string(m_track_id);
+            ImGui::SetClipboardText(id_str.c_str());
+            NotificationManager::GetInstance().Show(
+                COPY_DATA_NOTIFICATION.data(), NotificationLevel::Info);
+        }
+        ImGui::EndPopup();
+    }
+    ImGui::PopStyleVar(3);
 }
 
 void
@@ -702,6 +744,58 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
             break;
         }
     }
+
+    std::string track_type_label;
+    switch(track_info->topology.type)
+    {
+        case TrackInfo::TrackType::Queue:              track_type_label = "Queue"; break;
+        case TrackInfo::TrackType::Stream:             track_type_label = "Stream"; break;
+        case TrackInfo::TrackType::Counter:            track_type_label = "Counter"; break;
+        case TrackInfo::TrackType::InstrumentedThread: track_type_label = "Instrumented Thread"; break;
+        case TrackInfo::TrackType::SampledThread:      track_type_label = "Sampled Thread"; break;
+        default:                                       track_type_label = "Track"; break;
+    }
+
+    // Pick "events" vs "samples" based on the controller-side track type so
+    // counter tracks read "samples" and flame tracks read "events".
+    const bool is_sample_track =
+        track_info->track_type == kRPVControllerTrackTypeSamples;
+    const char* count_label = is_sample_track ? "Samples" : "Events";
+
+    std::string meta_lines;
+    meta_lines += "Track ID: " + std::to_string(track_info->id) + "\n";
+    meta_lines += "Type: " + track_type_label;
+    if(!track_info->category.empty() &&
+       track_info->category != track_type_label)
+    {
+        meta_lines += " (" + track_info->category + ")";
+    }
+    meta_lines += "\n";
+    if(show_node_id)
+    {
+        meta_lines += "Node ID: " + node_id_str + "\n";
+    }
+    if(show_process_id)
+    {
+        meta_lines += "Process ID: " + process_id_str + "\n";
+    }
+    meta_lines += std::string(count_label) + ": " +
+                  std::to_string(track_info->num_entries);
+    if(track_info->num_entries >= kCompactCountThreshold)
+    {
+        meta_lines += " (" + compact_number_format(
+                                static_cast<double>(track_info->num_entries)) +
+                      ")";
+    }
+
+    if(m_meta_area_tooltip.empty())
+    {
+        m_meta_area_tooltip = meta_lines;
+    }
+    else
+    {
+        m_meta_area_tooltip += "\n\n" + meta_lines;
+    }
 }
 
 bool
@@ -802,6 +896,9 @@ Pill::Pill(const std::string& label, bool shown, bool active)
 : m_pill_label(label)
 , m_show_pill_label(shown)
 , m_active(active)
+, m_has_last_screen_rect(false)
+, m_last_screen_min(0, 0)
+, m_last_screen_max(0, 0)
 , m_font_changed_token(static_cast<uint64_t>(-1))
 {
     CalculatePillSize();
@@ -862,12 +959,17 @@ Pill::RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
 {
     if(m_show_pill_label == false)
     {
+        m_has_last_screen_rect = false;
         return;
     }
     ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kDefault),
                     settings.GetFontManager().GetFontSize(FontSize::kSmall));
 
     ImVec2 pillbox_pos(reorder_grip_width, container_size.y - m_pillbox_size.y - 2.0f);
+    ImVec2 win_pos_for_rect = ImGui::GetWindowPos();
+    m_last_screen_min      = win_pos_for_rect + pillbox_pos;
+    m_last_screen_max      = m_last_screen_min + m_pillbox_size;
+    m_has_last_screen_rect = true;
 
     if (m_active)
     {
@@ -910,6 +1012,18 @@ ImVec2
 Pill::GetPillSize()
 {
     return m_pillbox_size;
+}
+
+bool
+Pill::GetLastScreenRect(ImVec2& out_min, ImVec2& out_max) const
+{
+    if(!m_has_last_screen_rect)
+    {
+        return false;
+    }
+    out_min = m_last_screen_min;
+    out_max = m_last_screen_max;
+    return true;
 }
 
 void

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -23,6 +23,7 @@ inline constexpr float    DEFAULT_GRIP_WIDTH             = 20.0f;
 inline constexpr uint64_t DEFAULT_CHUNK_DURATION         = TimeConstants::ns_per_s * 30;
 inline constexpr float    META_TOOLTIP_MAX_WIDTH         = 320.0f;
 inline constexpr uint64_t META_TOOLTIP_COMPACT_COUNT_MIN = 1000;
+constexpr const char*     TRACK_COPY_MENU_POPUP_NAME     = "TrackCopyMenu";
 
 float TrackItem::s_metadata_width = 400.0f;
 
@@ -358,24 +359,28 @@ TrackItem::RenderMetaArea()
                                    !ImGui::IsAnyItemHovered() &&
                                    !m_pill.WasLastHovered();
 
-    if(meta_area_hovered && !m_meta_area_tooltip.empty())
+    const ImGuiStyle& style = m_settings.GetDefaultStyle();
+
+    if(meta_area_hovered && !m_meta_area_tooltip.empty() &&
+       ImGui::IsItemHovered(ImGuiHoveredFlags_ForTooltip))
     {
+        const float wrap_width = META_TOOLTIP_MAX_WIDTH - 2.0f * style.WindowPadding.x;
         ImGui::SetNextWindowSizeConstraints(
             ImVec2(0, 0), ImVec2(META_TOOLTIP_MAX_WIDTH, FLT_MAX));
         BeginTooltipStyled();
-        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + META_TOOLTIP_MAX_WIDTH);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + wrap_width);
         ImGui::TextUnformatted(m_meta_area_tooltip.c_str());
         ImGui::PopTextWrapPos();
         EndTooltipStyled();
     }
 
-    const std::string copy_popup_id =
-        "##track_copy_menu_" + std::to_string(m_track_id);
     if(meta_area_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
     {
-        ImGui::OpenPopup(copy_popup_id.c_str());
+        ImGui::OpenPopup(TRACK_COPY_MENU_POPUP_NAME);
     }
-    if(ImGui::BeginPopup(copy_popup_id.c_str()))
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+    if(ImGui::BeginPopup(TRACK_COPY_MENU_POPUP_NAME))
     {
         auto copy_to_clipboard = [](const std::string& text) {
             ImGui::SetClipboardText(text.c_str());
@@ -392,6 +397,7 @@ TrackItem::RenderMetaArea()
         }
         ImGui::EndPopup();
     }
+    ImGui::PopStyleVar(2);
 }
 
 void
@@ -740,13 +746,15 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
     {
         meta_lines += "Process ID: " + process_id_str + "\n";
     }
-    meta_lines += std::string(count_label) + ": " +
-                  std::to_string(track_info->num_entries);
+    meta_lines += std::string(count_label) + ": ";
     if(track_info->num_entries >= META_TOOLTIP_COMPACT_COUNT_MIN)
     {
-        meta_lines += " (" + compact_number_format(
-                                static_cast<double>(track_info->num_entries)) +
-                      ")";
+        meta_lines +=
+            compact_number_format(static_cast<double>(track_info->num_entries));
+    }
+    else
+    {
+        meta_lines += std::to_string(track_info->num_entries);
     }
 
     if(m_meta_area_tooltip.empty())

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -18,11 +18,10 @@ namespace RocProfVis
 namespace View
 {
 
-inline constexpr float    DEFAULT_MIN_TRACK_HEIGHT     = 10.0f;
-inline constexpr float    DEFAULT_GRIP_WIDTH           = 20.0f;
-inline constexpr uint64_t DEFAULT_CHUNK_DURATION       = TimeConstants::ns_per_s * 30;
-inline constexpr float    META_TOOLTIP_WRAP_WIDTH_MIN  = 200.0f;
-inline constexpr float    META_TOOLTIP_WRAP_WIDTH_MAX  = 600.0f;
+inline constexpr float    DEFAULT_MIN_TRACK_HEIGHT       = 10.0f;
+inline constexpr float    DEFAULT_GRIP_WIDTH             = 20.0f;
+inline constexpr uint64_t DEFAULT_CHUNK_DURATION         = TimeConstants::ns_per_s * 30;
+inline constexpr float    META_TOOLTIP_MAX_WIDTH         = 320.0f;
 inline constexpr uint64_t META_TOOLTIP_COMPACT_COUNT_MIN = 1000;
 
 float TrackItem::s_metadata_width = 400.0f;
@@ -355,27 +354,16 @@ TrackItem::RenderMetaArea()
         m_meta_area_clicked = false;
     }
 
-    ImVec2 pill_min, pill_max;
-    const bool over_pill = m_pill.GetLastScreenRect(pill_min, pill_max) &&
-                           ImGui::IsMouseHoveringRect(pill_min, pill_max);
-    const bool meta_area_hovered =
-        ImGui::IsMouseHoveringRect(meta_min, meta_max) &&
-        !ImGui::IsAnyItemHovered() && !over_pill &&
-        !ImGui::IsPopupOpen(nullptr,
-            ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel);
+    const bool meta_area_hovered = ImGui::IsItemHovered() &&
+                                   !ImGui::IsAnyItemHovered() &&
+                                   !m_pill.WasLastHovered();
 
     if(meta_area_hovered && !m_meta_area_tooltip.empty())
     {
-        const float tooltip_max_width = std::max(
-            META_TOOLTIP_WRAP_WIDTH_MIN,
-            std::min(META_TOOLTIP_WRAP_WIDTH_MAX,
-                     s_metadata_width - m_reorder_grip_width -
-                         2.0f * m_metadata_padding.x));
-
-        ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),
-                                            ImVec2(tooltip_max_width, FLT_MAX));
+        ImGui::SetNextWindowSizeConstraints(
+            ImVec2(0, 0), ImVec2(META_TOOLTIP_MAX_WIDTH, FLT_MAX));
         BeginTooltipStyled();
-        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + tooltip_max_width);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + META_TOOLTIP_MAX_WIDTH);
         ImGui::TextUnformatted(m_meta_area_tooltip.c_str());
         ImGui::PopTextWrapPos();
         EndTooltipStyled();
@@ -383,15 +371,10 @@ TrackItem::RenderMetaArea()
 
     const std::string copy_popup_id =
         "##track_copy_menu_" + std::to_string(m_track_id);
-    if(meta_area_hovered &&
-       ImGui::IsMouseClicked(ImGuiMouseButton_Right))
+    if(meta_area_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
     {
         ImGui::OpenPopup(copy_popup_id.c_str());
     }
-    const ImGuiStyle& popup_style = m_settings.GetDefaultStyle();
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, popup_style.WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, popup_style.ItemSpacing);
-    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, popup_style.FramePadding);
     if(ImGui::BeginPopup(copy_popup_id.c_str()))
     {
         auto copy_to_clipboard = [](const std::string& text) {
@@ -409,7 +392,6 @@ TrackItem::RenderMetaArea()
         }
         ImGui::EndPopup();
     }
-    ImGui::PopStyleVar(3);
 }
 
 void
@@ -875,9 +857,6 @@ Pill::Pill(const std::string& label, bool shown, bool active)
 : m_pill_label(label)
 , m_show_pill_label(shown)
 , m_active(active)
-, m_has_last_screen_rect(false)
-, m_last_screen_min(0, 0)
-, m_last_screen_max(0, 0)
 , m_font_changed_token(static_cast<uint64_t>(-1))
 {
     CalculatePillSize();
@@ -939,17 +918,13 @@ Pill::RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
 {
     if(m_show_pill_label == false)
     {
-        m_has_last_screen_rect = false;
+        m_was_last_hovered = false;
         return;
     }
     ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kDefault),
                     settings.GetFontManager().GetFontSize(FontSize::kSmall));
 
     ImVec2 pillbox_pos(reorder_grip_width, container_size.y - m_pillbox_size.y - 2.0f);
-    ImVec2 win_pos_for_rect = ImGui::GetWindowPos();
-    m_last_screen_min      = win_pos_for_rect + pillbox_pos;
-    m_last_screen_max      = m_last_screen_min + m_pillbox_size;
-    m_has_last_screen_rect = true;
 
     if (m_active)
     {
@@ -979,7 +954,9 @@ Pill::RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
     ImVec2 text_pos = pillbox_pos + ImVec2(m_padding_x, m_padding_y);
     ImGui::SetCursorPos(text_pos);
     ImGui::TextUnformatted(m_pill_label.c_str());
-    if(!m_tooltip_label.empty() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+    m_was_last_hovered =
+        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled);
+    if(!m_tooltip_label.empty() && m_was_last_hovered)
     {
         SetTooltipStyled("%s", m_tooltip_label.c_str());
     }
@@ -992,18 +969,6 @@ ImVec2
 Pill::GetPillSize()
 {
     return m_pillbox_size;
-}
-
-bool
-Pill::GetLastScreenRect(ImVec2& out_min, ImVec2& out_max) const
-{
-    if(!m_has_last_screen_rect)
-    {
-        return false;
-    }
-    out_min = m_last_screen_min;
-    out_max = m_last_screen_max;
-    return true;
 }
 
 void

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -18,16 +18,14 @@ namespace RocProfVis
 namespace View
 {
 
-constexpr float kMinTooltipWrapWidth = 200.0f;
-constexpr float kMaxTooltipWrapWidth = 600.0f;
-
-inline constexpr uint64_t kCompactCountThreshold = 1000;
+inline constexpr float    DEFAULT_MIN_TRACK_HEIGHT     = 10.0f;
+inline constexpr float    DEFAULT_GRIP_WIDTH           = 20.0f;
+inline constexpr uint64_t DEFAULT_CHUNK_DURATION       = TimeConstants::ns_per_s * 30;
+inline constexpr float    META_TOOLTIP_WRAP_WIDTH_MIN  = 200.0f;
+inline constexpr float    META_TOOLTIP_WRAP_WIDTH_MAX  = 600.0f;
+inline constexpr uint64_t META_TOOLTIP_COMPACT_COUNT_MIN = 1000;
 
 float TrackItem::s_metadata_width = 400.0f;
-
-inline constexpr float    DEFAULT_MIN_TRACK_HEIGHT = 10.0f;
-inline constexpr float    DEFAULT_GRIP_WIDTH       = 20.0f;
-inline constexpr uint64_t DEFAULT_CHUNK_DURATION   = TimeConstants::ns_per_s * 30;
 
 TrackItem::TrackItem(DataProvider& dp, uint64_t id,
                      std::shared_ptr<TimePixelTransform> tpt)
@@ -369,9 +367,10 @@ TrackItem::RenderMetaArea()
     if(meta_area_hovered && !m_meta_area_tooltip.empty())
     {
         const float tooltip_max_width = std::max(
-            kMinTooltipWrapWidth,
-            std::min(kMaxTooltipWrapWidth, s_metadata_width - m_reorder_grip_width -
-                                               2.0f * m_metadata_padding.x));
+            META_TOOLTIP_WRAP_WIDTH_MIN,
+            std::min(META_TOOLTIP_WRAP_WIDTH_MAX,
+                     s_metadata_width - m_reorder_grip_width -
+                         2.0f * m_metadata_padding.x));
 
         ImGui::SetNextWindowSizeConstraints(ImVec2(0, 0),
                                             ImVec2(tooltip_max_width, FLT_MAX));
@@ -395,18 +394,18 @@ TrackItem::RenderMetaArea()
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, popup_style.FramePadding);
     if(ImGui::BeginPopup(copy_popup_id.c_str()))
     {
-        if(ImGui::MenuItem("Copy track name"))
-        {
-            ImGui::SetClipboardText(m_meta_area_label.c_str());
+        auto copy_to_clipboard = [](const std::string& text) {
+            ImGui::SetClipboardText(text.c_str());
             NotificationManager::GetInstance().Show(
                 COPY_DATA_NOTIFICATION.data(), NotificationLevel::Info);
+        };
+        if(ImGui::MenuItem("Copy track name"))
+        {
+            copy_to_clipboard(m_meta_area_label);
         }
         if(ImGui::MenuItem("Copy track ID"))
         {
-            std::string id_str = std::to_string(m_track_id);
-            ImGui::SetClipboardText(id_str.c_str());
-            NotificationManager::GetInstance().Show(
-                COPY_DATA_NOTIFICATION.data(), NotificationLevel::Info);
+            copy_to_clipboard(std::to_string(m_track_id));
         }
         ImGui::EndPopup();
     }
@@ -745,32 +744,12 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
         }
     }
 
-    std::string track_type_label;
-    switch(track_info->topology.type)
-    {
-        case TrackInfo::TrackType::Queue:              track_type_label = "Queue"; break;
-        case TrackInfo::TrackType::Stream:             track_type_label = "Stream"; break;
-        case TrackInfo::TrackType::Counter:            track_type_label = "Counter"; break;
-        case TrackInfo::TrackType::InstrumentedThread: track_type_label = "Instrumented Thread"; break;
-        case TrackInfo::TrackType::SampledThread:      track_type_label = "Sampled Thread"; break;
-        default:                                       track_type_label = "Track"; break;
-    }
-
-    // Pick "events" vs "samples" based on the controller-side track type so
-    // counter tracks read "samples" and flame tracks read "events".
     const bool is_sample_track =
         track_info->track_type == kRPVControllerTrackTypeSamples;
     const char* count_label = is_sample_track ? "Samples" : "Events";
 
     std::string meta_lines;
     meta_lines += "Track ID: " + std::to_string(track_info->id) + "\n";
-    meta_lines += "Type: " + track_type_label;
-    if(!track_info->category.empty() &&
-       track_info->category != track_type_label)
-    {
-        meta_lines += " (" + track_info->category + ")";
-    }
-    meta_lines += "\n";
     if(show_node_id)
     {
         meta_lines += "Node ID: " + node_id_str + "\n";
@@ -781,7 +760,7 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
     }
     meta_lines += std::string(count_label) + ": " +
                   std::to_string(track_info->num_entries);
-    if(track_info->num_entries >= kCompactCountThreshold)
+    if(track_info->num_entries >= META_TOOLTIP_COMPACT_COUNT_MIN)
     {
         meta_lines += " (" + compact_number_format(
                                 static_cast<double>(track_info->num_entries)) +
@@ -904,6 +883,7 @@ Pill::Pill(const std::string& label, bool shown, bool active)
     CalculatePillSize();
 
     auto font_changed_handler = [this](std::shared_ptr<RocEvent> e) {
+        (void) e;
         CalculatePillSize();
     };
     m_font_changed_token = EventManager::GetInstance()->Subscribe(

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -747,6 +747,9 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
         meta_lines += "Process ID: " + process_id_str + "\n";
     }
     meta_lines += std::string(count_label) + ": ";
+#ifdef ROCPROFVIS_DEVELOPER_MODE
+    meta_lines += std::to_string(track_info->num_entries);
+#else
     if(track_info->num_entries >= META_TOOLTIP_COMPACT_COUNT_MIN)
     {
         meta_lines +=
@@ -756,6 +759,7 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
     {
         meta_lines += std::to_string(track_info->num_entries);
     }
+#endif
 
     if(m_meta_area_tooltip.empty())
     {

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -58,6 +58,7 @@ public:
     void RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
                          float reorder_grip_width);
     ImVec2 GetPillSize();
+    bool   GetLastScreenRect(ImVec2& out_min, ImVec2& out_max) const;
 
 private:
     void                            CalculatePillSize();
@@ -66,6 +67,9 @@ private:
     std::string                     m_pill_label;
     std::string                     m_tooltip_label;
     ImVec2                          m_pillbox_size;
+    ImVec2                          m_last_screen_min;
+    ImVec2                          m_last_screen_max;
+    bool                            m_has_last_screen_rect;
     const float                     m_padding_x = 8.0f;
     const float                     m_padding_y = 2.0f;
     EventManager::SubscriptionToken m_font_changed_token;

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -58,18 +58,16 @@ public:
     void RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
                          float reorder_grip_width);
     ImVec2 GetPillSize();
-    bool   GetLastScreenRect(ImVec2& out_min, ImVec2& out_max) const;
+    bool   WasLastHovered() const { return m_was_last_hovered; }
 
 private:
     void                            CalculatePillSize();
     bool                            m_show_pill_label;
     bool                            m_active;
+    bool                            m_was_last_hovered = false;
     std::string                     m_pill_label;
     std::string                     m_tooltip_label;
     ImVec2                          m_pillbox_size;
-    ImVec2                          m_last_screen_min;
-    ImVec2                          m_last_screen_max;
-    bool                            m_has_last_screen_rect;
     const float                     m_padding_x = 8.0f;
     const float                     m_padding_y = 2.0f;
     EventManager::SubscriptionToken m_font_changed_token;


### PR DESCRIPTION
## Motivation

The track meta area on every timeline track had no quick way to inspect a track's full identity or copy its name / ID. This PR adds a hover tooltip and a right-click "Copy" menu.

While verifying the tooltip's event/sample count against the per-track table, the table consistently showed one fewer row than the tooltip when an event's start timestamp landed exactly on the trace's upper bound. This PR fixes that too.

## Technical Details

- `TrackItem` builds a tooltip with Track ID, optional Node/PID, and the Events/Samples count (compact form for large counts), and shows it on hover of the empty meta area. A right-click popup adds "Copy track name / Copy track ID" with the standard copy-notification toast.
- Hover predicate uses the repo's standard `IsItemHovered + IsAnyItemHovered` idiom plus one bool the `Pill` already tracks, so gear-icon and pill tooltips still win where they should.
- `ProfileDatabase::BuildTableQuery` uses `<=` instead of `<` on the upper bound of the final chunk in its chunked time filter. Internal seams keep strict `<` so no row is double-counted. Per-track table counts now match the tooltip total.