### PR TITLE
Bundle MoltenVK driver + ICD manifest into macOS app

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -173,9 +173,20 @@ jobs:
             exit 1
           fi
 
+          MOLTENVK_LIB="${VULKAN_SDK_DIR}/lib/libMoltenVK.dylib"
+          if [ ! -f "${MOLTENVK_LIB}" ]; then
+            MOLTENVK_LIB=$(find "${VULKAN_SDK_DIR}/lib" -maxdepth 1 -name 'libMoltenVK*.dylib' | sort | head -1)
+          fi
+          if [ -z "${MOLTENVK_LIB}" ] || [ ! -f "${MOLTENVK_LIB}" ]; then
+            echo "MoltenVK library not found under ${VULKAN_SDK_DIR}/lib"
+            ls -la "${VULKAN_SDK_DIR}/lib" || true
+            exit 1
+          fi
+
           echo "VULKAN_SDK=${VULKAN_SDK_DIR}" >> "${GITHUB_ENV}"
           echo "Vulkan_INCLUDE_DIR=${VULKAN_SDK_DIR}/include" >> "${GITHUB_ENV}"
           echo "Vulkan_LIBRARY=${VULKAN_LIB}" >> "${GITHUB_ENV}"
+          echo "MoltenVK_LIBRARY=${MOLTENVK_LIB}" >> "${GITHUB_ENV}"
           if [ -d "${VULKAN_SDK_DIR}/bin" ]; then
             echo "PATH=${VULKAN_SDK_DIR}/bin:${PATH}" >> "${GITHUB_ENV}"
           fi
@@ -187,14 +198,24 @@ jobs:
       - name: Build, Make, and Verify Installation
         run: |
           mkdir -p ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}
-          cmake -B ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }} --preset "${{ inputs.cmake_config_preset }}" -DROCPROFVIS_ENABLE_INTERNAL_BANNER=${{ env.ENABLE_INTERNAL_BANNER }}  -DVulkan_INCLUDE_DIR="$Vulkan_INCLUDE_DIR" -DVulkan_LIBRARY="$Vulkan_LIBRARY"
+          cmake -B ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }} --preset "${{ inputs.cmake_config_preset }}" -DROCPROFVIS_ENABLE_INTERNAL_BANNER=${{ env.ENABLE_INTERNAL_BANNER }}  -DVulkan_INCLUDE_DIR="$Vulkan_INCLUDE_DIR" -DVulkan_LIBRARY="$Vulkan_LIBRARY" -DROCPROFVIS_MOLTENVK_LIBRARY="$MoltenVK_LIBRARY"
           cmake --build ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }} --preset "${{ inputs.cmake_build_preset }}" --parallel 4 --target package
           ls -l ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}
 
-          if [ -d "${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BUILD_FILE_NAME }}.app" ]; then
+          APP="${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}/${{ env.BUILD_FILE_NAME }}.app"
+          if [ -d "${APP}" ]; then
             echo "✅ ${{ env.BUILD_FILE_NAME }}.app has been successfully built!"
           else
             echo "❌ ${{ env.BUILD_FILE_NAME }}.app was not built!"
+            exit 1
+          fi
+
+          MVK="${APP}/Contents/Frameworks/libMoltenVK.dylib"
+          ICD="${APP}/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
+          if [ -f "${MVK}" ] && [ -f "${ICD}" ]; then
+            echo "MoltenVK driver and ICD manifest bundled into the app"
+          else
+            echo "MoltenVK was not bundled (missing ${MVK} or ${ICD})"
             exit 1
           fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,31 @@ plist allows dlopen of the LunarG-signed dylib under Hardened Runtime.")
                 "was not found. Set Vulkan_LIBRARY to the SDK libvulkan.dylib.")
         endif()
 
+        set(ROCPROFVIS_MOLTENVK_LIBRARY "" CACHE FILEPATH
+            "Path to libMoltenVK.dylib to bundle into the macOS app. \
+Auto-detected from the Vulkan SDK / Homebrew when empty.")
+        if(NOT ROCPROFVIS_MOLTENVK_LIBRARY)
+            foreach(_mvk_dir
+                    "${ROCPROFVIS_VULKAN_LOADER_DIR}"
+                    "$ENV{VULKAN_SDK}/lib"
+                    "/opt/homebrew/lib"
+                    "/usr/local/lib")
+                if(_mvk_dir AND EXISTS "${_mvk_dir}/libMoltenVK.dylib")
+                    set(ROCPROFVIS_MOLTENVK_LIBRARY "${_mvk_dir}/libMoltenVK.dylib")
+                    break()
+                endif()
+            endforeach()
+        endif()
+        if(ROCPROFVIS_MOLTENVK_LIBRARY AND EXISTS "${ROCPROFVIS_MOLTENVK_LIBRARY}")
+            message(STATUS "Bundling MoltenVK from ${ROCPROFVIS_MOLTENVK_LIBRARY}")
+        else()
+            message(WARNING
+                "MoltenVK (libMoltenVK.dylib) was not found, so the bundled app "
+                "will rely on a system Vulkan driver at runtime (LunarG SDK or "
+                "'brew install molten-vk') or fall back to OpenGL. Set "
+                "ROCPROFVIS_MOLTENVK_LIBRARY to bundle the driver.")
+        endif()
+
     endif()
 
     set_target_properties(${TARGET_NAME} PROPERTIES
@@ -303,6 +328,21 @@ plist allows dlopen of the LunarG-signed dylib under Hardened Runtime.")
                 "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>/Contents/Resources/Licenses/Vulkan-Loader-LICENSE.txt"
             COMMENT "Staging Vulkan loader and license into the app bundle"
         )
+        if(ROCPROFVIS_MOLTENVK_LIBRARY AND EXISTS "${ROCPROFVIS_MOLTENVK_LIBRARY}")
+            add_custom_command(
+                TARGET ${TARGET_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E make_directory
+                    "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>/Contents/Frameworks"
+                    "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>/Contents/Resources/vulkan/icd.d"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${ROCPROFVIS_MOLTENVK_LIBRARY}"
+                    "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>/Contents/Frameworks/libMoltenVK.dylib"
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "${CMAKE_CURRENT_SOURCE_DIR}/resources/mac/MoltenVK_icd.json"
+                    "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>/Contents/Resources/vulkan/icd.d/MoltenVK_icd.json"
+                COMMENT "Staging MoltenVK driver and ICD manifest into the app bundle"
+            )
+        endif()
     endif()
 
     set(ROCPROFVIS_MACOS_CODESIGN_IDENTITY "" CACHE STRING
@@ -332,6 +372,7 @@ plist allows dlopen of the LunarG-signed dylib under Hardened Runtime.")
             COMMAND codesign --verify --verbose=2
                 "$<TARGET_BUNDLE_DIR:${TARGET_NAME}>"
             COMMENT "Codesigning bundle with identity '${ROCPROFVIS_MACOS_CODESIGN_IDENTITY}'"
+            VERBATIM
         )
     endif()
 endif()

--- a/resources/mac/MoltenVK_icd.json
+++ b/resources/mac/MoltenVK_icd.json
@@ -1,0 +1,8 @@
+{
+    "file_format_version": "1.0.0",
+    "ICD": {
+        "library_path": "../../../Frameworks/libMoltenVK.dylib",
+        "api_version": "1.2.0",
+        "is_portability_driver": true
+    }
+}

--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -300,6 +300,10 @@ main(int argc, char** argv)
         }
     }
 
+#ifdef __APPLE__
+    RocProfVis::Platform::configure_bundled_vulkan_icd();
+#endif
+
     glfwSetErrorCallback(glfw_error_callback);
 #ifdef __linux__
     // Force X11 on Linux for multi-viewport and window positioning support

--- a/src/app/src/rocprofvis_platform_helpers.h
+++ b/src/app/src/rocprofvis_platform_helpers.h
@@ -31,5 +31,11 @@ struct ModifierState
 ModifierState
 get_os_modifier_state();
 
+// macOS only. Points the Vulkan loader (VK_ICD_FILENAMES / VK_DRIVER_FILES) at
+// the MoltenVK ICD manifest bundled in the .app. No-op if the manifest is
+// missing or either variable is already set. Call before Vulkan/GLFW init.
+void
+configure_bundled_vulkan_icd();
+
 }  // namespace Platform
 }  // namespace RocProfVis

--- a/src/app/src/rocprofvis_platform_helpers_macos.mm
+++ b/src/app/src/rocprofvis_platform_helpers_macos.mm
@@ -4,6 +4,9 @@
 #include "rocprofvis_platform_helpers.h"
 
 #import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+#include <cstdlib>
 
 namespace RocProfVis
 {
@@ -24,6 +27,35 @@ get_os_modifier_state()
     state.alt   = (flags & NSEventModifierFlagOption) != 0;
     state.super = (flags & NSEventModifierFlagCommand) != 0;
     return state;
+}
+
+void
+configure_bundled_vulkan_icd()
+{
+    @autoreleasepool
+    {
+        if(getenv("VK_ICD_FILENAMES") != nullptr || getenv("VK_DRIVER_FILES") != nullptr)
+        {
+            return;
+        }
+
+        NSURL* icd = [[NSBundle mainBundle] URLForResource:@"MoltenVK_icd"
+                                             withExtension:@"json"
+                                              subdirectory:@"vulkan/icd.d"];
+        if(icd == nil)
+        {
+            return;
+        }
+
+        const char* path = [[icd path] fileSystemRepresentation];
+        if(path == nullptr)
+        {
+            return;
+        }
+
+        setenv("VK_ICD_FILENAMES", path, 1);
+        setenv("VK_DRIVER_FILES", path, 1);
+    }
 }
 
 }  // namespace Platform


### PR DESCRIPTION
This change fixes Vulkan failing to start on Macs that don't have the LunarG SDK installed: the .app bundled only the Vulkan loader (libvulkan.1.dylib) but no actual driver, so the loader had no MoltenVK (the Vulkan→Metal translator) to hand off to and initialization failed. The fix bundles libMoltenVK.dylib plus an ICD manifest (MoltenVK_icd.json, which points at the driver via a relocatable relative path) into the app at build time — wired up in CMakeLists.txt (with MoltenVK auto-detection from the SDK/Homebrew) and ci-mac.yml (locating the lib, passing it to CMake, and verifying it got bundled) — and at startup a new macOS helper configure_bundled_vulkan_icd() points the loader at that bundled manifest via the VK_ICD_FILENAMES/VK_DRIVER_FILES environment variables (called early in main.cpp, and a no-op if those vars are already set or the manifest is absent). It also slips in an unrelated CMake hardening fix: adding VERBATIM to the codesign command so signing identities containing spaces or parentheses don't corrupt the generated shell command.