### PR TITLE
Call destructors on objects when memory pool is freed (Fix mem leak)

### DIFF
--- a/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
+++ b/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
@@ -516,7 +516,23 @@ void MemoryManager::CleanUp() {
     {
         for(auto it1 : it->second)
         {
-            delete it1.second;
+            MemoryPool* pool = it1.second;
+
+            // Objects are placement-new'd into the pool's raw storage, so the
+            // pool's destructor (which only frees the block) would not run them.
+            // Destroy any still-live residents first so their non-trivial members
+            // (e.g. SampleLOD::m_children) are released; ~Handle() is virtual and
+            // dispatches to the concrete type.
+            char* base = static_cast<char*>(pool->m_base);
+            for(size_t slot = 0; slot < pool->m_bitmask.Size(); ++slot)
+            {
+                if(pool->m_bitmask.Test(slot))
+                {
+                    reinterpret_cast<Handle*>(base + slot * pool->m_size)->~Handle();
+                }
+            }
+
+            delete pool;
         }
     }
 }

--- a/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
+++ b/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
@@ -21,6 +21,7 @@
 #undef min
 #undef max
 #include <algorithm>
+#include <type_traits>
 
 
 namespace RocProfVis
@@ -500,6 +501,18 @@ MemoryManager::Allocate(size_t size, rocprofvis_object_type_t type, SegmentTimel
     throw std::runtime_error("Allocation problem!");
     return nullptr;
 }
+
+// The pool teardown below reinterpret_casts each live slot to Handle* and
+// invokes its virtual destructor. That is only valid because every type placed
+// into a pool (via the private Allocate(), used solely by New{Event,Sample,
+// SampleLOD}) derives from Handle, with Handle at offset 0 (single, non-virtual
+// inheritance). These asserts fail the build if that invariant ever breaks.
+static_assert(std::is_base_of<Handle, Event>::value,
+              "Pooled Event must derive from Handle");
+static_assert(std::is_base_of<Handle, Sample>::value,
+              "Pooled Sample must derive from Handle");
+static_assert(std::is_base_of<Handle, SampleLOD>::value,
+              "Pooled SampleLOD must derive from Handle");
 
 void MemoryManager::CleanUp() {
     std::lock_guard<std::mutex> lock(m_pool_mutex);


### PR DESCRIPTION
## Motivation

Address this memory leak:

```
Direct leak of 7402840 byte(s) in 54768 object(s) allocated from:
    #0 0x7f763ce73548 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x55b7ad742f13 in std::__new_allocator<RocProfVis::Controller::Sample*>::allocate(unsigned long, void const*) /usr/include/c++/13/bits/new_allocator.h:151
    #2 0x55b7ad742f13 in std::allocator_traits<std::allocator<RocProfVis::Controller::Sample*> >::allocate(std::allocator<RocProfVis::Controller::Sample*>&, unsigned long) /usr/include/c++/13/bits/alloc_traits.h:482
    #3 0x55b7ad742f13 in std::_Vector_base<RocProfVis::Controller::Sample*, std::allocator<RocProfVis::Controller::Sample*> >::_M_allocate(unsigned long) /usr/include/c++/13/bits/stl_vector.h:381
    #4 0x55b7ad742f13 in std::_Vector_base<RocProfVis::Controller::Sample*, std::allocator<RocProfVis::Controller::Sample*> >::_M_create_storage(unsigned long) /usr/include/c++/13/bits/stl_vector.h:398
    #5 0x55b7ad742f13 in std::_Vector_base<RocProfVis::Controller::Sample*, std::allocator<RocProfVis::Controller::Sample*> >::_Vector_base(unsigned long, std::allocator<RocProfVis::Controller::Sample*> const&) /usr/include/c++/13/bits/stl_vector.h:335
    #6 0x55b7ad742f13 in std::vector<RocProfVis::Controller::Sample*, std::allocator<RocProfVis::Controller::Sample*> >::vector(std::vector<RocProfVis::Controller::Sample*, std::allocator<RocProfVis::Controller::Sample*> > const&) /usr/include/c++/13/bits/stl_vector.h:603
    #7 0x55b7ad742f13 in RocProfVis::Controller::SampleLOD::SampleLOD(rocprofvis_controller_primitive_type_t, unsigned long, double, std::vector<RocProfVis::Controller::Sample*, std::allocator<RocProfVis::Controller::Sample*> >&) /__w/roc-optiq/roc-optiq/src/controller/src/system/rocprofvis_controller_sample_lod.cpp:87
    #8 0x55b7ad793e6b in RocProfVis::Controller::MemoryManager::NewSampleLOD(rocprofvis_controller_primitive_type_t, unsigned long, double, std::vector<RocProfVis::Controller::Sample*, std::allocator<RocProfVis::Controller::Sample*> >&, RocProfVis::Controller::SegmentTimeline*) /__w/roc-optiq/roc-optiq/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp:561
    #9 0x55b7ad737b0d in RocProfVis::Controller::Graph::GenerateLOD(unsigned int, double, double, std::vector<RocProfVis::Controller::Data, std::allocator<RocProfVis::Controller::Data> >&, RocProfVis::Controller::Future*) /__w/roc-optiq/roc-optiq/src/controller/src/system/rocprofvis_controller_graph.cpp:433
    #10 0x55b7ad739b41 in RocProfVis::Controller::Graph::GenerateLOD(unsigned int, double, double, RocProfVis::Controller::Future*) /__w/roc-optiq/roc-optiq/src/controller/src/system/rocprofvis_controller_graph.cpp:590
    #11 0x55b7ad73c62e in RocProfVis::Controller::Graph::Fetch(unsigned int, double, double, RocProfVis::Controller::Array&, unsigned long&, RocProfVis::Controller::Future*) /__w/roc-optiq/roc-optiq/src/controller/src/system/rocprofvis_controller_graph.cpp:673
    #12 0x55b7ad846efb in operator() /__w/roc-optiq/roc-optiq/src/controller/src/system/rocprofvis_controller_timeline.cpp:46
    #13 0x55b7ad846efb in __invoke_impl<rocprofvis_result_t, RocProfVis::Controller::Timeline::AsyncFetch(RocProfVis::Controller::Graph&, RocProfVis::Controller::Future&, RocProfVis::Controller::Array&, double, double, uint32_t)::<lambda(RocProfVis::Controller::Future*)>&, RocProfVis::Controller::Future*> /usr/include/c++/13/bits/invoke.h:61
    #14 0x55b7ad846efb in __invoke_r<rocprofvis_result_t, RocProfVis::Controller::Timeline::AsyncFetch(RocProfVis::Controller::Graph&, RocProfVis::Controller::Future&, RocProfVis::Controller::Array&, double, double, uint32_t)::<lambda(RocProfVis::Controller::Future*)>&, RocProfVis::Controller::Future*> /usr/include/c++/13/bits/invoke.h:114
    #15 0x55b7ad846efb in _M_invoke /usr/include/c++/13/bits/std_function.h:290
    #16 0x55b7ad83f215 in std::function<rocprofvis_result_t (RocProfVis::Controller::Future*)>::operator()(RocProfVis::Controller::Future*) const /usr/include/c++/13/bits/std_function.h:591
    #17 0x55b7ad83f215 in RocProfVis::Controller::Job::Execute() /__w/roc-optiq/roc-optiq/src/controller/src/rocprofvis_controller_job_system.cpp:31
    #18 0x55b7ad83f215 in operator() /__w/roc-optiq/roc-optiq/src/controller/src/rocprofvis_controller_job_system.cpp:112
    #19 0x55b7ad83f215 in __invoke_impl<void, RocProfVis::Controller::JobSystem::JobSystem()::<lambda()> > /usr/include/c++/13/bits/invoke.h:61
    #20 0x55b7ad83f215 in __invoke<RocProfVis::Controller::JobSystem::JobSystem()::<lambda()> > /usr/include/c++/13/bits/invoke.h:96
    #21 0x55b7ad83f215 in _M_invoke<0> /usr/include/c++/13/bits/std_thread.h:292
    #22 0x55b7ad83f215 in operator() /usr/include/c++/13/bits/std_thread.h:299
    #23 0x55b7ad83f215 in _M_run /usr/include/c++/13/bits/std_thread.h:244
    #24 0x7f763cbe3db3  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xecdb3) (BuildId: 753c6c8608b61d4e67be8f0c890e03e0aa046b8b)
    #25 0x7f763cdd3a41 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
    #26 0x7f763c86aaa3  (/lib/x86_64-linux-gnu/libc.so.6+0x9caa3) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
```

## Technical Details

When freeing the memory pool, call the destructors for the objects in each slot.

## Test Plan

Verify ASAN no longer shows this memory leak