### PR TITLE
Add user-facing Log Viewer for in-app spdlog output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ set(VIEW_FILES
     src/view/src/widgets/rocprofvis_tab_container.cpp
     src/view/src/widgets/rocprofvis_editable_textfield.cpp
     src/view/src/widgets/rocprofvis_debug_window.cpp
+    src/view/src/widgets/rocprofvis_log_viewer.cpp
     src/view/src/widgets/rocprofvis_gui_helpers.cpp
     src/view/src/widgets/rocprofvis_image_helpers.cpp
     src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp

--- a/src/core/inc/rocprofvis_core.h
+++ b/src/core/inc/rocprofvis_core.h
@@ -3,7 +3,13 @@
 
 #pragma once
 
-typedef void (*rocprofvis_core_process_log_t)(void* user_ptr, char const* log);
+/* Callback for rocprofvis_core_get_log_entries_ex. Each drained entry is split
+ * into severity level (trace=0, debug=1, info=2, warn=3, error=4, critical=5),
+ * a formatted timestamp string, and the bare message text (without the level or
+ * logger-name prefix). */
+typedef void (*rocprofvis_core_process_log_entry_t)(void* user_ptr, int level,
+                                                    char const* timestamp,
+                                                    char const* message);
 
 #ifdef __cplusplus
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
@@ -14,7 +20,12 @@ extern "C"
 
     void rocprofvis_core_enable_log(const char* log_path, int log_level);
 
-    void rocprofvis_core_get_log_entries(void* user_ptr, rocprofvis_core_process_log_t handler);
+    void rocprofvis_core_get_log_entries_ex(void*                               user_ptr,
+                                            rocprofvis_core_process_log_entry_t handler);
+
+    /* Returns the path of the active log file, or an empty string if logging has
+     * not been enabled. The returned pointer is owned by the core library. */
+    const char* rocprofvis_core_get_log_path(void);
 
 #ifdef __cplusplus
 }

--- a/src/core/src/rocprofvis_core.cpp
+++ b/src/core/src/rocprofvis_core.cpp
@@ -16,11 +16,12 @@
 #include "spdlog/details/circular_q.h"
 #include "spdlog/details/log_msg_buffer.h"
 #include "spdlog/details/null_mutex.h"
+#include "spdlog/pattern_formatter.h"
 #include "spdlog/sinks/base_sink.h"
 
 #include <mutex>
 #include <string>
-#include <vector>
+#include <utility>
 
 namespace RocProfVis {
 namespace Core {
@@ -39,16 +40,31 @@ public:
         return output;
     }
 
-    std::vector<std::string> Formatted()
+    struct StructuredEntry
+    {
+        int         level;
+        std::string timestamp;
+        std::string message;
+    };
+
+    std::vector<StructuredEntry> Structured()
     {
         std::lock_guard<Mutex> lock(spdlog::sinks::base_sink<Mutex>::mutex_);
-        std::vector<std::string> ret;
+        // Time-only pattern with an empty end-of-line so the timestamp column is
+        // clean; the message body comes straight from the record payload, so it
+        // carries no level/logger prefix.
+        spdlog::pattern_formatter time_formatter("%H:%M:%S.%e",
+                                                 spdlog::pattern_time_type::local,
+                                                 std::string());
+        std::vector<StructuredEntry> ret;
         ret.reserve(m_elements.size());
         for (auto& entry : m_elements)
         {
-            spdlog::memory_buf_t formatted;
-            spdlog::sinks::base_sink<Mutex>::formatter_->format(entry, formatted);
-            ret.push_back(SPDLOG_BUF_TO_STRING(formatted));
+            spdlog::memory_buf_t time_buf;
+            time_formatter.format(entry, time_buf);
+            ret.push_back(StructuredEntry{
+                static_cast<int>(entry.level), SPDLOG_BUF_TO_STRING(time_buf),
+                std::string(entry.payload.data(), entry.payload.size()) });
         }
         m_elements.clear();
         return ret;
@@ -70,6 +86,7 @@ using BufferSinkMT = BufferSink<std::mutex>;
 }
 
 static std::weak_ptr<RocProfVis::Core::BufferSinkMT> g_rpv_log_ringbuffer;
+static std::string                                   g_rpv_log_path;
 
 extern "C"
 {
@@ -79,6 +96,11 @@ extern "C"
         if (!is_inited)
         {
             is_inited = true;
+
+            if (log_path)
+            {
+                g_rpv_log_path = log_path;
+            }
 
             std::vector<std::shared_ptr<spdlog::sinks::sink>> sinks;
             auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path, true);
@@ -115,16 +137,23 @@ extern "C"
         }
     }
 
-    void rocprofvis_core_get_log_entries(void* user_ptr, rocprofvis_core_process_log_t handler)
+    void rocprofvis_core_get_log_entries_ex(void*                               user_ptr,
+                                            rocprofvis_core_process_log_entry_t handler)
     {
         auto sink = g_rpv_log_ringbuffer.lock();
         if(handler && sink)
         {
-            auto array = sink->Formatted();
-            for (auto entry : array)
+            auto array = sink->Structured();
+            for (auto& entry : array)
             {
-                handler(user_ptr, entry.c_str());
+                handler(user_ptr, entry.level, entry.timestamp.c_str(),
+                        entry.message.c_str());
             }
         }
+    }
+
+    const char* rocprofvis_core_get_log_path(void)
+    {
+        return g_rpv_log_path.c_str();
     }
 }

--- a/src/core/src/rocprofvis_core.cpp
+++ b/src/core/src/rocprofvis_core.cpp
@@ -74,10 +74,20 @@ protected:
     void sink_it_(const spdlog::details::log_msg &msg) override
     {
         m_elements.push_back(spdlog::details::log_msg_buffer{msg});
+
+        // Bound memory if nothing drains the sink (e.g. UI idle); keep newest.
+        if (m_elements.size() > MAX_BUFFERED_ENTRIES)
+        {
+            m_elements.erase(m_elements.begin(),
+                             m_elements.begin() + (m_elements.size() / 2));
+        }
     }
     void flush_() override {}
 
 private:
+    // Hard cap on retained records when the buffer is not being drained.
+    static constexpr size_t MAX_BUFFERED_ENTRIES = 100000;
+
     std::vector<spdlog::details::log_msg_buffer> m_elements;
 };
 

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -590,6 +590,13 @@ AppWindow::WantsContinuousRender()
         return true;
     }
 
+    // Keep rendering while the log viewer is open and unpaused so new log lines
+    // appear live instead of waiting for the next input to wake the idle loop.
+    if(LogViewer::GetInstance()->IsLiveUpdating())
+    {
+        return true;
+    }
+
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     if(m_test_data_provider.GetState() == ProviderState::kLoading ||
        m_test_data_provider.GetPendingRequestCount() > 0)

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -21,6 +21,7 @@
 #include "rocprofvis_trace_view.h"
 #include "rocprofvis_view_module.h"
 #include "widgets/rocprofvis_debug_window.h"
+#include "widgets/rocprofvis_log_viewer.h"
 #include "widgets/rocprofvis_dialog.h"
 #include "widgets/rocprofvis_gui_helpers.h"
 #include "widgets/rocprofvis_widget.h"
@@ -129,6 +130,8 @@ AppWindow::~AppWindow()
     }
     m_provider_cleanup_jobs.clear();
     m_projects.clear();
+
+    LogViewer::DestroyInstance();
 }
 
 bool
@@ -568,6 +571,7 @@ AppWindow::Update()
 
     HotkeyManager::GetInstance().ProcessInput();
     EventManager::GetInstance()->DispatchEvents();
+    LogViewer::GetInstance()->Poll();
     DebugWindow::GetInstance()->ClearTransient();
     m_tab_container->Update();
 #ifdef ROCPROFVIS_DEVELOPER_MODE
@@ -692,6 +696,8 @@ AppWindow::Render()
     ImGui::PopStyleVar(3);
 
     RenderFileDialog();
+
+    LogViewer::GetInstance()->Render();
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     RenderDebugOuput();
 #endif
@@ -1055,6 +1061,10 @@ AppWindow::RenderViewMenu(Project* project)
             }
         }
         ImGui::MenuItem("Show Summary", nullptr, &settings.show_summary);
+
+        ImGui::Separator();
+        ImGui::MenuItem("Show Log Viewer", nullptr,
+                        LogViewer::GetInstance()->VisiblePtr());
         ImGui::EndMenu();
     }
 }

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -134,6 +134,12 @@ constexpr std::array DARK_THEME_COLORS = {
     IM_COL32(255, 255, 255, 40),   // Colors::kBannerBorder
     IM_COL32(255, 255, 255, 255),  // Colors::kBannerText
     IM_COL32(228, 228, 228, 255),  // Colors::kDebugNavBarBg
+    IM_COL32(150, 150, 150, 255),  // Colors::kLogTrace
+    IM_COL32(150, 180, 210, 255),  // Colors::kLogDebug
+    IM_COL32(220, 220, 220, 255),  // Colors::kLogInfo
+    IM_COL32(235, 195, 90, 255),   // Colors::kLogWarning
+    IM_COL32(235, 110, 110, 255),  // Colors::kLogError
+    IM_COL32(255, 80, 80, 255),    // Colors::kLogCritical
     // This must follow the ordering of Colors enum.
 };
 
@@ -250,6 +256,12 @@ constexpr std::array LIGHT_THEME_COLORS = {
     IM_COL32(255, 255, 255, 40),   // Colors::kBannerBorder
     IM_COL32(255, 255, 255, 255),  // Colors::kBannerText
     IM_COL32(228, 228, 228, 255),  // Colors::kDebugNavBarBg
+    IM_COL32(120, 120, 120, 255),  // Colors::kLogTrace
+    IM_COL32(60, 110, 160, 255),   // Colors::kLogDebug
+    IM_COL32(40, 40, 40, 255),     // Colors::kLogInfo
+    IM_COL32(170, 120, 0, 255),    // Colors::kLogWarning
+    IM_COL32(190, 40, 40, 255),    // Colors::kLogError
+    IM_COL32(200, 0, 0, 255),      // Colors::kLogCritical
     // This must follow the ordering of Colors enum.
 };
 // Same hue order as origin/main, desaturated for the redesign.
@@ -600,7 +612,9 @@ SettingsManager::GetContrastColormapName() const
 SettingsManager::SettingsManager()
 : m_color_store(nullptr)
 , m_usersettings_default(
-      { DisplaySettings{ false, true, 6 }, UnitSettings{ TimeFormat::kTimecode } })
+      { DisplaySettings{ false, true, 6 }, UnitSettings{ TimeFormat::kTimecode }, false,
+        false, LOG_VIEWER_MAX_ENTRIES_DEFAULT,
+        LogViewerSettings{ LOG_VIEWER_DEFAULT_LEVEL_MASK, true, false, false, false } })
 , m_usersettings(m_usersettings_default)
 , m_appwindowsettings({ AppWindowSettings{ true, true, true, true, false } })
 , m_display_dpi(1.5f)
@@ -784,6 +798,13 @@ SettingsManager::SerializeOtherSettings(jt::Json& json)
 
     os[JSON_KEY_SETTINGS_DONT_ASK_BEFORE_EXIT] = m_usersettings.dont_ask_before_exit;
     os[JSON_KEY_SETTINGS_DONT_ASK_BEFORE_TAB_CLOSE] = m_usersettings.dont_ask_before_tab_closing;
+    os[JSON_KEY_SETTINGS_LOG_VIEWER_MAX_ENTRIES] = m_usersettings.log_viewer_max_entries;
+
+    os[JSON_KEY_SETTINGS_LOG_VIEWER_LEVEL_MASK]    = m_usersettings.log_viewer.level_mask;
+    os[JSON_KEY_SETTINGS_LOG_VIEWER_AUTO_SCROLL]   = m_usersettings.log_viewer.auto_scroll;
+    os[JSON_KEY_SETTINGS_LOG_VIEWER_USE_REGEX]     = m_usersettings.log_viewer.use_regex;
+    os[JSON_KEY_SETTINGS_LOG_VIEWER_RELATIVE_TIME] = m_usersettings.log_viewer.relative_time;
+    os[JSON_KEY_SETTINGS_LOG_VIEWER_VISIBLE]       = m_usersettings.log_viewer.visible;
 }
 
 void
@@ -799,6 +820,37 @@ SettingsManager::DeserializeOtherSettings(jt::Json& json)
     {
         m_usersettings.dont_ask_before_tab_closing =
             static_cast<bool>(os[JSON_KEY_SETTINGS_DONT_ASK_BEFORE_TAB_CLOSE].getBool());
+    }
+    if(os[JSON_KEY_SETTINGS_LOG_VIEWER_MAX_ENTRIES].isLong())
+    {
+        int value = static_cast<int>(os[JSON_KEY_SETTINGS_LOG_VIEWER_MAX_ENTRIES].getLong());
+        m_usersettings.log_viewer_max_entries =
+            std::clamp(value, LOG_VIEWER_MAX_ENTRIES_MIN, LOG_VIEWER_MAX_ENTRIES_MAX);
+    }
+    if(os[JSON_KEY_SETTINGS_LOG_VIEWER_LEVEL_MASK].isLong())
+    {
+        m_usersettings.log_viewer.level_mask =
+            static_cast<int>(os[JSON_KEY_SETTINGS_LOG_VIEWER_LEVEL_MASK].getLong());
+    }
+    if(os[JSON_KEY_SETTINGS_LOG_VIEWER_AUTO_SCROLL].isBool())
+    {
+        m_usersettings.log_viewer.auto_scroll =
+            static_cast<bool>(os[JSON_KEY_SETTINGS_LOG_VIEWER_AUTO_SCROLL].getBool());
+    }
+    if(os[JSON_KEY_SETTINGS_LOG_VIEWER_USE_REGEX].isBool())
+    {
+        m_usersettings.log_viewer.use_regex =
+            static_cast<bool>(os[JSON_KEY_SETTINGS_LOG_VIEWER_USE_REGEX].getBool());
+    }
+    if(os[JSON_KEY_SETTINGS_LOG_VIEWER_RELATIVE_TIME].isBool())
+    {
+        m_usersettings.log_viewer.relative_time =
+            static_cast<bool>(os[JSON_KEY_SETTINGS_LOG_VIEWER_RELATIVE_TIME].getBool());
+    }
+    if(os[JSON_KEY_SETTINGS_LOG_VIEWER_VISIBLE].isBool())
+    {
+        m_usersettings.log_viewer.visible =
+            static_cast<bool>(os[JSON_KEY_SETTINGS_LOG_VIEWER_VISIBLE].getBool());
     }
 }
 

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -32,12 +32,25 @@ typedef struct UnitSettings
     TimeFormat time_format;
 } UnitSettings;
 
+// Persisted UI state for the log viewer window. level_mask packs one bit per
+// spdlog severity level (bit i => level i enabled).
+typedef struct LogViewerSettings
+{
+    int  level_mask;
+    bool auto_scroll;
+    bool use_regex;
+    bool relative_time;
+    bool visible;
+} LogViewerSettings;
+
 typedef struct UserSettings
 {
-    DisplaySettings display_settings;
-    UnitSettings    unit_settings;
-    bool            dont_ask_before_tab_closing;
-    bool            dont_ask_before_exit;
+    DisplaySettings   display_settings;
+    UnitSettings      unit_settings;
+    bool              dont_ask_before_tab_closing;
+    bool              dont_ask_before_exit;
+    int               log_viewer_max_entries;
+    LogViewerSettings log_viewer;
 } UserSettings;
 
 typedef struct InternalSettings
@@ -177,6 +190,14 @@ enum class Colors
     kBannerText,
     kDebugNavBarBg,
 
+    // Log viewer per-level text colors
+    kLogTrace,
+    kLogDebug,
+    kLogInfo,
+    kLogWarning,
+    kLogError,
+    kLogCritical,
+
     // Used to get the size of the enum, insert new colors before this line
     __kLastColor
 };
@@ -200,6 +221,23 @@ constexpr size_t      MAX_RECENT_FILES                       = 5;
 
 constexpr const char* JSON_KEY_SETTINGS_DONT_ASK_BEFORE_EXIT = "dont_ask_before_exit";
 constexpr const char* JSON_KEY_SETTINGS_DONT_ASK_BEFORE_TAB_CLOSE = "dont_ask_before_tab_close";
+
+constexpr const char* JSON_KEY_SETTINGS_LOG_VIEWER_MAX_ENTRIES = "log_viewer_max_entries";
+// Bounds for the log viewer's in-memory cache size. Older lines fall off the
+// ring buffer once the cap is reached; the full history lives in the log file.
+constexpr int LOG_VIEWER_MAX_ENTRIES_DEFAULT   = 512;
+constexpr int LOG_VIEWER_MAX_ENTRIES_MIN       = 64;
+constexpr int LOG_VIEWER_MAX_ENTRIES_MAX       = 100000;
+constexpr int LOG_VIEWER_MAX_ENTRIES_STEP      = 64;
+constexpr int LOG_VIEWER_MAX_ENTRIES_STEP_FAST = 512;
+
+constexpr const char* JSON_KEY_SETTINGS_LOG_VIEWER_LEVEL_MASK    = "log_viewer_level_mask";
+constexpr const char* JSON_KEY_SETTINGS_LOG_VIEWER_AUTO_SCROLL   = "log_viewer_auto_scroll";
+constexpr const char* JSON_KEY_SETTINGS_LOG_VIEWER_USE_REGEX     = "log_viewer_use_regex";
+constexpr const char* JSON_KEY_SETTINGS_LOG_VIEWER_RELATIVE_TIME = "log_viewer_relative_time";
+constexpr const char* JSON_KEY_SETTINGS_LOG_VIEWER_VISIBLE       = "log_viewer_visible";
+// All six severity levels enabled (bits 0..5).
+constexpr int LOG_VIEWER_DEFAULT_LEVEL_MASK = 0x3F;
 
 constexpr const char* JSON_KEY_SETTINGS_CATEGORY_HOTKEYS = "hotkeys";
 

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -10,12 +10,15 @@
 #include "widgets/rocprofvis_notification_manager.h"
 #include "widgets/rocprofvis_widget.h"
 
+#include <algorithm>
+
 // Layout constants
 constexpr float kCategorywidth            = 150.0f;
 constexpr float kContentwidth             = 550.0f;
 constexpr float kContentHeight            = 450.0f;
 constexpr float kHotkeyCategoryColWidth   = 90.0f;
 constexpr float kHotkeyBindingColWidth    = 120.0f;
+constexpr float kLogViewerInputWidth      = 160.0f;
 
 namespace RocProfVis
 {
@@ -345,6 +348,29 @@ SettingsPanel::RenderOtherSettings()
                     &m_usersettings.dont_ask_before_exit);
     ImGui::Checkbox("Don't ask before closing tabs",
                     &m_usersettings.dont_ask_before_tab_closing);
+
+    ImGui::Dummy(ImVec2(0.0f, ImGui::GetStyle().ItemSpacing.y));
+    ImGui::TextUnformatted("Log viewer");
+    ImGui::Separator();
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Max cached entries");
+    if(ImGui::IsItemHovered())
+    {
+        SetTooltipStyled("Number of recent log lines kept in the in-memory log viewer.\n"
+                         "Older lines fall off once the cap is reached - open the log\n"
+                         "file for the complete history. Range: %d to %d.",
+                         LOG_VIEWER_MAX_ENTRIES_MIN, LOG_VIEWER_MAX_ENTRIES_MAX);
+    }
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(kLogViewerInputWidth);
+    if(ImGui::InputInt("##log_viewer_max_entries", &m_usersettings.log_viewer_max_entries,
+                       LOG_VIEWER_MAX_ENTRIES_STEP, LOG_VIEWER_MAX_ENTRIES_STEP_FAST))
+    {
+        m_usersettings.log_viewer_max_entries =
+            std::clamp(m_usersettings.log_viewer_max_entries, LOG_VIEWER_MAX_ENTRIES_MIN,
+                       LOG_VIEWER_MAX_ENTRIES_MAX);
+    }
+
     m_settings_changed = true;
 }
 

--- a/src/view/src/widgets/rocprofvis_debug_window.cpp
+++ b/src/view/src/widgets/rocprofvis_debug_window.cpp
@@ -2,11 +2,22 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_debug_window.h"
+
 #include "imgui.h"
-#include "rocprofvis_core.h"
 #include "rocprofvis_settings_manager.h"
 
 using namespace RocProfVis::View;
+
+namespace
+{
+constexpr float DEBUG_WINDOW_DEFAULT_WIDTH  = 400.0f;
+constexpr float DEBUG_WINDOW_DEFAULT_HEIGHT = 300.0f;
+constexpr float DEBUG_WINDOW_NAV_HEIGHT     = 30.0f;
+constexpr float DEBUG_WINDOW_NAV_PADDING_X  = 10.0f;
+constexpr float DEBUG_WINDOW_NAV_PADDING_Y  = 2.0f;
+constexpr float DEBUG_WINDOW_NAV_ITEM_SPACING = 4.0f;
+constexpr float DEBUG_WINDOW_CONTENT_PADDING  = 4.0f;
+}  // namespace
 
 DebugWindow* DebugWindow::s_instance = nullptr;
 
@@ -22,112 +33,39 @@ DebugWindow::GetInstance()
 }
 
 DebugWindow::DebugWindow()
-: m_persitent_debug_messages(500)
-, m_do_h_split(false)
 {
-    // create layout
-    LayoutItem nav_bar(0, 30.0f);
+    LayoutItem nav_bar(0, DEBUG_WINDOW_NAV_HEIGHT);
     nav_bar.m_item = std::make_shared<RocCustomWidget>([this]() { this->RenderNav(); });
-    nav_bar.m_window_padding = ImVec2(10, 2);
-    nav_bar.m_item_spacing   = ImVec2(4, 4);
+    nav_bar.m_window_padding = ImVec2(DEBUG_WINDOW_NAV_PADDING_X, DEBUG_WINDOW_NAV_PADDING_Y);
+    nav_bar.m_item_spacing   = ImVec2(DEBUG_WINDOW_NAV_ITEM_SPACING, DEBUG_WINDOW_NAV_ITEM_SPACING);
     nav_bar.m_bg_color       =
         ImColor(SettingsManager::GetInstance().GetColor(Colors::kDebugNavBarBg));
 
     LayoutItem content(0, 0.0f);
+    content.m_item = std::make_shared<RocCustomWidget>([this]() { this->RenderMessages(); });
+    content.m_window_padding = ImVec2(DEBUG_WINDOW_CONTENT_PADDING, DEBUG_WINDOW_CONTENT_PADDING);
+    content.m_child_flags    = ImGuiChildFlags_None;
 
-    std::shared_ptr<RocWidget> rp =
-        std::make_shared<RocCustomWidget>([this]() { this->RenderPersitent(); });
-    std::shared_ptr<RocWidget> rt =
-        std::make_shared<RocCustomWidget>([this]() { this->RenderTransient(); });
+    std::vector<LayoutItem> layout_items;
+    layout_items.push_back(nav_bar);
+    layout_items.push_back(content);
 
-    LayoutItem::Ptr top    = std::make_shared<LayoutItem>();
-    top->m_item           = rp;
-    top->m_window_padding = ImVec2(4, 4);
-    LayoutItem::Ptr bottom  = std::make_shared<LayoutItem>();
-    bottom->m_item           = rt;
-    bottom->m_window_padding = ImVec2(4, 4);
-
-    m_v_spilt_container = std::make_shared<VSplitContainer>(top, bottom);
-    m_v_spilt_container->SetMinTopHeight(10.0f);
-    m_v_spilt_container->SetMinBottomHeight(10.0f);
-
-    LayoutItem::Ptr left     = std::make_shared<LayoutItem>();
-    left->m_item           = rt;
-    left->m_window_padding = ImVec2(4, 4);
-    LayoutItem::Ptr right     = std::make_shared<LayoutItem>();
-    right->m_item           = rp;
-    right->m_window_padding = ImVec2(4, 4);
-
-    m_h_spilt_container = std::make_shared<HSplitContainer>(left, right);
-    m_h_spilt_container->SetMinLeftWidth(10.0f);
-    m_h_spilt_container->SetMinRightWidth(10.0f);
-
-    content.m_window_padding = ImVec2(2, 0);
-    if(m_do_h_split)
-    {
-        content.m_item       = m_h_spilt_container;
-        m_split_button_label = "Split Vertically";
-    }
-    else
-    {
-        content.m_item       = m_v_spilt_container;
-        m_split_button_label = "Split Horizontally";
-    }
-    content.m_child_flags = ImGuiChildFlags_None;
-
-    std::vector<LayoutItem> layoutItems;
-    layoutItems.push_back(nav_bar);
-    layoutItems.push_back(content);
-
-    m_main_container = std::make_shared<VFixedContainer>(layoutItems);
+    m_main_container = std::make_shared<VFixedContainer>(layout_items);
 }
 
 void
 DebugWindow::RenderNav()
 {
-    if(ImGui::Button(m_split_button_label.c_str()))
+    if(ImGui::Button("Clear"))
     {
-        m_do_h_split = !m_do_h_split;
-        LayoutItem tmp(0, 0.0f);
-        tmp.m_window_padding     = ImVec2(2, 0);
-        tmp.m_child_flags = ImGuiChildFlags_None;
-
-        if(m_do_h_split)
-        {
-            tmp.m_item           = m_h_spilt_container;
-            m_split_button_label = "Split Vertically";
-        }
-        else
-        {
-            tmp.m_item           = m_v_spilt_container;
-            m_split_button_label = "Split Horizontally";
-        }
-        m_main_container->SetAt(1, tmp);
-    }
-
-    ImGui::SameLine();
-
-    if(ImGui::Button("Clear Log"))
-    {
-        ClearPersitent();
+        ClearTransient();
     }
 }
 
 void
-DebugWindow::RenderPersitent()
+DebugWindow::RenderMessages()
 {
-    ImGui::Text("Log Messages");
-    ImGui::Separator();
-    for(const std::string& message : m_persitent_debug_messages.GetContainer())
-    {
-        ImGui::TextUnformatted(message.c_str());
-    }
-}
-
-void
-DebugWindow::RenderTransient()
-{
-    ImGui::Text("Debug Window Messages");
+    ImGui::TextUnformatted("Debug Messages");
     ImGui::Separator();
     for(const std::string& message : m_transient_debug_messages)
     {
@@ -138,12 +76,11 @@ DebugWindow::RenderTransient()
 void
 DebugWindow::Render()
 {
-    rocprofvis_core_get_log_entries((void*) this, &DebugWindow::Process);
-
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
 
-    ImGui::SetNextWindowSize(ImVec2(400, 300), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(DEBUG_WINDOW_DEFAULT_WIDTH, DEBUG_WINDOW_DEFAULT_HEIGHT),
+                              ImGuiCond_FirstUseEver);
     ImGui::Begin("Debug Window", nullptr, ImGuiWindowFlags_None);
     m_main_container->Render();
     ImGui::End();
@@ -158,52 +95,7 @@ DebugWindow::AddDebugMessage(const std::string& message)
 }
 
 void
-DebugWindow::AddPersitentDebugMessage(const std::string& message)
-{
-    // escape the message so characters that could be interpreted as format specifiers and
-    // escape sequences are not interpreted by ImGui
-    std::string escaped_message;
-    escaped_message.reserve(message.size());
-    for(char c : message)
-    {
-        if(c == '\\')
-        {
-            escaped_message.push_back('\\');
-        }
-        else if(c == '%')
-        {
-            escaped_message.push_back('%');
-        }
-        escaped_message.push_back(c);
-    }
-
-    m_persitent_debug_messages.Push(escaped_message);
-}
-
-void
 DebugWindow::ClearTransient()
 {
     m_transient_debug_messages.clear();
-}
-
-void
-DebugWindow::SetMaxMessageCount(int count)
-{
-    m_persitent_debug_messages.Resize(count);
-}
-
-void
-DebugWindow::ClearPersitent()
-{
-    m_persitent_debug_messages.Clear();
-}
-
-void
-DebugWindow::Process(void* user_ptr, char const* log)
-{
-    DebugWindow* self = (DebugWindow*) user_ptr;
-    if(self && log)
-    {
-        self->AddPersitentDebugMessage(log);
-    }
 }

--- a/src/view/src/widgets/rocprofvis_debug_window.h
+++ b/src/view/src/widgets/rocprofvis_debug_window.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "rocprofvis_utils.h"
 #include "rocprofvis_split_containers.h"
 #include <string>
 #include <vector>
@@ -13,6 +12,8 @@ namespace RocProfVis
 namespace View
 {
 
+// Developer-mode scratchpad for ad-hoc debug output (e.g. per-frame variable
+// traces via AddDebugMessage). Application logs are shown in LogViewer instead.
 class DebugWindow : public RocWidget
 {
 public:
@@ -20,30 +21,19 @@ public:
 
     virtual void Render();
     void         AddDebugMessage(const std::string& message);
-    void         AddPersitentDebugMessage(const std::string& message);
 
     void ClearTransient();
-    void SetMaxMessageCount(int count);
-    void ClearPersitent();
-    
+
 private:
     DebugWindow();
-    static void Process(void* user_ptr, char const* log);
 
     void RenderNav();
-    void RenderPersitent();
-    void RenderTransient();
+    void RenderMessages();
 
-    static DebugWindow*         s_instance;
-    std::vector<std::string>    m_transient_debug_messages;
-    CircularBuffer<std::string> m_persitent_debug_messages;
+    static DebugWindow*      s_instance;
+    std::vector<std::string> m_transient_debug_messages;
 
     std::shared_ptr<VFixedContainer> m_main_container;
-    std::shared_ptr<VSplitContainer> m_v_spilt_container;
-    std::shared_ptr<HSplitContainer> m_h_spilt_container;
-
-    std::string m_split_button_label;
-    bool m_do_h_split;
 };
 
 }  // namespace View

--- a/src/view/src/widgets/rocprofvis_log_viewer.cpp
+++ b/src/view/src/widgets/rocprofvis_log_viewer.cpp
@@ -289,6 +289,12 @@ LogViewer::Poll()
     SaveUiState();
 }
 
+bool
+LogViewer::IsLiveUpdating() const
+{
+    return m_visible && !m_paused;
+}
+
 void
 LogViewer::ProcessEntry(void* user_ptr, int level, char const* timestamp,
                         char const* message)

--- a/src/view/src/widgets/rocprofvis_log_viewer.cpp
+++ b/src/view/src/widgets/rocprofvis_log_viewer.cpp
@@ -1,0 +1,814 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_log_viewer.h"
+
+#include "icons/rocprovfis_icon_defines.h"
+#include "imgui.h"
+#include "rocprofvis_core.h"
+#include "rocprofvis_gui_helpers.h"
+#include "rocprofvis_notification_manager.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cfloat>
+#include <cstdio>
+#include <functional>
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+constexpr float LOG_VIEWER_DEFAULT_WIDTH      = 720.0f;
+constexpr float LOG_VIEWER_DEFAULT_HEIGHT     = 420.0f;
+constexpr float LOG_VIEWER_MIN_WIDTH          = 360.0f;
+constexpr float LOG_VIEWER_MIN_HEIGHT         = 200.0f;
+constexpr float LOG_VIEWER_TIME_COLUMN_WIDTH  = 130.0f;
+constexpr float LOG_VIEWER_LEVEL_COLUMN_WIDTH = 80.0f;
+constexpr float LOG_VIEWER_SEARCH_WIDTH       = 240.0f;
+constexpr float LOG_VIEWER_LEVEL_COMBO_WIDTH  = 160.0f;
+constexpr int   LOG_VIEWER_TABLE_COLUMN_COUNT = 3;
+
+constexpr float LOG_VIEWER_DIM_ALPHA              = 0.4f;
+constexpr float LOG_VIEWER_SWATCH_SCALE           = 0.6f;
+constexpr float LOG_VIEWER_SWATCH_ROUNDING        = 2.0f;
+constexpr float LOG_VIEWER_SWATCH_VERTICAL_CENTER = 0.5f;
+
+constexpr float LOG_VIEWER_SCROLL_BOTTOM_EPSILON = 1.0f;
+constexpr float LOG_VIEWER_JUMP_BUTTON_INSET     = 12.0f;
+constexpr float LOG_VIEWER_SCROLL_TO_BOTTOM_Y    = 1.0f;
+
+constexpr size_t LOG_VIEWER_CLIPBOARD_RESERVE_PER_LINE = 64;
+constexpr int    LOG_VIEWER_RELATIVE_TIME_BUFFER       = 32;
+constexpr int    LOG_VIEWER_RELATIVE_TIME_DECIMALS     = 3;
+
+// Severity used when a reported level falls outside the known range.
+constexpr int LOG_VIEWER_LEVEL_INFO_INDEX = 2;
+
+#ifdef NDEBUG
+constexpr int LOG_VIEWER_MIN_VISIBLE_LEVEL = LOG_VIEWER_LEVEL_INFO_INDEX;
+#else
+constexpr int LOG_VIEWER_MIN_VISIBLE_LEVEL = 0;
+#endif
+
+constexpr const char* LEVEL_LABELS[] = { "Trace", "Debug", "Info", "Warning", "Error",
+                                         "Critical" };
+constexpr const char* MIN_LEVEL_LABELS[] = { "All levels", "Debug & up", "Info & up",
+                                             "Warning & up", "Error & up", "Critical only" };
+constexpr Colors LEVEL_COLORS[] = { Colors::kLogTrace, Colors::kLogDebug, Colors::kLogInfo,
+                                    Colors::kLogWarning, Colors::kLogError,
+                                    Colors::kLogCritical };
+
+static int
+clamped_max_entries_from_settings()
+{
+    return std::clamp(
+        SettingsManager::GetInstance().GetUserSettings().log_viewer_max_entries,
+        LOG_VIEWER_MAX_ENTRIES_MIN, LOG_VIEWER_MAX_ENTRIES_MAX);
+}
+
+static std::string
+to_lower(const std::string& input)
+{
+    std::string out = input;
+    std::transform(out.begin(), out.end(), out.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return out;
+}
+
+static bool
+icontains(const std::string& haystack, const std::string& needle_lower)
+{
+    if(needle_lower.empty())
+    {
+        return true;
+    }
+    return std::search(haystack.begin(), haystack.end(), needle_lower.begin(),
+                       needle_lower.end(),
+                       [](char hay, char needle) {
+                           return static_cast<char>(std::tolower(
+                                      static_cast<unsigned char>(hay))) == needle;
+                       }) != haystack.end();
+}
+
+// Returns true when haystack matches the active search mode; optionally fills
+// the first match span for single-line highlight rendering.
+static bool
+text_matches_search(const std::string& haystack, bool has_search, bool use_regex,
+                    const std::string& search_lower, const std::regex& regex, bool regex_ok,
+                    size_t* match_start, size_t* match_len)
+{
+    if(!has_search)
+    {
+        return true;
+    }
+    if(use_regex)
+    {
+        if(!regex_ok)
+        {
+            return true;
+        }
+        std::smatch match;
+        if(!std::regex_search(haystack, match, regex) || match.empty())
+        {
+            return false;
+        }
+        if(match_start && match_len && haystack.find('\n') == std::string::npos)
+        {
+            *match_start = static_cast<size_t>(match.position(0));
+            *match_len   = static_cast<size_t>(match.length(0));
+        }
+        return true;
+    }
+
+    if(!icontains(haystack, search_lower))
+    {
+        return false;
+    }
+
+    if(match_start && match_len && haystack.find('\n') == std::string::npos)
+    {
+        std::string lowered = to_lower(haystack);
+        size_t      pos     = lowered.find(search_lower);
+        if(pos != std::string::npos)
+        {
+            *match_start = pos;
+            *match_len   = search_lower.size();
+        }
+    }
+    return true;
+}
+
+LogViewer* LogViewer::s_instance = nullptr;
+
+LogViewer*
+LogViewer::GetInstance()
+{
+    if(!s_instance)
+    {
+        s_instance = new LogViewer();
+    }
+    return s_instance;
+}
+
+void
+LogViewer::DestroyInstance()
+{
+    delete s_instance;
+    s_instance = nullptr;
+}
+
+LogViewer::LogViewer()
+: m_entries(static_cast<size_t>(clamped_max_entries_from_settings()))
+, m_cache_capacity(clamped_max_entries_from_settings())
+, m_visible(false)
+, m_auto_scroll(true)
+, m_use_regex(false)
+, m_relative_time(false)
+, m_paused(false)
+, m_regex_error(false)
+, m_scrolled_up(false)
+, m_request_scroll_bottom(false)
+, m_counts_dirty(true)
+, m_filter_dirty(true)
+, m_applied_level_mask(0)
+, m_applied_use_regex(false)
+, m_regex_ok(true)
+, m_start_time(std::chrono::steady_clock::now())
+{
+    m_widget_name = GenUniqueName("LogViewer");
+    m_level_enabled.fill(true);
+    m_level_counts.fill(0);
+    m_search_buffer.fill('\0');
+    LoadUiState();
+}
+
+const char*
+LogViewer::LevelLabel(int level)
+{
+    if(level >= 0 && level < LEVEL_COUNT)
+    {
+        return LEVEL_LABELS[level];
+    }
+    return LEVEL_LABELS[LOG_VIEWER_LEVEL_INFO_INDEX];
+}
+
+Colors
+LogViewer::LevelColor(int level)
+{
+    if(level >= 0 && level < LEVEL_COUNT)
+    {
+        return LEVEL_COLORS[level];
+    }
+    return LEVEL_COLORS[LOG_VIEWER_LEVEL_INFO_INDEX];
+}
+
+void
+LogViewer::LoadUiState()
+{
+    const LogViewerSettings& lv = SettingsManager::GetInstance().GetUserSettings().log_viewer;
+    for(int i = 0; i < LEVEL_COUNT; ++i)
+    {
+        m_level_enabled[i] = ((lv.level_mask >> i) & 1) != 0;
+    }
+    for(int i = 0; i < LOG_VIEWER_MIN_VISIBLE_LEVEL && i < LEVEL_COUNT; ++i)
+    {
+        m_level_enabled[i] = false;
+    }
+    m_auto_scroll   = lv.auto_scroll;
+    m_use_regex     = lv.use_regex;
+    m_relative_time = lv.relative_time;
+    m_visible       = lv.visible;
+}
+
+void
+LogViewer::SaveUiState() const
+{
+    LogViewerSettings& lv   = SettingsManager::GetInstance().GetUserSettings().log_viewer;
+    const int          mask = LevelMask();
+    if(lv.level_mask == mask && lv.auto_scroll == m_auto_scroll &&
+       lv.use_regex == m_use_regex && lv.relative_time == m_relative_time &&
+       lv.visible == m_visible)
+    {
+        return;
+    }
+    lv.level_mask    = mask;
+    lv.auto_scroll   = m_auto_scroll;
+    lv.use_regex     = m_use_regex;
+    lv.relative_time = m_relative_time;
+    lv.visible       = m_visible;
+}
+
+void
+LogViewer::SyncCacheCapacity()
+{
+    int desired = clamped_max_entries_from_settings();
+    if(desired != m_cache_capacity)
+    {
+        // Resize reallocates the ring buffer, invalidating the pointers held
+        // in m_filtered, so the filtered view must be rebuilt.
+        m_entries.Resize(static_cast<size_t>(desired));
+        m_cache_capacity = desired;
+        MarkDataDirty();
+    }
+}
+
+void
+LogViewer::MarkDataDirty()
+{
+    m_counts_dirty = true;
+    m_filter_dirty = true;
+}
+
+int
+LogViewer::LevelMask() const
+{
+    int mask = 0;
+    for(int i = 0; i < LEVEL_COUNT; ++i)
+    {
+        if(m_level_enabled[i])
+        {
+            mask |= (1 << i);
+        }
+    }
+    return mask;
+}
+
+void
+LogViewer::Poll()
+{
+    SyncCacheCapacity();
+    if(!m_paused)
+    {
+        rocprofvis_core_get_log_entries_ex(this, &LogViewer::ProcessEntry);
+    }
+    SaveUiState();
+}
+
+void
+LogViewer::ProcessEntry(void* user_ptr, int level, char const* timestamp,
+                        char const* message)
+{
+    LogViewer* self = static_cast<LogViewer*>(user_ptr);
+    if(self && message)
+    {
+        self->AddEntry(level, timestamp ? timestamp : "", message);
+    }
+}
+
+void
+LogViewer::AddEntry(int level, const char* timestamp, const char* message)
+{
+    int clamped_level = std::clamp(level, 0, LEVEL_COUNT - 1);
+
+    std::string text = message;
+    while(!text.empty() && (text.back() == '\n' || text.back() == '\r'))
+    {
+        text.pop_back();
+    }
+
+    double relative_s =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - m_start_time)
+            .count();
+
+    m_entries.Push(LogEntry{ clamped_level, timestamp, std::move(text), relative_s });
+    MarkDataDirty();
+}
+
+bool*
+LogViewer::VisiblePtr()
+{
+    return &m_visible;
+}
+
+void
+LogViewer::OpenLogFile()
+{
+    const char* path = rocprofvis_core_get_log_path();
+    if(path && path[0] != '\0')
+    {
+        if(!open_url(path))
+        {
+            spdlog::warn("Failed to open log file: {}", path);
+        }
+    }
+}
+
+void
+LogViewer::RecomputeCounts()
+{
+    m_level_counts.fill(0);
+    for(const LogEntry& entry : m_entries)
+    {
+        ++m_level_counts[entry.level];
+    }
+    m_counts_dirty = false;
+}
+
+int
+LogViewer::CurrentMinLevelPreset() const
+{
+    int floor_level = -1;
+    for(int i = LOG_VIEWER_MIN_VISIBLE_LEVEL; i < LEVEL_COUNT; ++i)
+    {
+        if(m_level_enabled[i])
+        {
+            floor_level = i;
+            break;
+        }
+    }
+    if(floor_level < 0)
+    {
+        return -1;
+    }
+    for(int i = LOG_VIEWER_MIN_VISIBLE_LEVEL; i < LEVEL_COUNT; ++i)
+    {
+        if(m_level_enabled[i] != (i >= floor_level))
+        {
+            return -1;
+        }
+    }
+    return floor_level;
+}
+
+void
+LogViewer::ApplyMinLevelPreset(int floor_level)
+{
+    for(int i = 0; i < LEVEL_COUNT; ++i)
+    {
+        m_level_enabled[i] = (i >= floor_level && i >= LOG_VIEWER_MIN_VISIBLE_LEVEL);
+    }
+}
+
+std::string
+LogViewer::FormatLine(const LogEntry& entry) const
+{
+    std::string time_str =
+        m_relative_time ? RelativeTimeString(entry.relative_s) : entry.timestamp;
+    return time_str + "\t[" + LevelLabel(entry.level) + "]\t" + entry.text;
+}
+
+std::string
+LogViewer::RelativeTimeString(double relative_s) const
+{
+    char buffer[LOG_VIEWER_RELATIVE_TIME_BUFFER];
+    std::snprintf(buffer, sizeof(buffer), "+%.*fs", LOG_VIEWER_RELATIVE_TIME_DECIMALS,
+                  relative_s);
+    return buffer;
+}
+
+void
+LogViewer::CopyVisibleToClipboard() const
+{
+    std::string out;
+    out.reserve(m_filtered.size() * LOG_VIEWER_CLIPBOARD_RESERVE_PER_LINE);
+    for(const LogEntry* entry : m_filtered)
+    {
+        out += FormatLine(*entry);
+        out += '\n';
+    }
+    ImGui::SetClipboardText(out.c_str());
+    NotificationManager::GetInstance().Show("Copied " + std::to_string(m_filtered.size()) +
+                                                " visible log lines",
+                                            NotificationLevel::Info);
+}
+
+void
+LogViewer::RenderLevelToggle(int level)
+{
+    SettingsManager& settings = SettingsManager::GetInstance();
+    const bool       has_any  = m_level_counts[level] > 0;
+    const float      alpha    = has_any ? 1.0f : LOG_VIEWER_DIM_ALPHA;
+
+    const ImVec2 origin     = ImGui::GetCursorScreenPos();
+    const float  swatch     = ImGui::GetFontSize() * LOG_VIEWER_SWATCH_SCALE;
+    const float  row_height = ImGui::GetFrameHeight();
+    const float  y_offset   = (row_height - swatch) * LOG_VIEWER_SWATCH_VERTICAL_CENTER;
+    ImGui::GetWindowDrawList()->AddRectFilled(
+        ImVec2(origin.x, origin.y + y_offset),
+        ImVec2(origin.x + swatch, origin.y + y_offset + swatch),
+        ApplyAlpha(settings.GetColor(LevelColor(level)), alpha), LOG_VIEWER_SWATCH_ROUNDING);
+    ImGui::Dummy(ImVec2(swatch, row_height));
+    ImGui::SameLine();
+
+    std::string label = std::string(LevelLabel(level)) + " (" +
+                        std::to_string(m_level_counts[level]) + ")###log_lvl" +
+                        std::to_string(level);
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::ColorConvertU32ToFloat4(ApplyAlpha(
+                                             settings.GetColor(Colors::kTextMain), alpha)));
+    ImGui::Checkbox(label.c_str(), &m_level_enabled[level]);
+    ImGui::PopStyleColor();
+}
+
+void
+LogViewer::RenderLevelsPopup()
+{
+    if(ImGui::Button("Levels"))
+    {
+        ImGui::OpenPopup("##log_levels_popup");
+    }
+    if(ImGui::BeginPopup("##log_levels_popup"))
+    {
+        int         preset  = CurrentMinLevelPreset();
+        const char* preview = preset >= 0 ? MIN_LEVEL_LABELS[preset] : "Custom";
+        ImGui::SetNextItemWidth(LOG_VIEWER_LEVEL_COMBO_WIDTH);
+        PushComboStyles();
+        if(ImGui::BeginCombo("##log_min_level", preview))
+        {
+            for(int i = LOG_VIEWER_MIN_VISIBLE_LEVEL; i < LEVEL_COUNT; ++i)
+            {
+                if(ImGui::Selectable(MIN_LEVEL_LABELS[i], preset == i))
+                {
+                    ApplyMinLevelPreset(i);
+                }
+            }
+            ImGui::EndCombo();
+        }
+        PopComboStyles();
+
+        ImGui::Separator();
+        for(int level = LOG_VIEWER_MIN_VISIBLE_LEVEL; level < LEVEL_COUNT; ++level)
+        {
+            RenderLevelToggle(level);
+        }
+        ImGui::EndPopup();
+    }
+}
+
+void
+LogViewer::RenderOptionsPopup()
+{
+    SettingsManager& settings = SettingsManager::GetInstance();
+    FontManager&     fonts    = settings.GetFontManager();
+
+    ImGui::PushFont(fonts.GetFont(FontType::kIcon), ImGui::GetFontSize());
+    bool open_options = ImGui::Button(ICON_GEAR);
+    ImGui::PopFont();
+    if(ImGui::IsItemHovered())
+    {
+        SetTooltipStyled("Options");
+    }
+    if(open_options)
+    {
+        ImGui::OpenPopup("##log_options_popup");
+    }
+    if(ImGui::BeginPopup("##log_options_popup"))
+    {
+        ImGui::MenuItem("Auto-scroll", nullptr, &m_auto_scroll);
+        ImGui::MenuItem("Relative time", nullptr, &m_relative_time);
+        ImGui::MenuItem("Use regex filter", nullptr, &m_use_regex);
+        ImGui::Separator();
+        if(IconMenuItem(ICON_TRASH_CAN, "Clear"))
+        {
+            m_entries.Clear();
+            MarkDataDirty();
+        }
+        if(IconMenuItem(ICON_OPEN, "Open log file"))
+        {
+            OpenLogFile();
+        }
+        ImGui::EndPopup();
+    }
+}
+
+void
+LogViewer::RenderNav()
+{
+    SettingsManager&  settings = SettingsManager::GetInstance();
+    const ImGuiStyle& style    = ImGui::GetStyle();
+
+    struct NavItem
+    {
+        float                 width;
+        std::function<void()> render;
+    };
+    std::vector<NavItem> items;
+    items.reserve(4);
+
+    const auto button_width = [&](const char* label) {
+        return ImGui::CalcTextSize(label).x + style.FramePadding.x * 2.0f;
+    };
+
+    items.push_back({ button_width("Levels"), [this]() { RenderLevelsPopup(); } });
+
+    items.push_back({ LOG_VIEWER_SEARCH_WIDTH, [this, &settings]() {
+                         if(m_regex_error)
+                         {
+                             ImGui::PushStyleColor(ImGuiCol_FrameBg,
+                                                   settings.GetColor(Colors::kBgError));
+                         }
+                         ImGui::SetNextItemWidth(LOG_VIEWER_SEARCH_WIDTH);
+                         ImGui::InputTextWithHint("##log_search",
+                                                  m_use_regex ? "Regex filter..."
+                                                              : "Filter messages...",
+                                                  m_search_buffer.data(),
+                                                  m_search_buffer.size());
+                         if(m_regex_error)
+                         {
+                             ImGui::PopStyleColor();
+                         }
+                     } });
+
+    const float pause_width =
+        std::max(button_width("Pause"), button_width("Resume"));
+    const char* pause_label = m_paused ? "Resume" : "Pause";
+    items.push_back({ pause_width, [this, pause_label]() {
+                         if(ImGui::Button(pause_label))
+                         {
+                             m_paused = !m_paused;
+                         }
+                     } });
+
+    items.push_back({ ImGui::GetFrameHeight(), [this]() { RenderOptionsPopup(); } });
+
+    const float right_edge =
+        ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
+    for(size_t i = 0; i < items.size(); ++i)
+    {
+        if(i > 0)
+        {
+            float next_end =
+                ImGui::GetItemRectMax().x + style.ItemSpacing.x + items[i].width;
+            if(next_end < right_edge)
+            {
+                ImGui::SameLine();
+            }
+        }
+        items[i].render();
+    }
+}
+
+void
+LogViewer::RenderJumpToLatest()
+{
+    if(!(m_auto_scroll && m_scrolled_up))
+    {
+        return;
+    }
+
+    SettingsManager&  settings  = SettingsManager::GetInstance();
+    const ImGuiStyle& style     = ImGui::GetStyle();
+    const ImVec2      table_max = ImGui::GetItemRectMax();
+    const char*       label     = "Jump to latest";
+    const ImVec2      text_sz   = ImGui::CalcTextSize(label);
+    const ImVec2      button_sz(text_sz.x + style.FramePadding.x * 2.0f,
+                                text_sz.y + style.FramePadding.y * 2.0f);
+    ImGui::SetCursorScreenPos(
+        ImVec2(table_max.x - button_sz.x - LOG_VIEWER_JUMP_BUTTON_INSET,
+               table_max.y - button_sz.y - LOG_VIEWER_JUMP_BUTTON_INSET));
+    ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kAccent));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kAccentHover));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kAccentActive));
+    ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextOnAccent));
+    if(ImGui::Button(label))
+    {
+        m_request_scroll_bottom = true;
+    }
+    ImGui::PopStyleColor(4);
+}
+
+void
+LogViewer::RebuildFilter()
+{
+    const std::string search_raw = m_search_buffer.data();
+    const bool        has_search = !search_raw.empty();
+    m_search_lower               = to_lower(search_raw);
+
+    m_regex_ok = true;
+    if(has_search && m_use_regex)
+    {
+        try
+        {
+            m_regex = std::regex(search_raw, std::regex::icase | std::regex::optimize);
+        }
+        catch(const std::regex_error&)
+        {
+            m_regex_ok = false;
+        }
+    }
+    m_regex_error = has_search && m_use_regex && !m_regex_ok;
+
+    m_filtered.clear();
+    for(const LogEntry& entry : m_entries)
+    {
+        if(!m_level_enabled[entry.level])
+        {
+            continue;
+        }
+        if(!text_matches_search(entry.text, has_search, m_use_regex, m_search_lower, m_regex,
+                                m_regex_ok, nullptr, nullptr))
+        {
+            continue;
+        }
+        m_filtered.push_back(&entry);
+    }
+}
+
+void
+LogViewer::RenderTable()
+{
+    SettingsManager& settings = SettingsManager::GetInstance();
+
+    const std::string search_raw = m_search_buffer.data();
+    const int         level_mask = LevelMask();
+    if(m_filter_dirty || level_mask != m_applied_level_mask ||
+       m_use_regex != m_applied_use_regex || search_raw != m_applied_search)
+    {
+        RebuildFilter();
+        m_filter_dirty       = false;
+        m_applied_level_mask = level_mask;
+        m_applied_use_regex  = m_use_regex;
+        m_applied_search     = search_raw;
+    }
+
+    const bool has_search = !search_raw.empty();
+
+    constexpr ImGuiTableFlags table_flags =
+        ImGuiTableFlags_ScrollY | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerH |
+        ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp;
+
+    const ImVec2 table_size = ImVec2(0.0f, ImGui::GetContentRegionAvail().y);
+
+    if(ImGui::BeginTable("##log_viewer_table", LOG_VIEWER_TABLE_COLUMN_COUNT, table_flags,
+                         table_size))
+    {
+        ImGui::TableSetupColumn(m_relative_time ? "Elapsed" : "Time",
+                                ImGuiTableColumnFlags_WidthFixed,
+                                LOG_VIEWER_TIME_COLUMN_WIDTH);
+        ImGui::TableSetupColumn("Level", ImGuiTableColumnFlags_WidthFixed,
+                                LOG_VIEWER_LEVEL_COLUMN_WIDTH);
+        ImGui::TableSetupColumn("Message", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupScrollFreeze(0, 1);
+        ImGui::TableHeadersRow();
+
+        const ImU32 text_main       = settings.GetColor(Colors::kTextMain);
+        const ImU32 highlight_color = settings.GetColor(Colors::kEventSearchHighlight);
+        const ImVec4 text_main_vec  = ImGui::ColorConvertU32ToFloat4(text_main);
+
+        ImGuiListClipper clipper;
+        clipper.Begin(static_cast<int>(m_filtered.size()));
+        while(clipper.Step())
+        {
+            for(int row = clipper.DisplayStart; row < clipper.DisplayEnd; ++row)
+            {
+                const LogEntry* entry = m_filtered[row];
+                ImGui::TableNextRow();
+
+                ImGui::TableSetColumnIndex(0);
+                ImGui::PushStyleColor(ImGuiCol_Text, text_main_vec);
+                const std::string& time_str = m_relative_time
+                                                  ? RelativeTimeString(entry->relative_s)
+                                                  : entry->timestamp;
+                ImGui::TextUnformatted(time_str.c_str());
+                ImGui::PopStyleColor();
+
+                ImGui::TableSetColumnIndex(1);
+                ImGui::PushStyleColor(
+                    ImGuiCol_Text,
+                    ImGui::ColorConvertU32ToFloat4(settings.GetColor(LevelColor(entry->level))));
+                ImGui::TextUnformatted(LevelLabel(entry->level));
+                ImGui::PopStyleColor();
+
+                ImGui::TableSetColumnIndex(2);
+                ImGui::PushStyleColor(ImGuiCol_Text, text_main_vec);
+
+                size_t match_start = std::string::npos;
+                size_t match_len   = 0;
+                if(has_search)
+                {
+                    text_matches_search(entry->text, has_search, m_use_regex, m_search_lower,
+                                        m_regex, m_regex_ok, &match_start, &match_len);
+                }
+
+                if(match_start != std::string::npos && match_len > 0)
+                {
+                    ImVec2 pos = ImGui::GetCursorScreenPos();
+                    float  x0  = pos.x +
+                                ImGui::CalcTextSize(
+                                    entry->text.substr(0, match_start).c_str())
+                                    .x;
+                    float x1 = pos.x +
+                               ImGui::CalcTextSize(
+                                   entry->text.substr(0, match_start + match_len).c_str())
+                                   .x;
+                    ImGui::GetWindowDrawList()->AddRectFilled(
+                        ImVec2(x0, pos.y),
+                        ImVec2(x1, pos.y + ImGui::GetTextLineHeight()), highlight_color);
+                }
+
+                CopyableTextUnformatted(
+                    entry->text.c_str(), std::to_string(row), COPY_DATA_NOTIFICATION,
+                    false, true, [this, entry](const char* value) {
+                        if(ImGui::BeginPopupContextItem())
+                        {
+                            if(IconMenuItem(ICON_COPY, "Copy message"))
+                            {
+                                ImGui::SetClipboardText(value);
+                                NotificationManager::GetInstance().Show(
+                                    "Message copied", NotificationLevel::Info);
+                            }
+                            if(IconMenuItem(ICON_COPY, "Copy line"))
+                            {
+                                ImGui::SetClipboardText(FormatLine(*entry).c_str());
+                                NotificationManager::GetInstance().Show(
+                                    "Log line copied", NotificationLevel::Info);
+                            }
+                            if(IconMenuItem(ICON_LIST, "Copy all visible"))
+                            {
+                                CopyVisibleToClipboard();
+                            }
+                            ImGui::EndPopup();
+                        }
+                    });
+                ImGui::PopStyleColor();
+            }
+        }
+
+        m_scrolled_up = (ImGui::GetScrollMaxY() - ImGui::GetScrollY()) >
+                        LOG_VIEWER_SCROLL_BOTTOM_EPSILON;
+        if(m_request_scroll_bottom || (m_auto_scroll && !m_scrolled_up))
+        {
+            ImGui::SetScrollHereY(LOG_VIEWER_SCROLL_TO_BOTTOM_Y);
+            m_scrolled_up = false;
+        }
+        m_request_scroll_bottom = false;
+
+        ImGui::EndTable();
+    }
+
+    RenderJumpToLatest();
+}
+
+void
+LogViewer::Render()
+{
+    if(!m_visible)
+    {
+        return;
+    }
+
+    if(m_counts_dirty)
+    {
+        RecomputeCounts();
+    }
+
+    ImGui::SetNextWindowSize(
+        ImVec2(LOG_VIEWER_DEFAULT_WIDTH, LOG_VIEWER_DEFAULT_HEIGHT),
+        ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSizeConstraints(
+        ImVec2(LOG_VIEWER_MIN_WIDTH, LOG_VIEWER_MIN_HEIGHT), ImVec2(FLT_MAX, FLT_MAX));
+    if(ImGui::Begin("Log Viewer", &m_visible))
+    {
+        RenderNav();
+        ImGui::Separator();
+        RenderTable();
+    }
+    ImGui::End();
+}
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/widgets/rocprofvis_log_viewer.h
+++ b/src/view/src/widgets/rocprofvis_log_viewer.h
@@ -1,0 +1,132 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocprofvis_settings_manager.h"
+#include "rocprofvis_utils.h"
+#include "rocprofvis_widget.h"
+
+#include <array>
+#include <chrono>
+#include <regex>
+#include <string>
+#include <vector>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+// User-facing log viewer. Mirrors the application's spdlog output (the same
+// stream written to the on-disk log file) into a virtualized, filterable,
+// color-coded table. Drains entries from the core logger via
+// rocprofvis_core_get_log_entries_ex.
+class LogViewer : public RocWidget
+{
+public:
+    // Number of spdlog severity levels the viewer distinguishes
+    // (trace, debug, info, warn, error, critical).
+    static constexpr int LEVEL_COUNT = 6;
+    static constexpr int SEARCH_BUFFER_SIZE = 256;
+
+    static LogViewer* GetInstance();
+    static void       DestroyInstance();
+
+    // Drains pending entries from the core logger. Call once per frame so log
+    // history keeps accumulating even while the window is hidden.
+    void Poll();
+
+    void Render() override;
+
+    bool* VisiblePtr();
+
+private:
+    LogViewer();
+
+    struct LogEntry
+    {
+        int         level;
+        std::string timestamp;  // wall-clock string from the core logger
+        std::string text;
+        double      relative_s = 0.0;  // seconds since the viewer started
+    };
+
+    static void        ProcessEntry(void* user_ptr, int level, char const* timestamp,
+                                    char const* message);
+    static const char* LevelLabel(int level);
+    static Colors      LevelColor(int level);
+
+    void AddEntry(int level, const char* timestamp, const char* message);
+
+    // Resizes the in-memory ring buffer to match the user-configured cache
+    // size when it changes. Cheap no-op when already in sync.
+    void SyncCacheCapacity();
+
+    // Invalidates the cached per-level counts and filtered view; call whenever
+    // the entry buffer changes (new entry, clear, capacity resize).
+    void MarkDataDirty();
+    void RecomputeCounts();
+
+    // Bitmask of the currently enabled severity levels (bit i == level i).
+    int  LevelMask() const;
+
+    // Rebuilds m_filtered and the cached search/regex state from the current
+    // entries and filter inputs. Only invoked when an input actually changed.
+    void RebuildFilter();
+
+    // Maps the current per-level checkbox state onto a "show this severity and
+    // above" preset, or -1 when the selection is custom.
+    int  CurrentMinLevelPreset() const;
+    void ApplyMinLevelPreset(int floor_level);
+
+    std::string FormatLine(const LogEntry& entry) const;
+    std::string RelativeTimeString(double relative_s) const;
+    void        CopyVisibleToClipboard() const;
+
+    // Mirrors the live UI toggles to/from the persisted user settings so the
+    // viewer remembers its state across sessions.
+    void LoadUiState();
+    void SaveUiState() const;
+
+    void RenderNav();
+    void RenderLevelsPopup();
+    void RenderLevelToggle(int level);
+    void RenderOptionsPopup();
+    void RenderJumpToLatest();
+    void RenderTable();
+    void OpenLogFile();
+
+    static LogViewer* s_instance;
+
+    CircularBuffer<LogEntry>      m_entries;
+    int                           m_cache_capacity;
+    std::array<bool, LEVEL_COUNT> m_level_enabled;
+    std::array<int, LEVEL_COUNT>  m_level_counts;
+    std::vector<const LogEntry*>  m_filtered;
+    std::array<char, SEARCH_BUFFER_SIZE> m_search_buffer;
+    bool                          m_visible;
+    bool                          m_auto_scroll;
+    bool                          m_use_regex;
+    bool                          m_relative_time;
+    bool                          m_paused;
+    bool                          m_regex_error;
+    bool                          m_scrolled_up;
+    bool                          m_request_scroll_bottom;
+    bool                          m_counts_dirty;
+
+    // Cached filter state. m_filtered is recomputed only when one of the
+    // applied-* values diverges from the live inputs (see RenderTable).
+    bool        m_filter_dirty;
+    int         m_applied_level_mask;
+    bool        m_applied_use_regex;
+    std::string m_applied_search;
+    std::string m_search_lower;  // lowercased search for substring matching
+    std::regex  m_regex;         // compiled when use_regex && search non-empty
+    bool        m_regex_ok;
+
+    std::chrono::steady_clock::time_point m_start_time;
+};
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/widgets/rocprofvis_log_viewer.h
+++ b/src/view/src/widgets/rocprofvis_log_viewer.h
@@ -41,6 +41,11 @@ public:
 
     bool* VisiblePtr();
 
+    // True when the viewer should refresh live. Used to keep the app out of its
+    // idle sleep (glfwWaitEvents) so logs appear without needing mouse/keyboard
+    // input. False while hidden or paused, so the app can sleep normally.
+    bool IsLiveUpdating() const;
+
 private:
     LogViewer();
 


### PR DESCRIPTION
## Motivation

Give users an in-app way to read, filter, and search the application's logs
instead of opening the on-disk spdlog file.

## Technical Details

Adds a `LogViewer` widget that mirrors the spdlog stream into a virtualized,
filterable, color-coded table reachable from the main UI:

- Per-level filtering with counts and a min-level preset (Trace/Debug hidden in
  release)
- Substring/regex search with highlighting
- Pause capture, auto-scroll + "jump to latest", absolute/relative timestamps
- Copy message/line/all-visible and open the log file
- Configurable cache size and persisted UI state via `LogViewerSettings`

`DebugWindow` is reduced to a developer-only scratchpad.