### PR TITLE
Store macOS settings under ~/Library/Application Support

### DIFF
--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -240,14 +240,14 @@ main(int argc, char** argv)
         return app_result_code;
     }
 
-    std::string config_path = rocprofvis_get_application_config_path();
+    std::string log_dir = rocprofvis_get_application_log_path();
 #ifndef NDEBUG
     std::filesystem::path log_path =
-        std::filesystem::path(config_path) / "roc-optiq.debug.log";
+        std::filesystem::path(log_dir) / "roc-optiq.debug.log";
     rocprofvis_core_enable_log(log_path.string().c_str(), spdlog::level::debug);
 #else
     std::filesystem::path log_path =
-        std::filesystem::path(config_path) / "roc-optiq.log";
+        std::filesystem::path(log_dir) / "roc-optiq.log";
     rocprofvis_core_enable_log(log_path.string().c_str(), spdlog::level::info);
 #endif
 

--- a/src/view/inc/rocprofvis_view_module.h
+++ b/src/view/inc/rocprofvis_view_module.h
@@ -61,6 +61,9 @@ rocprofvis_view_set_texture_backend(
 std::string
 rocprofvis_get_application_config_path();
 
+std::string
+rocprofvis_get_application_log_path();
+
 bool
 rocprofvis_view_is_remote_display_session();
 

--- a/src/view/src/rocprofvis_utils.cpp
+++ b/src/view/src/rocprofvis_utils.cpp
@@ -419,6 +419,26 @@ RocProfVis::View::get_application_config_path(bool create_dirs)
 }
 
 std::string
+RocProfVis::View::get_application_log_path(bool create_dirs)
+{
+#ifdef __APPLE__
+    std::filesystem::path home = sanitize_base_dir(safe_getenv("HOME"));
+    std::filesystem::path log_dir =
+        !home.empty() ? (home / "Library" / "Logs") : std::filesystem::current_path();
+    log_dir /= "ROCm-Optiq";
+    log_dir = log_dir.lexically_normal();
+    if(create_dirs)
+    {
+        std::filesystem::create_directories(log_dir);
+    }
+
+    return log_dir.string();
+#else
+    return get_application_config_path(create_dirs);
+#endif
+}
+
+std::string
 RocProfVis::View::compact_number_format(double number)
 {
     if(!std::isfinite(number))

--- a/src/view/src/rocprofvis_utils.cpp
+++ b/src/view/src/rocprofvis_utils.cpp
@@ -393,6 +393,12 @@ RocProfVis::View::get_application_config_path(bool create_dirs)
     std::filesystem::path base                = sanitize_base_dir(safe_getenv("LOCALAPPDATA"));
     std::filesystem::path config_dir =
         !base.empty() ? base : std::filesystem::current_path();
+#elif defined(__APPLE__)
+    const char*           app_config_dir_name = "ROCm-Optiq";
+    std::filesystem::path home                = sanitize_base_dir(safe_getenv("HOME"));
+    std::filesystem::path config_dir =
+        !home.empty() ? (home / "Library" / "Application Support")
+                       : std::filesystem::current_path();
 #else
     const char*           app_config_dir_name = "rocm-optiq";
     std::filesystem::path config_dir          = sanitize_base_dir(safe_getenv("XDG_CONFIG_HOME"));

--- a/src/view/src/rocprofvis_utils.h
+++ b/src/view/src/rocprofvis_utils.h
@@ -233,6 +233,9 @@ constexpr uint64_t minute_in_ns = minute_in_s * ns_per_s;
 std::string 
 get_application_config_path(bool create_dirs);
 
+std::string 
+get_application_log_path(bool create_dirs);
+
 std::string
 compact_number_format(double number);
 

--- a/src/view/src/rocprofvis_view_module.cpp
+++ b/src/view/src/rocprofvis_view_module.cpp
@@ -93,6 +93,12 @@ rocprofvis_get_application_config_path()
     return get_application_config_path(true);
 }
 
+std::string
+rocprofvis_get_application_log_path()
+{
+    return get_application_log_path(true);
+}
+
 bool
 rocprofvis_view_is_remote_display_session()
 {


### PR DESCRIPTION
Settings, logs, and presets on macOS were being written to ~/.config/rocm-optiq/, which doesn't follow Apple's convention of storing app-managed data under ~/Library/Application Support/. This adds a dedicated __APPLE__ branch in get_application_config_path that resolves to ~/Library/Application Support/ROCm-Optiq/, leaving Windows and Linux paths unchanged. Note: existing settings in ~/.config/rocm-optiq/ are not migrated, so users will start from defaults after upgrading.