### PR TITLE
Fix track reorder preview clamping and auto-scroll stalls

### DIFF
--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -74,6 +74,7 @@ TimelineView::TimelineView(DataProvider&                          dp,
 , m_unload_track_distance(LOADING_TRACK_DISTANCE)
 , m_sidebar_size(SIDEBAR_DEFAULT_SIZE)
 , m_resize_activity(false)
+, m_reorder_auto_scrolling(false)
 , m_highlighted_region({ TimelineSelection::INVALID_SELECTION_TIME,
                          TimelineSelection::INVALID_SELECTION_TIME })
 , m_new_track_token(EventManager::InvalidSubscriptionToken)
@@ -1298,6 +1299,9 @@ TimelineView::RenderGraphView()
 
     bool request_data = IsRequestDataNeeded();
 
+    // Re-set each frame by RenderReorderingTrack while in the auto-scroll zone.
+    m_reorder_auto_scrolling = false;
+
     for(int index = 0; index < m_graphs->size(); index++)
     {
         RenderTrack(index, request_data, window_flags, container_size);
@@ -1313,7 +1317,8 @@ TimelineView::WantsContinuousRender() const
 {
     // The loading-timer debounce gates track-data requests and only advances
     // while rendering, so keep rendering until it expires or the load stalls.
-    return m_loading_timer.IsRunning();
+    // Reorder auto-scroll also advances per frame, so keep rendering while active.
+    return m_loading_timer.IsRunning() || m_reorder_auto_scrolling;
 }
 
 bool
@@ -1692,6 +1697,7 @@ TimelineView::RenderReorderingTrack(TrackItem* track_item, ImVec2 container_size
                 std::min(1.0f, (container_size.y * REORDER_AUTO_SCROLL_THRESHOLD -
                                 mouse_relative_pos.y) /
                                    (container_size.y * REORDER_AUTO_SCROLL_THRESHOLD)));
+        m_reorder_auto_scrolling = true;
     }
     else if(mouse_relative_pos.y > container_size.y * (1 - REORDER_AUTO_SCROLL_THRESHOLD))
     {
@@ -1701,6 +1707,7 @@ TimelineView::RenderReorderingTrack(TrackItem* track_item, ImVec2 container_size
                 std::min(1.0f, (mouse_relative_pos.y -
                                 container_size.y * (1 - REORDER_AUTO_SCROLL_THRESHOLD)) /
                                    (container_size.y * REORDER_AUTO_SCROLL_THRESHOLD)));
+        m_reorder_auto_scrolling = true;
     }
     m_scroll_position_y = ImGui::GetScrollY();
 }

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1657,9 +1657,17 @@ TimelineView::RenderReorderingTrack(TrackItem* track_item, ImVec2 container_size
     ImVec2 mouse_pos          = ImGui::GetMousePos();
     ImVec2 mouse_relative_pos = mouse_pos - graph_view_pos;
 
-    ImGui::SetNextWindowPos(
-        ImVec2(graph_view_pos.x, mouse_pos.y - ImGui::GetFrameHeight() / 2),
-        ImGuiCond_Always);
+    // Clamp the preview within the track area so it never renders outside its
+    // box when the mouse moves above or below the visible track region.
+    const float track_height = track_item->GetTrackHeight();
+    const float view_height  = container_size.y - m_ruler_height;
+    const float preview_min_y = graph_view_pos.y;
+    const float preview_max_y =
+        std::max(preview_min_y, graph_view_pos.y + view_height - track_height);
+    const float preview_y = std::clamp(mouse_pos.y - ImGui::GetFrameHeight() / 2,
+                                       preview_min_y, preview_max_y);
+
+    ImGui::SetNextWindowPos(ImVec2(graph_view_pos.x, preview_y), ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
     if(ImGui::Begin(
            "##ReorderPreview", nullptr,

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -188,6 +188,7 @@ private:
     double                              m_previous_scroll_position;
     bool                                m_meta_map_made;
     bool                                m_resize_activity;
+    bool                                m_reorder_auto_scrolling;
     double                              m_last_data_req_v_width;
     float                               m_unload_track_distance;
     DataProvider&                       m_data_provider;


### PR DESCRIPTION
## Motivation

When dragging a track to reorder it, the floating preview ("ghost") could
render outside the timeline track area when the mouse moved above or below
the track region, even though the drop still worked. Separately, the
reorder auto-scroll would stall when the mouse was held still in the
top/bottom auto-scroll zone, requiring a mouse nudge to resume.

## Technical Details

- Clamp the reorder preview's Y position in `TimelineView::RenderReorderingTrack`
  so its top/bottom stay within the visible track region instead of following
  the raw mouse position.
- The app renders on-demand, so auto-scroll (which advances per frame) froze
  when no new frames were drawn. Added an `m_reorder_auto_scrolling` flag set
  while in the auto-scroll zone and reported via `WantsContinuousRender()`, so
  frames keep coming and scrolling continues smoothly while the mouse is still.