### PR TITLE
DPI Removal (Adopt IMGUI solution)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -320,7 +320,6 @@ bool rocprofvis_view_init(std::function<void(int)> notification_callback,
                           rocprofvis_view_file_dialog_preference_t pref);
 void rocprofvis_view_render(const rocprofvis_view_render_options_t& opts);
 void rocprofvis_view_destroy();
-void rocprofvis_view_set_dpi(float dpi);
 void rocprofvis_view_open_files(const std::vector<std::string>& paths);
 void rocprofvis_view_set_fullscreen_state(bool is_fullscreen);
 void rocprofvis_view_set_texture_backend(...);
@@ -1288,8 +1287,7 @@ JSON keys are constants in this header
 ### `FontManager` (`rocprofvis_font_manager.{h,cpp}`)
 
 Owns the text font and the icon font. `Init()` runs after the ImGui
-context is created. `GetDPIScaledFontIndex()` picks the right size
-when DPI scaling is enabled.
+context is created.
 
 ### `HotkeyManager` (`rocprofvis_hotkey_manager.{h,cpp}`)
 

--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -51,15 +51,6 @@ drop_callback(GLFWwindow* window, int count, const char* paths[])
 }
 
 static void
-content_scale_callback(GLFWwindow* window, float xscale, float yscale)
-{
-    // Unused parameters
-    (void) window;
-    (void) yscale;
-    rocprofvis_view_set_dpi(xscale);
-}
-
-static void
 close_callback(GLFWwindow* window)
 {
     g_render_options =
@@ -311,9 +302,6 @@ main(int argc, char** argv)
         // Create initial window with Vulkan hint (GLFW_NO_API) by default
         // The backend setup will recreate the window if OpenGL is needed
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
-#if defined(GLFW_SCALE_TO_MONITOR)  // GLFW 3.3+
-        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
-#endif
         GLFWwindow* window = glfwCreateWindow(RocProfVis::View::DEFAULT_WINDOWED_WIDTH,
                                               RocProfVis::View::DEFAULT_WINDOWED_HEIGHT,
                                               APP_NAME, nullptr, nullptr);
@@ -333,12 +321,6 @@ main(int argc, char** argv)
             {
                 // After init: window may be recreated (e.g. Vulkan -> OpenGL fallback)
                 glfwSetDropCallback(window, drop_callback);
-                glfwSetWindowContentScaleCallback(window, content_scale_callback);
-                {
-                    float xs, ys;
-                    glfwGetWindowContentScale(window, &xs, &ys);
-                    content_scale_callback(window, xs, ys);
-                }
                 glfwSetWindowCloseCallback(window, close_callback);
                 glfwSetWindowSizeCallback(window, window_size_change_callback);
                 glfwSetKeyCallback(window, key_callback);
@@ -350,9 +332,14 @@ main(int argc, char** argv)
                 ImGui::CreateContext();
                 ImGuiIO& io = ImGui::GetIO();
                 io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+                io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
+                io.ConfigDpiScaleFonts             = true;
+                io.ConfigDpiScaleViewports         = true;
+                io.ConfigViewportsNoTaskBarIcon    = false;
                 io.ConfigWindowsMoveFromTitleBarOnly = true;
 
                 ImGui::StyleColorsLight();
+                ImGui::GetStyle().FontScaleMain = 1.0f;
 
                 rocprofvis_view_init([window](int notification) -> void {
                     app_notification_callback(window, notification);
@@ -446,6 +433,16 @@ main(int argc, char** argv)
                     if(!is_minimized)
                     {
                         backend.m_render(&backend, draw_data, &clear_color);
+                        if((io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable) != 0)
+                        {
+                            GLFWwindow* backup_current_context = glfwGetCurrentContext();
+                            ImGui::UpdatePlatformWindows();
+                            ImGui::RenderPlatformWindowsDefault();
+                            if(backup_current_context != nullptr)
+                            {
+                                glfwMakeContextCurrent(backup_current_context);
+                            }
+                        }
                         backend.m_present(&backend);
                     }
 

--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -302,6 +302,9 @@ main(int argc, char** argv)
         // Create initial window with Vulkan hint (GLFW_NO_API) by default
         // The backend setup will recreate the window if OpenGL is needed
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+#if defined(GLFW_SCALE_TO_MONITOR)  // GLFW 3.3+
+        glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
+#endif
         GLFWwindow* window = glfwCreateWindow(RocProfVis::View::DEFAULT_WINDOWED_WIDTH,
                                               RocProfVis::View::DEFAULT_WINDOWED_HEIGHT,
                                               APP_NAME, nullptr, nullptr);

--- a/src/app/src/rocprofvis_imgui_backend.cpp
+++ b/src/app/src/rocprofvis_imgui_backend.cpp
@@ -23,6 +23,9 @@ setup_opengl_window_and_backend(rocprofvis_imgui_backend_t* backend, GLFWwindow*
 {
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
+#if defined(GLFW_SCALE_TO_MONITOR)
+    glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
+#endif
 #if defined(__APPLE__)
     // GL 3.2 + GLSL 150
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);

--- a/src/app/src/rocprofvis_imgui_backend.cpp
+++ b/src/app/src/rocprofvis_imgui_backend.cpp
@@ -23,9 +23,6 @@ setup_opengl_window_and_backend(rocprofvis_imgui_backend_t* backend, GLFWwindow*
 {
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
-#if defined(GLFW_SCALE_TO_MONITOR)
-    glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
-#endif
 #if defined(__APPLE__)
     // GL 3.2 + GLSL 150
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);

--- a/src/view/inc/rocprofvis_view_module.h
+++ b/src/view/inc/rocprofvis_view_module.h
@@ -44,9 +44,6 @@ void
 rocprofvis_view_destroy();
 
 void
-rocprofvis_view_set_dpi(float dpi);
-
-void
 rocprofvis_view_open_files(const std::vector<std::string>& file_paths);
 
 void

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -707,13 +707,12 @@ AppWindow::RenderShutdownState()
 {
     ImGui::OpenPopup(SHUTDOWN_DIALOG_NAME);
 
-    const float dpi = SettingsManager::GetInstance().GetDPI();
     ImGuiViewport* viewport = ImGui::GetMainViewport();
     ImGui::SetNextWindowPos(
         ImVec2(viewport->WorkPos.x + viewport->WorkSize.x * 0.5f,
                viewport->WorkPos.y + viewport->WorkSize.y * 0.5f),
         ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-    ImGui::SetNextWindowSize(ImVec2(360.0f * dpi, 0.0f), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(360.0f, 0.0f), ImGuiCond_Always);
 
     PopUpStyle ps;
     ps.PushPopupStyles();

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -162,7 +162,6 @@ AppWindow::Init()
     LayoutItem status_bar_item(-1, initial_status_bar_height);
     status_bar_item.m_item =
         std::make_shared<RocCustomWidget>([this]() { RenderStatusBar(); });
-    status_bar_item.m_window_flags = ImGuiWindowFlags_NoScrollbar;
     LayoutItem main_area_item(-1, -initial_status_bar_height);
     LayoutItem tool_bar_item(-1, 0);
     tool_bar_item.m_child_flags = ImGuiChildFlags_AutoResizeY;
@@ -1198,10 +1197,15 @@ AppWindow::HandleFontChanged()
         return;
     }
 
-    // Match RenderStatusBar()'s content extent (AlignTextToFramePadding + Dummy).
-    const float frame_h      = ImGui::GetFrameHeight();
-    const float line_h       = ImGui::GetTextLineHeight();
-    status_bar_item->m_height = frame_h + (frame_h - line_h) * 0.5f;
+    // Fit the slot to one framed line plus the child border so the status bar
+    // content cannot overflow into a scrollbar. FramePadding matches
+    // RenderStatusBar().
+    const ImGuiStyle& default_style = SettingsManager::GetInstance().GetDefaultStyle();
+    const float       content_height =
+        ImGui::GetFontSize() + (default_style.FramePadding.y * 2.0f);
+    const float border_height = (status_bar_item->m_window_padding.y * 2.0f) +
+                                (ImGui::GetStyle().ChildBorderSize * 2.0f);
+    status_bar_item->m_height = content_height + border_height;
 
     // adjust main view's size to account for new status bar height
     auto main_view_item = m_main_view->GetMutableAt(count - 2);

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -162,6 +162,7 @@ AppWindow::Init()
     LayoutItem status_bar_item(-1, initial_status_bar_height);
     status_bar_item.m_item =
         std::make_shared<RocCustomWidget>([this]() { RenderStatusBar(); });
+    status_bar_item.m_window_flags = ImGuiWindowFlags_NoScrollbar;
     LayoutItem main_area_item(-1, -initial_status_bar_height);
     LayoutItem tool_bar_item(-1, 0);
     tool_bar_item.m_child_flags = ImGuiChildFlags_AutoResizeY;
@@ -1197,12 +1198,10 @@ AppWindow::HandleFontChanged()
         return;
     }
 
-    // Calculate status bar height based on font size, with some padding.
-    ImGuiStyle& style     = ImGui::GetStyle();
-    float       line_pad  = style.CellPadding.y * 2.0f;
-    float       line_size = ImGui::GetTextLineHeight() + line_pad;
-
-    status_bar_item->m_height = line_size;
+    // Match RenderStatusBar()'s content extent (AlignTextToFramePadding + Dummy).
+    const float frame_h      = ImGui::GetFrameHeight();
+    const float line_h       = ImGui::GetTextLineHeight();
+    status_bar_item->m_height = frame_h + (frame_h - line_h) * 0.5f;
 
     // adjust main view's size to account for new status bar height
     auto main_view_item = m_main_view->GetMutableAt(count - 2);
@@ -1492,6 +1491,7 @@ AppWindow::ShowImGuiFileDialog(const std::string& title, const std::vector<FileF
 void
 AppWindow::UpdateStatusBar()
 {
+    HandleFontChanged();
     // Update status message every N frames
     const int UPDATE_STEP = 4;
     if(ImGui::GetFrameCount() % UPDATE_STEP == 0)

--- a/src/view/src/rocprofvis_font_manager.cpp
+++ b/src/view/src/rocprofvis_font_manager.cpp
@@ -6,7 +6,6 @@
 #include "icons/rocprovfis_icon_defines.h"
 #include "imgui.h"
 #include "rocprofvis_event_manager.h"
-#include "rocprofvis_settings_manager.h"
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
@@ -19,35 +18,96 @@ namespace View
 {
 
 constexpr float      BASE_FONT_SIZE       = 15.0f;
+constexpr float      MIN_USER_FONT_SIZE   = 13.0f;
+constexpr float      MAX_USER_FONT_SIZE   = 18.0f;
 constexpr std::array FONT_AVAILABLE_SIZES = { 9.0f,  10.0f, 11.0f, 12.0f, 13.0f,
                                               14.0f, 15.0f, 16.0f, 17.0f, 18.0f,
                                               19.0f, 20.0f, 21.0f, 22.0f, 23.0f,
                                               25.0f, 27.0f, 29.0f, 31.0f, 35.0f };
 
-// Size offsets applied to the base index to produce kSmall/kMedium/kMedLarge/kLarge.
-static constexpr int kSizeOffsets[FontManager::kNumSizes] = { -1, 0, 1, 2 };
+// Step offsets applied to the user-selected base index. Indexed by FontSize:
+// kSmall is one step below the base, kMedium is the base (what the user
+// picks in Settings), and kMedLarge / kLarge bump up from there.
+static constexpr int kSizeOffsets[FontManager::kNumSizes] = {
+    -1,  // FontSize::kSmall
+     0,  // FontSize::kMedium (== FontSize::kDefault, == user base)
+     1,  // FontSize::kMedLarge
+     2,  // FontSize::kLarge
+};
+
+static_assert(static_cast<int>(FontSize::kSmall)    == 0, "FontSize order changed");
+static_assert(static_cast<int>(FontSize::kMedium)   == 1, "FontSize order changed");
+static_assert(static_cast<int>(FontSize::kMedLarge) == 2, "FontSize order changed");
+static_assert(static_cast<int>(FontSize::kLarge)    == 3, "FontSize order changed");
+static_assert(static_cast<int>(FontSize::kDefault)  ==
+                  static_cast<int>(FontSize::kMedium),
+              "FontSize::kDefault should map to the user's base size");
+
+static int
+GetClosestFontSizeIndex(const std::vector<float>& available_sizes, float font_size)
+{
+    int best_index = 0;
+
+    if(!available_sizes.empty())
+    {
+        float best_delta = std::abs(available_sizes[0] - font_size);
+        for(int i = 1; i < static_cast<int>(available_sizes.size()); ++i)
+        {
+            float delta = std::abs(available_sizes[i] - font_size);
+            if(delta < best_delta)
+            {
+                best_delta = delta;
+                best_index = i;
+            }
+        }
+    }
+
+    return best_index;
+}
 
 FontManager::FontManager() {}
 
 FontManager::~FontManager() {}
 
-int
-FontManager::GetDPIScaledFontIndex()
+float
+FontManager::GetMinUserFontSize() const
 {
-    constexpr float DPI_EXPONENT = 0.75f;
+    return MIN_USER_FONT_SIZE;
+}
 
-    float scaled_size =
-        BASE_FONT_SIZE * std::pow(SettingsManager::GetInstance().GetDPI(), DPI_EXPONENT);
+float
+FontManager::GetMaxUserFontSize() const
+{
+    return MAX_USER_FONT_SIZE;
+}
 
-    // Find the index of the available size closest to scaled_size.
-    int best_index = 0;
-    for(int i = 1; i < static_cast<int>(m_available_sizes.size()); ++i)
-    {
-        if(std::abs(m_available_sizes[i] - scaled_size) <
-           std::abs(m_available_sizes[i - 1] - scaled_size))
-            best_index = i;
-    }
-    return best_index;
+float
+FontManager::GetFontSizeAt(int idx) const
+{
+    if(m_available_sizes.empty())
+        return BASE_FONT_SIZE;
+    idx = std::max(0, std::min(idx, static_cast<int>(m_available_sizes.size()) - 1));
+    return m_available_sizes[idx];
+}
+
+int
+FontManager::GetFontSizeIndex(float font_size) const
+{
+    return GetClosestFontSizeIndex(m_available_sizes, font_size);
+}
+
+int
+FontManager::GetDefaultFontSizeIndex() const
+{
+    return GetClosestFontSizeIndex(m_available_sizes, BASE_FONT_SIZE);
+}
+
+int
+FontManager::ClampFontSizeIndex(int idx) const
+{
+    int min_idx = GetFontSizeIndex(MIN_USER_FONT_SIZE);
+    int max_idx = GetFontSizeIndex(MAX_USER_FONT_SIZE);
+    return std::max(min_idx, std::min(idx, max_idx));
 }
 
 void
@@ -55,7 +115,7 @@ FontManager::SetFontSize(int idx)
 {
     if(m_available_sizes.empty())
         return;
-    idx = std::max(0, std::min(idx, static_cast<int>(m_available_sizes.size()) - 1));
+    idx = ClampFontSizeIndex(idx);
 
     for(int i = 0; i < kNumSizes; ++i)
     {
@@ -64,9 +124,11 @@ FontManager::SetFontSize(int idx)
         m_sizes[i] = m_available_sizes[size_idx];
     }
 
-    // Set the default font and its base size for the next frame.
-    ImGui::GetIO().FontDefault                   = m_text_font;
-    ImGui::GetStyle()._NextFrameFontSizeBase     = m_sizes[static_cast<int>(FontType::kDefault)];
+    // ImGui's default font and its base size for the next frame. Everything
+    // not pushing an explicit font/size renders at FontSize::kDefault, so the
+    // user's slider value matches what they see in the UI.
+    ImGui::GetIO().FontDefault               = m_text_font;
+    ImGui::GetStyle()._NextFrameFontSizeBase = m_sizes[static_cast<int>(FontSize::kDefault)];
 
     EventManager::GetInstance()->AddEvent(
         std::make_shared<RocEvent>(static_cast<int>(RocEvents::kFontSizeChanged)));
@@ -144,22 +206,10 @@ FontManager::Init()
     m_icon_font = io.Fonts->AddFontFromMemoryCompressedTTF(
         &icon_font_compressed_data, icon_font_compressed_size, 0.0f, &icon_config, icon_ranges);
 
-    int default_idx = static_cast<int>(std::distance(
-        FONT_AVAILABLE_SIZES.begin(),
-        std::find(FONT_AVAILABLE_SIZES.begin(), FONT_AVAILABLE_SIZES.end(), BASE_FONT_SIZE)));
-
-    if(default_idx >= static_cast<int>(m_available_sizes.size()))
-        default_idx = 6; // fallback to index of 13.0f
-    SetFontSize(default_idx);
+    SetFontSize(GetDefaultFontSizeIndex());
 
     // Don't call Build() - ImGui 1.92+ backend handles font atlas building automatically.
     return true;
-}
-
-const std::vector<float>
-FontManager::GetAvailableSizes() const
-{
-    return m_available_sizes;
 }
 
 ImFont*

--- a/src/view/src/rocprofvis_font_manager.h
+++ b/src/view/src/rocprofvis_font_manager.h
@@ -46,11 +46,18 @@ public:
      */
     bool Init();
 
-    const std::vector<float> GetAvailableSizes() const;
-    ImFont*                  GetFont(FontType font_type);
-    float                    GetFontSize(FontSize font_type) const;
-    int                      GetDPIScaledFontIndex();
-    void                     SetFontSize(int idx);
+    ImFont* GetFont(FontType font_type);
+    float   GetFontSize(FontSize font_type) const;
+
+    // User-controllable font size range. Sizes are in points and snap to
+    // entries in the internal size table.
+    float GetMinUserFontSize() const;
+    float GetMaxUserFontSize() const;
+    float GetFontSizeAt(int idx) const;
+    int   GetFontSizeIndex(float font_size) const;
+    int   GetDefaultFontSizeIndex() const;
+    int   ClampFontSizeIndex(int idx) const;
+    void  SetFontSize(int idx);
 
     static constexpr int kNumSizes = static_cast<int>(FontSize::__kLastSize);
 

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -433,8 +433,6 @@ SettingsManager::SerializeDisplaySettings(jt::Json& json)
     jt::Json& ds = json[JSON_KEY_GROUP_SETTINGS][JSON_KEY_SETTINGS_CATEGORY_DISPLAY];
     ds[JSON_KEY_SETTINGS_DISPLAY_DARK_MODE] =
         m_usersettings.display_settings.use_dark_mode;
-    ds[JSON_KEY_SETTINGS_DISPLAY_DPI_SCALING] =
-        m_usersettings.display_settings.dpi_based_scaling;
     ds[JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE] =
         m_usersettings.display_settings.font_size_index;
 }
@@ -450,15 +448,11 @@ SettingsManager::DeserializeDisplaySettings(jt::Json& json)
             m_usersettings.display_settings.use_dark_mode =
                 ds[JSON_KEY_SETTINGS_DISPLAY_DARK_MODE].getBool();
         }
-        if(ds[JSON_KEY_SETTINGS_DISPLAY_DPI_SCALING].isBool())
-        {
-            m_usersettings.display_settings.dpi_based_scaling =
-                ds[JSON_KEY_SETTINGS_DISPLAY_DPI_SCALING].getBool();
-        }
         if(ds[JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE].isLong())
         {
             m_usersettings.display_settings.font_size_index =
-                static_cast<int>(ds[JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE].getLong());
+                GetFontManager().ClampFontSizeIndex(
+                    static_cast<int>(ds[JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE].getLong()));
         }
     }
 }
@@ -518,18 +512,6 @@ SettingsManager::GetStandardConfigPath()
 }
 
 void
-SettingsManager::SetDPI(float dpi)
-{
-    m_display_dpi = dpi;
-}
-
-float
-SettingsManager::GetDPI()
-{
-    return m_display_dpi;
-}
-
-void
 SettingsManager::ApplyUserDisplaySettings(const UserSettings& old_settings)
 {
     (void) old_settings;  // currently unused
@@ -547,9 +529,9 @@ SettingsManager::ApplyUserDisplaySettings(const UserSettings& old_settings)
     }
     ApplyColorStyling();
 
-    GetFontManager().SetFontSize((m_usersettings.display_settings.dpi_based_scaling)
-                                     ? GetFontManager().GetDPIScaledFontIndex()
-                                     : m_usersettings.display_settings.font_size_index);
+    m_usersettings.display_settings.font_size_index =
+        GetFontManager().ClampFontSizeIndex(m_usersettings.display_settings.font_size_index);
+    GetFontManager().SetFontSize(m_usersettings.display_settings.font_size_index);
 }
 
 void
@@ -600,10 +582,9 @@ SettingsManager::GetContrastColormapName() const
 SettingsManager::SettingsManager()
 : m_color_store(nullptr)
 , m_usersettings_default(
-      { DisplaySettings{ false, true, 6 }, UnitSettings{ TimeFormat::kTimecode } })
+      { DisplaySettings{ false, 6 }, UnitSettings{ TimeFormat::kTimecode } })
 , m_usersettings(m_usersettings_default)
 , m_appwindowsettings({ AppWindowSettings{ true, true, true, true, false } })
-, m_display_dpi(1.5f)
 , m_json_path(GetStandardConfigPath())
 {}
 

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -22,7 +22,6 @@ enum class TimeFormat;
 typedef struct DisplaySettings
 {
     bool use_dark_mode;
-    bool dpi_based_scaling;
     int  font_size_index;
 
 } DisplaySettings;
@@ -189,9 +188,8 @@ constexpr const char* JSON_KEY_SETTINGS_CATEGORY_UNITS    = "units";
 constexpr const char* JSON_KEY_SETTINGS_CATEGORY_OTHER    = "other";
 constexpr const char* JSON_KEY_SETTINGS_CATEGORY_INTERNAL = "internal";
 
-constexpr const char* JSON_KEY_SETTINGS_DISPLAY_DARK_MODE   = "use_dark_mode";
-constexpr const char* JSON_KEY_SETTINGS_DISPLAY_DPI_SCALING = "dpi_based_scaling";
-constexpr const char* JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE   = "font_size_index";
+constexpr const char* JSON_KEY_SETTINGS_DISPLAY_DARK_MODE = "use_dark_mode";
+constexpr const char* JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE = "font_size_index";
 
 constexpr const char* JSON_KEY_SETTINGS_UNITS_TIME_FORMAT = "time_format";
 
@@ -215,8 +213,6 @@ public:
 
     // Fonts
     FontManager& GetFontManager();
-    void         SetDPI(float DPI);
-    float        GetDPI();
 
     // Styling
     ImU32                     GetColor(Colors color) const;
@@ -286,7 +282,6 @@ private:
     FontManager        m_font_manager;
     ImGuiStyle         m_default_imgui_style;
     ImGuiStyle         m_default_style;
-    float              m_display_dpi;
     const UserSettings m_usersettings_default;
     UserSettings       m_usersettings;
     InternalSettings   m_internalsettings;

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -32,8 +32,7 @@ SettingsPanel::SettingsPanel(SettingsManager& settings)
 , m_usersettings_default(settings.GetDefaultUserSettings())
 , m_usersettings_initial(m_usersettings_default)
 , m_usersettings(settings.GetUserSettings())
-, m_font_settings({ m_usersettings.display_settings.dpi_based_scaling,
-                    m_usersettings.display_settings.font_size_index })
+, m_pending_font_size_index(m_usersettings.display_settings.font_size_index)
 {
 }
 
@@ -42,12 +41,11 @@ SettingsPanel::~SettingsPanel() {}
 void
 SettingsPanel::Show()
 {
-    m_should_open               = true;
-    m_category                  = Display;
-    m_usersettings_initial      = m_usersettings;
-    m_usersettings_previous     = m_usersettings;
-    m_font_settings.dpi_scaling = m_usersettings.display_settings.dpi_based_scaling;
-    m_font_settings.size_index  = m_usersettings.display_settings.font_size_index;
+    m_should_open             = true;
+    m_category                = Display;
+    m_usersettings_initial    = m_usersettings;
+    m_usersettings_previous   = m_usersettings;
+    m_pending_font_size_index = m_usersettings.display_settings.font_size_index;
 }
 
 void
@@ -157,10 +155,8 @@ SettingsPanel::Render()
                                  ImGui::GetStyle().ItemSpacing.x - 2 * button_width);
             if(ImGui::Button("OK", ImVec2(button_width, 0)))
             {
-                m_usersettings.display_settings.dpi_based_scaling =
-                    m_font_settings.dpi_scaling;
                 m_usersettings.display_settings.font_size_index =
-                    m_font_settings.size_index;
+                    m_pending_font_size_index;
 
                 m_settings_changed   = true;
                 m_settings_confirmed = true;
@@ -229,65 +225,32 @@ SettingsPanel::RenderDisplayOptions()
     ImGui::TextUnformatted("Fonts");
     ImGui::Separator();
 
-    // DPI-based scaling toggle
-    ImGui::Checkbox("DPI-based Font Scaling", &m_font_settings.dpi_scaling);
-    if(ImGui::IsItemHovered())
-    {
-        SetTooltipStyled("Automatically scale font size based on display DPI.");
-    }
+    // Font size slider. Slider works in integer points, then snaps the
+    // pending index to the closest entry in the font manager's size table.
+    m_pending_font_size_index = m_fonts.ClampFontSizeIndex(m_pending_font_size_index);
+    int min_size  = static_cast<int>(m_fonts.GetMinUserFontSize());
+    int max_size  = static_cast<int>(m_fonts.GetMaxUserFontSize());
+    int font_size = static_cast<int>(m_fonts.GetFontSizeAt(m_pending_font_size_index));
 
-    // Font size section
-    float button_width = ImGui::CalcTextSize("+").x + 2 * style.FramePadding.x;
-    ImGui::BeginDisabled(m_font_settings.dpi_scaling);
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Font Size");
     ImGui::SameLine();
-    ImGui::BeginDisabled(m_font_settings.size_index < 1);
-    if(ImGui::Button("-", ImVec2(button_width, 0)))
+    ImGui::SetNextItemWidth(240.0f);
+    if(ImGui::SliderInt("##font_size", &font_size, min_size, max_size, "%d pt"))
     {
-        m_font_settings.size_index--;
+        m_pending_font_size_index = m_fonts.GetFontSizeIndex(static_cast<float>(font_size));
     }
-    ImGui::EndDisabled();
-    ImGui::SameLine();
-    ImGui::SetNextItemWidth(ImGui::CalcTextSize("00").x + 2 * style.FramePadding.x +
-                            ImGui::GetFrameHeightWithSpacing());
-    const auto& available_sizes   = m_fonts.GetAvailableSizes();
-    std::string current_label     = std::to_string(static_cast<int>(available_sizes[m_font_settings.size_index]));
-    if(ImGui::BeginCombo("##font_size", current_label.c_str()))
-    {
-        for(int i = 0; i < static_cast<int>(available_sizes.size()); ++i)
-        {
-            std::string label = std::to_string(static_cast<int>(available_sizes[i]));
-            if(ImGui::Selectable(label.c_str(), i == m_font_settings.size_index))
-                m_font_settings.size_index = i;
-            if(i == m_font_settings.size_index)
-                ImGui::SetItemDefaultFocus();
-        }
-        ImGui::EndCombo();
-    }
-    ImGui::SameLine();
-    ImGui::BeginDisabled(m_font_settings.size_index >
-                         static_cast<int>(m_fonts.GetAvailableSizes().size()) - 2);
-    if(ImGui::Button("+", ImVec2(button_width, 0)))
-    {
-        m_font_settings.size_index++;
-    }
-    ImGui::EndDisabled();
     if(ImGui::IsItemHovered())
     {
-        SetTooltipStyled("Increase or decrease the font size for the UI.");
+        SetTooltipStyled("Adjust the UI font within the supported layout range.");
     }
-    ImGui::EndDisabled();
-    // Font preview
+
+    // Font preview at the pending size.
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Preview");
     ImGui::SameLine();
     ImFont* preview_font = m_fonts.GetFont(FontType::kDefault);
-    int     preview_idx  = m_font_settings.dpi_scaling ? m_fonts.GetDPIScaledFontIndex()
-                                                        : m_font_settings.size_index;
-    float preview_size = available_sizes.empty() ? m_fonts.GetFontSize(FontSize::kDefault)
-                       : available_sizes[std::max(0, std::min(preview_idx,
-                             static_cast<int>(available_sizes.size()) - 1))];
+    float   preview_size = m_fonts.GetFontSizeAt(m_pending_font_size_index);
     if(preview_font)
     {
         ImGui::Spacing();
@@ -352,10 +315,8 @@ void
 SettingsPanel::ResetDisplayOptions()
 {
     m_usersettings.display_settings = m_usersettings_default.display_settings;
-    m_font_settings.dpi_scaling =
-        m_usersettings_default.display_settings.dpi_based_scaling;
-    m_font_settings.size_index = m_usersettings_default.display_settings.font_size_index;
-    m_settings_changed         = true;
+    m_pending_font_size_index       = m_usersettings_default.display_settings.font_size_index;
+    m_settings_changed              = true;
 }
 
 void

--- a/src/view/src/rocprofvis_settings_panel.h
+++ b/src/view/src/rocprofvis_settings_panel.h
@@ -21,11 +21,6 @@ public:
     void Render();
 
 private:
-    struct FontSettings
-    {
-        bool dpi_scaling;
-        int  size_index;
-    };
     enum Category
     {
         Display,
@@ -46,18 +41,20 @@ private:
 
     bool ResetButton();
 
-    bool                     m_should_open;
-    bool                     m_settings_changed;
-    bool                     m_settings_confirmed;
-    Category                 m_category;
+    bool             m_should_open;
+    bool             m_settings_changed;
+    bool             m_settings_confirmed;
+    Category         m_category;
     SettingsManager& m_settings;
     FontManager&     m_fonts;
     UserSettings&    m_usersettings;
 
     const UserSettings& m_usersettings_default;
-    UserSettings m_usersettings_initial;
-    UserSettings m_usersettings_previous;
-    FontSettings m_font_settings;
+    UserSettings        m_usersettings_initial;
+    UserSettings        m_usersettings_previous;
+
+    // Pending font size index applied to user settings only when OK is pressed.
+    int m_pending_font_size_index;
 
     HotkeyActionId m_rebinding_action  = HotkeyActionId::kCount;
     bool           m_rebinding_primary = true;

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -385,8 +385,7 @@ TraceView::Render()
             popup_style.PushPopupStyles();
             popup_style.PushTitlebarColors();
 
-            float dpi = SettingsManager::GetInstance().GetDPI();
-            ImGui::SetNextWindowSize(ImVec2(400.0f * dpi, 290.0f * dpi));
+            ImGui::SetNextWindowSize(ImVec2(400.0f, 290.0f));
             if(ImGui::Begin("Minimap", &m_show_minimap_popup,
                             ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse))
             {

--- a/src/view/src/rocprofvis_view_module.cpp
+++ b/src/view/src/rocprofvis_view_module.cpp
@@ -3,8 +3,6 @@
 
 #include "rocprofvis_view_module.h"
 #include "rocprofvis_appwindow.h"
-#include "rocprofvis_settings_manager.h"
-#include "rocprofvis_font_manager.h"
 #include "rocprofvis_utils.h"
 #include "widgets/rocprofvis_image_helpers.h"
 #include "spdlog/spdlog.h"
@@ -45,21 +43,6 @@ void
 rocprofvis_view_destroy()
 {
     AppWindow::GetInstance()->DestroyInstance();
-}
-
-void
-rocprofvis_view_set_dpi(float dpi)
-{
-    SettingsManager& settings = SettingsManager::GetInstance();
-    if(settings.GetUserSettings().display_settings.dpi_based_scaling)
-    {
-        if(settings.GetDPI() != dpi)
-        {
-            settings.SetDPI(dpi);
-            FontManager& fonts = settings.GetFontManager();
-            fonts.SetFontSize(fonts.GetDPIScaledFontIndex());
-        }
-    }
 }
 
 void

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -503,16 +503,20 @@ DrawInternalBuildBanner(const char* text /*= "Internal Build"*/)
 {
     if(!text || !*text) return;
 
-    ImDrawList*   dl   = ImGui::GetForegroundDrawList();
-    const ImVec2& disp = ImGui::GetIO().DisplaySize;
+    ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImDrawList*    dl       = ImGui::GetForegroundDrawList(viewport);
+    const ImVec2&  vp_pos   = viewport->Pos;
+    const ImVec2&  vp_size  = viewport->Size;
 
     // Parameters
-    static constexpr float ribbon_thickness = 20.0f;
-    static constexpr float min_base_length  = 150.0f;
-    SettingsManager& settings    = SettingsManager::GetInstance();
-    const ImU32      col_fill     = settings.GetColor(Colors::kBannerFill);
-    const ImU32      col_border   = settings.GetColor(Colors::kBannerBorder);
-    const ImU32      col_text     = settings.GetColor(Colors::kBannerText);
+    static constexpr float BASE_FONT_SIZE   = 15.0f;
+    const float            ui_scale         = ImGui::GetFontSize() / BASE_FONT_SIZE;
+    const float            ribbon_thickness = 20.0f * ui_scale;
+    const float            min_base_length  = 150.0f * ui_scale;
+    SettingsManager&       settings         = SettingsManager::GetInstance();
+    const ImU32            col_fill         = settings.GetColor(Colors::kBannerFill);
+    const ImU32            col_border       = settings.GetColor(Colors::kBannerBorder);
+    const ImU32            col_text         = settings.GetColor(Colors::kBannerText);
 
     // use precomputed cos/sin for 45 degrees to avoid trig calls
     static constexpr float c_45 = 0.70710678118f;
@@ -530,9 +534,10 @@ DrawInternalBuildBanner(const char* text /*= "Internal Build"*/)
     const float half_thick = ribbon_thickness * 0.5f;
 
     // Center a rotated rectangle so it visually emerges from the top-right corner
-    ImVec2 center = ImVec2(disp.x - half_len * 0.5f, half_len * 0.5f);
+    ImVec2 center =
+        ImVec2(vp_pos.x + vp_size.x - half_len * 0.5f, vp_pos.y + half_len * 0.5f);
 
-    // Axis‑aligned rect (local space before rotation)
+    // Axis-aligned rect (local space before rotation)
     ImVec2 local[4] = { ImVec2(-half_len, -half_thick), ImVec2(half_len, -half_thick),
                         ImVec2(half_len, half_thick), ImVec2(-half_len, half_thick) };
 
@@ -557,10 +562,10 @@ DrawInternalBuildBanner(const char* text /*= "Internal Build"*/)
 
     for(int i = v_start; i < v_end; ++i)
     {
-        ImDrawVert&   v = dl->VtxBuffer[i];
-        const ImVec2  p = v.pos - center;
-        v.pos.x         = center.x + p.x * c_45 - p.y * s_45;
-        v.pos.y         = center.y + p.x * s_45 + p.y * c_45;
+        ImDrawVert&  v = dl->VtxBuffer[i];
+        const ImVec2 p = v.pos - center;
+        v.pos.x        = center.x + p.x * c_45 - p.y * s_45;
+        v.pos.y        = center.y + p.x * s_45 + p.y * c_45;
     }
 }
 #endif // ROCPROFVIS_ENABLE_INTERNAL_BANNER


### PR DESCRIPTION
## Remove custom DPI handling — switch to ImGui auto-DPI font sizing
### Summary
Replaces the app's hand-rolled DPI machinery with Dear ImGui's built-in per-monitor DPI/font scaling (ImGui 1.92+). The old approach tracked a manual `m_display_dpi`, derived a font index from it (`GetDPIScaledFontIndex`), and exposed a "DPI-based Font Scaling" toggle. That is removed in favor of ImGui scaling fonts/viewports automatically, with the user choosing an absolute font size via a simple slider.
This branch was rebased onto current `main` by cherry-picking the 5 DPI commits from `sw-dpi-removal`. Conflicts from main's divergence were resolved so unrelated work (e.g. themed banner colors) is preserved.
### What changed
**App / window setup (`src/app/`)**
- Enable ImGui auto-DPI: `io.ConfigDpiScaleFonts`, `io.ConfigDpiScaleViewports`, `ImGuiConfigFlags_ViewportsEnable`, and `FontScaleMain = 1.0f`.
- Drive multi-viewport rendering in the main loop (`UpdatePlatformWindows` / `RenderPlatformWindowsDefault`, restoring the GL context afterward).
- Remove the GLFW `content_scale_callback` and the `rocprofvis_view_set_dpi` plumbing.
- Keep `GLFW_SCALE_TO_MONITOR` on both the Vulkan and OpenGL-fallback windows for correct per-monitor scaling.
**Fonts (`rocprofvis_font_manager`)**
- Drop `GetDPIScaledFontIndex` and `GetAvailableSizes`.
- Add a clamped user-font-size API: `GetMinUserFontSize`, `GetMaxUserFontSize`, `GetFontSizeAt`, `GetFontSizeIndex`, `GetDefaultFontSizeIndex`, `ClampFontSizeIndex` (range 13–18 pt, snapping to the internal size table). `FontSize::kDefault` maps to the user's base size.
**Settings (`rocprofvis_settings_manager`)**
- Remove `SetDPI` / `GetDPI`, `m_display_dpi`, and the `dpi_based_scaling` field plus `JSON_KEY_SETTINGS_DISPLAY_DPI_SCALING`.
- Loaded `font_size_index` is now clamped through `ClampFontSizeIndex` on deserialize and apply.
**Settings panel (`rocprofvis_settings_panel`)**
- Replace the DPI checkbox and the `−` / combo / `+` font picker with a single Font Size `SliderInt` (`"%d pt"`) plus a live preview at the pending size. The pending value is held in `m_pending_font_size_index` and committed only on OK.
**Layout fixes for the new scaling model**
- Status bar slot is sized to one framed line + child border (removes the scrollbar sliver and the `NoScrollbar` workaround); recomputed via `HandleFontChanged`.
- Internal-build banner, minimap popup, and shutdown dialog drop their manual `* dpi` multipliers. The banner now positions off the main viewport and scales its ribbon by `GetFontSize() / BASE_FONT_SIZE`, while keeping main's themed banner colors.
