### PR TITLE
Duplicate File Open Protection

### DIFF
--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -68,12 +68,14 @@ app_notification_callback(GLFWwindow* window, int notification)
     {
         glfwSetWindowShouldClose(window, GLFW_TRUE);
     }
+#ifndef __APPLE__
     else if(notification ==
             static_cast<int>(rocprofvis_view_notification_t::
                                  kRocProfVisViewNotification_Toggle_Fullscreen))
     {
         RocProfVis::View::toggle_fullscreen(window, g_fullscreen_state);
     }
+#endif
 }
 
 static void
@@ -91,15 +93,20 @@ glfw_error_callback(int error, const char* description)
 static void
 key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
 {
-    // Unused parameters
     (void) scancode;
     (void) mods;
 
+#ifndef __APPLE__
     // Toggle fullscreen with F11
     if(key == GLFW_KEY_F11 && action == GLFW_PRESS)
     {
         RocProfVis::View::toggle_fullscreen(window, g_fullscreen_state);
     }
+#else
+    (void) window;
+    (void) key;
+    (void) action;
+#endif
 }
 
 static void

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -952,6 +952,7 @@ AppWindow::RenderViewMenu(Project* project)
                 tool_bar_item->m_visible = settings.show_toolbar;
             }
         }
+#ifndef __APPLE__
         if(ImGui::MenuItem("Fullscreen", "F11", m_is_fullscreen))
         {
             if(m_notification_callback)
@@ -961,6 +962,7 @@ AppWindow::RenderViewMenu(Project* project)
                         kRocProfVisViewNotification_Toggle_Fullscreen);
             }
         }
+#endif
         ImGui::SeparatorText("System Profiler Panels");
         if(ImGui::MenuItem("Show Advanced Details Panel", nullptr,
                            &settings.show_details_panel))

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -754,7 +754,12 @@ AppWindow::OpenFile(std::string file_path)
         }
         case Project::OpenResult::Duplicate:
         {
-            // File is already opened, just switch to that tab
+            // trace already open, tell the user which tab and switch to it
+            Project* existing = GetProject(file_path);
+            ShowMessageDialog("Trace Already Open",
+                              "This trace is already open in \"" +
+                                  (existing ? existing->GetName() : file_path) +
+                                  "\".\n\nSwitched to the existing tab.");
             m_tab_container->SetActiveTab(file_path);
             break;
         }

--- a/src/view/src/rocprofvis_project.cpp
+++ b/src/view/src/rocprofvis_project.cpp
@@ -163,14 +163,15 @@ Project::OpenProject(std::string& file_path)
 Project::OpenResult
 Project::OpenTrace(std::string& file_path)
 {
-    OpenResult result    = Failed;
-    Project*   duplicate = AppWindow::GetInstance()->GetProject(file_path);
+    OpenResult result = Failed;
+    // canonicalize so a .db and the path stored in a .rpv resolve to the same trace
+    file_path = std::filesystem::weakly_canonical(file_path).string();
+    // trace already open, return duplicate so we switch tabs instead of loading it twice
+    Project* duplicate = AppWindow::GetInstance()->GetProject(file_path);
     if(duplicate)
     {
         file_path = duplicate->GetID();
         result    = Duplicate;
-        NotificationManager::GetInstance().Show(file_path + " already open.",
-                                                NotificationLevel::Warning);
     }
     else if(!m_view)
     {

--- a/src/view/src/rocprofvis_project.cpp
+++ b/src/view/src/rocprofvis_project.cpp
@@ -163,15 +163,15 @@ Project::OpenProject(std::string& file_path)
 Project::OpenResult
 Project::OpenTrace(std::string& file_path)
 {
-    OpenResult result = Failed;
+    OpenResult open_result = Failed;
     // canonicalize so a .db and the path stored in a .rpv resolve to the same trace
     file_path = std::filesystem::weakly_canonical(file_path).string();
     // trace already open, return duplicate so we switch tabs instead of loading it twice
     Project* duplicate = AppWindow::GetInstance()->GetProject(file_path);
     if(duplicate)
     {
-        file_path = duplicate->GetID();
-        result    = Duplicate;
+        file_path   = duplicate->GetID();
+        open_result = Duplicate;
     }
     else if(!m_view)
     {
@@ -216,14 +216,14 @@ Project::OpenTrace(std::string& file_path)
                                                                   : m_trace_file_path)
                          .filename()
                          .string();
-            result = Success;
+            open_result = Success;
         }
         else
         {
             rocprofvis_controller_free(controller);
         }
     }
-    return result;
+    return open_result;
 }
 
 bool


### PR DESCRIPTION
<img width="1315" height="784" alt="Screenshot 2026-06-08 at 1 09 54 PM" src="https://github.com/user-attachments/assets/b54f9521-3986-4625-93f1-16b79835a613" />

- File > Open rejected a second file (.db or .rpv) whose underlying trace .db was already open in another tab, showing a confusing "<path> already open" toast and leaving the user on the current tab.

- Root cause: a project is identified by its underlying trace path, so any file that resolves to the same .db (a .db and a .rpv saved from it, or two .rpv files from one .db) collided — and the raw-path comparison made detection inconsistent.

-We keep the intended one-tab-per-trace behavior but make it correct and clear: the trace path is canonicalized before the duplicate lookup so every file resolving to an open trace is caught, and the toast is replaced with a popup that names the existing tab and switches to it.