### PR TITLE
Fix timeline highlight artifacts

### DIFF
--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1520,6 +1520,9 @@ TimelineView::RenderNormalTrack(TrackGraph& track_graph, int track_index,
             m_settings.GetColor(Colors::kAccent));
     }
 
+    // Keep the track row square so the highlight fill reaches the corners; otherwise the
+    // rounded corners leave notches where the accent selection stripe bleeds through.
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 0.0f);
     ImGui::PushStyleColor(ImGuiCol_ChildBg, selection_color);
     ImGui::PushID(track_index);
     if(ImGui::BeginChild("", ImVec2(0, track_height), false,
@@ -1593,6 +1596,7 @@ TimelineView::RenderNormalTrack(TrackGraph& track_graph, int track_index,
     ImGui::EndChild();
     ImGui::PopID();
     ImGui::PopStyleColor();
+    ImGui::PopStyleVar();  // ImGuiStyleVar_ChildRounding
 
     // Draw border around the track
     // This is done after the child window to ensure it is on top

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -216,12 +216,8 @@ TrackItem::RenderSecondaryMetaPill(const ImVec2& content_size)
 void
 TrackItem::RenderMetaArea()
 {
-    // Shrink the meta data content area by one unit in the vertical direction so that the
-    // borders rendered by the parent are visible other wise the bg fill will cover them
-    // up.
-    ImVec2 metadata_shrink_padding(0.0f, 1.0f);
     ImVec2 outer_container_size = ImGui::GetContentRegionAvail();
-    m_track_content_height      = m_track_height - metadata_shrink_padding.y * 2.0f;
+    m_track_content_height      = m_track_height;
 
     ImVec2 name_label_min(0.0f, 0.0f);
     ImVec2 name_label_max(0.0f, 0.0f);
@@ -231,8 +227,9 @@ TrackItem::RenderMetaArea()
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(4, 4));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(4, 3));
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(5, 5));
-    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding,
-                        m_settings.GetDefaultStyle().ChildRounding);
+    // Keep the meta-area square so the selection highlight fill reaches the corners
+    // instead of bleeding through rounded edges.
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 0.0f);
 
     ImGui::PushStyleColor(ImGuiCol_ChildBg,
                           m_selected
@@ -240,10 +237,9 @@ TrackItem::RenderMetaArea()
                               : (m_request_state == TrackDataRequestState::kError
                                      ? m_settings.GetColor(Colors::kGridRed)
                                      : m_settings.GetColor(Colors::kMetaDataColor)));
-    ImGui::SetCursorPos(metadata_shrink_padding);
+    ImGui::SetCursorPos(ImVec2(0.0f, 0.0f));
     if(ImGui::BeginChild("MetaData Area",
-                         ImVec2(s_metadata_width, outer_container_size.y -
-                                                      metadata_shrink_padding.y * 2.0f),
+                         ImVec2(s_metadata_width, outer_container_size.y),
                          ImGuiChildFlags_None,
                          ImGuiWindowFlags_NoScrollbar |
                              ImGuiWindowFlags_NoScrollWithMouse))

--- a/src/view/src/widgets/rocprofvis_split_containers.cpp
+++ b/src/view/src/widgets/rocprofvis_split_containers.cpp
@@ -116,9 +116,10 @@ void SplitContainerBase::Render()
     if(m_first && m_first->m_visible && m_second && m_second->m_visible)
     {
         bool fill_active = false;
-        ImGui::Selectable(m_handle_name.c_str(), false,
-                          ImGuiSelectableFlags_AllowDoubleClick,
-                          GetSplitterSize(total_size));
+        // Use an invisible button instead of a Selectable so ImGui does not draw its
+        // own (rounded) hover / nav-focus highlight, which bled past the corners of the
+        // splitter fill we draw manually below.
+        ImGui::InvisibleButton(m_handle_name.c_str(), GetSplitterSize(total_size));
         ImVec2 splitter_min = ImGui::GetItemRectMin();
         ImVec2 splitter_max = ImGui::GetItemRectMax();
         if(ImGui::IsItemHovered())


### PR DESCRIPTION
<img width="2624" height="1536" alt="image" src="https://github.com/user-attachments/assets/bb91ce6a-b277-4618-999e-123e904ff4c1" />

The changes remove rounded/extra ImGui highlight artifacts by making timeline track rows and metadata areas square, removing the metadata 1px vertical inset that exposed blue selection bleed, and replacing the splitter Selectable with an InvisibleButton so ImGui doesn’t draw its own rounded hover/nav highlight.