### PR TITLE
Fix (sub) futures not freed

### DIFF
--- a/src/model/src/database/rocprofvis_db_future.h
+++ b/src/model/src/database/rocprofvis_db_future.h
@@ -84,7 +84,7 @@ class Future
 
         const char*                         GetAsyncQueryPtr(){return m_async_query.c_str(); }
 
-        std::vector<Future*>&               SubFeatures() { return m_sub_futures; }
+        std::vector<Future*>&               GetSubFutures() { return m_sub_futures; }
         template <typename T> 
         void                                SetRuntimeStorageValue(rocprofvis_db_future_runtime_storage_t key, T&& value) 
         {

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -905,16 +905,23 @@ ProfileDatabase::ExecuteQueryForAllTracksAsync(
 rocprofvis_dm_result_t
 ProfileDatabase::ExecuteQueriesAsync(
     std::vector<std::pair<DbInstance*, std::string>>& queries,
-    std::vector<Future*> & sub_futures,
+    std::vector<Future*>& sub_futures,
     rocprofvis_dm_handle_t handle,
     RpvSqliteExecuteQueryCallback callback)
 {
-    std::vector<Future*> futures = sub_futures;
+    (void) sub_futures;
     rocprofvis_dm_result_t result = kRocProfVisDmResultSuccess;
-    futures.resize(queries.size());
+    // These worker futures are local: allocate, run, wait, then free directly.
+    // We intentionally do NOT register them in the parent's sub-future list:
+    // ExecuteQueriesAsync runs on the parent future's own worker thread, and
+    // taking the parent's mutex (via AddSubFuture/DeleteSubFuture) from here
+    // can deadlock against other holders of that mutex. Each worker remains
+    // independently interruptible via its own future (LinkDatabase /
+    // Interrupted() checks in the callback).
+    std::vector<Future*> futures(queries.size(), nullptr);
     for(int i = 0; i < queries.size(); i++)
     {
-        futures[i]     = (Future*)rocprofvis_db_future_alloc(nullptr);
+        futures[i] = (Future*)rocprofvis_db_future_alloc(nullptr);
         try
         {
             futures[i]->SetWorker(std::move(
@@ -924,6 +931,11 @@ ProfileDatabase::ExecuteQueriesAsync(
                     queries[i].second.c_str(), handle, i, callback)));
         } catch(std::exception ex)
         {
+            // The worker thread never started, so the future's promise will
+            // never be set; free it now to avoid a wait below that would block
+            // forever on an unfulfilled promise.
+            rocprofvis_db_future_free(futures[i]);
+            futures[i] = nullptr;
             result = kRocProfVisDmResultUnknownError;
             ROCPROFVIS_ASSERT_MSG_BREAK(false, ex.what());
         }       
@@ -937,16 +949,10 @@ ProfileDatabase::ExecuteQueriesAsync(
             {
                 result = kRocProfVisDmResultUnknownError;
             }
-            auto it = std::find_if(sub_futures.begin(), sub_futures.end(), [&](Future* f) { return f == futures[i]; });
-            if (it != sub_futures.end())
-            {
-                sub_futures.erase(it);
-                rocprofvis_db_future_free(*it);
-                futures[i] = nullptr;
-            }
+            rocprofvis_db_future_free(futures[i]);
+            futures[i] = nullptr;
         }
     }
-    futures.clear();
     return result;
 }
 

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -905,23 +905,19 @@ ProfileDatabase::ExecuteQueryForAllTracksAsync(
 rocprofvis_dm_result_t
 ProfileDatabase::ExecuteQueriesAsync(
     std::vector<std::pair<DbInstance*, std::string>>& queries,
-    std::vector<Future*>& sub_futures,
+    Future* parent,
     rocprofvis_dm_handle_t handle,
     RpvSqliteExecuteQueryCallback callback)
 {
-    (void) sub_futures;
     rocprofvis_dm_result_t result = kRocProfVisDmResultSuccess;
-    // These worker futures are local: allocate, run, wait, then free directly.
-    // We intentionally do NOT register them in the parent's sub-future list:
-    // ExecuteQueriesAsync runs on the parent future's own worker thread, and
-    // taking the parent's mutex (via AddSubFuture/DeleteSubFuture) from here
-    // can deadlock against other holders of that mutex. Each worker remains
-    // independently interruptible via its own future (LinkDatabase /
-    // Interrupted() checks in the callback).
+    // Register each worker as a sub-future of the parent so it is reachable by
+    // the parent's SetInterrupted() (cancellation) and is freed through the
+    // mutex-protected DeleteSubFuture() path. AddSubFuture() both allocates and
+    // registers; WaitAndDeleteSubFuture() waits, then unregisters and frees.
     std::vector<Future*> futures(queries.size(), nullptr);
     for(int i = 0; i < queries.size(); i++)
     {
-        futures[i] = (Future*)rocprofvis_db_future_alloc(nullptr);
+        futures[i] = parent->AddSubFuture();
         try
         {
             futures[i]->SetWorker(std::move(
@@ -931,10 +927,10 @@ ProfileDatabase::ExecuteQueriesAsync(
                     queries[i].second.c_str(), handle, i, callback)));
         } catch(std::exception ex)
         {
-            // The worker thread never started, so the future's promise will
-            // never be set; free it now to avoid a wait below that would block
-            // forever on an unfulfilled promise.
-            rocprofvis_db_future_free(futures[i]);
+            // The worker thread never started, so the sub-future's promise will
+            // never be set; unregister and free it now to avoid a wait below
+            // that would block forever on an unfulfilled promise.
+            parent->DeleteSubFuture(futures[i]);
             futures[i] = nullptr;
             result = kRocProfVisDmResultUnknownError;
             ROCPROFVIS_ASSERT_MSG_BREAK(false, ex.what());
@@ -945,11 +941,10 @@ ProfileDatabase::ExecuteQueriesAsync(
         if(futures[i] != nullptr)
         {
             if(kRocProfVisDmResultSuccess !=
-                rocprofvis_db_future_wait(futures[i], UINT64_MAX))
+                parent->WaitAndDeleteSubFuture(futures[i]))
             {
                 result = kRocProfVisDmResultUnknownError;
             }
-            rocprofvis_db_future_free(futures[i]);
             futures[i] = nullptr;
         }
     }

--- a/src/model/src/database/rocprofvis_db_profile.h
+++ b/src/model/src/database/rocprofvis_db_profile.h
@@ -218,7 +218,7 @@ class ProfileDatabase : public SqliteDatabase
                             guid_list_t run_for_db_instances);
         rocprofvis_dm_result_t ExecuteQueriesAsync(
                             std::vector<std::pair<DbInstance*, std::string>>& queries,
-                            std::vector<Future*>& futures,
+                            std::vector<Future*>& sub_futures,
                             rocprofvis_dm_handle_t handle,
                             RpvSqliteExecuteQueryCallback callback);
 

--- a/src/model/src/database/rocprofvis_db_profile.h
+++ b/src/model/src/database/rocprofvis_db_profile.h
@@ -218,7 +218,7 @@ class ProfileDatabase : public SqliteDatabase
                             guid_list_t run_for_db_instances);
         rocprofvis_dm_result_t ExecuteQueriesAsync(
                             std::vector<std::pair<DbInstance*, std::string>>& queries,
-                            std::vector<Future*>& sub_futures,
+                            Future* parent,
                             rocprofvis_dm_handle_t handle,
                             RpvSqliteExecuteQueryCallback callback);
 

--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -117,7 +117,7 @@ namespace DataModel
 
                 if (new_queries.size())
                 {
-                    result = m_db->ExecuteQueriesAsync(new_queries, future->SubFeatures(), (rocprofvis_dm_handle_t)this, &CallbackRunCompoundQuery);
+                    result = m_db->ExecuteQueriesAsync(new_queries, future->GetSubFutures(), (rocprofvis_dm_handle_t)this, &CallbackRunCompoundQuery);
                     if (kRocProfVisDmResultSuccess == result)
                     {
                         try {

--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -117,7 +117,7 @@ namespace DataModel
 
                 if (new_queries.size())
                 {
-                    result = m_db->ExecuteQueriesAsync(new_queries, future->GetSubFutures(), (rocprofvis_dm_handle_t)this, &CallbackRunCompoundQuery);
+                    result = m_db->ExecuteQueriesAsync(new_queries, future, (rocprofvis_dm_handle_t)this, &CallbackRunCompoundQuery);
                     if (kRocProfVisDmResultSuccess == result)
                     {
                         try {


### PR DESCRIPTION
## Motivation

Fix this memory leak:

```
2026-06-22T19:11:17.3602657Z Direct leak of 328 byte(s) in 1 object(s) allocated from:
2026-06-22T19:11:17.3603162Z     #0 0x7fe317118548 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
2026-06-22T19:11:17.3603881Z     #1 0x5614f3d9f247 in rocprofvis_db_future_alloc /__w/roc-optiq/roc-optiq/src/model/src/common/rocprofvis_c_interface.cpp:166
2026-06-22T19:11:17.3606141Z     #2 0x5614f3f46f6f in RocProfVis::DataModel::ProfileDatabase::ExecuteQueriesAsync(std::vector<std::pair<DbInstance*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<DbInstance*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >&, std::vector<RocProfVis::DataModel::Future*, std::allocator<RocProfVis::DataModel::Future*> >&, void*, int (*)(void*, int, sqlite3_stmt*, char**)) /__w/roc-optiq/roc-optiq/src/model/src/database/rocprofvis_db_profile.cpp:917
2026-06-22T19:11:17.3612500Z     #3 0x5614f413a38f in RocProfVis::DataModel::TableProcessor::ExecuteCompoundQuery(RocProfVis::DataModel::Future*, std::unordered_map<unsigned int, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RocProfVis::DataModel::rocprofvis_db_compound_query_info, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RocProfVis::DataModel::rocprofvis_db_compound_query_info> > >, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, RocProfVis::DataModel::rocprofvis_db_compound_query_info, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, RocProfVis::DataModel::rocprofvis_db_compound_query_info> > > > > >&, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> >&, std::vector<RocProfVis::DataModel::rocprofvis_db_compound_query_command, std::allocator<RocProfVis::DataModel::rocprofvis_db_compound_query_command> >, void*, bool) /__w/roc-optiq/roc-optiq/src/model/src/database/rocprofvis_db_table_processor.cpp:120
2026-06-22T19:11:17.3618042Z     #4 0x5614f3f48f39 in RocProfVis::DataModel::ProfileDatabase::ExecuteQuery(char const*, char const*, RocProfVis::DataModel::Future*) /__w/roc-optiq/roc-optiq/src/model/src/database/rocprofvis_db_profile.cpp:1531
2026-06-22T19:11:17.3619074Z     #5 0x7fe316e88db3  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xecdb3) (BuildId: 753c6c8608b61d4e67be8f0c890e03e0aa046b8b)
2026-06-22T19:11:17.3619736Z     #6 0x7fe317078a41 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
2026-06-22T19:11:17.3620367Z     #7 0x7fe316b0faa3  (/lib/x86_64-linux-gnu/libc.so.6+0x9caa3) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
```

## Technical Details

### The bug

`ExecuteQueriesAsync` allocated one worker Future per query but never freed them:

It copied the caller's sub-future vector into a local (`std::vector<Future*> futures = sub_futures`), resized it, then overwrote every slot with a freshly rocprofvis_db_future_alloc'd future — so the new workers were never present in the caller's vector.
The cleanup loop then tried to free each worker only if std::find_if(sub_futures, …) located it in the caller's vector. Since the workers were never in that vector, the lookup always failed and nothing was ever freed.

That dead cleanup branch also had a latent use-after-erase (rocprofvis_db_future_free(*it) after sub_futures.erase(it)).

### The fix

Manage the worker futures through the existing, mutex-safe sub-future API instead of hand-rolling the vector:

Change the signature to take the parent `Future*` rather than its sub-future vector.
Create each worker via `parent->AddSubFuture()` (allocates and registers it under the parent's mutex).

Reclaim each via `parent->WaitAndDeleteSubFuture()` (waits, then unregisters and frees under the mutex).
On worker-launch failure (SetWorker throws), `DeleteSubFuture()` immediately and skip it in the wait loop, so we never block forever on a promise that will never be set.

Update the `TableProcessor::ExecuteCompoundQuery` caller to pass future directly, and rename `Future::SubFeatures()` → `Future::GetSubFutures()` fix typo.

As a bonus, registering the workers as sub-futures also makes them reachable from the parent's SetInterrupted(), in addition to their existing per-future interrupt paths.

## Test Plan

Verify this memory leak is no longer present in ASAN builds.