### PR TITLE
Fix track options icon disappearing when submenu is open

### DIFF
--- a/src/view/src/widgets/rocprofvis_widget.cpp
+++ b/src/view/src/widgets/rocprofvis_widget.cpp
@@ -130,9 +130,10 @@ MenuLabelWithIconPadding(const char* icon, const char* label)
     return padded;
 }
 
-// row_start is the cursor screen position captured before the menu widget.
+// Pass the parent menu's draw list, captured before BeginMenu opens a submenu
+// and retargets the current window's draw list.
 static void
-DrawMenuItemIcon(const char* icon, const ImVec2& row_start, bool enabled)
+DrawMenuItemIcon(ImDrawList* draw_list, const char* icon, const ImVec2& row_start, bool enabled)
 {
     if(!icon || icon[0] == '\0')
         return;
@@ -143,17 +144,18 @@ DrawMenuItemIcon(const char* icon, const ImVec2& row_start, bool enabled)
     const ImVec2 pos(row_start.x, row_start.y + (font_size - icon_size.y) * 0.5f);
     const ImU32  color = ImGui::GetColorU32(enabled ? ImGuiCol_Text : ImGuiCol_TextDisabled);
 
-    ImGui::GetWindowDrawList()->AddText(icon_font, font_size, pos, color, icon);
+    draw_list->AddText(icon_font, font_size, pos, color, icon);
 }
 
 bool
 IconMenuItem(const char* icon, const char* label, bool enabled)
 {
+    ImDrawList*  draw_list    = ImGui::GetWindowDrawList();
     const ImVec2 row_start    = ImGui::GetCursorScreenPos();
     std::string  padded_label = MenuLabelWithIconPadding(icon, label);
 
     bool clicked = ImGui::MenuItem(padded_label.c_str(), nullptr, false, enabled);
-    DrawMenuItemIcon(icon, row_start, enabled);
+    DrawMenuItemIcon(draw_list, icon, row_start, enabled);
 
     if(clicked)
         ImGui::CloseCurrentPopup();
@@ -163,11 +165,12 @@ IconMenuItem(const char* icon, const char* label, bool enabled)
 bool
 IconBeginMenu(const char* icon, const char* label)
 {
+    ImDrawList*  draw_list    = ImGui::GetWindowDrawList();
     const ImVec2 row_start    = ImGui::GetCursorScreenPos();
     std::string  padded_label = MenuLabelWithIconPadding(icon, label);
 
     bool open = ImGui::BeginMenu(padded_label.c_str());
-    DrawMenuItemIcon(icon, row_start, true);
+    DrawMenuItemIcon(draw_list, icon, row_start, true);
 
     return open;
 }


### PR DESCRIPTION
## Motivation

Hotfix for a regression: the gear icon next to "Track Options" disappeared while its submenu was open.

## Technical Details

`IconBeginMenu` drew the icon after `ImGui::BeginMenu`, so when the submenu was open `GetWindowDrawList()` returned the submenu popup's draw list and the icon was clipped out of the parent menu. Capture the parent menu's draw list before `BeginMenu` and draw into it explicitly.