### PR TITLE
Make Event Details table right-click hitboxes consistent and dedupe scaffolding

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -490,12 +490,6 @@ reusable types they expose.
   defining a one-off `RocWidget` subclass for trivial content.
 - `struct TabItem` - `{ label, id, widget, can_close }`, the shape of a
   tab.
-- Free functions:
-  - `WithPadding(left, right, top, bottom, content_fn)` - RAII padding.
-  - `CopyableTextUnformatted(text, unique_id, ...)` - clickable copy-to-
-    clipboard text. Use this for any cell whose value the user may want
-    to copy (events, args, paths).
-  - `COPY_DATA_NOTIFICATION` - canonical "data was copied" toast text.
 - `class PopUpStyle` - RAII helper that pushes consistent popup colors,
   borders, and centering. Use this around `BeginPopupModal` instead of
   hand-rolling style pushes.
@@ -557,6 +551,15 @@ Use these instead of inlining their logic anywhere new.
   make ImGui combo boxes visually distinct from plain text inputs.
 - `IconButton(icon, icon_font, size, tooltip, frameless, ...)` - the
   canonical glyph button. Must use the icon font from `FontManager`.
+- `CopyableTextUnformatted(text, unique_id, ...)` - clickable copy-to-
+  clipboard text. Use this for any cell whose value the user may want
+  to copy (events, args, paths).
+- `IconMenuItem(icon, label, enabled)` / `IconBeginMenu(icon, label)` -
+  menu entries with a leading icon-font glyph. Use inside
+  `BeginPopup`/`BeginPopupContextItem` blocks instead of plain
+  `ImGui::MenuItem` / `ImGui::BeginMenu` when you want an icon.
+- `COPY_DATA_NOTIFICATION` / `COPY_ROW_DATA_NOTIFICATION` - canonical
+  "data was copied" toast strings for a single cell / a whole row.
 - `IsMouseReleasedWithDragCheck(button, drag_threshold)` - "click
   vs drag" disambiguator.
 - `InputTextWithClear(id, hint, buf, buf_size, icon_font, bg_color,
@@ -1895,17 +1898,18 @@ For fast lookup. Each entry: class -> file -> one-line role.
 ### Widget library (`src/view/src/widgets/`)
 
 - `RocWidget`, `LayoutItem`, `RocCustomWidget`, `TabItem`,
-  `PopUpStyle`, `WithPadding`, `CopyableTextUnformatted`,
-  `COPY_DATA_NOTIFICATION` -> `rocprofvis_widget.h`.
+  `PopUpStyle` -> `rocprofvis_widget.h`.
 - `ConfirmationDialog`, `MessageDialog` -> `rocprofvis_dialog.h`.
 - `VFixedContainer`, `SplitContainerBase`, `HSplitContainer`,
   `VSplitContainer` -> `rocprofvis_split_containers.h`.
 - `FlexItem`, `FlexContainer` -> `rocprofvis_flex_container.h`.
 - `TabContainer` -> `rocprofvis_tab_container.h`.
 - `RenderLoadingIndicator`, `LoadingIndicatorCentering`,
-  `IconButton`, `XButton`, `SectionTitle`, `VerticalSeparator`,
-  `ElidedText`, `Alignment`, `CenterNextItem`, `InputTextWithClear`,
-  `BeginTooltipStyled`, `BeginItemTooltipStyled`,
+  `IconButton`, `CopyableTextUnformatted`, `IconMenuItem`,
+  `IconBeginMenu`, `COPY_DATA_NOTIFICATION`,
+  `COPY_ROW_DATA_NOTIFICATION`, `XButton`, `SectionTitle`,
+  `VerticalSeparator`, `ElidedText`, `Alignment`, `CenterNextItem`,
+  `InputTextWithClear`, `BeginTooltipStyled`, `BeginItemTooltipStyled`,
   `EndTooltipStyled`, `SetTooltipStyled`, `ApplyAlpha`, `ThemeColor`,
   `GetResponsiveWindowSize`, `PushComboStyles/PopComboStyles`,
   `TableRowHeight`, `IsMouseReleasedWithDragCheck`,

--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -11,6 +11,9 @@
 #include "rocprofvis_utils.h"
 #include "widgets/rocprofvis_notification_manager.h"
 
+#include <array>
+#include <vector>
+
 namespace RocProfVis
 {
 namespace View
@@ -23,6 +26,9 @@ constexpr ImGuiTableFlags TABLE_FLAGS = ImGuiTableFlags_BordersOuter |
 
 constexpr int kFlowColumnCount      = 6;
 constexpr int kCallStackColumnCount = 5;
+constexpr int kArgColumnCount       = 4;
+constexpr int kBasicColumnCount     = 2;
+constexpr int kExtColumnCount       = 2;
 
 namespace
 {
@@ -63,6 +69,12 @@ EventsView::EventsView(DataProvider&                      dp,
 , m_context_menu_flow_column(-1)
 , m_context_menu_callstack_index(-1)
 , m_context_menu_callstack_column(-1)
+, m_context_menu_arg_index(-1)
+, m_context_menu_arg_column(-1)
+, m_context_menu_basic_index(-1)
+, m_context_menu_basic_column(-1)
+, m_context_menu_ext_index(-1)
+, m_context_menu_ext_column(-1)
 {
     static_assert(CallStackHoverState::kInvalidId ==
                       TimelineSelection::INVALID_SELECTION_ID,
@@ -214,30 +226,95 @@ EventsView::RenderBasicData(const EventInfo* event_data)
     std::string duration_label = nanosecond_to_formatted_str(info.duration,
                                                              time_format, true);
 
-    if(ImGui::BeginTable("EventSummaryTable", 2,
+    std::vector<std::array<std::string, kBasicColumnCount>> rows = {
+        { std::string("ID"), db_id_label },
+        { std::string("Name"), info.name },
+        { std::string("Start"), start_label },
+        { std::string("Duration"), duration_label },
+    };
+#ifdef ROCPROFVIS_DEVELOPER_MODE
+    rows.push_back({ std::string("Level"), std::to_string(info.level) });
+#endif
+
+    if(ImGui::BeginTable("EventSummaryTable", kBasicColumnCount,
                          ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_NoSavedSettings))
     {
         ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthFixed,
                                 ImGui::GetFontSize() * 8.5f);
         ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
 
-        const auto row = [&](const char* label, const char* value, const char* id) {
+        bool open_basic_context_menu = false;
+
+        for(int i = 0; i < static_cast<int>(rows.size()); i++)
+        {
+            std::string row_str = std::to_string(i);
+
+            ImGui::PushID(i);
             ImGui::TableNextRow();
-            ImGui::TableNextColumn();
-            ImGui::TextDisabled("%s", label);
-            ImGui::TableNextColumn();
-            CopyableTextUnformatted(value, id, DATA_COPIED_NOTIFICATION, false, true);
-        };
+            ImGui::TableSetColumnIndex(0);
 
-        row("ID", db_id_label.c_str(), "ID");
-        row("Name", info.name.c_str(), "Name");
-        row("Start", start_label.c_str(), "Start_time");
-        row("Duration", duration_label.c_str(), "Duration");
+            ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
+            ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
+            ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
+            ImGui::Selectable(("##basic_sel_" + row_str).c_str(), false,
+                              ImGuiSelectableFlags_SpanAllColumns |
+                                  ImGuiSelectableFlags_AllowOverlap,
+                              ImVec2(0.0f, 0.0f));
+            if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
+            {
+                m_context_menu_basic_index = i;
+                int hovered_col            = ImGui::TableGetHoveredColumn();
+                m_context_menu_basic_column =
+                    (hovered_col >= 0 && hovered_col < kBasicColumnCount) ? hovered_col
+                                                                         : 0;
+                open_basic_context_menu = true;
+            }
+            ImGui::PopStyleColor(3);
 
-#ifdef ROCPROFVIS_DEVELOPER_MODE
-        std::string level_label = std::to_string(info.level);
-        row("Level", level_label.c_str(), "Level");
-#endif
+            ImGui::SameLine();
+            ImGui::TextDisabled("%s", rows[i][0].c_str());
+            ImGui::TableSetColumnIndex(1);
+            CopyableTextUnformatted(rows[i][1].c_str(), "##basic_value",
+                                    DATA_COPIED_NOTIFICATION, false, false);
+            ImGui::PopID();
+        }
+
+        if(open_basic_context_menu)
+        {
+            ImGui::OpenPopup("##BasicContextMenu");
+        }
+
+        auto style = m_settings.GetDefaultStyle();
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+        if(ImGui::BeginPopup("##BasicContextMenu"))
+        {
+            if(m_context_menu_basic_index >= 0 &&
+               m_context_menu_basic_index < static_cast<int>(rows.size()))
+            {
+                const auto& ctx_row = rows[m_context_menu_basic_index];
+
+                if(ImGui::MenuItem("Copy Row Data"))
+                {
+                    std::string row_text;
+                    for(int c = 0; c < kBasicColumnCount; c++)
+                    {
+                        if(c > 0) row_text += '\t';
+                        row_text += ctx_row[c];
+                    }
+                    ImGui::SetClipboardText(row_text.c_str());
+                }
+                if(ImGui::MenuItem("Copy Cell Data"))
+                {
+                    int col = m_context_menu_basic_column;
+                    if(col >= 0 && col < kBasicColumnCount)
+                        ImGui::SetClipboardText(ctx_row[col].c_str());
+                }
+            }
+            ImGui::EndPopup();
+        }
+        ImGui::PopStyleVar(2);
+
         ImGui::EndTable();
     }
     return true;
@@ -262,23 +339,15 @@ EventsView::RenderEventExtData(const EventInfo* event_data)
         }
         else
         {
-            if(ImGui::BeginTable("ExtDataTable", 2, TABLE_FLAGS))
+            if(ImGui::BeginTable("ExtDataTable", kExtColumnCount, TABLE_FLAGS))
             {
                 ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthFixed);
                 ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
-                double     offset_ns = 0;
                 TimeFormat time_format =
                     m_settings.GetUserSettings().unit_settings.time_format;
 
-                for(size_t i = 0; i < event_data->ext_info.size(); ++i)
-                {
-                    ImGui::TableNextRow();
-                    ImGui::TableSetColumnIndex(0);
-                    CopyableTextUnformatted(event_data->ext_info[i].name.c_str(),
-                                            std::to_string(i), COPY_DATA_NOTIFICATION,
-                                            false, true);
-                    ImGui::TableSetColumnIndex(1);
-
+                auto format_ext_value = [&](int i) -> std::string {
+                    double offset_ns = 0;
                     switch(event_data->ext_info[i].category_enum)
                     {
                         case kRocProfVisEventEssentialDataStart:
@@ -286,23 +355,92 @@ EventsView::RenderEventExtData(const EventInfo* event_data)
                             offset_ns =
                                 m_data_provider.DataModel().GetTimeline().GetStartTime();
                         case kRocProfVisEventEssentialDataDuration:
-                        {
-                            CopyableTextUnformatted(nanosecond_str_to_formatted_str(
-                                                        event_data->ext_info[i].value,
-                                                        offset_ns, time_format, true)
-                                                        .c_str(),
-                                                    std::to_string(i),
-                                                    COPY_DATA_NOTIFICATION, false, true);
-                            offset_ns = 0;
-                            break;
-                        }
+                            return nanosecond_str_to_formatted_str(
+                                event_data->ext_info[i].value, offset_ns, time_format,
+                                true);
                         default:
-                            CopyableTextUnformatted(event_data->ext_info[i].value.c_str(),
-                                                    std::to_string(i),
-                                                    COPY_DATA_NOTIFICATION, false, true);
-                            break;
+                            return event_data->ext_info[i].value;
                     }
+                };
+
+                bool open_ext_context_menu = false;
+
+                for(int i = 0; i < static_cast<int>(event_data->ext_info.size()); i++)
+                {
+                    std::string row_str = std::to_string(i);
+
+                    ImGui::PushID(i);
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+
+                    ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
+                    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
+                    ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
+                    ImGui::Selectable(("##ext_sel_" + row_str).c_str(), false,
+                                      ImGuiSelectableFlags_SpanAllColumns |
+                                          ImGuiSelectableFlags_AllowOverlap,
+                                      ImVec2(0.0f, 0.0f));
+                    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
+                    {
+                        m_context_menu_ext_index = i;
+                        int hovered_col          = ImGui::TableGetHoveredColumn();
+                        m_context_menu_ext_column =
+                            (hovered_col >= 0 && hovered_col < kExtColumnCount)
+                                ? hovered_col
+                                : 0;
+                        open_ext_context_menu = true;
+                    }
+                    ImGui::PopStyleColor(3);
+
+                    ImGui::SameLine();
+                    CopyableTextUnformatted(event_data->ext_info[i].name.c_str(),
+                                            "##ext_name", COPY_DATA_NOTIFICATION, false,
+                                            false);
+                    ImGui::TableSetColumnIndex(1);
+                    CopyableTextUnformatted(format_ext_value(i).c_str(), "##ext_value",
+                                            COPY_DATA_NOTIFICATION, false, false);
+                    ImGui::PopID();
                 }
+
+                if(open_ext_context_menu)
+                {
+                    ImGui::OpenPopup("##ExtContextMenu");
+                }
+
+                auto style = m_settings.GetDefaultStyle();
+                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+                ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+                if(ImGui::BeginPopup("##ExtContextMenu"))
+                {
+                    if(m_context_menu_ext_index >= 0 &&
+                       m_context_menu_ext_index <
+                           static_cast<int>(event_data->ext_info.size()))
+                    {
+                        std::string cells[kExtColumnCount] = {
+                            event_data->ext_info[m_context_menu_ext_index].name,
+                            format_ext_value(m_context_menu_ext_index) };
+
+                        if(ImGui::MenuItem("Copy Row Data"))
+                        {
+                            std::string row_text;
+                            for(int c = 0; c < kExtColumnCount; c++)
+                            {
+                                if(c > 0) row_text += '\t';
+                                row_text += cells[c];
+                            }
+                            ImGui::SetClipboardText(row_text.c_str());
+                        }
+                        if(ImGui::MenuItem("Copy Cell Data"))
+                        {
+                            int col = m_context_menu_ext_column;
+                            if(col >= 0 && col < kExtColumnCount)
+                                ImGui::SetClipboardText(cells[col].c_str());
+                        }
+                    }
+                    ImGui::EndPopup();
+                }
+                ImGui::PopStyleVar(2);
+
                 ImGui::EndTable();
             }
         }
@@ -737,37 +875,109 @@ EventsView::RenderArgumentData(const EventInfo* event_data)
         }
         else
         {
-            if(ImGui::BeginTable("EventArgTable", 4, TABLE_FLAGS))
+            if(ImGui::BeginTable("EventArgTable", kArgColumnCount, TABLE_FLAGS))
             {
                 ImGui::TableSetupColumn("Pos");
                 ImGui::TableSetupColumn("Type");
                 ImGui::TableSetupColumn("Name");
                 ImGui::TableSetupColumn("Value");
                 ImGui::TableHeadersRow();
+
+                bool open_arg_context_menu = false;
+
+                auto arg_cell = [&](int col, const char* text, std::string_view col_id) {
+                    if(col > 0)
+                        ImGui::TableSetColumnIndex(col);
+                    else
+                        ImGui::SameLine();
+                    CopyableTextUnformatted(text, col_id, COPY_DATA_NOTIFICATION, false,
+                                            false);
+                };
+
                 ImGuiListClipper clipper;
                 clipper.Begin(static_cast<int>(event_data->args.size()));
                 while(clipper.Step())
                 {
                     for(int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
                     {
+                        std::string row_str = std::to_string(i);
+
                         ImGui::PushID(i);
                         ImGui::TableNextRow();
                         ImGui::TableSetColumnIndex(0);
-                        CopyableTextUnformatted(
-                            std::to_string(event_data->args[i].position).c_str(), "",
-                            COPY_DATA_NOTIFICATION, false, true);
-                        ImGui::TableSetColumnIndex(1);
-                        CopyableTextUnformatted(event_data->args[i].data_type.c_str(), "",
-                                                COPY_DATA_NOTIFICATION, false, true);
-                        ImGui::TableSetColumnIndex(2);
-                        CopyableTextUnformatted(event_data->args[i].name.c_str(), "",
-                                                COPY_DATA_NOTIFICATION, false, true);
-                        ImGui::TableSetColumnIndex(3);
-                        CopyableTextUnformatted(event_data->args[i].value.c_str(), "",
-                                                COPY_DATA_NOTIFICATION, false, true);
+
+                        ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
+                        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
+                        ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
+                        ImGui::Selectable(("##arg_sel_" + row_str).c_str(), false,
+                                          ImGuiSelectableFlags_SpanAllColumns |
+                                              ImGuiSelectableFlags_AllowOverlap,
+                                          ImVec2(0.0f, 0.0f));
+                        if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
+                        {
+                            m_context_menu_arg_index = i;
+                            int hovered_col          = ImGui::TableGetHoveredColumn();
+                            m_context_menu_arg_column =
+                                (hovered_col >= 0 && hovered_col < kArgColumnCount)
+                                    ? hovered_col
+                                    : 0;
+                            open_arg_context_menu = true;
+                        }
+                        ImGui::PopStyleColor(3);
+
+                        std::string pos_str =
+                            std::to_string(event_data->args[i].position);
+
+                        arg_cell(0, pos_str.c_str(), "##arg_pos");
+                        arg_cell(1, event_data->args[i].data_type.c_str(), "##arg_type");
+                        arg_cell(2, event_data->args[i].name.c_str(), "##arg_name");
+                        arg_cell(3, event_data->args[i].value.c_str(), "##arg_value");
                         ImGui::PopID();
                     }
                 }
+
+                if(open_arg_context_menu)
+                {
+                    ImGui::OpenPopup("##ArgContextMenu");
+                }
+
+                auto style = m_settings.GetDefaultStyle();
+                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+                ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+                if(ImGui::BeginPopup("##ArgContextMenu"))
+                {
+                    if(m_context_menu_arg_index >= 0 &&
+                       m_context_menu_arg_index <
+                           static_cast<int>(event_data->args.size()))
+                    {
+                        const auto& ctx_arg =
+                            event_data->args[m_context_menu_arg_index];
+
+                        std::string cells[] = { std::to_string(ctx_arg.position),
+                                                ctx_arg.data_type, ctx_arg.name,
+                                                ctx_arg.value };
+
+                        if(ImGui::MenuItem("Copy Row Data"))
+                        {
+                            std::string row_text;
+                            for(int c = 0; c < kArgColumnCount; c++)
+                            {
+                                if(c > 0) row_text += '\t';
+                                row_text += cells[c];
+                            }
+                            ImGui::SetClipboardText(row_text.c_str());
+                        }
+                        if(ImGui::MenuItem("Copy Cell Data"))
+                        {
+                            int col = m_context_menu_arg_column;
+                            if(col >= 0 && col < kArgColumnCount)
+                                ImGui::SetClipboardText(cells[col].c_str());
+                        }
+                    }
+                    ImGui::EndPopup();
+                }
+                ImGui::PopStyleVar(2);
+
                 ImGui::EndTable();
             }
         }

--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -12,6 +12,7 @@
 #include "widgets/rocprofvis_notification_manager.h"
 
 #include <array>
+#include <string_view>
 #include <vector>
 
 namespace RocProfVis
@@ -43,6 +44,104 @@ PushSectionHeaderStyle(SettingsManager& settings)
                           settings.GetColor(Colors::kButtonActive));
 }
 
+// Positions the cursor for a cell: column 0 shares the row with the hit-box via
+// SameLine(), later columns move to their own column.
+void
+PositionCell(int col)
+{
+    if(col > 0)
+        ImGui::TableSetColumnIndex(col);
+    else
+        ImGui::SameLine();
+}
+
+// Renders the transparent, full-row selectable that acts as the right-click
+// hit-box for the empty areas of a table row. Cells drawn on top capture
+// right-clicks that land directly on their text (see CaptureCellRightClick).
+// On a right-click, records the row and hovered column into target and raises
+// open. Returns whether the row is hovered (for double-click / highlight use).
+bool
+RenderRowHitbox(const char* hitbox_id, int row, int column_count,
+                CellMenuTarget& target, bool& open)
+{
+    ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
+    bool clicked = ImGui::Selectable(hitbox_id, false,
+                                     ImGuiSelectableFlags_SpanAllColumns |
+                                         ImGuiSelectableFlags_AllowOverlap,
+                                     ImVec2(0.0f, 0.0f));
+    bool hovered = clicked ||
+                   ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem |
+                                        ImGuiHoveredFlags_AllowWhenOverlappedByItem);
+    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
+    {
+        int hovered_col = ImGui::TableGetHoveredColumn();
+        target.row      = row;
+        target.column =
+            (hovered_col >= 0 && hovered_col < column_count) ? hovered_col : 0;
+        open = true;
+    }
+    ImGui::PopStyleColor(3);
+    return hovered;
+}
+
+// Records a right-click that landed on the cell content just submitted (the
+// copyable text/button steals hover from the row hit-box over its own area).
+// Call immediately after rendering a cell's content.
+void
+CaptureCellRightClick(int col, int row, CellMenuTarget& target, bool& open)
+{
+    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
+    {
+        target.row    = row;
+        target.column = col;
+        open          = true;
+    }
+}
+
+// Opens the shared cell context-menu popup with consistent styling. When true is
+// returned, the caller fills in menu items and must call EndCellContextMenu().
+bool
+BeginCellContextMenu(const char* popup_id)
+{
+    const ImGuiStyle& style = SettingsManager::GetInstance().GetDefaultStyle();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+    bool open = ImGui::BeginPopup(popup_id);
+    if(!open)
+        ImGui::PopStyleVar(2);
+    return open;
+}
+
+void
+EndCellContextMenu()
+{
+    ImGui::EndPopup();
+    ImGui::PopStyleVar(2);
+}
+
+// Adds the shared "Copy Row Data" / "Copy Cell Data" items for the given row.
+void
+AddCopyRowCellMenuItems(const std::string* cells, int column_count, int column)
+{
+    if(ImGui::MenuItem("Copy Row Data"))
+    {
+        std::string row_text;
+        for(int c = 0; c < column_count; c++)
+        {
+            if(c > 0) row_text += '\t';
+            row_text += cells[c];
+        }
+        ImGui::SetClipboardText(row_text.c_str());
+    }
+    if(ImGui::MenuItem("Copy Cell Data"))
+    {
+        if(column >= 0 && column < column_count)
+            ImGui::SetClipboardText(cells[column].c_str());
+    }
+}
+
 }  // namespace
 
 bool
@@ -65,16 +164,6 @@ EventsView::EventsView(DataProvider&                      dp,
 , m_settings(SettingsManager::GetInstance())
 , m_timeline_selection(timeline_selection)
 , m_event_item_id(0)
-, m_context_menu_flow_index(-1)
-, m_context_menu_flow_column(-1)
-, m_context_menu_callstack_index(-1)
-, m_context_menu_callstack_column(-1)
-, m_context_menu_arg_index(-1)
-, m_context_menu_arg_column(-1)
-, m_context_menu_basic_index(-1)
-, m_context_menu_basic_column(-1)
-, m_context_menu_ext_index(-1)
-, m_context_menu_ext_column(-1)
 {
     static_assert(CallStackHoverState::kInvalidId ==
                       TimelineSelection::INVALID_SELECTION_ID,
@@ -243,77 +332,41 @@ EventsView::RenderBasicData(const EventInfo* event_data)
                                 ImGui::GetFontSize() * 8.5f);
         ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
 
-        bool open_basic_context_menu = false;
+        bool open_menu = false;
 
         for(int i = 0; i < static_cast<int>(rows.size()); i++)
         {
-            std::string row_str = std::to_string(i);
-
             ImGui::PushID(i);
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);
+            RenderRowHitbox("##basic_sel", i, kBasicColumnCount, m_basic_menu, open_menu);
 
-            ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
-            ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
-            ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
-            ImGui::Selectable(("##basic_sel_" + row_str).c_str(), false,
-                              ImGuiSelectableFlags_SpanAllColumns |
-                                  ImGuiSelectableFlags_AllowOverlap,
-                              ImVec2(0.0f, 0.0f));
-            if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-            {
-                m_context_menu_basic_index = i;
-                int hovered_col            = ImGui::TableGetHoveredColumn();
-                m_context_menu_basic_column =
-                    (hovered_col >= 0 && hovered_col < kBasicColumnCount) ? hovered_col
-                                                                         : 0;
-                open_basic_context_menu = true;
-            }
-            ImGui::PopStyleColor(3);
-
-            ImGui::SameLine();
+            PositionCell(0);
             ImGui::TextDisabled("%s", rows[i][0].c_str());
-            ImGui::TableSetColumnIndex(1);
+            CaptureCellRightClick(0, i, m_basic_menu, open_menu);
+
+            PositionCell(1);
             CopyableTextUnformatted(rows[i][1].c_str(), "##basic_value",
-                                    DATA_COPIED_NOTIFICATION, false, false);
+                                    COPY_DATA_NOTIFICATION, false, false);
+            CaptureCellRightClick(1, i, m_basic_menu, open_menu);
             ImGui::PopID();
         }
 
-        if(open_basic_context_menu)
+        if(open_menu)
         {
             ImGui::OpenPopup("##BasicContextMenu");
         }
 
-        auto style = m_settings.GetDefaultStyle();
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-        if(ImGui::BeginPopup("##BasicContextMenu"))
+        if(BeginCellContextMenu("##BasicContextMenu"))
         {
-            if(m_context_menu_basic_index >= 0 &&
-               m_context_menu_basic_index < static_cast<int>(rows.size()))
+            if(m_basic_menu.row >= 0 &&
+               m_basic_menu.row < static_cast<int>(rows.size()))
             {
-                const auto& ctx_row = rows[m_context_menu_basic_index];
-
-                if(ImGui::MenuItem("Copy Row Data"))
-                {
-                    std::string row_text;
-                    for(int c = 0; c < kBasicColumnCount; c++)
-                    {
-                        if(c > 0) row_text += '\t';
-                        row_text += ctx_row[c];
-                    }
-                    ImGui::SetClipboardText(row_text.c_str());
-                }
-                if(ImGui::MenuItem("Copy Cell Data"))
-                {
-                    int col = m_context_menu_basic_column;
-                    if(col >= 0 && col < kBasicColumnCount)
-                        ImGui::SetClipboardText(ctx_row[col].c_str());
-                }
+                AddCopyRowCellMenuItems(rows[m_basic_menu.row].data(), kBasicColumnCount,
+                                        m_basic_menu.column);
             }
-            ImGui::EndPopup();
+            EndCellContextMenu();
         }
-        ImGui::PopStyleVar(2);
 
         ImGui::EndTable();
     }
@@ -363,83 +416,45 @@ EventsView::RenderEventExtData(const EventInfo* event_data)
                     }
                 };
 
-                bool open_ext_context_menu = false;
+                bool open_menu = false;
 
                 for(int i = 0; i < static_cast<int>(event_data->ext_info.size()); i++)
                 {
-                    std::string row_str = std::to_string(i);
-
                     ImGui::PushID(i);
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
+                    RenderRowHitbox("##ext_sel", i, kExtColumnCount, m_ext_menu, open_menu);
 
-                    ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
-                    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
-                    ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
-                    ImGui::Selectable(("##ext_sel_" + row_str).c_str(), false,
-                                      ImGuiSelectableFlags_SpanAllColumns |
-                                          ImGuiSelectableFlags_AllowOverlap,
-                                      ImVec2(0.0f, 0.0f));
-                    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-                    {
-                        m_context_menu_ext_index = i;
-                        int hovered_col          = ImGui::TableGetHoveredColumn();
-                        m_context_menu_ext_column =
-                            (hovered_col >= 0 && hovered_col < kExtColumnCount)
-                                ? hovered_col
-                                : 0;
-                        open_ext_context_menu = true;
-                    }
-                    ImGui::PopStyleColor(3);
-
-                    ImGui::SameLine();
+                    PositionCell(0);
                     CopyableTextUnformatted(event_data->ext_info[i].name.c_str(),
                                             "##ext_name", COPY_DATA_NOTIFICATION, false,
                                             false);
-                    ImGui::TableSetColumnIndex(1);
+                    CaptureCellRightClick(0, i, m_ext_menu, open_menu);
+
+                    PositionCell(1);
                     CopyableTextUnformatted(format_ext_value(i).c_str(), "##ext_value",
                                             COPY_DATA_NOTIFICATION, false, false);
+                    CaptureCellRightClick(1, i, m_ext_menu, open_menu);
                     ImGui::PopID();
                 }
 
-                if(open_ext_context_menu)
+                if(open_menu)
                 {
                     ImGui::OpenPopup("##ExtContextMenu");
                 }
 
-                auto style = m_settings.GetDefaultStyle();
-                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-                ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-                if(ImGui::BeginPopup("##ExtContextMenu"))
+                if(BeginCellContextMenu("##ExtContextMenu"))
                 {
-                    if(m_context_menu_ext_index >= 0 &&
-                       m_context_menu_ext_index <
-                           static_cast<int>(event_data->ext_info.size()))
+                    if(m_ext_menu.row >= 0 &&
+                       m_ext_menu.row < static_cast<int>(event_data->ext_info.size()))
                     {
                         std::string cells[kExtColumnCount] = {
-                            event_data->ext_info[m_context_menu_ext_index].name,
-                            format_ext_value(m_context_menu_ext_index) };
-
-                        if(ImGui::MenuItem("Copy Row Data"))
-                        {
-                            std::string row_text;
-                            for(int c = 0; c < kExtColumnCount; c++)
-                            {
-                                if(c > 0) row_text += '\t';
-                                row_text += cells[c];
-                            }
-                            ImGui::SetClipboardText(row_text.c_str());
-                        }
-                        if(ImGui::MenuItem("Copy Cell Data"))
-                        {
-                            int col = m_context_menu_ext_column;
-                            if(col >= 0 && col < kExtColumnCount)
-                                ImGui::SetClipboardText(cells[col].c_str());
-                        }
+                            event_data->ext_info[m_ext_menu.row].name,
+                            format_ext_value(m_ext_menu.row) };
+                        AddCopyRowCellMenuItems(cells, kExtColumnCount, m_ext_menu.column);
                     }
-                    ImGui::EndPopup();
+                    EndCellContextMenu();
                 }
-                ImGui::PopStyleVar(2);
 
                 ImGui::EndTable();
             }
@@ -489,20 +504,14 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                         ? m_flow_hover.flow_event_id
                         : TimelineSelection::INVALID_SELECTION_ID;
 
-                auto flow_cell = [&](int col, const char* text, const char* id, int row)
-                {
-                    if(col > 0)
-                        ImGui::TableSetColumnIndex(col);
-                    else
-                        ImGui::SameLine();
-                    CopyableTextUnformatted(text, id, COPY_DATA_NOTIFICATION,
-                                            false, false);
-                    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-                    {
-                        m_context_menu_flow_index  = row;
-                        m_context_menu_flow_column = col;
-                        ImGui::OpenPopup("##FlowContextMenu");
-                    }
+                bool open_menu = false;
+
+                auto flow_cell = [&](int col, const char* text, std::string_view id,
+                                     int row) {
+                    PositionCell(col);
+                    CopyableTextUnformatted(text, id, COPY_DATA_NOTIFICATION, false,
+                                            false);
+                    CaptureCellRightClick(col, row, m_flow_menu, open_menu);
                 };
 
                 ImGuiListClipper clipper;
@@ -512,8 +521,8 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                     for(int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
                     {
                         const auto& flow = event_data->flow_info[i];
-                        std::string row_str = std::to_string(i);
 
+                        ImGui::PushID(i);
                         ImGui::TableNextRow();
                         if(flow.id.uuid == prev_hovered_flow_event_id)
                         {
@@ -528,31 +537,9 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                                 m_settings.GetColor(Colors::kAreaOfInterest));
                         }
                         ImGui::TableSetColumnIndex(0);
-
-                        ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
-                        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
-                        ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
-                        bool row_clicked = ImGui::Selectable(
-                            ("##flow_sel_" + row_str).c_str(), false,
-                            ImGuiSelectableFlags_SpanAllColumns |
-                                ImGuiSelectableFlags_AllowOverlap,
-                            ImVec2(0.0f, 0.0f));
-                        bool row_hovered =
-                            row_clicked ||
-                            ImGui::IsItemHovered(
-                                ImGuiHoveredFlags_AllowWhenBlockedByActiveItem |
-                                ImGuiHoveredFlags_AllowWhenOverlappedByItem);
-                        if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-                        {
-                            m_context_menu_flow_index = i;
-                            int hovered_col           = ImGui::TableGetHoveredColumn();
-                            m_context_menu_flow_column =
-                                (hovered_col >= 0 && hovered_col < kFlowColumnCount)
-                                    ? hovered_col
-                                    : 0;
-                            ImGui::OpenPopup("##FlowContextMenu");
-                        }
-                        ImGui::PopStyleColor(3);
+                        bool row_hovered = RenderRowHitbox("##flow_sel", i,
+                                                           kFlowColumnCount, m_flow_menu,
+                                                           open_menu);
 
                         std::string id_str        = std::to_string(flow.id.bitfield.event_id);
                         std::string timestamp_str = nanosecond_to_formatted_str(
@@ -561,12 +548,12 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                         std::string level_str     = std::to_string(flow.level);
                         std::string dir_str       = std::to_string(flow.direction);
 
-                        flow_cell(0, id_str.c_str(),        ("##id_" + row_str).c_str(), i);
-                        flow_cell(1, flow.name.c_str(),     ("##name_" + row_str).c_str(), i);
-                        flow_cell(2, timestamp_str.c_str(), ("##ts_" + row_str).c_str(), i);
-                        flow_cell(3, track_str.c_str(),     ("##tid_" + row_str).c_str(), i);
-                        flow_cell(4, level_str.c_str(),     ("##lvl_" + row_str).c_str(), i);
-                        flow_cell(5, dir_str.c_str(),       ("##dir_" + row_str).c_str(), i);
+                        flow_cell(0, id_str.c_str(),        "##flow_id", i);
+                        flow_cell(1, flow.name.c_str(),     "##flow_name", i);
+                        flow_cell(2, timestamp_str.c_str(), "##flow_ts", i);
+                        flow_cell(3, track_str.c_str(),     "##flow_tid", i);
+                        flow_cell(4, level_str.c_str(),     "##flow_lvl", i);
+                        flow_cell(5, dir_str.c_str(),       "##flow_dir", i);
 
                         if(row_hovered &&
                            ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
@@ -588,20 +575,22 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                                     "This is the selected event for this flow.");
                             }
                         }
+                        ImGui::PopID();
                     }
                 }
 
-                auto style = m_settings.GetDefaultStyle();
-                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-                ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-                if(ImGui::BeginPopup("##FlowContextMenu"))
+                if(open_menu)
                 {
-                    if(m_context_menu_flow_index >= 0 &&
-                       m_context_menu_flow_index <
+                    ImGui::OpenPopup("##FlowContextMenu");
+                }
+
+                if(BeginCellContextMenu("##FlowContextMenu"))
+                {
+                    if(m_flow_menu.row >= 0 &&
+                       m_flow_menu.row <
                            static_cast<int>(event_data->flow_info.size()))
                     {
-                        const auto& ctx_flow =
-                            event_data->flow_info[m_context_menu_flow_index];
+                        const auto& ctx_flow = event_data->flow_info[m_flow_menu.row];
 
                         if(ImGui::MenuItem("Go To Event"))
                         {
@@ -622,26 +611,11 @@ EventsView::RenderEventFlowInfo(const EventInfo* event_data)
                             std::to_string(ctx_flow.level),
                             std::to_string(ctx_flow.direction)};
 
-                        if(ImGui::MenuItem("Copy Row Data"))
-                        {
-                            std::string row_text;
-                            for(int c = 0; c < kFlowColumnCount; c++)
-                            {
-                                if(c > 0) row_text += '\t';
-                                row_text += cells[c];
-                            }
-                            ImGui::SetClipboardText(row_text.c_str());
-                        }
-                        if(ImGui::MenuItem("Copy Cell Data"))
-                        {
-                            int col = m_context_menu_flow_column;
-                            if(col >= 0 && col < kFlowColumnCount)
-                                ImGui::SetClipboardText(cells[col].c_str());
-                        }
+                        AddCopyRowCellMenuItems(cells, kFlowColumnCount,
+                                                m_flow_menu.column);
                     }
-                    ImGui::EndPopup();
+                    EndCellContextMenu();
                 }
-                ImGui::PopStyleVar(2);
 
                 ImGui::EndTable();
             }
@@ -678,14 +652,11 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                 ImGui::TableSetupColumn("PC");
                 ImGui::TableHeadersRow();
 
-                bool open_callstack_context_menu = false;
+                bool open_menu = false;
 
                 auto callstack_cell = [&](int col, const std::string& text,
                                            std::string_view col_id, int row) {
-                    if(col > 0)
-                        ImGui::TableSetColumnIndex(col);
-                    else
-                        ImGui::SameLine();
+                    PositionCell(col);
 
                     if(text.empty())
                     {
@@ -702,12 +673,7 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                                                 COPY_DATA_NOTIFICATION, false, false);
                     }
 
-                    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-                    {
-                        m_context_menu_callstack_index  = row;
-                        m_context_menu_callstack_column = col;
-                        open_callstack_context_menu     = true;
-                    }
+                    CaptureCellRightClick(col, row, m_callstack_menu, open_menu);
                 };
 
                 const uint64_t this_owner_event_id = event_data->basic_info.id.uuid;
@@ -731,7 +697,6 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                         const auto& frame    = event_data->call_stack_info[i];
                         const uint64_t uuid  = frame.id.uuid;
                         const bool     is_owner_frame = (uuid == this_owner_event_id);
-                        std::string row_str = std::to_string(i);
 
                         ImGui::PushID(i);
                         ImGui::TableNextRow();
@@ -749,30 +714,9 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                         }
 
                         ImGui::TableSetColumnIndex(0);
-                        ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
-                        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
-                        ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
-                        bool row_clicked = ImGui::Selectable(
-                            ("##cs_sel_" + row_str).c_str(), false,
-                            ImGuiSelectableFlags_SpanAllColumns |
-                                ImGuiSelectableFlags_AllowOverlap,
-                            ImVec2(0.0f, 0.0f));
-                        bool row_hovered =
-                            row_clicked ||
-                            ImGui::IsItemHovered(
-                                ImGuiHoveredFlags_AllowWhenBlockedByActiveItem |
-                                ImGuiHoveredFlags_AllowWhenOverlappedByItem);
-                        if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-                        {
-                            m_context_menu_callstack_index = i;
-                            int hovered_col                = ImGui::TableGetHoveredColumn();
-                            m_context_menu_callstack_column =
-                                (hovered_col >= 0 && hovered_col < kCallStackColumnCount)
-                                    ? hovered_col
-                                    : 0;
-                            open_callstack_context_menu = true;
-                        }
-                        ImGui::PopStyleColor(3);
+                        bool row_hovered = RenderRowHitbox("##cs_sel", i,
+                                                           kCallStackColumnCount,
+                                                           m_callstack_menu, open_menu);
 
                         callstack_cell(0, std::to_string(frame.id.bitfield.event_id),
                                        "##cs_id", i);
@@ -802,22 +746,19 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                     }
                 }
 
-                if(open_callstack_context_menu)
+                if(open_menu)
                 {
                     ImGui::OpenPopup("##CallStackContextMenu");
                 }
 
-                auto style = m_settings.GetDefaultStyle();
-                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-                ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-                if(ImGui::BeginPopup("##CallStackContextMenu"))
+                if(BeginCellContextMenu("##CallStackContextMenu"))
                 {
-                    if(m_context_menu_callstack_index >= 0 &&
-                       m_context_menu_callstack_index <
+                    if(m_callstack_menu.row >= 0 &&
+                       m_callstack_menu.row <
                            static_cast<int>(event_data->call_stack_info.size()))
                     {
                         const auto& ctx_frame =
-                            event_data->call_stack_info[m_context_menu_callstack_index];
+                            event_data->call_stack_info[m_callstack_menu.row];
 
                         if(ImGui::MenuItem("Go To Event"))
                         {
@@ -829,26 +770,11 @@ EventsView::RenderCallStackData(const EventInfo* event_data)
                             ctx_frame.address, ctx_frame.name, ctx_frame.file,
                             ctx_frame.pc};
 
-                        if(ImGui::MenuItem("Copy Row Data"))
-                        {
-                            std::string row_text;
-                            for(int c = 0; c < kCallStackColumnCount; c++)
-                            {
-                                if(c > 0) row_text += '\t';
-                                row_text += cells[c];
-                            }
-                            ImGui::SetClipboardText(row_text.c_str());
-                        }
-                        if(ImGui::MenuItem("Copy Cell Data"))
-                        {
-                            int col = m_context_menu_callstack_column;
-                            if(col >= 0 && col < kCallStackColumnCount)
-                                ImGui::SetClipboardText(cells[col].c_str());
-                        }
+                        AddCopyRowCellMenuItems(cells, kCallStackColumnCount,
+                                                m_callstack_menu.column);
                     }
-                    ImGui::EndPopup();
+                    EndCellContextMenu();
                 }
-                ImGui::PopStyleVar(2);
                 ImGui::EndTable();
             }
         }
@@ -883,15 +809,14 @@ EventsView::RenderArgumentData(const EventInfo* event_data)
                 ImGui::TableSetupColumn("Value");
                 ImGui::TableHeadersRow();
 
-                bool open_arg_context_menu = false;
+                bool open_menu = false;
 
-                auto arg_cell = [&](int col, const char* text, std::string_view col_id) {
-                    if(col > 0)
-                        ImGui::TableSetColumnIndex(col);
-                    else
-                        ImGui::SameLine();
+                auto arg_cell = [&](int col, const char* text, std::string_view col_id,
+                                    int row) {
+                    PositionCell(col);
                     CopyableTextUnformatted(text, col_id, COPY_DATA_NOTIFICATION, false,
                                             false);
+                    CaptureCellRightClick(col, row, m_arg_menu, open_menu);
                 };
 
                 ImGuiListClipper clipper;
@@ -900,83 +825,43 @@ EventsView::RenderArgumentData(const EventInfo* event_data)
                 {
                     for(int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++)
                     {
-                        std::string row_str = std::to_string(i);
-
                         ImGui::PushID(i);
                         ImGui::TableNextRow();
                         ImGui::TableSetColumnIndex(0);
-
-                        ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
-                        ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
-                        ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
-                        ImGui::Selectable(("##arg_sel_" + row_str).c_str(), false,
-                                          ImGuiSelectableFlags_SpanAllColumns |
-                                              ImGuiSelectableFlags_AllowOverlap,
-                                          ImVec2(0.0f, 0.0f));
-                        if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-                        {
-                            m_context_menu_arg_index = i;
-                            int hovered_col          = ImGui::TableGetHoveredColumn();
-                            m_context_menu_arg_column =
-                                (hovered_col >= 0 && hovered_col < kArgColumnCount)
-                                    ? hovered_col
-                                    : 0;
-                            open_arg_context_menu = true;
-                        }
-                        ImGui::PopStyleColor(3);
+                        RenderRowHitbox("##arg_sel", i, kArgColumnCount, m_arg_menu,
+                                        open_menu);
 
                         std::string pos_str =
                             std::to_string(event_data->args[i].position);
 
-                        arg_cell(0, pos_str.c_str(), "##arg_pos");
-                        arg_cell(1, event_data->args[i].data_type.c_str(), "##arg_type");
-                        arg_cell(2, event_data->args[i].name.c_str(), "##arg_name");
-                        arg_cell(3, event_data->args[i].value.c_str(), "##arg_value");
+                        arg_cell(0, pos_str.c_str(), "##arg_pos", i);
+                        arg_cell(1, event_data->args[i].data_type.c_str(), "##arg_type", i);
+                        arg_cell(2, event_data->args[i].name.c_str(), "##arg_name", i);
+                        arg_cell(3, event_data->args[i].value.c_str(), "##arg_value", i);
                         ImGui::PopID();
                     }
                 }
 
-                if(open_arg_context_menu)
+                if(open_menu)
                 {
                     ImGui::OpenPopup("##ArgContextMenu");
                 }
 
-                auto style = m_settings.GetDefaultStyle();
-                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-                ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-                if(ImGui::BeginPopup("##ArgContextMenu"))
+                if(BeginCellContextMenu("##ArgContextMenu"))
                 {
-                    if(m_context_menu_arg_index >= 0 &&
-                       m_context_menu_arg_index <
-                           static_cast<int>(event_data->args.size()))
+                    if(m_arg_menu.row >= 0 &&
+                       m_arg_menu.row < static_cast<int>(event_data->args.size()))
                     {
-                        const auto& ctx_arg =
-                            event_data->args[m_context_menu_arg_index];
+                        const auto& ctx_arg = event_data->args[m_arg_menu.row];
 
                         std::string cells[] = { std::to_string(ctx_arg.position),
                                                 ctx_arg.data_type, ctx_arg.name,
                                                 ctx_arg.value };
 
-                        if(ImGui::MenuItem("Copy Row Data"))
-                        {
-                            std::string row_text;
-                            for(int c = 0; c < kArgColumnCount; c++)
-                            {
-                                if(c > 0) row_text += '\t';
-                                row_text += cells[c];
-                            }
-                            ImGui::SetClipboardText(row_text.c_str());
-                        }
-                        if(ImGui::MenuItem("Copy Cell Data"))
-                        {
-                            int col = m_context_menu_arg_column;
-                            if(col >= 0 && col < kArgColumnCount)
-                                ImGui::SetClipboardText(cells[col].c_str());
-                        }
+                        AddCopyRowCellMenuItems(cells, kArgColumnCount, m_arg_menu.column);
                     }
-                    ImGui::EndPopup();
+                    EndCellContextMenu();
                 }
-                ImGui::PopStyleVar(2);
 
                 ImGui::EndTable();
             }

--- a/src/view/src/rocprofvis_events_view.cpp
+++ b/src/view/src/rocprofvis_events_view.cpp
@@ -9,7 +9,6 @@
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_timeline_selection.h"
 #include "rocprofvis_utils.h"
-#include "widgets/rocprofvis_notification_manager.h"
 
 #include <array>
 #include <string_view>
@@ -42,104 +41,6 @@ PushSectionHeaderStyle(SettingsManager& settings)
                           settings.GetColor(Colors::kButtonHovered));
     ImGui::PushStyleColor(ImGuiCol_HeaderActive,
                           settings.GetColor(Colors::kButtonActive));
-}
-
-// Positions the cursor for a cell: column 0 shares the row with the hit-box via
-// SameLine(), later columns move to their own column.
-void
-PositionCell(int col)
-{
-    if(col > 0)
-        ImGui::TableSetColumnIndex(col);
-    else
-        ImGui::SameLine();
-}
-
-// Renders the transparent, full-row selectable that acts as the right-click
-// hit-box for the empty areas of a table row. Cells drawn on top capture
-// right-clicks that land directly on their text (see CaptureCellRightClick).
-// On a right-click, records the row and hovered column into target and raises
-// open. Returns whether the row is hovered (for double-click / highlight use).
-bool
-RenderRowHitbox(const char* hitbox_id, int row, int column_count,
-                CellMenuTarget& target, bool& open)
-{
-    ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
-    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
-    ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
-    bool clicked = ImGui::Selectable(hitbox_id, false,
-                                     ImGuiSelectableFlags_SpanAllColumns |
-                                         ImGuiSelectableFlags_AllowOverlap,
-                                     ImVec2(0.0f, 0.0f));
-    bool hovered = clicked ||
-                   ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem |
-                                        ImGuiHoveredFlags_AllowWhenOverlappedByItem);
-    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-    {
-        int hovered_col = ImGui::TableGetHoveredColumn();
-        target.row      = row;
-        target.column =
-            (hovered_col >= 0 && hovered_col < column_count) ? hovered_col : 0;
-        open = true;
-    }
-    ImGui::PopStyleColor(3);
-    return hovered;
-}
-
-// Records a right-click that landed on the cell content just submitted (the
-// copyable text/button steals hover from the row hit-box over its own area).
-// Call immediately after rendering a cell's content.
-void
-CaptureCellRightClick(int col, int row, CellMenuTarget& target, bool& open)
-{
-    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
-    {
-        target.row    = row;
-        target.column = col;
-        open          = true;
-    }
-}
-
-// Opens the shared cell context-menu popup with consistent styling. When true is
-// returned, the caller fills in menu items and must call EndCellContextMenu().
-bool
-BeginCellContextMenu(const char* popup_id)
-{
-    const ImGuiStyle& style = SettingsManager::GetInstance().GetDefaultStyle();
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-    bool open = ImGui::BeginPopup(popup_id);
-    if(!open)
-        ImGui::PopStyleVar(2);
-    return open;
-}
-
-void
-EndCellContextMenu()
-{
-    ImGui::EndPopup();
-    ImGui::PopStyleVar(2);
-}
-
-// Adds the shared "Copy Row Data" / "Copy Cell Data" items for the given row.
-void
-AddCopyRowCellMenuItems(const std::string* cells, int column_count, int column)
-{
-    if(IconMenuItem(ICON_COPY, "Copy Row Data"))
-    {
-        std::string row_text;
-        for(int c = 0; c < column_count; c++)
-        {
-            if(c > 0) row_text += '\t';
-            row_text += cells[c];
-        }
-        ImGui::SetClipboardText(row_text.c_str());
-    }
-    if(IconMenuItem(ICON_COPY, "Copy Cell Data"))
-    {
-        if(column >= 0 && column < column_count)
-            ImGui::SetClipboardText(cells[column].c_str());
-    }
 }
 
 }  // namespace

--- a/src/view/src/rocprofvis_events_view.h
+++ b/src/view/src/rocprofvis_events_view.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "widgets/rocprofvis_gui_helpers.h"
 #include "widgets/rocprofvis_split_containers.h"
 #include <cstdint>
 #include <limits>
@@ -17,14 +18,6 @@ class DataProvider;
 class SettingsManager;
 class TimelineSelection;
 struct EventInfo;
-
-// Identifies the row/column of the cell whose right-click opened a table's
-// copy context menu. Shared by every Event Details table.
-struct CellMenuTarget
-{
-    int row    = -1;
-    int column = -1;
-};
 
 class EventsView : public RocWidget
 {

--- a/src/view/src/rocprofvis_events_view.h
+++ b/src/view/src/rocprofvis_events_view.h
@@ -7,7 +7,6 @@
 #include <limits>
 #include <list>
 #include <string>
-#include <string_view>
 
 namespace RocProfVis
 {
@@ -18,6 +17,14 @@ class DataProvider;
 class SettingsManager;
 class TimelineSelection;
 struct EventInfo;
+
+// Identifies the row/column of the cell whose right-click opened a table's
+// copy context menu. Shared by every Event Details table.
+struct CellMenuTarget
+{
+    int row    = -1;
+    int column = -1;
+};
 
 class EventsView : public RocWidget
 {
@@ -76,21 +83,15 @@ private:
     std::shared_ptr<TimelineSelection>       m_timeline_selection;
     std::list<EventItem>                     m_event_items;
     int                                      m_event_item_id;
-    int                                      m_context_menu_flow_index;
-    int                                      m_context_menu_flow_column;
-    int                                      m_context_menu_callstack_index;
-    int                                      m_context_menu_callstack_column;
-    int                                      m_context_menu_arg_index;
-    int                                      m_context_menu_arg_column;
-    int                                      m_context_menu_basic_index;
-    int                                      m_context_menu_basic_column;
-    int                                      m_context_menu_ext_index;
-    int                                      m_context_menu_ext_column;
+    CellMenuTarget                           m_flow_menu;
+    CellMenuTarget                           m_callstack_menu;
+    CellMenuTarget                           m_arg_menu;
+    CellMenuTarget                           m_basic_menu;
+    CellMenuTarget                           m_ext_menu;
     FlowHighlightState                       m_flow_hover;
     FlowHighlightState                       m_frame_flow_hover;
     CallStackHoverState                      m_callstack_hover;
     CallStackHoverState                      m_frame_callstack_hover;
-    const std::string_view DATA_COPIED_NOTIFICATION = "Data was copied";
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_events_view.h
+++ b/src/view/src/rocprofvis_events_view.h
@@ -80,6 +80,12 @@ private:
     int                                      m_context_menu_flow_column;
     int                                      m_context_menu_callstack_index;
     int                                      m_context_menu_callstack_column;
+    int                                      m_context_menu_arg_index;
+    int                                      m_context_menu_arg_column;
+    int                                      m_context_menu_basic_index;
+    int                                      m_context_menu_basic_column;
+    int                                      m_context_menu_ext_index;
+    int                                      m_context_menu_ext_column;
     FlowHighlightState                       m_flow_hover;
     FlowHighlightState                       m_frame_flow_hover;
     CallStackHoverState                      m_callstack_hover;

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -7,7 +7,6 @@
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_notification_manager.h"
-#include "widgets/rocprofvis_widget.h"
 #include <algorithm>
 #include <cmath>
 
@@ -567,6 +566,147 @@ DrawInternalBuildBanner(const char* text /*= "Internal Build"*/)
 }
 #endif // ROCPROFVIS_ENABLE_INTERNAL_BANNER
 
+// Menu icon spacing, in multiples of the font size.
+inline constexpr float MENU_ICON_GAP_EM       = 0.7f;
+inline constexpr float MENU_NO_ICON_INDENT_EM = 1.0f;
+
+static float
+MenuIconWidth(const char* icon)
+{
+    const float font_size = ImGui::GetFontSize();
+    if(!icon || icon[0] == '\0')
+        return font_size * MENU_NO_ICON_INDENT_EM;
+
+    ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+    return icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon).x;
+}
+
+// Pads the label with leading spaces to leave room for the left-aligned icon.
+static std::string
+MenuLabelWithIconPadding(const char* icon, const char* label)
+{
+    const float offset  = MenuIconWidth(icon) + ImGui::GetFontSize() * MENU_ICON_GAP_EM;
+    const float space_w = ImGui::CalcTextSize(" ").x;
+    const int   pad     = space_w > 0.0f ? static_cast<int>(std::ceil(offset / space_w)) : 1;
+    std::string padded(static_cast<size_t>(std::max(pad, 1)), ' ');
+    padded += label;
+    return padded;
+}
+
+// row_start is the cursor screen position captured before the menu widget.
+static void
+DrawMenuItemIcon(const char* icon, const ImVec2& row_start, bool enabled)
+{
+    if(!icon || icon[0] == '\0')
+        return;
+
+    ImFont*      icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+    const float  font_size = ImGui::GetFontSize();
+    const ImVec2 icon_size = icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon);
+    const ImVec2 pos(row_start.x, row_start.y + (font_size - icon_size.y) * 0.5f);
+    const ImU32  color = ImGui::GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled);
+
+    ImGui::GetWindowDrawList()->AddText(icon_font, font_size, pos, color, icon);
+}
+
+bool
+IconMenuItem(const char* icon, const char* label, bool enabled)
+{
+    const ImVec2 row_start    = ImGui::GetCursorScreenPos();
+    std::string  padded_label = MenuLabelWithIconPadding(icon, label);
+
+    bool clicked = ImGui::MenuItem(padded_label.c_str(), nullptr, false, enabled);
+    DrawMenuItemIcon(icon, row_start, enabled);
+
+    if(clicked)
+        ImGui::CloseCurrentPopup();
+    return clicked;
+}
+
+bool
+IconBeginMenu(const char* icon, const char* label)
+{
+    const ImVec2 row_start    = ImGui::GetCursorScreenPos();
+    std::string  padded_label = MenuLabelWithIconPadding(icon, label);
+
+    bool open = ImGui::BeginMenu(padded_label.c_str());
+    DrawMenuItemIcon(icon, row_start, true);
+
+    return open;
+}
+
+bool
+CopyableTextUnformatted(
+    const char* text, std::string_view unique_id, std::string_view notification,
+    bool one_click_copy, bool context_menu,
+    std::function<void(const char* value_to_copy)> menu_func)
+{
+    bool clicked = false;
+    if(!unique_id.empty())
+        ImGui::PushID(unique_id.data());
+
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+
+    if(ImGui::Button(text, ImVec2(0, 0)))
+    {
+        clicked = true;
+        if(one_click_copy)
+        {
+            ImGui::SetClipboardText(text);
+            if(!notification.empty())
+            {
+                NotificationManager::GetInstance().Show(notification.data(),
+                                                        NotificationLevel::Info);
+            }
+        }
+    }
+
+    if(context_menu)
+    {
+        auto style = SettingsManager::GetInstance().GetDefaultStyle();
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+        if(menu_func)
+        {
+            menu_func(text);
+        }
+        else if(ImGui::BeginPopupContextItem())
+        {
+            if(IconMenuItem(ICON_COPY, "Copy"))
+            {
+                ImGui::SetClipboardText(text);
+                if(!notification.empty())
+                {
+                    NotificationManager::GetInstance().Show(notification.data(),
+                                                            NotificationLevel::Info);
+                }
+            }
+            ImGui::EndPopup();
+        }
+        ImGui::PopStyleVar(2);
+    }
+
+    if(one_click_copy)
+    {
+        if(ImGui::IsItemHovered())
+        {
+            ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
+        }
+    }
+
+    ImGui::PopStyleVar();
+    ImGui::PopStyleColor(3);
+
+    if(!unique_id.empty())
+    {
+        ImGui::PopID();
+    }
+    return clicked;
+}
+
 void
 PositionCell(int col)
 {
@@ -644,7 +784,7 @@ AddCopyRowCellMenuItems(const std::string* cells, int column_count, int column)
             row_text += cells[c];
         }
         ImGui::SetClipboardText(row_text.c_str());
-        NotificationManager::GetInstance().Show(COPY_DATA_NOTIFICATION.data(),
+        NotificationManager::GetInstance().Show(COPY_ROW_DATA_NOTIFICATION.data(),
                                                 NotificationLevel::Info);
     }
     if(IconMenuItem(ICON_COPY, "Copy Cell Data"))

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -6,6 +6,8 @@
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
+#include "widgets/rocprofvis_notification_manager.h"
+#include "widgets/rocprofvis_widget.h"
 #include <algorithm>
 #include <cmath>
 
@@ -564,6 +566,97 @@ DrawInternalBuildBanner(const char* text /*= "Internal Build"*/)
     }
 }
 #endif // ROCPROFVIS_ENABLE_INTERNAL_BANNER
+
+void
+PositionCell(int col)
+{
+    if(col > 0)
+        ImGui::TableSetColumnIndex(col);
+    else
+        ImGui::SameLine();
+}
+
+bool
+RenderRowHitbox(const char* hitbox_id, int row, int column_count,
+                CellMenuTarget& target, bool& open)
+{
+    ImGui::PushStyleColor(ImGuiCol_Header, ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0, 0, 0, 0));
+    ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImVec4(0, 0, 0, 0));
+    bool clicked = ImGui::Selectable(hitbox_id, false,
+                                     ImGuiSelectableFlags_SpanAllColumns |
+                                         ImGuiSelectableFlags_AllowOverlap,
+                                     ImVec2(0.0f, 0.0f));
+    bool hovered = clicked ||
+                   ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem |
+                                        ImGuiHoveredFlags_AllowWhenOverlappedByItem);
+    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
+    {
+        int hovered_col = ImGui::TableGetHoveredColumn();
+        target.row      = row;
+        target.column =
+            (hovered_col >= 0 && hovered_col < column_count) ? hovered_col : 0;
+        open = true;
+    }
+    ImGui::PopStyleColor(3);
+    return hovered;
+}
+
+void
+CaptureCellRightClick(int col, int row, CellMenuTarget& target, bool& open)
+{
+    if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
+    {
+        target.row    = row;
+        target.column = col;
+        open          = true;
+    }
+}
+
+bool
+BeginCellContextMenu(const char* popup_id)
+{
+    const ImGuiStyle& style = SettingsManager::GetInstance().GetDefaultStyle();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+    bool open = ImGui::BeginPopup(popup_id);
+    if(!open)
+        ImGui::PopStyleVar(2);
+    return open;
+}
+
+void
+EndCellContextMenu()
+{
+    ImGui::EndPopup();
+    ImGui::PopStyleVar(2);
+}
+
+void
+AddCopyRowCellMenuItems(const std::string* cells, int column_count, int column)
+{
+    if(IconMenuItem(ICON_COPY, "Copy Row Data"))
+    {
+        std::string row_text;
+        for(int c = 0; c < column_count; c++)
+        {
+            if(c > 0) row_text += '\t';
+            row_text += cells[c];
+        }
+        ImGui::SetClipboardText(row_text.c_str());
+        NotificationManager::GetInstance().Show(COPY_DATA_NOTIFICATION.data(),
+                                                NotificationLevel::Info);
+    }
+    if(IconMenuItem(ICON_COPY, "Copy Cell Data"))
+    {
+        if(column >= 0 && column < column_count)
+        {
+            ImGui::SetClipboardText(cells[column].c_str());
+            NotificationManager::GetInstance().Show(COPY_DATA_NOTIFICATION.data(),
+                                                    NotificationLevel::Info);
+        }
+    }
+}
 
 }   // namespace View
 }   // namespace RocProfVis

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -3,7 +3,9 @@
 
 #pragma once
 #include "imgui.h"
+#include <functional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace RocProfVis
@@ -125,6 +127,31 @@ VerticalSeparator(SettingsManager* settings = nullptr);
 
 float
 TableRowHeight();
+
+// Toast text shown after copying a single cell / a whole row to the clipboard.
+inline constexpr std::string_view COPY_DATA_NOTIFICATION     = "Cell data was copied";
+inline constexpr std::string_view COPY_ROW_DATA_NOTIFICATION = "Row data copied to clipboard";
+
+// Similar to ImGui::TextUnformatted(), but allows copying the text to the clipboard
+// via left-click or a context menu.
+// If multiple instances with the same text can appear within the same frame,
+// the caller must provide a unique, stable identifier to avoid ID collisions.
+// For items created in loops, the loop index or iterator is typically sufficient.
+bool
+CopyableTextUnformatted(
+    const char* text, std::string_view unique_id = "", std::string_view notification = "",
+    bool one_click_copy = false, bool context_menu = false,
+    std::function<void(const char* value_to_copy)> menu_func = nullptr);
+
+// Renders a selectable menu item with an icon (from the icon font) followed by a text label.
+// Returns true when clicked. Intended for use inside BeginPopup/BeginPopupContextItem blocks.
+bool
+IconMenuItem(const char* icon, const char* label, bool enabled = true);
+
+// Opens a submenu entry with a leading icon (from the icon font) before the label.
+// Returns true when the submenu is open; call ImGui::EndMenu() only when it returns true.
+bool
+IconBeginMenu(const char* icon, const char* label);
 
 // Identifies the row/column of the cell whose right-click opened a table's copy
 // context menu. Reusable by any table that wants the shared full-row right-click

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "imgui.h"
+#include <string>
 #include <utility>
 
 namespace RocProfVis
@@ -124,6 +125,48 @@ VerticalSeparator(SettingsManager* settings = nullptr);
 
 float
 TableRowHeight();
+
+// Identifies the row/column of the cell whose right-click opened a table's copy
+// context menu. Reusable by any table that wants the shared full-row right-click
+// hit-box plus copy menu (see RenderRowHitbox / AddCopyRowCellMenuItems).
+struct CellMenuTarget
+{
+    int row    = -1;
+    int column = -1;
+};
+
+// Positions the cursor for a cell: column 0 shares the row with the hit-box via
+// SameLine(), later columns move to their own column.
+void
+PositionCell(int col);
+
+// Renders the transparent, full-row selectable that acts as the right-click
+// hit-box for the empty areas of a table row. Cells drawn on top capture
+// right-clicks that land directly on their text (see CaptureCellRightClick).
+// On a right-click, records the row and hovered column into target and raises
+// open. Returns whether the row is hovered (for double-click / highlight use).
+bool
+RenderRowHitbox(const char* hitbox_id, int row, int column_count,
+                CellMenuTarget& target, bool& open);
+
+// Records a right-click that landed on the cell content just submitted (the
+// copyable text/button steals hover from the row hit-box over its own area).
+// Call immediately after rendering a cell's content.
+void
+CaptureCellRightClick(int col, int row, CellMenuTarget& target, bool& open);
+
+// Opens the shared cell context-menu popup with consistent styling. When true is
+// returned, the caller fills in menu items and must call EndCellContextMenu().
+bool
+BeginCellContextMenu(const char* popup_id);
+
+void
+EndCellContextMenu();
+
+// Adds the shared "Copy Row Data" / "Copy Cell Data" items for the given row,
+// copying to the clipboard and raising the copy notification.
+void
+AddCopyRowCellMenuItems(const std::string* cells, int column_count, int column);
 
 #ifdef ROCPROFVIS_ENABLE_INTERNAL_BANNER
 void

--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -2,16 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_widget.h"
-#include "icons/rocprovfis_icon_defines.h"
 #include "imgui.h"
 #include "rocprofvis_core.h"
 #include "rocprofvis_debug_window.h"
 #include "rocprofvis_utils.h"
-#include "widgets/rocprofvis_gui_helpers.h"
-#include "widgets/rocprofvis_notification_manager.h"
 #include "rocprofvis_settings_manager.h"
-#include <algorithm>
-#include <cmath>
 #include <iostream>
 #include <sstream>
 
@@ -19,10 +14,6 @@ namespace RocProfVis
 {
 namespace View
 {
-
-// Menu icon spacing, in multiples of the font size.
-inline constexpr float MENU_ICON_GAP_EM       = 0.7f;
-inline constexpr float MENU_NO_ICON_INDENT_EM = 1.0f;
 
 RocWidget::~RocWidget() { spdlog::debug("RocWidget object destroyed"); }
 
@@ -69,180 +60,6 @@ LayoutItem::CreateFromWidget(std::shared_ptr<RocWidget> widget, float w, float h
     Ptr item     = std::make_shared<LayoutItem>(w, h);
     item->m_item = widget;
     return item;
-}
-
-
-void
-WithPadding(float left, float right, float top, float bottom,
-            const std::function<void()>& content)
-{
-    if(top > 0.0f) ImGui::Dummy(ImVec2(0, top));
-
-    // No border flags for invisible borders
-    if(ImGui::BeginTable("##padding_table", 3, ImGuiTableFlags_SizingFixedFit))
-    {
-        ImGui::TableSetupColumn("LeftPad", ImGuiTableColumnFlags_WidthFixed, left);
-        ImGui::TableSetupColumn("Content", ImGuiTableColumnFlags_WidthStretch);
-        ImGui::TableSetupColumn("RightPad", ImGuiTableColumnFlags_WidthFixed, right);
-
-        ImGui::TableNextRow();
-
-        // Left padding
-        ImGui::TableSetColumnIndex(0);
-        if(left > 0.0f) ImGui::Dummy(ImVec2(left, 0));
-
-        // Content
-        ImGui::TableSetColumnIndex(1);
-        ImGui::BeginGroup();
-        content();
-        ImGui::EndGroup();
-
-        // Right padding
-        ImGui::TableSetColumnIndex(2);
-        if(right > 0.0f) ImGui::Dummy(ImVec2(right, 0));
-
-        ImGui::EndTable();
-    }
-
-    if(bottom > 0.0f) ImGui::Dummy(ImVec2(0, bottom));
-}
-
-static float
-MenuIconWidth(const char* icon)
-{
-    const float font_size = ImGui::GetFontSize();
-    if(!icon || icon[0] == '\0')
-        return font_size * MENU_NO_ICON_INDENT_EM;
-
-    ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-    return icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon).x;
-}
-
-// Pads the label with leading spaces to leave room for the left-aligned icon.
-static std::string
-MenuLabelWithIconPadding(const char* icon, const char* label)
-{
-    const float offset  = MenuIconWidth(icon) + ImGui::GetFontSize() * MENU_ICON_GAP_EM;
-    const float space_w = ImGui::CalcTextSize(" ").x;
-    const int   pad     = space_w > 0.0f ? static_cast<int>(std::ceil(offset / space_w)) : 1;
-    std::string padded(static_cast<size_t>(std::max(pad, 1)), ' ');
-    padded += label;
-    return padded;
-}
-
-// row_start is the cursor screen position captured before the menu widget.
-static void
-DrawMenuItemIcon(const char* icon, const ImVec2& row_start, bool enabled)
-{
-    if(!icon || icon[0] == '\0')
-        return;
-
-    ImFont*      icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-    const float  font_size = ImGui::GetFontSize();
-    const ImVec2 icon_size = icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon);
-    const ImVec2 pos(row_start.x, row_start.y + (font_size - icon_size.y) * 0.5f);
-    const ImU32  color = ImGui::GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled);
-
-    ImGui::GetWindowDrawList()->AddText(icon_font, font_size, pos, color, icon);
-}
-
-bool
-IconMenuItem(const char* icon, const char* label, bool enabled)
-{
-    const ImVec2 row_start    = ImGui::GetCursorScreenPos();
-    std::string  padded_label = MenuLabelWithIconPadding(icon, label);
-
-    bool clicked = ImGui::MenuItem(padded_label.c_str(), nullptr, false, enabled);
-    DrawMenuItemIcon(icon, row_start, enabled);
-
-    if(clicked)
-        ImGui::CloseCurrentPopup();
-    return clicked;
-}
-
-bool
-IconBeginMenu(const char* icon, const char* label)
-{
-    const ImVec2 row_start    = ImGui::GetCursorScreenPos();
-    std::string  padded_label = MenuLabelWithIconPadding(icon, label);
-
-    bool open = ImGui::BeginMenu(padded_label.c_str());
-    DrawMenuItemIcon(icon, row_start, true);
-
-    return open;
-}
-
-bool
-CopyableTextUnformatted(
-    const char* text, std::string_view unique_id, std::string_view notification,
-    bool one_click_copy, bool context_menu,
-                        std::function<void(const char* value_to_copy)> menu_func)
-{
-    bool clicked = false;
-    if(!unique_id.empty())
-        ImGui::PushID(unique_id.data());
-
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0, 0, 0, 0));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0, 0, 0, 0));
-    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-
-    if(ImGui::Button(text, ImVec2(0, 0)))
-    {
-        clicked = true;
-        if(one_click_copy)
-        {
-            ImGui::SetClipboardText(text);
-            if(!notification.empty())
-            {
-                NotificationManager::GetInstance().Show(notification.data(),
-                                                        NotificationLevel::Info);
-            }
-        }
-    }
-    
-    if(context_menu)
-    {
-        auto style = SettingsManager::GetInstance().GetDefaultStyle();
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
-        if (menu_func)
-        {
-            menu_func(text);
-        }
-        else if(ImGui::BeginPopupContextItem())
-        {
-            if(IconMenuItem(ICON_COPY, "Copy"))
-            {
-                ImGui::SetClipboardText(text);
-                if(!notification.empty())
-                {
-                    NotificationManager::GetInstance().Show(notification.data(),
-                                                            NotificationLevel::Info);
-                }
-            }
-            ImGui::EndPopup();
-        }
-        ImGui::PopStyleVar(2);
-    }
-
-    if(one_click_copy)
-    {
-        if(ImGui::IsItemHovered())
-        {
-            ImGui::SetMouseCursor(ImGuiMouseCursor_Hand);
-        }
-    }
-
-    ImGui::PopStyleVar();
-    ImGui::PopStyleColor(3);
-
-
-    if(!unique_id.empty())
-    {
-        ImGui::PopID();
-    }
-    return clicked;
 }
 
 PopUpStyle::PopUpStyle()

--- a/src/view/src/widgets/rocprofvis_widget.h
+++ b/src/view/src/widgets/rocprofvis_widget.h
@@ -80,32 +80,6 @@ struct TabItem
     bool                       m_can_close;
 };
 
-void
-WithPadding(float left, float right, float top, float bottom,
-            const std::function<void()>& content);
-
-// Similar to ImGui::TextUnformatted(), but allows copying the text to the clipboard
-// via left-click or a context menu.
-// If multiple instances with the same text can appear within the same frame,
-// the caller must provide a unique, stable identifier to avoid ID collisions.
-// For items created in loops, the loop index or iterator is typically sufficient.
-bool
-CopyableTextUnformatted(
-    const char* text, std::string_view unique_id = "", std::string_view notification = "",
-    bool one_click_copy = false, bool context_menu = false,
-    std::function<void(const char* value_to_copy)> menu_func = nullptr);
-
-
-// Renders a selectable menu item with an icon (from the icon font) followed by a text label.
-// Returns true when clicked. Intended for use inside BeginPopup/BeginPopupContextItem blocks.
-bool IconMenuItem(const char* icon, const char* label, bool enabled = true);
-
-// Opens a submenu entry with a leading icon (from the icon font) before the label.
-// Returns true when the submenu is open; call ImGui::EndMenu() only when it returns true.
-bool IconBeginMenu(const char* icon, const char* label);
-
-inline constexpr std::string_view COPY_DATA_NOTIFICATION = "Cell data was copied";
-
 class PopUpStyle
 {
 public:


### PR DESCRIPTION
## Motivation

In the Event Details panel, right-click behavior was inconsistent across
tables. The Flow and Call Stack tables opened their context menu when you
right-clicked anywhere in a cell, but the Arguments table only responded
when you clicked directly on the cell's text, not the surrounding cell
area. On top of that, right-clicking directly on the text in the Basic
Data, Extended Data, and Arguments tables failed to open the menu at all.

This PR makes the right-click hitbox span the full row for every Event
Details table so the interaction is predictable and consistent, and fixes
the missed right-clicks on cell text.

## Technical Details

- Made the right-click hitbox span the full row (rather than just the
  text bounds) across all Event Details tables: Basic Data, Extended
  Data, Arguments, Flow, and Call Stack.
- Fixed a bug where right-clicking directly on a cell's text did not open
  the context menu in the Basic Data, Extended Data, and Arguments tables
  by adding per-cell right-click capture.
- Refactored the duplicated context-menu scaffolding into shared helpers
  (row hit-box rendering, per-cell right-click capture, styled popup
  begin/end, and copy-menu item insertion) to remove repetition across
  the five tables.
- Replaced the multiple member variables that tracked context-menu
  row/column state with a single `CellMenuTarget` struct.
- Minor cleanup: removed unused constants and includes, and standardized
  on `COPY_DATA_NOTIFICATION` for the copy toast.