### PR TITLE
Fixed multi-node and compare-mode topology node identification

### DIFF
--- a/src/model/src/common/rocprofvis_common_types.h
+++ b/src/model/src/common/rocprofvis_common_types.h
@@ -69,6 +69,7 @@ typedef union{
 #define TRACK_ID_STORE_ID 6
 #define TRACK_ID_RECORD_COUNT 7
 
+#define TOPOLOGY_INSTANCE_BIT_POS 54
 
 typedef struct
 {
@@ -305,8 +306,8 @@ typedef struct
 class DbInstance
 {
 public:
-    static constexpr uint32_t NoGuidId = INVALID_INDEX;
-    DbInstance() : m_file_index(0), m_guid_index(NoGuidId) {}
+    static constexpr const int NoGuidId = -1;
+    DbInstance() : m_file_index(0), m_guid_index(NoGuidId), m_process_instance(0) {}
     DbInstance(uint32_t file_index, uint32_t guid_index) : m_file_index(file_index), m_guid_index(guid_index) {}
     uint32_t FileIndex() { return m_file_index; };
     uint32_t GuidIndex() { 
@@ -315,8 +316,11 @@ public:
         }
         return m_guid_index; 
     };
+    void SetProcessInstance(uint32_t index) { m_process_instance = index; }
+    uint32_t ProcessInstance() { return m_process_instance; }
 private:
     uint32_t m_file_index;
     uint32_t m_guid_index;
+    uint32_t m_process_instance;
 };
 

--- a/src/model/src/datamodel/rocprofvis_dm_topology.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_topology.cpp
@@ -8,6 +8,18 @@ namespace RocProfVis
 namespace DataModel
 {
 
+TopologyNode::TopologyNode(
+	rocprofvis_controller_topology_node_type_t type, 
+	TopologyNodeId id, 
+	TopologyNode* prev_node, 
+	rocprofvis_db_instance_t db_instance):
+	m_type(type), 
+	m_id(id), 
+	m_prev_node(prev_node), 
+	m_db_instance(db_instance) 
+{
+};
+
 TopologyNode* TopologyNode::GetRootNode() {
 	if (m_prev_node == nullptr)
 	{
@@ -530,6 +542,10 @@ bool TopologyNodeThreadInstrumented::DoesThisNodeMatchIdentifiers(rocprofvis_dm_
 	{
 		result = track_identifiers->category == kRocProfVisDmRegionMainTrack || track_identifiers->category == kRocProfVisDmRegionTrack;
 	}
+	if (result)
+	{
+		result = m_db_instance == track_identifiers->db_instance;
+	}
 	return result;
 }
 
@@ -539,6 +555,10 @@ bool TopologyNodeThreadSampled::DoesThisNodeMatchIdentifiers(rocprofvis_dm_track
 	if (result)
 	{
 		result = track_identifiers->category == kRocProfVisDmRegionSampleTrack;
+	}
+	if (result)
+	{
+		result = m_db_instance == track_identifiers->db_instance;
 	}
 	return result;
 }
@@ -575,7 +595,7 @@ std::string TopologyNodeMemoryCopy::GetNodeName() {
 rocprofvis_dm_result_t TopologyNodeMemoryAllocation::GetPropertyAsUint64(rocprofvis_dm_property_t property, rocprofvis_dm_property_index_t index, uint64_t* value) {
 	if (kRPVControllerTopologyNodePropertyValueKeyed == property && kRPVControllerQueueId == index)
 	{
-		rocprofvis_dm_result_t result = m_prev_node->GetPropertyAsUint64(property, kRPVControllerProcessorId, value);
+		rocprofvis_dm_result_t result = TopologyNodeQueue::GetPropertyAsUint64(property, kRPVControllerQueueId, value);
 		*value += kRocProfVisDmMemoryAllocationTrack;
 		return result;
 	}
@@ -588,7 +608,7 @@ rocprofvis_dm_result_t TopologyNodeMemoryAllocation::GetPropertyAsUint64(rocprof
 rocprofvis_dm_result_t TopologyNodeMemoryCopy::GetPropertyAsUint64(rocprofvis_dm_property_t property, rocprofvis_dm_property_index_t index, uint64_t* value) {
 	if (kRPVControllerTopologyNodePropertyValueKeyed == property && kRPVControllerQueueId == index)
 	{
-		rocprofvis_dm_result_t result = m_prev_node->GetPropertyAsUint64(property, kRPVControllerProcessorId, value);
+		rocprofvis_dm_result_t result = TopologyNodeQueue::GetPropertyAsUint64(property, kRPVControllerQueueId, value);
 		*value += kRocProfVisDmMemoryCopyTrack;
 		return result;
 	}
@@ -604,6 +624,10 @@ bool TopologyNodeQueue::DoesThisNodeMatchIdentifiers(rocprofvis_dm_track_identif
 	if (result)
 	{
 		result = m_pid == track_identifiers->process_id;
+	}
+	if (result)
+	{
+		result = m_db_instance == track_identifiers->db_instance;
 	}
 	return result;
 }
@@ -649,6 +673,16 @@ std::string TopologyNodeStream::GetNodeName() {
 	return name;
 }
 
+bool TopologyNodeStream::DoesThisNodeMatchIdentifiers(rocprofvis_dm_track_identifiers_t* track_identifiers)
+{
+	bool result = TopologyNode::DoesThisNodeMatchIdentifiers(track_identifiers);
+	if (result)
+	{
+		result = m_db_instance == track_identifiers->db_instance;
+	}
+	return result;
+}
+
 std::string TopologyNodeCounter::GetNodeName() {
 	std::string name;
 	auto it = m_properties.find(kRPVControllerCounterName);
@@ -669,6 +703,10 @@ bool TopologyNodeCounter::DoesThisNodeMatchIdentifiers(rocprofvis_dm_track_ident
 	if (result)
 	{
 		result = m_pid == track_identifiers->process_id;
+	}
+	if (result)
+	{
+		result = m_db_instance == track_identifiers->db_instance;
 	}
 	return result;
 }

--- a/src/model/src/datamodel/rocprofvis_dm_topology.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_topology.cpp
@@ -31,9 +31,10 @@ TopologyNode* TopologyNode::GetRootNode() {
 	}
 }
 
-rocprofvis_dm_result_t   TopologyNode::SetBasicProperty(const char* name, uint64_t db_instance, rocprofvis_db_topology_data_type_t type, const char* value) {
+rocprofvis_dm_result_t   TopologyNode::SetBasicProperty(const char* name, rocprofvis_db_instance_t db_instance, rocprofvis_db_topology_data_type_t type, const char* value) {
 	auto props_map = GetPropertiesMap();
 	auto it = props_map->find(name);
+	DbInstance* db_instance_ptr = (DbInstance*)db_instance;
 	if (it != props_map->end())
 	{
 		bool is_topology_id =
@@ -43,16 +44,27 @@ rocprofvis_dm_result_t   TopologyNode::SetBasicProperty(const char* name, uint64
 			it->second == kRPVControllerStreamId;
 		switch (type)
 		{
-			case kRPVTopologyDataTypeInt:
+		case kRPVTopologyDataTypeInt:
+		{
+			uint64_t ival = std::atoll(value);
+			if (is_topology_id)
 			{
-				uint64_t ival = std::atoll(value);
-				if (is_topology_id)
-				{
-					ival |= db_instance << 54;
-				}
-				m_properties[it->second] = ival;
-				break;
+				ival |= (uint64_t)db_instance_ptr->GuidIndex() << TOPOLOGY_INSTANCE_BIT_POS;
 			}
+			auto prop_it = m_properties.find(it->second);
+			if (prop_it == m_properties.end())
+			{
+				m_properties[it->second] = ival;
+			}
+			else
+			{
+				if (it->second == kRPVControllerProcessorId)
+				{
+					db_instance_ptr->SetProcessInstance(std::get<uint64_t>(prop_it->second) >> TOPOLOGY_INSTANCE_BIT_POS);
+				}
+			}
+			break;
+		}
 			case kRPVTopologyDataTypeDouble:
 			{
 				double dval = std::atof(value);
@@ -87,11 +99,10 @@ rocprofvis_dm_result_t   TopologyNode::SetBasicProperty(const char* name, uint64
 
 
 rocprofvis_dm_result_t   TopologyNodeRoot::AddProperty(rocprofvis_dm_track_identifiers_t* track_identifiers, rocprofvis_db_topology_data_type_t type, const char* table, const char* name, void* value) {
-	DbInstance* db_instance = (DbInstance*)track_identifiers->db_instance;
 	TopologyNode* node = FindRelevantPropertyNode(track_identifiers, table);
 	if (node)
 	{
-		node->SetBasicProperty(name, db_instance->GuidIndex(), type, (const char*)value);
+		node->SetBasicProperty(name, track_identifiers->db_instance, type, (const char*)value);
 	}
 
 	node = FindRelevantTopologyNode(track_identifiers, table);

--- a/src/model/src/datamodel/rocprofvis_dm_topology.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_topology.cpp
@@ -58,9 +58,11 @@ rocprofvis_dm_result_t   TopologyNode::SetBasicProperty(const char* name, rocpro
 			}
 			else
 			{
+				ival = std::min(ival, std::get<uint64_t>(prop_it->second));
+				m_properties[it->second] = ival;
 				if (it->second == kRPVControllerProcessorId)
 				{
-					db_instance_ptr->SetProcessInstance(std::get<uint64_t>(prop_it->second) >> TOPOLOGY_INSTANCE_BIT_POS);
+					db_instance_ptr->SetProcessInstance(ival >> TOPOLOGY_INSTANCE_BIT_POS);
 				}
 			}
 			break;

--- a/src/model/src/datamodel/rocprofvis_dm_topology.h
+++ b/src/model/src/datamodel/rocprofvis_dm_topology.h
@@ -24,7 +24,11 @@ class TopologyNode : public DmBase {
 public:
 	using TopologyProperty = std::variant<uint64_t, double, std::string>;
     using TopologyNodeId = uint64_t;
-	TopologyNode(rocprofvis_controller_topology_node_type_t type, TopologyNodeId id, TopologyNode* prev_node):m_type(type), m_id(id), m_prev_node(prev_node) {};
+    TopologyNode(
+        rocprofvis_controller_topology_node_type_t type, 
+        TopologyNodeId id, 
+        TopologyNode* prev_node, 
+        rocprofvis_db_instance_t db_instance);
 	virtual ~TopologyNode() {};
 
     TopologyNodeId GetId() { return m_id; };
@@ -88,12 +92,13 @@ protected:
 	std::map<uint32_t, TopologyProperty>         m_properties;
     TopologyNode*                                m_prev_node;
     std::string                                  m_name;
+    rocprofvis_db_instance_t                     m_db_instance;
 };
 
 
 class TopologyNodeRoot : public TopologyNode {
 public:
-    TopologyNodeRoot():TopologyNode(kRPVControllerTopologyNodeRoot,0, nullptr) {};
+    TopologyNodeRoot():TopologyNode(kRPVControllerTopologyNodeRoot,0, nullptr, nullptr) {};
     ~TopologyNodeRoot() {};
 
     rocprofvis_dm_result_t          AddNode(rocprofvis_dm_track_identifiers_t* track_identifiers) override;
@@ -121,7 +126,7 @@ protected:
 class TopologyNodeSystemNode :  public TopologyNode {
 public:
     TopologyNodeSystemNode(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx):
-        TopologyNode(kRPVControllerTopologyNodeSytemNode, track_identifiers->id[TRACK_ID_NODE], ctx) {};
+        TopologyNode(kRPVControllerTopologyNodeSytemNode, track_identifiers->id[TRACK_ID_NODE], ctx, track_identifiers->db_instance) {};
     ~TopologyNodeSystemNode() {};
     rocprofvis_dm_result_t AddNode(rocprofvis_dm_track_identifiers_t* track_identifiers) override;
     std::string GetNodeName() override;
@@ -160,7 +165,7 @@ class TopologyNodeProcess : public TopologyNode {
 public:
 
     TopologyNodeProcess(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) :
-        TopologyNode(kRPVControllerTopologyNodeProcess, track_identifiers->id[TRACK_ID_PID], ctx) {}
+        TopologyNode(kRPVControllerTopologyNodeProcess, track_identifiers->id[TRACK_ID_PID], ctx, track_identifiers->db_instance) {}
     ~TopologyNodeProcess() {};
     rocprofvis_dm_result_t AddNode(rocprofvis_dm_track_identifiers_t* track_identifiers) override;
     std::string GetNodeName() override;
@@ -186,7 +191,8 @@ private:
 class TopologyNodeProcessor : public TopologyNode {
 public:
 
-    TopologyNodeProcessor(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) :TopologyNode(kRPVControllerTopologyNodeProcessor, track_identifiers->id[TRACK_ID_AGENT], ctx) {}
+    TopologyNodeProcessor(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) :
+        TopologyNode(kRPVControllerTopologyNodeProcessor, track_identifiers->id[TRACK_ID_AGENT], ctx, track_identifiers->db_instance) {}
     ~TopologyNodeProcessor() {};
     rocprofvis_dm_result_t AddNode(rocprofvis_dm_track_identifiers_t* track_identifiers) override;
     std::string GetNodeName() override;
@@ -217,7 +223,7 @@ class TopologyNodeThread : public TopologyNode, public TopologyTrackRefence {
 public:
 
     TopologyNodeThread(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) :
-        TopologyNode(kRPVControllerTopologyNodeThread, track_identifiers->id[TRACK_ID_TID], ctx),
+        TopologyNode(kRPVControllerTopologyNodeThread, track_identifiers->id[TRACK_ID_TID], ctx, track_identifiers->db_instance),
         TopologyTrackRefence(track_identifiers->track_id),
         m_thread_type(track_identifiers->category == kRocProfVisDmRegionSampleTrack ? kRPVControllerThreadTypeSampled : kRPVControllerThreadTypeInstrumented) {}
     virtual ~TopologyNodeThread() {};
@@ -267,7 +273,7 @@ class TopologyNodeQueue : public TopologyNode , public TopologyTrackRefence, pub
 public:
 
     TopologyNodeQueue(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) :
-        TopologyNode(kRPVControllerTopologyNodeQueue, track_identifiers->id[TRACK_ID_QUEUE], ctx),
+        TopologyNode(kRPVControllerTopologyNodeQueue, track_identifiers->id[TRACK_ID_QUEUE], ctx, track_identifiers->db_instance),
         TopologyTrackRefence(track_identifiers->track_id),
         TopologyProcessRefence(track_identifiers->process_id) {}
     virtual ~TopologyNodeQueue() {};
@@ -318,7 +324,7 @@ class TopologyNodeStream : public TopologyNode, public TopologyTrackRefence {
 public:
 
     TopologyNodeStream(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) :
-        TopologyNode(kRPVControllerTopologyNodeStream, track_identifiers->id[TRACK_ID_STREAM], ctx),
+        TopologyNode(kRPVControllerTopologyNodeStream, track_identifiers->id[TRACK_ID_STREAM], ctx, track_identifiers->db_instance),
         TopologyTrackRefence(track_identifiers->track_id){}
     ~TopologyNodeStream() {};
     std::string GetNodeName() override;
@@ -330,6 +336,7 @@ private:
     const std::map<std::string, uint32_t>* GetPropertiesMap() override { return &s_columns_ids; }
     bool IsRelevantPropertyTableName(std::string table_name) override { return table_name == "Stream"; }
     bool IsRelevantTopologyTableName(std::string table_name) override { return table_name == "QueueRef"; };
+    bool DoesThisNodeMatchIdentifiers(rocprofvis_dm_track_identifiers_t* track_identifiers) override;
     inline static const std::map<std::string, uint32_t> 
         s_columns_ids = {
         { "id", kRPVControllerStreamId },
@@ -346,7 +353,8 @@ public:
     TopologyNodeCounter(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) :
         TopologyNode(kRPVControllerTopologyNodeCounter, 
             track_identifiers->id[TRACK_ID_COUNTER],
-            ctx),
+            ctx, 
+            track_identifiers->db_instance),
         TopologyTrackRefence(track_identifiers->track_id),
         TopologyProcessRefence(track_identifiers->process_id),
     m_tag(track_identifiers->tag[TRACK_ID_COUNTER]) { }
@@ -388,7 +396,7 @@ private:
 class TopologyReferenceNode : public TopologyNode {
 public:
     TopologyReferenceNode(rocprofvis_controller_topology_node_type_t type, uint64_t id, rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) 
-        :TopologyNode(type, id, ctx) { downstream_track_identifiers = *track_identifiers; }
+        :TopologyNode(type, id, ctx, track_identifiers->db_instance) { downstream_track_identifiers = *track_identifiers; }
     virtual rocprofvis_dm_result_t          GetPropertyAsUint64(rocprofvis_dm_property_t property, 
         rocprofvis_dm_property_index_t index, 
         uint64_t* value) override;  

--- a/src/model/src/datamodel/rocprofvis_dm_topology.h
+++ b/src/model/src/datamodel/rocprofvis_dm_topology.h
@@ -68,7 +68,7 @@ public:
 
     virtual rocprofvis_dm_result_t  AddNode(rocprofvis_dm_track_identifiers_t* track_identifiers) { (void) track_identifiers; return kRocProfVisDmResultSuccess; };
     virtual TopologyNode* FindNodeMatchingIdentifiers(rocprofvis_dm_track_identifiers_t* track_identifiers);
-    rocprofvis_dm_result_t  SetBasicProperty(const char* name, uint64_t db_instance, rocprofvis_db_topology_data_type_t type, const char* value);
+    rocprofvis_dm_result_t  SetBasicProperty(const char* name, rocprofvis_db_instance_t db_instance, rocprofvis_db_topology_data_type_t type, const char* value);
     virtual rocprofvis_dm_result_t  ProcessProperty(const char* name, rocprofvis_db_topology_data_type_t type, void* value) { (void) name; (void) type; (void) value; return kRocProfVisDmResultSuccess;};
     rocprofvis_controller_topology_node_type_t GetType() { return m_type; };
     virtual std::string GetNodeName() = 0;

--- a/src/model/src/datamodel/rocprofvis_dm_track.h
+++ b/src/model/src/datamodel/rocprofvis_dm_track.h
@@ -38,7 +38,12 @@ public:
     // Returns node id
     rocprofvis_dm_node_id_t                             NodeId() { return m_track_params->track_indentifiers.id[TRACK_ID_NODE]; }
     // Returns pid or agent id
-    rocprofvis_dm_process_id_t                          ProcessId() { return m_track_params->track_indentifiers.id[TRACK_ID_PID_OR_AGENT]; }
+    rocprofvis_dm_process_id_t                          ProcessId() 
+    { 
+        uint64_t process_instance = m_track_params->track_indentifiers.db_instance == nullptr ?
+            0 : ((DbInstance*)m_track_params->track_indentifiers.db_instance)->ProcessInstance();
+        return (process_instance << TOPOLOGY_INSTANCE_BIT_POS) | m_track_params->track_indentifiers.id[TRACK_ID_PID_OR_AGENT]; 
+    }
     // Returns tid or queue id
     rocprofvis_dm_process_id_t                          SubProcessId() { return m_track_params->track_indentifiers.id[TRACK_ID_TID_OR_QUEUE]; }
     // Returns pointer to process string


### PR DESCRIPTION
## Motivation

Topology tree is missing proper track identification when memory copy/allocation tracks are compared.
Topology tree is not built correctly when node id and process id are the same in compared traces. That may happen when rename and compare databases or if process id matches in sequential runs.

## Technical Details

Memory copy/allocation nodes in topology tree were inheriting IDs from processor. That doesn't work in multi-node/compare mode because we try to keep same hardware topology for multiple instances of the same node. Changed to use Queue ID, which is 0 for memory tracks ORed with instance id ORed with predefined memory allocate/copy IDs .

Added DB instance into account when check some topology nodes identification existence in order to build topology tree of two exactly same instances for compare or yaml mode.
