### PR TITLE
When opening a file set the newly created tab as active.

### DIFF
--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -748,6 +748,7 @@ AppWindow::OpenFile(std::string file_path)
             TabItem tab =
                 TabItem{ project->GetName(), project->GetID(), project->GetView(), true };
             m_tab_container->AddTab(std::move(tab));
+            m_tab_container->SetActiveTab(project->GetID());            
             m_projects[project->GetID()] = std::move(project);
             SettingsManager::GetInstance().AddRecentFile(file_path);
             break;


### PR DESCRIPTION
## Motivation

When opening a file set the newly created tab as active.

## Technical Details

Set tab as active after creating.