### PR TITLE
Free futures after use in test code

### DIFF
--- a/src/controller/tests/rocprofvis_controller_system_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_system_tests.cpp
@@ -832,6 +832,9 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
 
         std::filesystem::remove(csv_path);
 
+        spdlog::info("Free Future");
+        rocprofvis_controller_future_free(future);
+
         spdlog::info("Free Args");
         rocprofvis_controller_arguments_free(args);
     }
@@ -1132,6 +1135,9 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
         REQUIRE(file_size > 0);
 
         std::filesystem::remove(csv_path);
+
+        spdlog::info("Free Future");
+        rocprofvis_controller_future_free(future);
 
         spdlog::info("Free Args");
         rocprofvis_controller_arguments_free(args);


### PR DESCRIPTION
## Motivation

Fix mem leaks in test code, like:

```
2026-06-23T17:04:55.7493297Z Indirect leak of 192 byte(s) in 1 object(s) allocated from:
2026-06-23T17:04:55.7493717Z     #0 0x7fb75c77a548 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
2026-06-23T17:04:55.7494107Z     #1 0x564139d2da14 in rocprofvis_controller_future_alloc /__w/roc-optiq/roc-optiq/src/controller/src/rocprofvis_controller.cpp:242
2026-06-23T17:04:55.7494437Z     #2 0x564139c91349 in test /__w/roc-optiq/roc-optiq/src/controller/tests/rocprofvis_controller_system_tests.cpp:1110
2026-06-23T17:04:55.7494737Z     #3 0x56413a81c4ce in Catch::TestCaseHandle::invoke() const src/catch2/../catch2/catch_test_case_info.hpp:124
2026-06-23T17:04:55.7495193Z     #4 0x56413a81c4ce in Catch::RunContext::invokeActiveTestCase() src/catch2/internal/catch_run_context.cpp:580
2026-06-23T17:04:55.7495482Z     #5 0x56413a81c4ce in Catch::RunContext::runCurrentTest() src/catch2/internal/catch_run_context.cpp:543
2026-06-23T17:04:55.7495841Z     #6 0x56413a81d775 in Catch::RunContext::runTest(Catch::TestCaseHandle const&) src/catch2/internal/catch_run_context.cpp:240
2026-06-23T17:04:55.7496005Z     #7 0x56413a764398 in execute src/catch2/catch_session.cpp:117
2026-06-23T17:04:55.7496216Z     #8 0x56413a764398 in Catch::Session::runInternal() src/catch2/catch_session.cpp:337
2026-06-23T17:04:55.7496414Z     #9 0x56413a7665bc in Catch::Session::run() src/catch2/catch_session.cpp:269
2026-06-23T17:04:55.7496737Z     #10 0x564139b9d3df in main /__w/roc-optiq/roc-optiq/src/controller/tests/rocprofvis_controller_system_tests.cpp:43
2026-06-23T17:04:55.7497047Z     #11 0x7fb75c0ff1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
2026-06-23T17:04:55.7497431Z     #12 0x7fb75c0ff28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 8e9fd827446c24067541ac5390e6f527fb5947bb)
2026-06-23T17:04:55.7497972Z     #13 0x564139c45334 in _start (/__w/roc-optiq/roc-optiq/build/src/controller/roc-optiq-controller-system-tests+0x255334) (BuildId: 4132ce2b9b598d8931e34354a07c80a9c6b35e2c)
```

## Technical Details

Free futures after use.

## Test Plan

Verify that leak is no longer reported.

