### PR TITLE
Add icons to context menus across the view

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -924,7 +924,7 @@ KernelMetricTable::RenderBarChartContextMenu(int col)
     if(ImGui::BeginPopupContextItem("##bar_ctx"))
     {
         bool has_bars = m_bar_chart_columns.count(col) > 0;
-        if(ImGui::MenuItem(has_bars ? "Hide Bar Chart" : "Show Bar Chart"))
+        if(IconMenuItem(ICON_CHART_BAR, has_bars ? "Hide Bar Chart" : "Show Bar Chart"))
         {
             if(has_bars)
             {

--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -22,6 +22,7 @@ constexpr ImWchar icon_ranges[] = {
     0xF35C, 0xF35D,
     0xF366, 0xF366,
     0xF37E, 0xF37F,
+    0xF386, 0xF386,
     0xF39C, 0xF39C,
     0xF3A8, 0xF3A8,
     0xF424, 0xF424,
@@ -29,6 +30,7 @@ constexpr ImWchar icon_ranges[] = {
     0xF472, 0xF472,
     0xF484, 0xF484,
     0xF41B, 0xF41B,
+    0xF41E, 0xF41E,
     0xF30F, 0xF30F,
     0
 };
@@ -53,6 +55,7 @@ inline constexpr const char* ICON_ARROW_DOWN    = u8"\uF35D";
 inline constexpr const char* ICON_ARROW_UP      = u8"\uF366";
 inline constexpr const char* ICON_EDIT          = u8"\uF37E";
 inline constexpr const char* ICON_TRASH_CAN     = u8"\uF37F";
+inline constexpr const char* ICON_EXPAND        = u8"\uF386";
 inline constexpr const char* ICON_OPEN          = u8"\uF39C";
 inline constexpr const char* ICON_ARROWS_CYCLE  = u8"\uF3A8";
 inline constexpr const char* ICON_EYE_THIN      = u8"\uF424";
@@ -60,6 +63,7 @@ inline constexpr const char* ICON_LIST          = u8"\uF454";
 inline constexpr const char* ICON_STICKY_NOTE   = u8"\uF472";
 inline constexpr const char* ICON_CHART_PIE     = u8"\uF484";
 inline constexpr const char* ICON_COPY          = u8"\uF41B";
+inline constexpr const char* ICON_CROP          = u8"\uF41E";
 inline constexpr const char* ICON_ARROW_FORWARD = u8"\uF30F";
 
 }  // namespace View

--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -465,7 +465,7 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                         const auto& ctx_flow =
                             event_data->flow_info[m_context_menu_flow_index];
 
-                        if(ImGui::MenuItem("Go To Event"))
+                        if(IconMenuItem(ICON_COMPASS, "Go To Event"))
                         {
                             m_timeline_selection->NavigateToEvent(
                                 ctx_flow.track_id, ctx_flow.id.uuid,
@@ -484,7 +484,7 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                             std::to_string(ctx_flow.level),
                             std::to_string(ctx_flow.direction)};
 
-                        if(ImGui::MenuItem("Copy Row Data"))
+                        if(IconMenuItem(ICON_COPY, "Copy Row Data"))
                         {
                             std::string row_text;
                             for(int c = 0; c < kFlowColumnCount; c++)
@@ -494,7 +494,7 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                             }
                             ImGui::SetClipboardText(row_text.c_str());
                         }
-                        if(ImGui::MenuItem("Copy Cell Data"))
+                        if(IconMenuItem(ICON_COPY, "Copy Cell Data"))
                         {
                             int col = m_context_menu_flow_column;
                             if(col >= 0 && col < kFlowColumnCount)
@@ -681,7 +681,7 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                         const auto& ctx_frame =
                             event_data->call_stack_info[m_context_menu_callstack_index];
 
-                        if(ImGui::MenuItem("Go To Event"))
+                        if(IconMenuItem(ICON_COMPASS, "Go To Event"))
                         {
                             navigate_to_frame(ctx_frame.id.uuid);
                         }
@@ -691,7 +691,7 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                             ctx_frame.address, ctx_frame.name, ctx_frame.file,
                             ctx_frame.pc};
 
-                        if(ImGui::MenuItem("Copy Row Data"))
+                        if(IconMenuItem(ICON_COPY, "Copy Row Data"))
                         {
                             std::string row_text;
                             for(int c = 0; c < kCallStackColumnCount; c++)
@@ -701,7 +701,7 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                             }
                             ImGui::SetClipboardText(row_text.c_str());
                         }
-                        if(ImGui::MenuItem("Copy Cell Data"))
+                        if(IconMenuItem(ICON_COPY, "Copy Cell Data"))
                         {
                             int col = m_context_menu_callstack_column;
                             if(col >= 0 && col < kCallStackColumnCount)

--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -465,7 +465,7 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                         const auto& ctx_flow =
                             event_data->flow_info[m_context_menu_flow_index];
 
-                        if(IconMenuItem(ICON_COMPASS, "Go To Event"))
+                        if(IconMenuItem(ICON_ARROW_FORWARD, "Go To Event"))
                         {
                             m_timeline_selection->NavigateToEvent(
                                 ctx_flow.track_id, ctx_flow.id.uuid,
@@ -681,7 +681,7 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                         const auto& ctx_frame =
                             event_data->call_stack_info[m_context_menu_callstack_index];
 
-                        if(IconMenuItem(ICON_COMPASS, "Go To Event"))
+                        if(IconMenuItem(ICON_ARROW_FORWARD, "Go To Event"))
                         {
                             navigate_to_frame(ctx_frame.id.uuid);
                         }

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_timeline_view.h"
+#include "icons/rocprovfis_icon_defines.h"
 #include "imgui.h"
 #include "rocprofvis_annotations.h"
 #include "rocprofvis_click_manager.h"
@@ -425,7 +426,7 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
         // right-click landed.
         if(m_timeline_selection->HasSelectedEvents())
         {
-            if(ImGui::MenuItem("Make Time Range Selection"))
+            if(IconMenuItem(ICON_GRID, "Make Time Range Selection"))
             {
                 double start_ts, end_ts;
                 if(m_timeline_selection->GetSelectedEventsTimeRange(start_ts, end_ts))
@@ -436,40 +437,37 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
                                              m_tpt->NormalizeTime(end_ts) };
                     m_timeline_selection->SelectTimeRange(start_ts, end_ts);
                 }
-                ImGui::CloseCurrentPopup();
             }
 
             std::vector<uint64_t> selected_event_ids;
             m_timeline_selection->GetSelectedEvents(selected_event_ids);
             const bool multiple_events = selected_event_ids.size() > 1;
-            if(ImGui::MenuItem(multiple_events ? "Copy Event Names" : "Copy Event Name"))
+            if(IconMenuItem(ICON_COPY,
+                            multiple_events ? "Copy Event Names" : "Copy Event Name"))
             {
                 CopySelectedEventNames();
-                ImGui::CloseCurrentPopup();
             }
-            if(ImGui::MenuItem("Copy Event Details"))
+            if(IconMenuItem(ICON_COPY, "Copy Event Details"))
             {
                 CopySelectedEventDetails();
-                ImGui::CloseCurrentPopup();
             }
         }
         if(m_highlighted_region.first != TimelineSelection::INVALID_SELECTION_TIME ||
            m_highlighted_region.second != TimelineSelection::INVALID_SELECTION_TIME)
         {
-            if(ImGui::MenuItem("Remove Time Range Selection"))
+            if(IconMenuItem(ICON_TRASH_CAN, "Remove Time Range Selection"))
             {
                 ClearTimeRangeSelection();
             }
         }
 
-        if(ImGui::MenuItem("Add Annotation"))
+        if(IconMenuItem(ICON_ADD_NOTE, "Add Annotation"))
         {
             float  x_in_chart = rel_mouse_pos.x;
             double time_ns    = m_tpt->PixelToTime(x_in_chart);
             float  y_offset   = rel_mouse_pos.y;
             m_annotations->OpenStickyNotePopup(time_ns, y_offset, m_tpt->GetVMinX(),
                                                m_tpt->GetVMaxX(), m_tpt->GetGraphSize());
-            ImGui::CloseCurrentPopup();
         }
 
         ImGui::Separator();
@@ -477,27 +475,24 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
         MeasurementController& fm = *m_measurement;
         if(fm.IsMeasurementMode())
         {
-            if(ImGui::MenuItem("Exit Measurement Mode"))
+            if(IconMenuItem(ICON_COMPASS, "Exit Measurement Mode"))
             {
                 fm.ExitMeasurementMode();
-                ImGui::CloseCurrentPopup();
             }
         }
         else
         {
-            if(ImGui::MenuItem("Enter Measurement Mode"))
+            if(IconMenuItem(ICON_COMPASS, "Enter Measurement Mode"))
             {
                 fm.EnterMeasurementMode();
-                ImGui::CloseCurrentPopup();
             }
         }
         if(fm.GetPoint(0).valid || fm.GetPoint(1).valid)
         {
-            if(ImGui::MenuItem("Clear Measurement"))
+            if(IconMenuItem(ICON_TRASH_CAN, "Clear Measurement"))
             {
                 fm.ClearMeasurement();
                 m_timeline_selection->UnhighlightPersistentEvents();
-                ImGui::CloseCurrentPopup();
             }
         }
 

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -426,7 +426,7 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
         // right-click landed.
         if(m_timeline_selection->HasSelectedEvents())
         {
-            if(IconMenuItem(ICON_GRID, "Make Time Range Selection"))
+            if(IconMenuItem(ICON_EXPAND, "Make Time Range Selection"))
             {
                 double start_ts, end_ts;
                 if(m_timeline_selection->GetSelectedEventsTimeRange(start_ts, end_ts))
@@ -475,14 +475,14 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
         MeasurementController& fm = *m_measurement;
         if(fm.IsMeasurementMode())
         {
-            if(IconMenuItem(ICON_COMPASS, "Exit Measurement Mode"))
+            if(IconMenuItem(ICON_CROP, "Exit Measurement Mode"))
             {
                 fm.ExitMeasurementMode();
             }
         }
         else
         {
-            if(IconMenuItem(ICON_COMPASS, "Enter Measurement Mode"))
+            if(IconMenuItem(ICON_CROP, "Enter Measurement Mode"))
             {
                 fm.EnterMeasurementMode();
             }

--- a/src/view/src/widgets/rocprofvis_compute_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_compute_widget.cpp
@@ -193,14 +193,14 @@ MetricTableBase::ContextMenu(const char* value_to_copy, uint32_t column_index,
     (void) value_to_copy;
     if(ImGui::BeginPopupContextItem())
     {
-        if(ImGui::MenuItem("Pin metric"))
+        if(IconMenuItem(ICON_CHAIN, "Pin metric"))
         {
             row.second.pinned = !row.second.pinned;
             m_pin_metric_clicked(
                 { row.first.category_id, row.first.table_id, row.first.entry_id });
         }
         if(!m_event_source_id.empty() &&
-           ImGui::MenuItem("Send metric to kernel details"))
+           IconMenuItem(ICON_ARROW_FORWARD, "Send metric to kernel details"))
         {
             AddMetricToKernelDetails(row.first, m_columns[column_index]);
         }

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -585,7 +585,7 @@ InfiniteScrollTable::RenderContextMenu()
             m_important_column_idxs[kTrackId], m_important_column_idxs[kStreamId]);
         if(target_track_id != INVALID_UINT64_INDEX)
         {
-            if(IconMenuItem(ICON_COMPASS,
+            if(IconMenuItem(ICON_ARROW_FORWARD,
                             m_table_type == TableType::kSampleTable ? "Go To Sample"
                                                                     : "Go To Event",
                             target_track_id != INVALID_UINT64_INDEX))

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_infinite_scroll_table.h"
+#include "icons/rocprovfis_icon_defines.h"
 #include "rocprofvis_appwindow.h"
 #include "rocprofvis_common_defs.h"
 #include "rocprofvis_settings_manager.h"
@@ -584,20 +585,21 @@ InfiniteScrollTable::RenderContextMenu()
             m_important_column_idxs[kTrackId], m_important_column_idxs[kStreamId]);
         if(target_track_id != INVALID_UINT64_INDEX)
         {
-            if(ImGui::MenuItem(m_table_type == TableType::kSampleTable ? "Go To Sample"
-                                                                       : "Go To Event",
-                               nullptr, false, target_track_id != INVALID_UINT64_INDEX))
+            if(IconMenuItem(ICON_COMPASS,
+                            m_table_type == TableType::kSampleTable ? "Go To Sample"
+                                                                    : "Go To Event",
+                            target_track_id != INVALID_UINT64_INDEX))
             {
                 SelectedRowNavigateEvent(m_important_column_idxs[kTrackId],
                                          m_important_column_idxs[kStreamId]);
             }
             ImGui::Separator();
         }        
-        if(ImGui::MenuItem("Copy Row Data", nullptr, false))
+        if(IconMenuItem(ICON_COPY, "Copy Row Data"))
         {
             SelectedRowToClipboard();
         }
-        else if(ImGui::MenuItem("Copy Cell Data", nullptr, false))
+        else if(IconMenuItem(ICON_COPY, "Copy Cell Data"))
         {
             SelectedCellToClipboard(true);
         }
@@ -616,14 +618,14 @@ InfiniteScrollTable::RenderContextMenu()
         }
         if(show_copy_unformatted)
         {
-            if(ImGui::MenuItem("Copy Unformatted Cell Data", nullptr, false))
+            if(IconMenuItem(ICON_COPY, "Copy Unformatted Cell Data"))
             {
                 SelectedCellToClipboard(false);
             }
         }
         ImGui::Separator();
-        if(ImGui::MenuItem(
-               "Export To File", nullptr, false,
+        if(IconMenuItem(
+               ICON_ARCHIVE, "Export To File",
                !m_data_provider.IsRequestPending(DataProvider::TABLE_EXPORT_REQUEST_ID)))
         {
             ExportToFile();

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -106,19 +106,30 @@ IconMenuItem(const char* icon, const char* label, bool enabled)
 {
     ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
 
+    // Reserve a fixed-width icon column so labels start at the same x with or
+    // without an icon, and keep each row a single frame tall.
+    const float icon_column_width = ImGui::GetFrameHeight();
+
     if(!enabled)
         ImGui::BeginDisabled();
 
     bool clicked = ImGui::Selectable(("##menu_item" + std::string(label)).c_str(), false,
                                      ImGuiSelectableFlags_SpanAllColumns,
-                                     ImVec2(0, ImGui::GetTextLineHeightWithSpacing()));
+                                     ImVec2(0, ImGui::GetFrameHeight()));
     ImGui::SameLine(0.0f, 0.0f);
 
+    const float row_start_x = ImGui::GetCursorPosX();
+
     ImGui::BeginGroup();
-    ImGui::PushFont(icon_font);
-    ImGui::TextUnformatted(icon);
-    ImGui::PopFont();
-    ImGui::SameLine(0.f, ImGui::GetStyle().ItemSpacing.x);
+    ImGui::AlignTextToFramePadding();
+    if(icon && icon[0] != '\0')
+    {
+        ImGui::PushFont(icon_font);
+        ImGui::TextUnformatted(icon);
+        ImGui::PopFont();
+    }
+    ImGui::SameLine(0.0f, 0.0f);
+    ImGui::SetCursorPosX(row_start_x + icon_column_width);
     ImGui::TextUnformatted(label);
     ImGui::EndGroup();
 

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -20,6 +20,10 @@ namespace RocProfVis
 namespace View
 {
 
+// Menu icon spacing, in multiples of the font size.
+inline constexpr float MENU_ICON_GAP_EM       = 0.7f;
+inline constexpr float MENU_NO_ICON_INDENT_EM = 1.0f;
+
 RocWidget::~RocWidget() { spdlog::debug("RocWidget object destroyed"); }
 
 void
@@ -103,40 +107,40 @@ WithPadding(float left, float right, float top, float bottom,
     if(bottom > 0.0f) ImGui::Dummy(ImVec2(0, bottom));
 }
 
-// Width of the reserved icon column shared by IconMenuItem and IconBeginMenu so
-// every label starts at the same x regardless of the icon. Tracks the font size.
 static float
-MenuIconColumnWidth()
+MenuIconWidth(const char* icon)
 {
-    return ImGui::GetFrameHeight();
+    const float font_size = ImGui::GetFontSize();
+    if(!icon || icon[0] == '\0')
+        return font_size * MENU_NO_ICON_INDENT_EM;
+
+    ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+    return icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon).x;
 }
 
-// Pads a label with leading spaces sized to reserve the icon column in front of
-// the text when rendered by a native ImGui menu widget.
+// Pads the label with leading spaces to leave room for the left-aligned icon.
 static std::string
-MenuLabelWithIconPadding(const char* label, float column_width)
+MenuLabelWithIconPadding(const char* icon, const char* label)
 {
+    const float offset  = MenuIconWidth(icon) + ImGui::GetFontSize() * MENU_ICON_GAP_EM;
     const float space_w = ImGui::CalcTextSize(" ").x;
-    const int   pad     = space_w > 0.0f ? static_cast<int>(std::ceil(column_width / space_w)) : 1;
+    const int   pad     = space_w > 0.0f ? static_cast<int>(std::ceil(offset / space_w)) : 1;
     std::string padded(static_cast<size_t>(std::max(pad, 1)), ' ');
     padded += label;
     return padded;
 }
 
-// Draws the menu icon centered in the reserved icon column, vertically aligned
-// with the row's text. Call with the cursor screen position captured before the
-// native menu widget is emitted.
+// row_start is the cursor screen position captured before the menu widget.
 static void
-DrawMenuItemIcon(const char* icon, const ImVec2& row_start, float column_width, bool enabled)
+DrawMenuItemIcon(const char* icon, const ImVec2& row_start, bool enabled)
 {
     if(!icon || icon[0] == '\0')
         return;
 
     ImFont*      icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
     const float  font_size = ImGui::GetFontSize();
-    const float  icon_w    = icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon).x;
-    const ImVec2 pos(row_start.x + (column_width - icon_w) * 0.5f,
-                     row_start.y + (ImGui::GetFrameHeight() - font_size) * 0.5f);
+    const ImVec2 icon_size = icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon);
+    const ImVec2 pos(row_start.x, row_start.y + (font_size - icon_size.y) * 0.5f);
     const ImU32  color = ImGui::GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled);
 
     ImGui::GetWindowDrawList()->AddText(icon_font, font_size, pos, color, icon);
@@ -145,12 +149,11 @@ DrawMenuItemIcon(const char* icon, const ImVec2& row_start, float column_width, 
 bool
 IconMenuItem(const char* icon, const char* label, bool enabled)
 {
-    const float  column_width = MenuIconColumnWidth();
     const ImVec2 row_start    = ImGui::GetCursorScreenPos();
-    std::string  padded_label = MenuLabelWithIconPadding(label, column_width);
+    std::string  padded_label = MenuLabelWithIconPadding(icon, label);
 
     bool clicked = ImGui::MenuItem(padded_label.c_str(), nullptr, false, enabled);
-    DrawMenuItemIcon(icon, row_start, column_width, enabled);
+    DrawMenuItemIcon(icon, row_start, enabled);
 
     if(clicked)
         ImGui::CloseCurrentPopup();
@@ -160,12 +163,11 @@ IconMenuItem(const char* icon, const char* label, bool enabled)
 bool
 IconBeginMenu(const char* icon, const char* label)
 {
-    const float  column_width = MenuIconColumnWidth();
     const ImVec2 row_start    = ImGui::GetCursorScreenPos();
-    std::string  padded_label = MenuLabelWithIconPadding(label, column_width);
+    std::string  padded_label = MenuLabelWithIconPadding(icon, label);
 
     bool open = ImGui::BeginMenu(padded_label.c_str());
-    DrawMenuItemIcon(icon, row_start, column_width, true);
+    DrawMenuItemIcon(icon, row_start, true);
 
     return open;
 }

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -102,9 +102,12 @@ WithPadding(float left, float right, float top, float bottom,
 }
 
 bool
-IconMenuItem(const char* icon, const char* label)
+IconMenuItem(const char* icon, const char* label, bool enabled)
 {
     ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+
+    if(!enabled)
+        ImGui::BeginDisabled();
 
     bool clicked = ImGui::Selectable(("##menu_item" + std::string(label)).c_str(), false,
                                      ImGuiSelectableFlags_SpanAllColumns,
@@ -118,6 +121,9 @@ IconMenuItem(const char* icon, const char* label)
     ImGui::SameLine(0.f, ImGui::GetStyle().ItemSpacing.x);
     ImGui::TextUnformatted(label);
     ImGui::EndGroup();
+
+    if(!enabled)
+        ImGui::EndDisabled();
 
     if(clicked)
         ImGui::CloseCurrentPopup();

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -103,40 +103,54 @@ WithPadding(float left, float right, float top, float bottom,
     if(bottom > 0.0f) ImGui::Dummy(ImVec2(0, bottom));
 }
 
+// Width of the reserved icon column shared by IconMenuItem and IconBeginMenu so
+// every label starts at the same x regardless of the icon. Tracks the font size.
+static float
+MenuIconColumnWidth()
+{
+    return ImGui::GetFrameHeight();
+}
+
+// Pads a label with leading spaces sized to reserve the icon column in front of
+// the text when rendered by a native ImGui menu widget.
+static std::string
+MenuLabelWithIconPadding(const char* label, float column_width)
+{
+    const float space_w = ImGui::CalcTextSize(" ").x;
+    const int   pad     = space_w > 0.0f ? static_cast<int>(std::ceil(column_width / space_w)) : 1;
+    std::string padded(static_cast<size_t>(std::max(pad, 1)), ' ');
+    padded += label;
+    return padded;
+}
+
+// Draws the menu icon centered in the reserved icon column, vertically aligned
+// with the row's text. Call with the cursor screen position captured before the
+// native menu widget is emitted.
+static void
+DrawMenuItemIcon(const char* icon, const ImVec2& row_start, float column_width, bool enabled)
+{
+    if(!icon || icon[0] == '\0')
+        return;
+
+    ImFont*      icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+    const float  font_size = ImGui::GetFontSize();
+    const float  icon_w    = icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon).x;
+    const ImVec2 pos(row_start.x + (column_width - icon_w) * 0.5f,
+                     row_start.y + (ImGui::GetFrameHeight() - font_size) * 0.5f);
+    const ImU32  color = ImGui::GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled);
+
+    ImGui::GetWindowDrawList()->AddText(icon_font, font_size, pos, color, icon);
+}
+
 bool
 IconMenuItem(const char* icon, const char* label, bool enabled)
 {
-    ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+    const float  column_width = MenuIconColumnWidth();
+    const ImVec2 row_start    = ImGui::GetCursorScreenPos();
+    std::string  padded_label = MenuLabelWithIconPadding(label, column_width);
 
-    // Reserve a fixed-width icon column so labels start at the same x with or
-    // without an icon, and keep each row a single frame tall.
-    const float icon_column_width = ImGui::GetFrameHeight();
-
-    if(!enabled)
-        ImGui::BeginDisabled();
-
-    bool clicked = ImGui::Selectable(("##menu_item" + std::string(label)).c_str(), false,
-                                     ImGuiSelectableFlags_SpanAllColumns,
-                                     ImVec2(0, ImGui::GetFrameHeight()));
-    ImGui::SameLine(0.0f, 0.0f);
-
-    const float row_start_x = ImGui::GetCursorPosX();
-
-    ImGui::BeginGroup();
-    ImGui::AlignTextToFramePadding();
-    if(icon && icon[0] != '\0')
-    {
-        ImGui::PushFont(icon_font);
-        ImGui::TextUnformatted(icon);
-        ImGui::PopFont();
-    }
-    ImGui::SameLine(0.0f, 0.0f);
-    ImGui::SetCursorPosX(row_start_x + icon_column_width);
-    ImGui::TextUnformatted(label);
-    ImGui::EndGroup();
-
-    if(!enabled)
-        ImGui::EndDisabled();
+    bool clicked = ImGui::MenuItem(padded_label.c_str(), nullptr, false, enabled);
+    DrawMenuItemIcon(icon, row_start, column_width, enabled);
 
     if(clicked)
         ImGui::CloseCurrentPopup();
@@ -146,24 +160,13 @@ IconMenuItem(const char* icon, const char* label, bool enabled)
 bool
 IconBeginMenu(const char* icon, const char* label)
 {
-    ImFont* icon_font =
-        SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-    ImDrawList* draw_list = ImGui::GetWindowDrawList();
-    ImVec2      row_start = ImGui::GetCursorScreenPos();
-    float       font_size = ImGui::GetFontSize();
-    float       icon_w    = icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon).x;
-    float       space_w   = ImGui::CalcTextSize(" ").x;
-    float       gap       = ImGui::GetStyle().ItemInnerSpacing.x;
-
-    int pad_spaces =
-        space_w > 0.0f ? static_cast<int>(std::ceil((icon_w + gap) / space_w)) : 1;
-    std::string padded_label(static_cast<size_t>(std::max(pad_spaces, 1)), ' ');
-    padded_label += label;
+    const float  column_width = MenuIconColumnWidth();
+    const ImVec2 row_start    = ImGui::GetCursorScreenPos();
+    std::string  padded_label = MenuLabelWithIconPadding(label, column_width);
 
     bool open = ImGui::BeginMenu(padded_label.c_str());
+    DrawMenuItemIcon(icon, row_start, column_width, true);
 
-    draw_list->AddText(icon_font, font_size, row_start,
-                       ImGui::GetColorU32(ImGuiCol_Text), icon);
     return open;
 }
 

--- a/src/view/src/widgets/rocprofvis_widget.h
+++ b/src/view/src/widgets/rocprofvis_widget.h
@@ -98,7 +98,7 @@ CopyableTextUnformatted(
 
 // Renders a selectable menu item with an icon (from the icon font) followed by a text label.
 // Returns true when clicked. Intended for use inside BeginPopup/BeginPopupContextItem blocks.
-bool IconMenuItem(const char* icon, const char* label);
+bool IconMenuItem(const char* icon, const char* label, bool enabled = true);
 
 inline constexpr std::string_view COPY_DATA_NOTIFICATION = "Cell data was copied";
 


### PR DESCRIPTION
## Motivation

Right-click context menus throughout the app used plain text menu items, while the compute metric tables already showed icons next to each action. This PR brings the rest of the menus in line so the context-menu styling is consistent across the whole view layer, making actions quicker to scan and visually matching the compute tables.

## Technical Details

Converted the remaining hand-rolled and `ImGui::MenuItem`-based context menus to use the shared `IconMenuItem` helper, with context-appropriate glyphs:

- **Shared table row menu** (`InfiniteScrollTable`) — used by the event, sample, event-search, and kernel-instance tables: compass for "Go To Event/Sample", copy for copy actions, archive for export.
- **Timeline event menu** (`TimelineView`): grid for time-range selection, copy for copy actions, trash for removal, note for annotation, compass for navigation.
- **Event call-stack and flow menus** (`EventsView`): compass and copy. These were hand-rolled separately from the table menu, so they were updated to match.
- **Kernel bar-chart column menu** (`KernelMetricTable`): bar-chart icon.

`IconMenuItem` gained an optional `enabled` parameter so it can fully replace `ImGui::MenuItem` in menus that have conditionally disabled entries. Redundant explicit `ImGui::CloseCurrentPopup()` calls were removed since `IconMenuItem` already closes the popup on click.