### PR TITLE
Fix memory leak of owned objects stored in result Arrays

### DIFF
--- a/src/controller/src/compute/rocprofvis_controller_table_compute.cpp
+++ b/src/controller/src/compute/rocprofvis_controller_table_compute.cpp
@@ -48,7 +48,12 @@ rocprofvis_result_t ComputeTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_
                 row_data[c].SetType(m_rows[r][c].GetType());
                 row_data[c] = m_rows[r][c];
             }
-            result = array.SetObject(kRPVControllerArrayEntryIndexed, r, (rocprofvis_handle_t*)row_array);
+            result = array.SetOwnedObject(kRPVControllerArrayEntryIndexed, r, (rocprofvis_handle_t*)row_array);
+            if (result != kRocProfVisResultSuccess)
+            {
+                // Ownership was not transferred to the outer array; reclaim it.
+                delete row_array;
+            }
         }
     }
     return result;

--- a/src/controller/src/compute/rocprofvis_controller_table_compute_pivot.cpp
+++ b/src/controller/src/compute/rocprofvis_controller_table_compute_pivot.cpp
@@ -276,10 +276,11 @@ ComputePivotTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t index, uint64
 
     for(size_t i = 0; i < m_rows.size(); i++)
     {
+        Array* row_array = nullptr;
         try
         {
-            Array* row_array = new Array();
-        
+            row_array = new Array();
+
             auto& row_vec = row_array->GetVector();
             row_vec.resize(m_rows[i].size());
             for(uint32_t j = 0; j < m_rows[i].size(); j++)
@@ -287,12 +288,18 @@ ComputePivotTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t index, uint64
                 row_vec[j].SetType(m_rows[i][j].GetType());
                 row_vec[j] = m_rows[i][j];
             }
-            result = array.SetObject(kRPVControllerArrayEntryIndexed, i,
+            result = array.SetOwnedObject(kRPVControllerArrayEntryIndexed, i,
                                         (rocprofvis_handle_t*) row_array);
-        
+
             ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            if(result != kRocProfVisResultSuccess)
+            {
+                // Ownership was not transferred to the outer array; reclaim it.
+                delete row_array;
+            }
         } catch(const std::exception&)
         {
+            delete row_array;
             result = kRocProfVisResultMemoryAllocError;
         }
     }

--- a/src/controller/src/rocprofvis_controller_array.cpp
+++ b/src/controller/src/rocprofvis_controller_array.cpp
@@ -277,6 +277,36 @@ rocprofvis_result_t Array::SetObject(rocprofvis_property_t property, uint64_t in
     }
     return result;
 }
+rocprofvis_result_t Array::SetOwnedObject(rocprofvis_property_t property, uint64_t index,
+                                rocprofvis_handle_t* value)
+{
+    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
+    if(value)
+    {
+        switch(property)
+        {
+            case kRPVControllerArrayEntryIndexed:
+            {
+                if(index < m_array.size())
+                {
+                    m_array[index].SetType(kRPVControllerPrimitiveTypeObject);
+                    result = m_array[index].SetOwnedObject(value);
+                }
+                else
+                {
+                    result = kRocProfVisResultOutOfRange;
+                }
+                break;
+            }
+            default:
+            {
+                result = UnhandledProperty(property);
+                break;
+            }
+        }
+    }
+    return result;
+}
 rocprofvis_result_t Array::SetString(rocprofvis_property_t property, uint64_t index,
                                 char const* value) 
 {

--- a/src/controller/src/rocprofvis_controller_array.h
+++ b/src/controller/src/rocprofvis_controller_array.h
@@ -44,6 +44,13 @@ public:
                                   double value) final;
     rocprofvis_result_t SetObject(rocprofvis_property_t property, uint64_t index,
                                   rocprofvis_handle_t* value) final;
+
+    // Like SetObject(), but the Array takes ownership of the entry: the object
+    // is deleted when this Array is destroyed (via rocprofvis_controller_array_free).
+    // Use for heap children whose lifetime is bound to this Array, such as the
+    // per-row Arrays produced by table fetches.
+    rocprofvis_result_t SetOwnedObject(rocprofvis_property_t property, uint64_t index,
+                                       rocprofvis_handle_t* value);
     rocprofvis_result_t SetString(rocprofvis_property_t property, uint64_t index,
                                   char const* value) final;
 

--- a/src/controller/src/rocprofvis_controller_data.cpp
+++ b/src/controller/src/rocprofvis_controller_data.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <utility>
 
 namespace RocProfVis
 {
@@ -20,6 +21,12 @@ void Data::Reset()
     {
         case kRPVControllerPrimitiveTypeObject:
         {
+            if (m_owns_object && m_object)
+            {
+                delete reinterpret_cast<Handle*>(m_object);
+            }
+            m_owns_object = false;
+            m_object      = nullptr;
             break;
         }
         case kRPVControllerPrimitiveTypeString:
@@ -55,7 +62,8 @@ Data::Data(Data const& other)
 Data::Data(Data&& other)
 : m_type(other.m_type)
 {
-    operator=(other);
+    m_uint64 = 0;
+    operator=(std::move(other));
 }
 
 Data& Data::operator=(Data const& other)
@@ -63,10 +71,13 @@ Data& Data::operator=(Data const& other)
     if (this != &other)
     {
         Reset();
+        m_type = other.m_type;
         switch(m_type)
         {
             case kRPVControllerPrimitiveTypeObject:
             {
+                // A copy only borrows the object; ownership is never shared so
+                // that the owning Data remains the sole deleter.
                 SetObject(other.m_object);
                 break;
             }
@@ -96,14 +107,20 @@ Data& Data::operator=(Data const& other)
 
 Data& Data::operator=(Data&& other)
 {
+    if (this == &other)
+    {
+        return *this;
+    }
     Reset();
     m_type = other.m_type;
     switch(m_type)
     {
         case kRPVControllerPrimitiveTypeObject:
         {
-            m_object = other.m_object;
-            other.m_object = nullptr;
+            m_object             = other.m_object;
+            m_owns_object        = other.m_owns_object;
+            other.m_object       = nullptr;
+            other.m_owns_object  = false;
             break;
         }
         case kRPVControllerPrimitiveTypeString:
@@ -178,6 +195,10 @@ Data::~Data()
     {
         case kRPVControllerPrimitiveTypeObject:
         {
+            if (m_owns_object && m_object)
+            {
+                delete reinterpret_cast<Handle*>(m_object);
+            }
             break;
         }
         case kRPVControllerPrimitiveTypeString:
@@ -246,8 +267,44 @@ rocprofvis_result_t Data::SetObject(rocprofvis_handle_t* object)
         {
             case kRPVControllerPrimitiveTypeObject:
             {
-                m_object = object;
-                result = kRocProfVisResultSuccess;
+                m_object      = object;
+                m_owns_object = false;
+                result        = kRocProfVisResultSuccess;
+                break;
+            }
+            case kRPVControllerPrimitiveTypeString:
+            case kRPVControllerPrimitiveTypeUInt64:
+            case kRPVControllerPrimitiveTypeDouble:
+            {
+                result = kRocProfVisResultInvalidType;
+                break;
+            }
+            default:
+            {
+                result = kRocProfVisResultInvalidEnum;
+                break;
+            }
+        }
+    }
+    return result;
+}
+
+rocprofvis_result_t Data::SetOwnedObject(rocprofvis_handle_t* object)
+{
+    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
+    if (object)
+    {
+        switch(m_type)
+        {
+            case kRPVControllerPrimitiveTypeObject:
+            {
+                if (m_owns_object && m_object && m_object != object)
+                {
+                    delete reinterpret_cast<Handle*>(m_object);
+                }
+                m_object      = object;
+                m_owns_object = true;
+                result        = kRocProfVisResultSuccess;
                 break;
             }
             case kRPVControllerPrimitiveTypeString:

--- a/src/controller/src/rocprofvis_controller_data.h
+++ b/src/controller/src/rocprofvis_controller_data.h
@@ -45,6 +45,12 @@ public:
 
     rocprofvis_result_t SetObject(rocprofvis_handle_t* object);
 
+    // Stores an object the Data takes ownership of: the referenced Handle is
+    // deleted when this Data is reset/destroyed. Use for heap objects (e.g.
+    // per-row Arrays) whose lifetime is bound to the containing Array, as
+    // opposed to SetObject() which only borrows a pointer (e.g. pooled events).
+    rocprofvis_result_t SetOwnedObject(rocprofvis_handle_t* object);
+
     rocprofvis_result_t GetString(char* string, uint32_t* length);
 
     rocprofvis_result_t SetString(char const* string);
@@ -61,6 +67,7 @@ public:
 
 private:
     rocprofvis_controller_primitive_type_t m_type;
+    bool m_owns_object = false;
     union
     {
         rocprofvis_handle_t* m_object;

--- a/src/controller/src/system/rocprofvis_controller_event.cpp
+++ b/src/controller/src/system/rocprofvis_controller_event.cpp
@@ -279,7 +279,7 @@ Event::FetchDataModelStackTraceProperty(uint64_t event_id, Array& array,
                                             result = array.SetUInt64(kRPVControllerArrayNumEntries, 0, entry_counter + 1);
                                             if(result == kRocProfVisResultSuccess)
                                             {
-                                                result = array.SetObject(kRPVControllerArrayEntryIndexed, entry_counter++, (rocprofvis_handle_t*) call_stack);
+                                                result = array.SetOwnedObject(kRPVControllerArrayEntryIndexed, entry_counter++, (rocprofvis_handle_t*) call_stack);
                                             }
                                             if(result != kRocProfVisResultSuccess)
                                             {
@@ -386,10 +386,14 @@ Event::FetchDataModelExtendedDataProperty(uint64_t event_id, Array& array, rocpr
 
                                         if(result == kRocProfVisResultSuccess)
                                         {
-                                            result = array.SetObject(
+                                            result = array.SetOwnedObject(
                                                 kRPVControllerArrayEntryIndexed,
                                                 entry_counter++,
                                                 (rocprofvis_handle_t*) ext_data);
+                                        }
+                                        if(result != kRocProfVisResultSuccess)
+                                        {
+                                            delete ext_data;
                                         }
                                     }
                                 }
@@ -426,10 +430,14 @@ Event::FetchDataModelExtendedDataProperty(uint64_t event_id, Array& array, rocpr
                                                 kRPVDataTypeString, kRocProfVisEventArgumentData, position, type);
                                         if(result == kRocProfVisResultSuccess)
                                         {
-                                            result = array.SetObject(
+                                            result = array.SetOwnedObject(
                                                 kRPVControllerArrayEntryIndexed,
                                                 entry_counter++,
                                                 (rocprofvis_handle_t*) arg_data);
+                                        }
+                                        if(result != kRocProfVisResultSuccess)
+                                        {
+                                            delete arg_data;
                                         }
                                     }
                                 }

--- a/src/controller/src/system/rocprofvis_controller_table_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_table_system.cpp
@@ -185,9 +185,10 @@ rocprofvis_result_t SystemTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t
             for(uint32_t i = index;
                 (result == kRocProfVisResultSuccess) && i < index + num_records; i++)
             {
+                Array* row_array = nullptr;
                 try
                 {
-                    Array* row_array = new Array();
+                    row_array = new Array();
                     {
                         auto& row_vec = row_array->GetVector();
                         row_vec.resize(m_rows[i].size());
@@ -196,12 +197,17 @@ rocprofvis_result_t SystemTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t
                             row_vec[j].SetType(m_rows[i][j].GetType());
                             row_vec[j] = m_rows[i][j];
                         }
-                        result = array.SetObject(kRPVControllerArrayEntryIndexed, i - index,
+                        result = array.SetOwnedObject(kRPVControllerArrayEntryIndexed, i - index,
                                         (rocprofvis_handle_t*)row_array);
+                        if(result != kRocProfVisResultSuccess)
+                        {
+                            delete row_array;
+                        }
                     }
                 }
                 catch(const std::exception&)
                 {
+                    delete row_array;
                     result = kRocProfVisResultMemoryAllocError;
                 }
             }


### PR DESCRIPTION
## Motivation

The bug: LeakSanitizer reported ~847 KB leaked across ~48.5K allocations, originating in ComputePivotTable::Fetch:

https://github.com/ROCm/roc-optiq/actions/runs/27769081821/job/82163994443?pr=887

```
Direct leak of 336 byte(s) in 7 object(s)         -> new Array() per row (line 281)
Indirect leak of 775712 byte(s) in 7 object(s)    -> each row's std::vector<Data> (line 284)
Indirect leak of 70732 byte(s) in 48482 object(s) -> Data::SetString cell strings (line 288)
```

When the controller returns tabular/structured data to the View, each row (or call-stack frame, or extended-data record) is wrapped in a heap-allocated child Array/Handle and stored as an object-type entry inside an outer result Array. The View consumes the data and then frees the outer array via rocprofvis_controller_array_free().

## Technical Details

The problem: nothing ever deleted those child objects.

Data::SetObject() only stored the raw pointer.
Data::~Data() did nothing for object-type entries.
Array::~Array() was empty.
rocprofvis_controller_array_free() only deleted the top-level array.

So every table/call-stack/extended-data fetch orphaned its child objects (and their nested Data vectors and copied strings).

This couldn't be fixed by having the producing object (e.g. the Table) own and free the rows on the next fetch, because the View may hold multiple result arrays simultaneously and expects each to stay valid until it individually calls ..._array_free(). The lifetime of the children correctly belongs to the outer array, not the producer.

It also couldn't be a blanket delete in ~Array, because object-type Data entries have two ownership models:

Owned — heap rows/frames/records created with new (must be deleted).
Borrowed — MemoryManager-pooled Event*/Sample* (segments/tracks) and plot-series member pointers (must not be deleted, or we double-free).
The fix
Introduce explicit per-entry ownership so the outer array reclaims only what it owns:

Data: added an m_owns_object flag (absorbed into existing struct padding — sizeof(Data) is unchanged at 16 bytes) and a new SetOwnedObject(). Reset()/~Data() now delete the object only when owned. Fixed move semantics to transfer ownership and null the source; copy semantics explicitly borrow (a copy never claims ownership). SetObject() remains the borrowing path.
Array: added SetOwnedObject(); destroying the array now cascades through its Data entries and frees owned children. Borrowed entries are untouched.

Producers switched to owning storage (with cleanup if ownership transfer fails): ComputePivotTable::Fetch, SystemTable::Fetch, ComputeTable::Fetch, and Event call-stack (CallStack) and extended-data (ExtData, ArgumentData) fetches — all of which had the same latent leak.

Left borrowed (unchanged): segment/track fetches storing pooled events/samples, and Plot::Fetch storing &m_series member addresses.

Why it's safe

The View only reads these handles into its own model structs and then frees the array; it never deletes the handles itself, so the cascade is the sole deleter — no double-free. Each outer array independently owns its own children, preserving the "valid until you free it" contract even when the View holds several arrays at once.


## Test Plan

 Re-run the LeakSanitizer build that produced the original report; confirm the ComputePivotTable::Fetch leaks (and the call-stack / extended-data paths) are gone.

 Open a compute trace and exercise the pivot/kernel tables; open a systems trace and exercise event tables, call-stack, and extended-data panels.

 Verify no double-free / use-after-free under ASan when holding multiple table result arrays before freeing.

