### PR TITLE
Redesign timeline annotations: track-bound notes with inline editing and floating windows

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1232,7 +1232,7 @@ EventManager::GetInstance()->AddEvent(
   same-frame ordering with the dispatcher.
 - Use the typed `RocEvent` subclasses in `rocprofvis_events.h`:
   `NavigationEvent`, `TrackDataEvent`, `TableDataEvent`,
-  `StickyNoteEvent`, `ScrollToTrackEvent`, `TabEvent`,
+  `ScrollToTrackEvent`, `TabEvent`,
   `TrackSelectionChangedEvent`, `TimeRangeSelectionChangedEvent`,
   `EventSelectionChangedEvent`, `EventHighlightChangedEvent`,
   `RangeEvent`, `RequestProgressUpdateEvent`,
@@ -1249,7 +1249,7 @@ The full list is in `rocprofvis_events.h`. Examples used widely:
 `kTimelineTrackSelectionChanged`, `kTimelineTimeRangeChanged`,
 `kTimelineEventSelectionChanged`, `kTimelineEventHighlightChanged`,
 `kHandleUserGraphNavigationEvent`, `kTrackMetadataChanged`,
-`kStickyNoteEdited`, `kFontSizeChanged`, `kSetViewRange`,
+`kFontSizeChanged`, `kSetViewRange`,
 `kGoToTimelineSpot`, `kTimeFormatChanged`, `kTopologyChanged`,
 `kRequestProgressUpdate`. Compute-only:
 `kComputeWorkloadSelectionChanged`,
@@ -1829,7 +1829,7 @@ For fast lookup. Each entry: class -> file -> one-line role.
 - `RocEvent`, `RocEvents` (enum), `RocEventType` (enum) ->
   `rocprofvis_events.h`.
 - Typed events in same file: `NavigationEvent`, `TrackDataEvent`,
-  `TableDataEvent`, `StickyNoteEvent`, `ScrollToTrackEvent`,
+  `TableDataEvent`, `ScrollToTrackEvent`,
   `TabEvent`, `TrackSelectionChangedEvent`,
   `TimeRangeSelectionChangedEvent`, `EventSelectionChangedEvent`,
   `EventHighlightChangedEvent`, `RangeEvent`,

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -939,13 +939,18 @@ counter) for the track, then renders an `InfoTable`.
 ### `Annotations` and `StickyNote`
 
 - `AnnotationsManager` (`rocprofvis_annotations.{h,cpp}`) - holds the
-  list of `StickyNote`s, the popup state for adding/editing, and the
-  visibility flag. Persisted via `AnnotationsManagerProjectSettings`.
+  list of `StickyNote`s and the visibility flag, creates new notes
+  inline via `CreateStickyNote`, and removes user-deleted notes via
+  `RemoveNotesPendingDelete`. Persisted via
+  `AnnotationsManagerProjectSettings`.
 - `StickyNote` (`rocprofvis_stickynote.{h,cpp}`) - one note. Carries
   position (time + y_offset), size, text/title, and view-range
-  metadata. `Render(draw_list, window_pos, tpt)`,
-  `HandleResize(...)`, `HandleDrag(...)`. Edit handled via
-  `kStickyNoteEdited` event.
+  metadata. `Render(draw_list, window_pos, tpt)` and `HandleDrag(...)`
+  drag the timeline anchor (minimized or expanded), and the timeline
+  auto-scrolls when the anchor nears a viewport edge. The expanded note
+  is a floating window with an inline-editable title (click to edit) and
+  body; `BeginInlineEdit()` opens a freshly created note focused for
+  typing.
 - `AnnotationView` (`rocprofvis_annotation_view.{h,cpp}`) - the
   sub-tab in `AnalysisView` that lists notes and lets the user
   select/hide them.

--- a/src/view/src/rocprofvis_annotation_view.cpp
+++ b/src/view/src/rocprofvis_annotation_view.cpp
@@ -4,6 +4,7 @@
 #include "rocprofvis_annotation_view.h"
 #include "icons/rocprovfis_icon_defines.h"
 #include "rocprofvis_data_provider.h"
+#include "rocprofvis_event_manager.h"
 #include "rocprofvis_events.h"
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_utils.h"

--- a/src/view/src/rocprofvis_annotation_view.cpp
+++ b/src/view/src/rocprofvis_annotation_view.cpp
@@ -117,9 +117,11 @@ AnnotationView::Render()
             ImGui::PopID();
 
             // Track column: the bound track's display name, or a placeholder
-            // for unbound legacy notes.
+            // for unbound legacy notes. Match the Text column's vertical offset
+            // so ElidedText lines up with the other columns.
             ImGui::TableNextColumn();
-            ImGui::AlignTextToFramePadding();
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() +
+                                 ImGui::GetStyle().FramePadding.y);
             const std::string track_name =
                 m_data_provider.DataModel().BuildTrackName(note.GetTrackId());
             if(track_name.empty())
@@ -140,12 +142,16 @@ AnnotationView::Render()
                                         true);
             ImGui::TextUnformatted(time_label.c_str());
 
-            // Visibility column
+            // Visibility column. When the bound track is hidden the note is
+            // force-hidden on the timeline, so disable (grey out) the toggle.
             ImGui::TableNextColumn();
-            bool        visible     = note.IsVisible();
-            std::string checkbox_id = "##visible_" + std::to_string(note.GetID());
+            bool        visible       = note.IsVisible();
+            const bool  track_hidden  = note.IsTrackHidden();
+            std::string checkbox_id   = "##visible_" + std::to_string(note.GetID());
+            if(track_hidden) ImGui::BeginDisabled();
             ImGui::Checkbox(checkbox_id.c_str(), &visible);
-            if(visible != note.IsVisible()) note.SetVisibility(visible);
+            if(track_hidden) ImGui::EndDisabled();
+            if(!track_hidden && visible != note.IsVisible()) note.SetVisibility(visible);
 
             ImGui::PopID();
         }

--- a/src/view/src/rocprofvis_annotation_view.cpp
+++ b/src/view/src/rocprofvis_annotation_view.cpp
@@ -3,6 +3,7 @@
 
 #include "rocprofvis_annotation_view.h"
 #include "icons/rocprovfis_icon_defines.h"
+#include "rocprofvis_data_provider.h"
 #include "rocprofvis_events.h"
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_utils.h"
@@ -38,13 +39,15 @@ AnnotationView::Render()
                              0.5f);
         ImGui::TextDisabled("No annotations.");
     }
-    else if(ImGui::BeginTable("StickyNotesTable", 4,
+    else if(ImGui::BeginTable("StickyNotesTable", 5,
                               ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV |
                                   ImGuiTableFlags_RowBg | ImGuiTableFlags_Resizable |
                                   ImGuiTableFlags_SizingStretchProp))
     {
         ImGui::TableSetupColumn("Title");
         ImGui::TableSetupColumn("Text");
+        ImGui::TableSetupColumn("Track", ImGuiTableColumnFlags_WidthFixed,
+                                ImGui::GetFontSize() * 10.0f);
         ImGui::TableSetupColumn("Time", ImGuiTableColumnFlags_WidthFixed,
                                 ImGui::GetFontSize() * 12.0f);
         ImGui::TableSetupColumn("Visible", ImGuiTableColumnFlags_WidthFixed,
@@ -93,7 +96,8 @@ AnnotationView::Render()
             {
                 m_selected_note_id = note.GetID();
                 auto event         = std::make_shared<NavigationEvent>(
-                    note.GetVMinX(), note.GetVMaxX(), note.GetYOffset(), true);
+                    note.GetVMinX(), note.GetVMaxX(), note.GetYOffset(), true,
+                    note.GetTrackId());
                 EventManager::GetInstance()->AddEvent(event);
             }
             ImGui::PopStyleVar();
@@ -110,6 +114,23 @@ AnnotationView::Render()
             ImGui::PushID("note_preview");
             ElidedText(note_preview.c_str(), ImGui::GetContentRegionAvail().x);
             ImGui::PopID();
+
+            // Track column: the bound track's display name, or a placeholder
+            // for unbound legacy notes.
+            ImGui::TableNextColumn();
+            ImGui::AlignTextToFramePadding();
+            const std::string track_name =
+                m_data_provider.DataModel().BuildTrackName(note.GetTrackId());
+            if(track_name.empty())
+            {
+                ImGui::TextDisabled("Unbound");
+            }
+            else
+            {
+                ImGui::PushID("note_track");
+                ElidedText(track_name.c_str(), ImGui::GetContentRegionAvail().x);
+                ImGui::PopID();
+            }
 
             // Time column
             ImGui::TableNextColumn();

--- a/src/view/src/rocprofvis_annotation_view.cpp
+++ b/src/view/src/rocprofvis_annotation_view.cpp
@@ -124,6 +124,9 @@ AnnotationView::Render()
                                  ImGui::GetStyle().FramePadding.y);
             const std::string track_name =
                 m_data_provider.DataModel().BuildTrackName(note.GetTrackId());
+            // Binding finalizes on drop; grey the column and keep the value.
+            const bool note_dragging = note.IsDragging();
+            if(note_dragging) ImGui::BeginDisabled();
             if(track_name.empty())
             {
                 ImGui::TextDisabled("Unbound");
@@ -134,6 +137,7 @@ AnnotationView::Render()
                 ElidedText(track_name.c_str(), ImGui::GetContentRegionAvail().x);
                 ImGui::PopID();
             }
+            if(note_dragging) ImGui::EndDisabled();
 
             // Time column
             ImGui::TableNextColumn();

--- a/src/view/src/rocprofvis_annotations.cpp
+++ b/src/view/src/rocprofvis_annotations.cpp
@@ -3,13 +3,8 @@
 
 #include "rocprofvis_annotations.h"
 #include "json.h"
-#include "rocprofvis_events.h"
-#include "rocprofvis_settings_manager.h"
 #include "rocprofvis_stickynote.h"
-#include "widgets/rocprofvis_gui_helpers.h"
-#include "widgets/rocprofvis_widget.h"
 #include <algorithm>
-#include <cstring>
 #include <vector>
 namespace RocProfVis
 {
@@ -136,48 +131,12 @@ AnnotationsManagerProjectSettings::Valid() const
 
 AnnotationsManager::AnnotationsManager(const std::string& project_id)
 : m_project_settings(project_id, *this)
-, m_project_id(project_id)
 , m_show_annotations(true)
-, m_visible_center(0.0f, 0.0f)
-, m_dragged_sticky_id(-1)
 {
     if(m_project_settings.Valid())
     {
         m_project_settings.FromJson();
     }
-
-    auto sticky_note_handler = [this](std::shared_ptr<RocEvent> e) {
-        auto evt = std::dynamic_pointer_cast<StickyNoteEvent>(e);
-        if(evt && evt->GetSourceId() == m_project_id)
-        {
-            m_show_sticky_edit_popup = true;
-            m_edit_sticky_id         = evt->GetNoteId();
-
-            for(int i = 0; i < m_sticky_notes.size(); i++)
-            {
-                if(m_sticky_notes[i].GetID() == m_edit_sticky_id)
-                {
-                    const std::string& title = m_sticky_notes[i].GetTitle();
-                    size_t len_title = std::min(title.size(), sizeof(m_sticky_title) - 1);
-                    std::memcpy(m_sticky_title, title.c_str(), len_title);
-                    m_sticky_title[len_title] = '\0';
-                    // Copy the text string to m_sticky_text safely
-                    const std::string& text = m_sticky_notes[i].GetText();
-                    size_t len_text = std::min(text.size(), sizeof(m_sticky_text) - 1);
-                    std::memcpy(m_sticky_text, text.c_str(), len_text);
-                    m_sticky_text[len_text] = '\0';
-                    break;
-                }
-            }
-        }
-    };
-    m_edit_token = EventManager::GetInstance()->Subscribe(
-        static_cast<int>(RocEvents::kStickyNoteEdited), sticky_note_handler);
-}
-AnnotationsManager::~AnnotationsManager()
-{
-    EventManager::GetInstance()->Unsubscribe(
-        static_cast<int>(RocEvents::kStickyNoteEdited), m_edit_token);
 }
 
 void
@@ -192,8 +151,8 @@ AnnotationsManager::AddSticky(double time_ns, float y_offset, const ImVec2& size
                               double v_min, double v_max, uint64_t track_id,
                               bool is_minimized)
 {
-    m_sticky_notes.emplace_back(time_ns, y_offset, size, text, title, m_project_id, v_min,
-                                v_max, track_id, is_minimized);
+    m_sticky_notes.emplace_back(time_ns, y_offset, size, text, title, v_min, v_max,
+                                track_id, is_minimized);
 }
 
 bool
@@ -209,223 +168,34 @@ AnnotationsManager::SetVisible(bool SetVisible)
 }
 
 void
-AnnotationsManager::ShowStickyNoteEditPopup()
+AnnotationsManager::CreateStickyNote(double time_ns, float y_offset, double v_min,
+                                     double v_max, ImVec2 graph_size, uint64_t track_id)
 {
-    if(!m_show_sticky_edit_popup) return;
+    constexpr ImVec2 kNewNoteSize(220.0f, 150.0f);
 
-    SettingsManager& settings   = SettingsManager::GetInstance();
-    ImU32            text_color = settings.GetColor(Colors::kTextMain);
-
-    PopUpStyle popup_style;
-    popup_style.PushPopupStyles();
-    popup_style.PushTitlebarColors();
-    popup_style.CenterPopup();
-    
-    ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-
-    ImGui::OpenPopup("Edit Annotation");
-
-    ImGui::SetNextWindowSize(
-        GetResponsiveWindowSize(ImVec2(390.0f, 420.0f), ImVec2(320.0f, 320.0f)),
-        ImGuiCond_Once);  // Initial size, user can resize
-    if(ImGui::BeginPopupModal("Edit Annotation", nullptr, ImGuiWindowFlags_NoCollapse))
-    {
-        ImGui::TextDisabled("Title");
-        ImGui::SetNextItemWidth(-FLT_MIN);  // Full width
-        ImGui::InputText("##StickyTitle", m_sticky_title, IM_ARRAYSIZE(m_sticky_title),
-                         ImGuiInputTextFlags_AutoSelectAll);
-
-        ImGui::Spacing();
-
-        ImGui::TextDisabled("Note");
-        ImVec2 text_box_size = ImVec2(ImGui::GetContentRegionAvail().x,
-                                      std::max(140.0f,
-                                               ImGui::GetContentRegionAvail().y -
-                                                   ImGui::GetFrameHeightWithSpacing() -
-                                                   ImGui::GetStyle().ItemSpacing.y * 2.0f));
-        ImGui::InputTextMultiline("##StickyText", m_sticky_text,
-                                  IM_ARRAYSIZE(m_sticky_text), text_box_size,
-                                  ImGuiInputTextFlags_AllowTabInput);
-
-        ImGui::Spacing();
-
-        float button_width       = 88.0f;
-        float spacing            = ImGui::GetStyle().ItemSpacing.x;
-        float total_button_width = button_width * 3 + spacing * 2;
-        float cursor_x           = ImGui::GetContentRegionAvail().x - total_button_width;
-        if(cursor_x > 0) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cursor_x);
-
-        bool save_clicked = ImGui::Button("Save", ImVec2(button_width, 0));
-        ImGui::SameLine();
-        bool cancel_clicked = ImGui::Button("Cancel", ImVec2(button_width, 0));
-        ImGui::SameLine();
-        ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kAccent));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
-                              settings.GetColor(Colors::kAccentHover));
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive,
-                              settings.GetColor(Colors::kAccentActive));
-        bool delete_clicked = ImGui::Button("Delete", ImVec2(button_width, 0));
-
-        ImGui::PopStyleColor(3);
-
-        if(save_clicked)
-        {
-            for(auto& note : m_sticky_notes)
-            {
-                if(note.GetID() == m_edit_sticky_id)
-                {
-                    note.SetText(std::string(m_sticky_text));
-                    note.SetTitle(std::string(m_sticky_title));
-                    m_edit_sticky_id         = -1;
-                    m_show_sticky_edit_popup = false;
-                    ImGui::CloseCurrentPopup();
-                    break;
-                }
-            }
-        }
-        if(cancel_clicked)
-        {
-            m_show_sticky_edit_popup = false;
-            m_edit_sticky_id         = -1;
-            ImGui::CloseCurrentPopup();
-        }
-        if(delete_clicked)
-        {
-            int count = 0;
-            for(auto& note : m_sticky_notes)
-            {
-                if(note.GetID() == m_edit_sticky_id)
-                {
-                    m_sticky_notes.erase(m_sticky_notes.begin() + count);
-                    break;
-                }
-                count++;
-            }
-            m_show_sticky_edit_popup = false;
-            m_edit_sticky_id         = -1;
-            ImGui::CloseCurrentPopup();
-        }
-
-        ImGui::EndPopup();
-    }
-    ImGui::PopStyleColor(1);  // Pop text color
-    // PopUpStyle destructor will automatically pop remaining styles
-}
-
-void
-AnnotationsManager::ShowStickyNotePopup()
-{
-    if(!m_show_sticky_popup) return;
-
-    int count = 0;
-    for(auto& note : m_sticky_notes)
-    {
-        if(note.GetID() == m_edit_sticky_id)
-        {
-            const std::string& title = note.GetTitle();
-            size_t len_title = std::min(title.size(), sizeof(m_sticky_title) - 1);
-            std::memcpy(m_sticky_title, title.c_str(), len_title);
-            m_sticky_title[len_title] = '\0';
-            // Copy the text string to m_sticky_text safely
-            const std::string& text = note.GetText();
-            size_t len_text = std::min(text.size(), sizeof(m_sticky_text) - 1);
-            std::memcpy(m_sticky_text, text.c_str(), len_text);
-            m_sticky_text[len_text] = '\0';
-        }
-        count++;
-    }
-
-    SettingsManager& settings   = SettingsManager::GetInstance();
-    ImU32            text_color = settings.GetColor(Colors::kTextMain);
-
-    PopUpStyle popup_style;
-    popup_style.PushPopupStyles();
-    popup_style.PushTitlebarColors();
-    popup_style.CenterPopup();
-    
-    ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-
-    ImGui::OpenPopup("Add Annotation");
-
-    ImGui::SetNextWindowSize(
-        GetResponsiveWindowSize(ImVec2(390.0f, 420.0f), ImVec2(320.0f, 320.0f)),
-        ImGuiCond_Once);  // Initial size, user can resize
-    if(ImGui::BeginPopupModal("Add Annotation", nullptr, ImGuiWindowFlags_NoCollapse))
-    {
-        ImGui::TextDisabled("Title");
-        ImGui::SetNextItemWidth(-FLT_MIN);  // Make the input take the full width
-        ImGui::InputText("##StickyTitle", m_sticky_title, IM_ARRAYSIZE(m_sticky_title),
-                         ImGuiInputTextFlags_AutoSelectAll);
-
-        ImGui::Spacing();
-
-        ImGui::TextDisabled("Note");
-        ImVec2 text_box_size = ImVec2(ImGui::GetContentRegionAvail().x,
-                                      std::max(140.0f,
-                                               ImGui::GetContentRegionAvail().y -
-                                                   ImGui::GetFrameHeightWithSpacing() -
-                                                   ImGui::GetStyle().ItemSpacing.y * 2.0f));
-        ImGui::InputTextMultiline("##StickyText", m_sticky_text,
-                                  IM_ARRAYSIZE(m_sticky_text), text_box_size,
-                                  ImGuiInputTextFlags_AllowTabInput);
-
-        ImGui::Spacing();
-
-        // Button row, right-aligned
-        float button_width       = 100.0f;
-        float spacing            = ImGui::GetStyle().ItemSpacing.x;
-        float total_button_width = button_width * 2 + spacing;
-        float cursor_x           = ImGui::GetContentRegionAvail().x - total_button_width;
-        if(cursor_x > 0) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + cursor_x);
-
-        bool save_clicked = ImGui::Button("Save", ImVec2(button_width, 0));
-        ImGui::SameLine();
-        bool cancel_clicked = ImGui::Button("Cancel", ImVec2(button_width, 0));
-
-        if(save_clicked)
-        {
-            AddSticky(m_sticky_time_ns, m_sticky_y_offset, ImVec2(180, 80),
-                      std::string(m_sticky_text), std::string(m_sticky_title), m_v_min_x,
-                      m_v_max_x, m_sticky_track_id);
-            m_show_sticky_popup = false;
-            ImGui::CloseCurrentPopup();
-        }
-        if(cancel_clicked)
-        {
-            m_show_sticky_popup = false;
-            ImGui::CloseCurrentPopup();
-        }
-
-        ImGui::EndPopup();
-    }
-    ImGui::PopStyleColor(1);  // Pop text color
-    // PopUpStyle destructor will automatically pop remaining styles
-}
-
-void
-AnnotationsManager::OpenStickyNotePopup(double time_ns, float y_offset, double v_min,
-                                        double v_max, ImVec2 graph_size,
-                                        uint64_t track_id)
-{
+    double note_time = time_ns;
+    float  note_y    = y_offset;
     if(time_ns == INVALID_TIME_NS)
     {
-        double center_time_ns  = v_min + (v_max - v_min) * 0.5;
-        float  center_y_offset = y_offset + graph_size.y * 0.5f;
-        m_sticky_time_ns       = center_time_ns;
-        m_sticky_y_offset      = center_y_offset;
-    }
-    else
-    {
-        m_sticky_time_ns  = time_ns;
-        m_sticky_y_offset = y_offset;
+        note_time = v_min + (v_max - v_min) * 0.5;
+        note_y    = y_offset + graph_size.y * 0.5f;
     }
 
-    m_sticky_title[0]   = '\0';
-    m_sticky_text[0]    = '\0';
-    m_show_sticky_popup = true;
-    m_v_min_x           = v_min;
-    m_v_max_x           = v_max;
-    m_sticky_track_id   = track_id;
+    AddSticky(note_time, note_y, kNewNoteSize, std::string(), std::string(), v_min, v_max,
+              track_id, /*is_minimized=*/false);
+    if(!m_sticky_notes.empty())
+    {
+        m_sticky_notes.back().BeginInlineEdit();
+    }
+}
+
+void
+AnnotationsManager::RemoveNotesPendingDelete()
+{
+    m_sticky_notes.erase(
+        std::remove_if(m_sticky_notes.begin(), m_sticky_notes.end(),
+                       [](const StickyNote& note) { return note.WantsDelete(); }),
+        m_sticky_notes.end());
 }
 
 std::vector<StickyNote>&

--- a/src/view/src/rocprofvis_annotations.cpp
+++ b/src/view/src/rocprofvis_annotations.cpp
@@ -52,9 +52,19 @@ AnnotationsManagerProjectSettings::FromJson()
             is_minimized = note_json[JSON_KEY_ANNOTATION_IS_MINIMIZED].getBool();
         }
 
+        // Legacy projects have no track binding; load as unbound and re-anchor
+        // on first render.
+        uint64_t track_id = INVALID_TRACK_ID;
+        if(note_json.contains(JSON_KEY_ANNOTATION_TRACK_ID) &&
+           note_json[JSON_KEY_ANNOTATION_TRACK_ID].isNumber())
+        {
+            track_id = static_cast<uint64_t>(
+                note_json[JSON_KEY_ANNOTATION_TRACK_ID].getNumber());
+        }
+
         ImVec2 size(size_x, size_y);
         m_annotations_manager.AddSticky(time_ns, y_offset, size, text, title, v_min,
-                                        v_max, is_minimized);
+                                        v_max, track_id, is_minimized);
     }
 }
 
@@ -74,6 +84,8 @@ AnnotationsManagerProjectSettings::ToJson()
         sticky_json[JSON_KEY_ANNOTATION_TEXT]             = notes[i].GetText();
         sticky_json[JSON_KEY_ANNOTATION_TITLE]            = notes[i].GetTitle();
         sticky_json[JSON_KEY_ANNOTATION_ID]               = notes[i].GetID();
+        sticky_json[JSON_KEY_ANNOTATION_TRACK_ID] =
+            static_cast<double>(notes[i].GetTrackId());
         sticky_json[JSON_KEY_TIMELINE_ANNOTATION_V_MIN_X] = notes[i].GetVMinX();
         sticky_json[JSON_KEY_TIMELINE_ANNOTATION_V_MAX_X] = notes[i].GetVMaxX();
         sticky_json[JSON_KEY_ANNOTATION_IS_MINIMIZED]     = notes[i].IsMinimized();
@@ -177,10 +189,11 @@ AnnotationsManager::Clear()
 void
 AnnotationsManager::AddSticky(double time_ns, float y_offset, const ImVec2& size,
                               const std::string& text, const std::string& title,
-                              double v_min, double v_max, bool is_minimized)
+                              double v_min, double v_max, uint64_t track_id,
+                              bool is_minimized)
 {
     m_sticky_notes.emplace_back(time_ns, y_offset, size, text, title, m_project_id, v_min,
-                                v_max, is_minimized);
+                                v_max, track_id, is_minimized);
 }
 
 bool
@@ -373,7 +386,7 @@ AnnotationsManager::ShowStickyNotePopup()
         {
             AddSticky(m_sticky_time_ns, m_sticky_y_offset, ImVec2(180, 80),
                       std::string(m_sticky_text), std::string(m_sticky_title), m_v_min_x,
-                      m_v_max_x);
+                      m_v_max_x, m_sticky_track_id);
             m_show_sticky_popup = false;
             ImGui::CloseCurrentPopup();
         }
@@ -391,7 +404,8 @@ AnnotationsManager::ShowStickyNotePopup()
 
 void
 AnnotationsManager::OpenStickyNotePopup(double time_ns, float y_offset, double v_min,
-                                        double v_max, ImVec2 graph_size)
+                                        double v_max, ImVec2 graph_size,
+                                        uint64_t track_id)
 {
     if(time_ns == INVALID_TIME_NS)
     {
@@ -411,6 +425,7 @@ AnnotationsManager::OpenStickyNotePopup(double time_ns, float y_offset, double v
     m_show_sticky_popup = true;
     m_v_min_x           = v_min;
     m_v_max_x           = v_max;
+    m_sticky_track_id   = track_id;
 }
 
 std::vector<StickyNote>&

--- a/src/view/src/rocprofvis_annotations.cpp
+++ b/src/view/src/rocprofvis_annotations.cpp
@@ -50,11 +50,17 @@ AnnotationsManagerProjectSettings::FromJson()
         // Legacy projects have no track binding; load as unbound and re-anchor
         // on first render.
         uint64_t track_id = INVALID_TRACK_ID;
-        if(note_json.contains(JSON_KEY_ANNOTATION_TRACK_ID) &&
-           note_json[JSON_KEY_ANNOTATION_TRACK_ID].isNumber())
+        if(note_json.contains(JSON_KEY_ANNOTATION_TRACK_ID))
         {
-            track_id = static_cast<uint64_t>(
-                note_json[JSON_KEY_ANNOTATION_TRACK_ID].getNumber());
+            const jt::Json& track_id_json = note_json[JSON_KEY_ANNOTATION_TRACK_ID];
+            if(track_id_json.isLong())
+            {
+                track_id = static_cast<uint64_t>(track_id_json.getLong());
+            }
+            else if(track_id_json.isNumber())
+            {
+                track_id = static_cast<uint64_t>(track_id_json.getNumber());
+            }
         }
 
         ImVec2 size(size_x, size_y);
@@ -80,7 +86,7 @@ AnnotationsManagerProjectSettings::ToJson()
         sticky_json[JSON_KEY_ANNOTATION_TITLE]            = notes[i].GetTitle();
         sticky_json[JSON_KEY_ANNOTATION_ID]               = notes[i].GetID();
         sticky_json[JSON_KEY_ANNOTATION_TRACK_ID] =
-            static_cast<double>(notes[i].GetTrackId());
+            static_cast<long long>(notes[i].GetTrackId());
         sticky_json[JSON_KEY_TIMELINE_ANNOTATION_V_MIN_X] = notes[i].GetVMinX();
         sticky_json[JSON_KEY_TIMELINE_ANNOTATION_V_MAX_X] = notes[i].GetVMaxX();
         sticky_json[JSON_KEY_ANNOTATION_IS_MINIMIZED]     = notes[i].IsMinimized();

--- a/src/view/src/rocprofvis_annotations.h
+++ b/src/view/src/rocprofvis_annotations.h
@@ -50,13 +50,15 @@ public:
     void SetCenter(const ImVec2& center);
     void AddSticky(double time_ns, float y_offset, const ImVec2& size,
                    const std::string& text, const std::string& title, double v_min,
-                   double v_max, bool is_minimized = true);
+                   double v_max, uint64_t track_id = INVALID_TRACK_ID,
+                   bool is_minimized = true);
     
 
     void                     ShowStickyNotePopup();
     void                     ShowStickyNoteEditPopup();
     std::vector<StickyNote>& GetStickyNotes();
-    void OpenStickyNotePopup(double time_ns, float y_offset, double v_min, double v_max, ImVec2 graph_size);
+    void OpenStickyNotePopup(double time_ns, float y_offset, double v_min, double v_max,
+                             ImVec2 graph_size, uint64_t track_id = INVALID_TRACK_ID);
 
 private:
     std::vector<StickyNote>           m_sticky_notes;
@@ -64,6 +66,7 @@ private:
     bool                              m_show_sticky_edit_popup = false;
     double                            m_sticky_time_ns         = 0.0;
     float                             m_sticky_y_offset        = 0.0f;
+    uint64_t                          m_sticky_track_id        = INVALID_TRACK_ID;
     char                              m_sticky_title[128]      = { 0 };
     char                              m_sticky_text[512]       = { 0 };
     int                               m_edit_sticky_id         = -1;

--- a/src/view/src/rocprofvis_annotations.h
+++ b/src/view/src/rocprofvis_annotations.h
@@ -5,8 +5,6 @@
 
 #include "imgui.h"
 #include "rocprofvis_data_provider.h"
-#include "rocprofvis_event_manager.h"
-#include "rocprofvis_events.h"
 #include "rocprofvis_project.h"
 #include "rocprofvis_stickynote.h"
 #include <string>
@@ -17,8 +15,8 @@ namespace RocProfVis
 namespace View
 {
 
-constexpr double INVALID_TIME_NS   = std::numeric_limits<double>::lowest();
- 
+constexpr double INVALID_TIME_NS = std::numeric_limits<double>::lowest();
+
 class AnnotationsManager;
 
 class AnnotationsManagerProjectSettings : public ProjectSetting
@@ -36,48 +34,30 @@ private:
     AnnotationsManager& m_annotations_manager;
 };
 
-class AnnotationsManagerProjectSettings;
-
 class AnnotationsManager
 {
 public:
     AnnotationsManager(const std::string& project_id);
-    ~AnnotationsManager();
 
     bool IsVisibile();
     void SetVisible(bool visible);
     void Clear();
-    void SetCenter(const ImVec2& center);
     void AddSticky(double time_ns, float y_offset, const ImVec2& size,
                    const std::string& text, const std::string& title, double v_min,
                    double v_max, uint64_t track_id = INVALID_TRACK_ID,
                    bool is_minimized = true);
-    
 
-    void                     ShowStickyNotePopup();
-    void                     ShowStickyNoteEditPopup();
+    void                     RemoveNotesPendingDelete();
     std::vector<StickyNote>& GetStickyNotes();
-    void OpenStickyNotePopup(double time_ns, float y_offset, double v_min, double v_max,
-                             ImVec2 graph_size, uint64_t track_id = INVALID_TRACK_ID);
+
+    // Drops a new note at the location, expanded and focused for inline typing.
+    void CreateStickyNote(double time_ns, float y_offset, double v_min, double v_max,
+                          ImVec2 graph_size, uint64_t track_id = INVALID_TRACK_ID);
 
 private:
     std::vector<StickyNote>           m_sticky_notes;
-    bool                              m_show_sticky_popup      = false;
-    bool                              m_show_sticky_edit_popup = false;
-    double                            m_sticky_time_ns         = 0.0;
-    float                             m_sticky_y_offset        = 0.0f;
-    uint64_t                          m_sticky_track_id        = INVALID_TRACK_ID;
-    char                              m_sticky_title[128]      = { 0 };
-    char                              m_sticky_text[512]       = { 0 };
-    int                               m_edit_sticky_id         = -1;
-    EventManager::SubscriptionToken   m_edit_token;
     bool                              m_show_annotations;
-    ImVec2                            m_visible_center;
-    std::string                       m_project_id;
     AnnotationsManagerProjectSettings m_project_settings;
-    double                            m_v_min_x;  
-    double                            m_v_max_x;  
-    int m_dragged_sticky_id; 
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_events.cpp
+++ b/src/view/src/rocprofvis_events.cpp
@@ -342,19 +342,6 @@ EventHighlightChangedEvent::IsBatch() const
     return m_is_batch;
 }
 
-StickyNoteEvent::StickyNoteEvent(int id, const std::string& source_id)
-: RocEvent(static_cast<int>(RocEvents::kStickyNoteEdited), source_id)
-, m_id(id)
-{
-    SetType(RocEventType::kStickyNoteEvent);
-}
-
-const int
-StickyNoteEvent::GetNoteId() const
-{
-    return m_id;
-}
-
 RangeEvent::RangeEvent(int event_id, double start_ns, double end_ns,
                        const std::string& source_id)
 : RocEvent(event_id, source_id)

--- a/src/view/src/rocprofvis_events.cpp
+++ b/src/view/src/rocprofvis_events.cpp
@@ -375,12 +375,14 @@ RangeEvent::GetEndNs() const
 {
     return m_end_ns;
 }
-NavigationEvent::NavigationEvent(double v_min, double v_max, double y_position, bool center )
+NavigationEvent::NavigationEvent(double v_min, double v_max, double y_position,
+                                 bool center, uint64_t track_id)
 : RocEvent(static_cast<int>(RocEvents::kGoToTimelineSpot))
 , m_v_min(v_min)
 , m_v_max(v_max)
 , m_y_position(y_position)
 , m_center(center)
+, m_track_id(track_id)
 {
     SetType(RocEventType::kNavigationEvent);
 }
@@ -406,6 +408,11 @@ bool
 NavigationEvent::GetCenter() const
 {
     return m_center;
+}
+uint64_t
+NavigationEvent::GetTrackId() const
+{
+    return m_track_id;
 }
 
 RequestProgressUpdateEvent::RequestProgressUpdateEvent(

--- a/src/view/src/rocprofvis_events.h
+++ b/src/view/src/rocprofvis_events.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <cstdint>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <vector>
 namespace RocProfVis
@@ -135,18 +136,23 @@ private:
 class NavigationEvent : public RocEvent
 {
 public:
-    NavigationEvent(double v_min, double v_max, double y_position, bool center);
+    // For a valid track_id, y_position is relative to that track's top;
+    // otherwise it is an absolute content-space Y.
+    NavigationEvent(double v_min, double v_max, double y_position, bool center,
+                    uint64_t track_id = std::numeric_limits<uint64_t>::max());
 
-    double GetVMin() const;
-    double GetVMax() const;
-    double GetYPosition() const;
-    bool   GetCenter() const;   
+    double   GetVMin() const;
+    double   GetVMax() const;
+    double   GetYPosition() const;
+    bool     GetCenter() const;
+    uint64_t GetTrackId() const;
 
 private:
-    double m_v_min;
-    double m_v_max;
-    double m_y_position;
-    bool m_center;
+    double   m_v_min;
+    double   m_v_max;
+    double   m_y_position;
+    bool     m_center;
+    uint64_t m_track_id;
 };
 
 class TrackDataEvent : public RocEvent

--- a/src/view/src/rocprofvis_events.h
+++ b/src/view/src/rocprofvis_events.h
@@ -25,7 +25,6 @@ enum class RocEvents
     kTimelineEventHighlightChanged,
     kHandleUserGraphNavigationEvent,
     kTrackMetadataChanged,
-    kStickyNoteEdited,
     kFontSizeChanged,
     kSetViewRange,
     kGoToTimelineSpot,
@@ -51,7 +50,6 @@ enum class RocEventType
     kTimelineEventSelectionChangedEvent,
     kTimelineEventHighlightChangedEvent,
     kScrollToTrackEvent,
-    kStickyNoteEvent,
     kRangeEvent,
     kNavigationEvent,
     kRequestProgressUpdateEvent,
@@ -180,16 +178,6 @@ public:
 private:
     uint64_t    m_request_id;
     uint64_t    m_response_code;
-};
-
-class StickyNoteEvent : public RocEvent
-{
-public:
-    StickyNoteEvent(int id, const std::string& source_id);
-    const int GetNoteId() const;
-
-private:
-    int m_id;
 };
 
 class ScrollToTrackEvent : public RocEvent

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -158,6 +158,7 @@ constexpr const char* JSON_KEY_ANNOTATION_SIZE_Y           = "size_y";
 constexpr const char* JSON_KEY_ANNOTATION_TEXT             = "text";
 constexpr const char* JSON_KEY_ANNOTATION_TITLE            = "title";
 constexpr const char* JSON_KEY_ANNOTATION_ID               = "id";
+constexpr const char* JSON_KEY_ANNOTATION_TRACK_ID         = "track_id";
 constexpr const char* JSON_KEY_TIMELINE_ANNOTATION_V_MIN_X = "view_start_ns";
 constexpr const char* JSON_KEY_TIMELINE_ANNOTATION_V_MAX_X = "view_end_ns";
 constexpr const char* JSON_KEY_ANNOTATION_IS_MINIMIZED     = "is_minimized";

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -121,15 +121,15 @@ constexpr std::array DARK_THEME_COLORS = {
     IM_COL32(231, 196, 65, 255),   // Colors::kMemChartHit
     IM_COL32(235, 82, 98, 255),    // Colors::kMemChartStall
     IM_COL32(0, 0, 0, 85),         // Colors::kMemChartShadow
-    IM_COL32(58, 53, 36, 245),     // Colors::kStickyNoteBg
-    IM_COL32(62, 116, 168, 220),   // Colors::kStickyNoteBorder
-    IM_COL32(70, 62, 40, 248),     // Colors::kStickyNoteHeader
-    IM_COL32(0, 0, 0, 85),         // Colors::kStickyNoteShadow
-    IM_COL32(238, 243, 255, 255),  // Colors::kStickyNoteText
-    IM_COL32(145, 156, 174, 255),  // Colors::kStickyNoteTextMuted
-    IM_COL32(225, 203, 78, 235),   // Colors::kStickyNoteAccent
-    IM_COL32(200, 200, 80, 255),   // Colors::kStickyNoteResize
-    IM_COL32(200, 100, 100, 255),  // Colors::kStickyNoteResizeActive
+    IM_COL32(240, 214, 92, 250),   // Colors::kStickyNoteBg
+    IM_COL32(193, 154, 40, 235),   // Colors::kStickyNoteBorder
+    IM_COL32(232, 200, 78, 252),   // Colors::kStickyNoteHeader
+    IM_COL32(0, 0, 0, 110),        // Colors::kStickyNoteShadow
+    IM_COL32(48, 40, 12, 255),     // Colors::kStickyNoteText
+    IM_COL32(112, 92, 40, 255),    // Colors::kStickyNoteTextMuted
+    IM_COL32(176, 130, 24, 235),   // Colors::kStickyNoteAccent
+    IM_COL32(176, 130, 24, 255),   // Colors::kStickyNoteResize
+    IM_COL32(150, 96, 24, 255),    // Colors::kStickyNoteResizeActive
     IM_COL32(200, 16, 32, 150),    // Colors::kBannerFill
     IM_COL32(255, 255, 255, 40),   // Colors::kBannerBorder
     IM_COL32(255, 255, 255, 255),  // Colors::kBannerText
@@ -237,15 +237,15 @@ constexpr std::array LIGHT_THEME_COLORS = {
     IM_COL32(177, 130, 0, 255),    // Colors::kMemChartHit
     IM_COL32(204, 55, 70, 255),    // Colors::kMemChartStall
     IM_COL32(76, 95, 128, 35),     // Colors::kMemChartShadow
-    IM_COL32(255, 252, 228, 248),  // Colors::kStickyNoteBg
-    IM_COL32(91, 139, 184, 205),   // Colors::kStickyNoteBorder
-    IM_COL32(255, 247, 204, 248),  // Colors::kStickyNoteHeader
+    IM_COL32(255, 245, 186, 250),  // Colors::kStickyNoteBg
+    IM_COL32(214, 176, 66, 230),   // Colors::kStickyNoteBorder
+    IM_COL32(255, 236, 158, 250),  // Colors::kStickyNoteHeader
     IM_COL32(76, 95, 128, 35),     // Colors::kStickyNoteShadow
-    IM_COL32(25, 38, 56, 255),     // Colors::kStickyNoteText
-    IM_COL32(92, 106, 126, 255),   // Colors::kStickyNoteTextMuted
-    IM_COL32(168, 128, 0, 235),    // Colors::kStickyNoteAccent
-    IM_COL32(200, 200, 80, 255),   // Colors::kStickyNoteResize
-    IM_COL32(200, 100, 100, 255),  // Colors::kStickyNoteResizeActive
+    IM_COL32(56, 46, 14, 255),     // Colors::kStickyNoteText
+    IM_COL32(120, 100, 50, 255),   // Colors::kStickyNoteTextMuted
+    IM_COL32(190, 146, 34, 235),   // Colors::kStickyNoteAccent
+    IM_COL32(190, 146, 34, 255),   // Colors::kStickyNoteResize
+    IM_COL32(150, 100, 24, 255),   // Colors::kStickyNoteResizeActive
     IM_COL32(200, 16, 32, 150),    // Colors::kBannerFill
     IM_COL32(255, 255, 255, 40),   // Colors::kBannerBorder
     IM_COL32(255, 255, 255, 255),  // Colors::kBannerText

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -127,6 +127,8 @@ StickyNote::EnsureBound(const TrackLayout& layout)
 float
 StickyNote::ResolveAnchorY(const TrackLayout& layout) const
 {
+    if(m_dragging) return m_drag_abs_y;
+
     float track_top_y = 0.0f;
     if(m_track_id != INVALID_TRACK_ID && layout.top_of &&
        layout.top_of(m_track_id, track_top_y))
@@ -639,6 +641,11 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     bool   mouse_down     = ImGui::IsMouseDown(ImGuiMouseButton_Left);
     bool   mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
 
+    // The anchor draws straight to the draw list, so modals on top don't shield
+    // it; don't start a drag while a popup is open.
+    const bool blocked_by_popup = ImGui::IsPopupOpen(
+        nullptr, ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel);
+
     // A click inside the expanded window must move only the window, not the
     // anchor it overlaps.
     bool over_expanded_window = false;
@@ -653,12 +660,14 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     }
 
     if((dragged_id == INVALID_STICKY_ID || dragged_id == m_id) && !m_dragging &&
-       !over_expanded_window && ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
+       !over_expanded_window && !blocked_by_popup &&
+       ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
        ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
        !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
     {
         m_dragging    = true;
         m_drag_offset = ImVec2(mouse_pos.x - icon_pos.x, mouse_pos.y - icon_pos.y);
+        m_drag_abs_y  = y;
         dragged_id    = m_id;
         TimelineFocusManager::GetInstance().RequestLayerFocus(Layer::kInteractiveLayer);
     }
@@ -682,26 +691,28 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         new_y = std::clamp(new_y, min_y, std::max(min_y, max_y));
 
         m_time_ns = conversion_manager->PixelToTime(new_x);
-        // Re-anchor to the track under the cursor, storing a track-relative
-        // offset so the note follows reorder / collapse / resize.
-        uint64_t track_id    = INVALID_TRACK_ID;
-        float    track_top_y = 0.0f;
-        if(layout.track_at && layout.track_at(new_y, track_id, track_top_y))
-        {
-            m_track_id = track_id;
-            m_y_offset = new_y - track_top_y;
-        }
-        else
-        {
-            m_y_offset = new_y;
-        }
-        m_v_max_x = conversion_manager->GetVMaxX();
-        m_v_min_x = conversion_manager->GetVMinX();
+        // Re-anchor only on drop (track_at scans every graph); hold an absolute Y.
+        m_drag_abs_y = new_y;
+        m_v_max_x    = conversion_manager->GetVMaxX();
+        m_v_min_x    = conversion_manager->GetVMinX();
         return true;
     }
 
     if(m_dragging && mouse_released)
     {
+        // Bind to the track under the drop, keeping a track-relative offset.
+        uint64_t track_id    = INVALID_TRACK_ID;
+        float    track_top_y = 0.0f;
+        if(layout.track_at && layout.track_at(m_drag_abs_y, track_id, track_top_y))
+        {
+            m_track_id = track_id;
+            m_y_offset = m_drag_abs_y - track_top_y;
+        }
+        else
+        {
+            m_y_offset = m_drag_abs_y;
+        }
+
         m_dragging = false;
         dragged_id = INVALID_STICKY_ID;
         TimelineFocusManager::GetInstance().RequestLayerFocus(Layer::kNone);

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -212,7 +212,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         const float marker_rounding =
             SettingsManager::GetInstance().GetDefaultStyle().ChildRounding *
             kMarkerRoundingScale;
-        DrawGlow(ImGui::GetForegroundDrawList(), anchor_pos, marker_max, marker_rounding);
+        DrawGlow(draw_list, anchor_pos, marker_max, marker_rounding);
     }
 
     if((pair_hovered || m_dragging) && draw_list)

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -470,7 +470,9 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
             const ImVec2 title_min(win_pos.x + kNoteMargin, win_pos.y);
             const ImVec2 title_max(title_min.x + title_width,
                                    win_pos.y + kExpandedHeaderHeight);
-            if(ImGui::IsMouseHoveringRect(title_min, title_max) &&
+            // IsWindowHovered ignores clicks landing on a window drawn on top.
+            if(ImGui::IsWindowHovered() &&
+               ImGui::IsMouseHoveringRect(title_min, title_max) &&
                IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
             {
                 m_editing_title = true;
@@ -641,27 +643,13 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     bool   mouse_down     = ImGui::IsMouseDown(ImGuiMouseButton_Left);
     bool   mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
 
-    // The anchor draws straight to the draw list, so modals on top don't shield
-    // it; don't start a drag while a popup is open.
-    const bool blocked_by_popup = ImGui::IsPopupOpen(
-        nullptr, ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel);
-
-    // A click inside the expanded window must move only the window, not the
-    // anchor it overlaps.
-    bool over_expanded_window = false;
-    if(!m_is_minimized && IsExpandedPlaced())
-    {
-        const ImVec2 win_max = ImVec2(m_expanded_screen_pos.x + m_size.x,
-                                      m_expanded_screen_pos.y + m_size.y);
-        over_expanded_window = mouse_pos.x >= m_expanded_screen_pos.x &&
-                               mouse_pos.x <= win_max.x &&
-                               mouse_pos.y >= m_expanded_screen_pos.y &&
-                               mouse_pos.y <= win_max.y;
-    }
+    // The anchor draws to the timeline draw list, so gate it on the timeline
+    // being hovered; this is false when a window or popup covers the cursor.
+    const bool timeline_hovered =
+        ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
 
     if((dragged_id == INVALID_STICKY_ID || dragged_id == m_id) && !m_dragging &&
-       !over_expanded_window && !blocked_by_popup &&
-       ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
+       timeline_hovered && ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
        ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
        !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
     {

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -11,6 +11,7 @@
 #include "rocprofvis_settings_manager.h"
 #include "widgets/rocprofvis_gui_helpers.h"
 #include <algorithm>
+#include <cfloat>
 #include <spdlog/spdlog.h>
 
 namespace RocProfVis
@@ -21,6 +22,18 @@ namespace View
 namespace
 {
 constexpr float kExpandedHeaderHeight = 36.0f;
+constexpr float kExpandedMinWidth     = 160.0f;
+constexpr float kExpandedMinHeight    = 96.0f;
+constexpr float kWindowBorderSize     = 1.0f;
+constexpr float kNoteMargin           = 14.0f;
+constexpr float kHeaderButtonGap      = 8.0f;
+constexpr float kHeaderButtonMinSize  = 34.0f;
+constexpr float kHeaderButtonPadding  = 14.0f;
+constexpr float kAccentStripeWidth    = 3.0f;
+constexpr float kAccentStripeAlpha    = 0.78f;
+constexpr float kHeaderSeparatorAlpha = 0.42f;
+constexpr float kIconHoverAlpha       = 0.12f;
+constexpr float kIconActiveAlpha      = 0.22f;
 }  // namespace
 
 static int s_unique_id_counter = 0;
@@ -168,33 +181,30 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         return false;
     }
     EnsureBound(layout);
-    SettingsManager& settings      = SettingsManager::GetInstance();
-    ImU32            bg_color          = settings.GetColor(Colors::kStickyNoteBg);
-    ImU32            border_color      = settings.GetColor(Colors::kStickyNoteBorder);
-    ImU32            header_color      = settings.GetColor(Colors::kStickyNoteHeader);
-    ImU32            shadow_color      = settings.GetColor(Colors::kStickyNoteShadow);
-    ImU32            icon_hover_color =
-        ApplyAlpha(settings.GetColor(Colors::kButtonHovered), 0.74f);
+    SettingsManager& settings     = SettingsManager::GetInstance();
+    ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
+    ImU32            border_color = settings.GetColor(Colors::kStickyNoteBorder);
+    ImU32            header_color = settings.GetColor(Colors::kStickyNoteHeader);
+    ImU32            shadow_color = settings.GetColor(Colors::kStickyNoteShadow);
+    // Overlay derived from the note text color so hover/active stays in palette.
+    ImU32 icon_hover_color =
+        ApplyAlpha(settings.GetColor(Colors::kStickyNoteText), kIconHoverAlpha);
     ImU32 icon_active_color =
-        ApplyAlpha(settings.GetColor(Colors::kButtonActive), 0.86f);
-    ImU32            text_color        = settings.GetColor(Colors::kStickyNoteText);
-    ImU32            muted_text_color  = settings.GetColor(Colors::kStickyNoteTextMuted);
-    ImU32            accent_color      = settings.GetColor(Colors::kStickyNoteAccent);
+        ApplyAlpha(settings.GetColor(Colors::kStickyNoteText), kIconActiveAlpha);
+    ImU32 text_color       = settings.GetColor(Colors::kStickyNoteText);
+    ImU32 muted_text_color = settings.GetColor(Colors::kStickyNoteTextMuted);
+    ImU32 accent_color     = settings.GetColor(Colors::kStickyNoteAccent);
 
-    const float rounding      = settings.GetDefaultStyle().ChildRounding;
-    const float margin        = 14.0f;
-    const float icon_btn_gap  = 8.0f;
+    const float rounding = settings.GetDefaultStyle().ChildRounding;
 
     float  x           = tpt->TimeToPixel(m_time_ns);
     float  y           = ResolveAnchorY(layout);
     ImVec2 sticky_pos  = ImVec2(window_position.x + x, window_position.y + y);
     ImVec2 sticky_size = m_size;
 
-    // Set the cursor to the sticky note position inside the parent window
-    ImGui::SetCursorScreenPos(sticky_pos);
-
     if(m_is_minimized)
     {
+        ImGui::SetCursorScreenPos(sticky_pos);
         std::string child_id = "StickyButtonArea##" + std::to_string(m_id);
         ImGui::BeginChild(child_id.c_str(), m_size, false, ImGuiWindowFlags_None);
 
@@ -251,167 +261,138 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     }
     else
     {
-        ImVec2 window_size = ImGui::GetWindowSize();
-        float  adjusted_x;
-        float  adjusted_y;
-
-        if(m_expanded_screen_pos.x >= 0 && m_expanded_screen_pos.y >= 0)
+        // Floating window: ImGui owns move/resize; we only seed the first
+        // position from the marker anchor, then track it live.
+        if(m_expanded_screen_pos.x < 0 || m_expanded_screen_pos.y < 0)
         {
-            adjusted_x = m_expanded_screen_pos.x;
-            adjusted_y = m_expanded_screen_pos.y;
-        }
-        else
-        {
-            float note_end_x = x + sticky_size.x;
-            float note_end_y = y + sticky_size.y;
-            adjusted_x       = x;
-            adjusted_y       = y;
-
-            if(note_end_x > window_size.x)
-            {
-                adjusted_x = x - (sticky_size.x * 1.1f);
-                adjusted_x = std::max(adjusted_x, 0.0f);
-            }
-            if(note_end_y > window_size.y)
-            {
-                adjusted_y = y - (sticky_size.y * 1.1f);
-                adjusted_y = std::max(adjusted_y, 0.0f);
-            }
+            const ImGuiViewport* viewport = ImGui::GetMainViewport();
+            ImVec2               anchor   = sticky_pos;
+            anchor.x = std::clamp(anchor.x, viewport->WorkPos.x,
+                                  viewport->WorkPos.x + viewport->WorkSize.x - sticky_size.x);
+            anchor.y = std::clamp(anchor.y, viewport->WorkPos.y,
+                                  viewport->WorkPos.y + viewport->WorkSize.y - sticky_size.y);
+            m_expanded_screen_pos = anchor;
         }
 
-        sticky_pos = ImVec2(window_position.x + adjusted_x, window_position.y + adjusted_y);
-        ImGui::SetCursorPos(ImVec2(adjusted_x, adjusted_y));
+        ImGui::SetNextWindowPos(m_expanded_screen_pos, ImGuiCond_Appearing);
+        ImGui::SetNextWindowSize(sticky_size, ImGuiCond_Appearing);
+        ImGui::SetNextWindowSizeConstraints(
+            ImVec2(kExpandedMinWidth, kExpandedMinHeight), ImVec2(FLT_MAX, FLT_MAX));
 
-        ImVec2 expanded_max =
-            ImVec2(sticky_pos.x + sticky_size.x, sticky_pos.y + sticky_size.y);
-        if((ImGui::IsMouseHoveringRect(sticky_pos, expanded_max) || m_dragging) &&
-           draw_list)
-        {
-            RenderTimeIndicator(draw_list, window_position, tpt);
-        }
-
-        if(draw_list)
-        {
-            draw_list->AddRectFilled(
-                ImVec2(sticky_pos.x + 3.0f, sticky_pos.y + 4.0f),
-                ImVec2(sticky_pos.x + sticky_size.x + 3.0f,
-                       sticky_pos.y + sticky_size.y + 4.0f),
-                shadow_color, rounding);
-        }
-
-        // Round corners
-        ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, rounding);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, rounding);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleColor(ImGuiCol_ChildBg, bg_color);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, kWindowBorderSize);
+        ImGui::PushStyleColor(ImGuiCol_WindowBg, bg_color);
         ImGui::PushStyleColor(ImGuiCol_Border, border_color);
 
-        ImGui::BeginChild(
-            ("StickyNoteChild##" + std::to_string(reinterpret_cast<uintptr_t>(this)))
-                .c_str(),
-            sticky_size, true);
+        const ImGuiWindowFlags window_flags =
+            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse |
+            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse |
+            ImGuiWindowFlags_NoSavedSettings;
 
-        ImDrawList* note_draw_list = ImGui::GetWindowDrawList();
-        const ImVec2 note_min      = ImGui::GetWindowPos();
-        const ImVec2 header_min    = note_min;
-        const ImVec2 header_max    = ImVec2(note_min.x + sticky_size.x,
-                                            note_min.y + kExpandedHeaderHeight);
-        note_draw_list->AddRectFilled(header_min, header_max, header_color, rounding,
-                                      ImDrawFlags_RoundCornersTop);
-        note_draw_list->AddRectFilled(header_min,
-                                      ImVec2(note_min.x + 3.0f, note_min.y + sticky_size.y),
-                                      ApplyAlpha(accent_color, 0.78f), rounding,
-                                      ImDrawFlags_RoundCornersLeft);
-        note_draw_list->AddLine(ImVec2(note_min.x, header_max.y),
-                                ImVec2(note_min.x + sticky_size.x, header_max.y),
-                                ApplyAlpha(border_color, 0.42f));
+        std::string window_id = "StickyNoteWindow##" + std::to_string(m_id);
+        bool        visible   = ImGui::Begin(window_id.c_str(), nullptr, window_flags);
 
-        // Title (left)
-        ImGui::SetCursorPos(
-            ImVec2(margin,
-                   (kExpandedHeaderHeight - ImGui::GetTextLineHeight()) * 0.5f));
-        ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-        ImGui::TextUnformatted(m_title.c_str());
-        ImGui::PopStyleColor();
-
-        // Edit button (left of close)
-        ImFont* action_icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(
-            FontType::kIcon);
-        ImGui::PushFont(action_icon_font);
-        ImVec2 edit_icon_size  = ImGui::CalcTextSize(ICON_EDIT);
-        ImVec2 close_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
-        const float action_btn_size =
-            std::max({34.0f, edit_icon_size.x + 14.0f, close_icon_size.x + 14.0f});
-        const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
-
-        ImGui::SetCursorPos(ImVec2(sticky_size.x - action_btn_size * 2.0f - margin -
-                                       icon_btn_gap,
-                                   action_btn_y));
-        ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
-        ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
-        if(ImGui::Button((std::string(ICON_EDIT) + "##" +
-                          std::to_string(reinterpret_cast<uintptr_t>(this)))
-                             .c_str(),
-                         ImVec2(action_btn_size, action_btn_size)))
+        bool blocks_timeline_input = false;
+        if(visible)
         {
-            EventManager::GetInstance()->AddEvent(
-                std::make_shared<StickyNoteEvent>(m_id, m_project_id));
-        }
-        ImGui::PopStyleColor(4);
+            const ImVec2 win_pos  = ImGui::GetWindowPos();
+            const ImVec2 win_size = ImGui::GetWindowSize();
 
-        ImGui::SetCursorPos(ImVec2(sticky_size.x - action_btn_size - margin,
-                                   action_btn_y));
-        ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
-        ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
-        if(ImGui::Button(
-               (std::string(ICON_X_CIRCLED) + "##icon_switch_" + std::to_string(m_id))
-                   .c_str(),
-               ImVec2(action_btn_size, action_btn_size)))
-        {
-            m_is_minimized = true;
-        }
-        ImGui::PopStyleColor(4);
-        ImGui::PopFont();
+            ImDrawList*  note_draw_list = ImGui::GetWindowDrawList();
+            const ImVec2 header_max     = ImVec2(win_pos.x + win_size.x,
+                                                 win_pos.y + kExpandedHeaderHeight);
+            note_draw_list->AddRectFilled(win_pos, header_max, header_color, rounding,
+                                          ImDrawFlags_RoundCornersTop);
+            note_draw_list->AddRectFilled(
+                win_pos, ImVec2(win_pos.x + kAccentStripeWidth, win_pos.y + win_size.y),
+                ApplyAlpha(accent_color, kAccentStripeAlpha), rounding,
+                ImDrawFlags_RoundCornersLeft);
+            note_draw_list->AddLine(ImVec2(win_pos.x, header_max.y),
+                                    ImVec2(win_pos.x + win_size.x, header_max.y),
+                                    ApplyAlpha(border_color, kHeaderSeparatorAlpha));
 
-        // Scroll only the note body; the header/actions stay pinned.
-        const float body_y      = kExpandedHeaderHeight + margin;
-        const float body_height = std::max(0.0f, sticky_size.y - body_y - margin);
-        ImGui::SetCursorPos(ImVec2(margin, body_y));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kTransparent));
-        ImGui::BeginChild("StickyNoteBody", ImVec2(sticky_size.x - margin * 2.0f,
-                                                   body_height), false);
-        ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
-        ImGui::TextUnformatted(m_text.c_str());
-        ImGui::PopTextWrapPos();
-        ImGui::PopStyleColor();
-        ImGui::EndChild();
-        ImGui::PopStyleColor();
-        ImGui::PopStyleVar();
+            ImGui::SetCursorPos(
+                ImVec2(kNoteMargin,
+                       (kExpandedHeaderHeight - ImGui::GetTextLineHeight()) * 0.5f));
+            ImGui::PushStyleColor(ImGuiCol_Text, text_color);
+            ImGui::TextUnformatted(m_title.c_str());
+            ImGui::PopStyleColor();
 
-        ImGui::EndChild();
-        // Cover hover case for input control
-        ImVec2 sticky_max =
-            ImVec2(sticky_pos.x + sticky_size.x, sticky_pos.y + sticky_size.y);
-        bool blocks_timeline_input =
-            ImGui::IsMouseHoveringRect(sticky_pos, sticky_max) &&
-            !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect);
-        if(blocks_timeline_input)
-        {
-            TimelineFocusManager::GetInstance().RequestLayerFocus(Layer::kInteractiveLayer);
+            ImFont* action_icon_font =
+                SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+            ImGui::PushFont(action_icon_font);
+            ImVec2      edit_icon_size  = ImGui::CalcTextSize(ICON_EDIT);
+            ImVec2      close_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
+            const float action_btn_size =
+                std::max({kHeaderButtonMinSize, edit_icon_size.x + kHeaderButtonPadding,
+                          close_icon_size.x + kHeaderButtonPadding});
+            const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
+
+            ImGui::SetCursorPos(ImVec2(win_size.x - action_btn_size * 2.0f - kNoteMargin -
+                                           kHeaderButtonGap,
+                                       action_btn_y));
+            ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
+            ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
+            if(ImGui::Button((std::string(ICON_EDIT) + "##edit_" + std::to_string(m_id))
+                                 .c_str(),
+                             ImVec2(action_btn_size, action_btn_size)))
+            {
+                EventManager::GetInstance()->AddEvent(
+                    std::make_shared<StickyNoteEvent>(m_id, m_project_id));
+            }
+            ImGui::PopStyleColor(4);
+
+            ImGui::SetCursorPos(
+                ImVec2(win_size.x - action_btn_size - kNoteMargin, action_btn_y));
+            ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
+            ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
+            if(ImGui::Button(
+                   (std::string(ICON_X_CIRCLED) + "##close_" + std::to_string(m_id)).c_str(),
+                   ImVec2(action_btn_size, action_btn_size)))
+            {
+                m_is_minimized = true;
+            }
+            ImGui::PopStyleColor(4);
+            ImGui::PopFont();
+
+            // Scroll only the note body; the header/actions stay pinned.
+            const float body_y      = kExpandedHeaderHeight + kNoteMargin;
+            const float body_height = std::max(0.0f, win_size.y - body_y - kNoteMargin);
+            ImGui::SetCursorPos(ImVec2(kNoteMargin, body_y));
+            ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kTransparent));
+            ImGui::BeginChild("StickyNoteBody",
+                              ImVec2(win_size.x - kNoteMargin * 2.0f, body_height), false);
+            ImGui::PushStyleColor(ImGuiCol_Text, text_color);
+            ImGui::PushTextWrapPos(ImGui::GetCursorPosX() +
+                                   ImGui::GetContentRegionAvail().x);
+            ImGui::TextUnformatted(m_text.c_str());
+            ImGui::PopTextWrapPos();
+            ImGui::PopStyleColor();
+            ImGui::EndChild();
+            ImGui::PopStyleColor();
+
+            blocks_timeline_input =
+                ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+            if(blocks_timeline_input && draw_list)
+            {
+                RenderTimeIndicator(draw_list, window_position, tpt);
+            }
+
+            m_expanded_screen_pos = win_pos;
+            m_size                = win_size;
         }
-        else
-        {
-            TimelineFocusManager::GetInstance().RequestLayerFocus(Layer::kNone);
-        }
+        ImGui::End();
 
         ImGui::PopStyleColor(2);
         ImGui::PopStyleVar(3);
+
+        TimelineFocusManager::GetInstance().RequestLayerFocus(
+            blocks_timeline_input ? Layer::kInteractiveLayer : Layer::kNone);
         return blocks_timeline_input;
     }
 }
@@ -421,8 +402,7 @@ StickyNote::RenderDragGhost(ImDrawList* draw_list, const ImVec2& screen_pos) con
 {
     if(!draw_list) return;
 
-    // Mirrors the minimized-note marker drawn in Render(): a drop shadow offset
-    // by a couple of pixels and corners at a fraction of the panel rounding.
+    // Mirrors the minimized-note marker drawn in Render().
     constexpr float kShadowOffsetX = 2.0f;
     constexpr float kShadowOffsetY = 3.0f;
     constexpr float kRoundingScale = 0.6f;
@@ -468,72 +448,37 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         spdlog::error("StickyNote::HandleDrag: conversion_manager shared_ptr is null");
         return false;
     }
-    if(m_resizing) return false;
+    // Expanded notes live in their own floating window, which owns move/resize.
+    if(!m_is_minimized) return false;
 
     EnsureBound(layout);
-
-    ImVec2 drag_pos;
-    ImVec2 drag_max;
-    float  drag_w = 0.0f;
-    float  drag_h = 0.0f;
 
     float x = conversion_manager->TimeToPixel(m_time_ns);
     float y = ResolveAnchorY(layout);
 
-    if(m_is_minimized)
-    {
-        ImVec2 icon_pos = ImVec2(window_position.x + x, window_position.y + y);
+    ImVec2  icon_pos  = ImVec2(window_position.x + x, window_position.y + y);
+    ImFont* icon_font =
+        SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+    ImGui::PushFont(icon_font, 0.0f);
+    ImVec2 icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
+    ImGui::PopFont();
 
-        ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-        ImGui::PushFont(icon_font, 0.0f);
-        ImVec2 icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
-        ImGui::PopFont();
-
-        ImVec2 padding = ImGui::GetStyle().FramePadding;
-        drag_w         = icon_size.x + padding.x * 2.0f;
-        drag_h         = icon_size.y + padding.y * 2.0f;
-        drag_pos       = icon_pos;
-        drag_max       = ImVec2(icon_pos.x + drag_w, icon_pos.y + drag_h);
-    }
-    else
-    {
-        if(m_expanded_screen_pos.x >= 0 && m_expanded_screen_pos.y >= 0)
-        {
-            drag_pos = ImVec2(window_position.x + m_expanded_screen_pos.x,
-                              window_position.y + m_expanded_screen_pos.y);
-        }
-        else
-        {
-            drag_pos = ImVec2(window_position.x + x, window_position.y + y);
-        }
-        // Expanded notes drag by the header so the scrollable body can own
-        // scrollbar/body interactions.
-        drag_w   = m_size.x;
-        drag_max = ImVec2(drag_pos.x + drag_w,
-                          drag_pos.y + kExpandedHeaderHeight);
-    }
+    ImVec2 padding  = ImGui::GetStyle().FramePadding;
+    float  drag_w   = icon_size.x + padding.x * 2.0f;
+    float  drag_h   = icon_size.y + padding.y * 2.0f;
+    ImVec2 drag_max = ImVec2(icon_pos.x + drag_w, icon_pos.y + drag_h);
 
     ImVec2 mouse_pos      = ImGui::GetMousePos();
     bool   mouse_down     = ImGui::IsMouseDown(ImGuiMouseButton_Left);
     bool   mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
 
-    if(!m_is_minimized)
-    {
-        const float handle_size = 12.0f;
-        ImVec2      sticky_max  = ImVec2(drag_pos.x + m_size.x, drag_pos.y + m_size.y);
-        ImVec2      handle_pos  = ImVec2(sticky_max.x - handle_size,
-                                         sticky_max.y - handle_size);
-        if(ImGui::IsMouseHoveringRect(handle_pos, sticky_max))
-            return false;
-    }
-
-    // Only allow drag if no other note is being dragged or this is the one
     if((dragged_id == -1 || dragged_id == m_id) && !m_dragging &&
-       ImGui::IsMouseHoveringRect(drag_pos, drag_max) &&
-       ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
+       ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
+       ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
+       !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
     {
         m_dragging    = true;
-        m_drag_offset = ImVec2(mouse_pos.x - drag_pos.x, mouse_pos.y - drag_pos.y);
+        m_drag_offset = ImVec2(mouse_pos.x - icon_pos.x, mouse_pos.y - icon_pos.y);
         dragged_id    = m_id;
         TimelineFocusManager::GetInstance().RequestLayerFocus(Layer::kInteractiveLayer);
     }
@@ -544,34 +489,24 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         float  new_y       = mouse_pos.y - window_position.y - m_drag_offset.y;
         ImVec2 window_size = ImGui::GetWindowSize();
         new_x = std::clamp(new_x, 0.0f, window_size.x - drag_w);
-        new_y = std::clamp(new_y, 0.0f,
-                           window_size.y -
-                               (m_is_minimized ? drag_h : kExpandedHeaderHeight));
+        new_y = std::clamp(new_y, 0.0f, window_size.y - drag_h);
 
-        if(m_is_minimized)
+        m_time_ns = conversion_manager->PixelToTime(new_x);
+        // Re-anchor to the track under the cursor, storing a track-relative
+        // offset so the note follows reorder / collapse / resize.
+        uint64_t track_id    = INVALID_TRACK_ID;
+        float    track_top_y = 0.0f;
+        if(layout.track_at && layout.track_at(new_y, track_id, track_top_y))
         {
-            m_time_ns = conversion_manager->PixelToTime(new_x);
-            // Re-anchor to the track under the cursor, storing a track-relative
-            // offset so the note follows reorder / collapse / resize.
-            uint64_t track_id    = INVALID_TRACK_ID;
-            float    track_top_y = 0.0f;
-            if(layout.track_at && layout.track_at(new_y, track_id, track_top_y))
-            {
-                m_track_id = track_id;
-                m_y_offset = new_y - track_top_y;
-            }
-            else
-            {
-                m_y_offset = new_y;
-            }
-            m_v_max_x  = conversion_manager->GetVMaxX();
-            m_v_min_x  = conversion_manager->GetVMinX();
+            m_track_id = track_id;
+            m_y_offset = new_y - track_top_y;
         }
         else
         {
-            m_expanded_screen_pos = ImVec2(new_x, new_y);
+            m_y_offset = new_y;
         }
-
+        m_v_max_x = conversion_manager->GetVMaxX();
+        m_v_min_x = conversion_manager->GetVMinX();
         return true;
     }
 
@@ -583,75 +518,6 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     }
 
     return m_dragging;
-}
-
-bool
-StickyNote::HandleResize(const ImVec2&                       window_position,
-                         std::shared_ptr<TimePixelTransform> conversion_manager,
-                         const TrackLayout&                  layout)
-{
-    if(!conversion_manager)
-    {
-        spdlog::error("StickyNote::HandleResize: conversion_manager shared_ptr is null");
-        return false;
-    }
-    // Only allow resize if not dragging
-    if(m_dragging || m_is_minimized) return false;
-
-    ImVec2 sticky_pos;
-    if(m_expanded_screen_pos.x >= 0 && m_expanded_screen_pos.y >= 0)
-    {
-        sticky_pos = ImVec2(window_position.x + m_expanded_screen_pos.x,
-                            window_position.y + m_expanded_screen_pos.y);
-    }
-    else
-    {
-        float x = conversion_manager->TimeToPixel(m_time_ns);
-        float y = ResolveAnchorY(layout);
-        sticky_pos = ImVec2(window_position.x + x, window_position.y + y);
-    }
-    ImVec2 sticky_max = ImVec2(sticky_pos.x + m_size.x, sticky_pos.y + m_size.y);
-
-    const float handle_size = 12.0f;
-    ImVec2 handle_pos = ImVec2(sticky_max.x - handle_size, sticky_max.y - handle_size);
-    ImVec2 handle_max = ImVec2(sticky_max.x, sticky_max.y);
-
-    ImVec2 mouse_pos      = ImGui::GetMousePos();
-    bool   mouse_down     = ImGui::IsMouseDown(ImGuiMouseButton_Left);
-    bool   mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
-
-    // Draw resize handle (should be done in Render, but safe here for logic)
-    ImDrawList* draw_list = ImGui::GetWindowDrawList();
-    SettingsManager& settings = SettingsManager::GetInstance();
-    ImU32            handle_color =
-        m_resizing ? settings.GetColor(Colors::kStickyNoteResizeActive)
-                   : settings.GetColor(Colors::kStickyNoteResize);
-    draw_list->AddRectFilled(handle_pos, handle_max, handle_color, 3.0f);
-
-    if(!m_resizing && ImGui::IsMouseHoveringRect(handle_pos, handle_max) &&
-       ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
-    {
-        m_resizing      = true;
-        m_resize_offset = ImVec2(mouse_pos.x - sticky_max.x, mouse_pos.y - sticky_max.y);
-    }
-
-    if(m_resizing && mouse_down)
-    {
-        float new_width  = mouse_pos.x - sticky_pos.x - m_resize_offset.x;
-        float new_height = mouse_pos.y - sticky_pos.y - m_resize_offset.y;
-        m_size.x         = std::max(new_width, 60.0f);
-        m_size.y         = std::max(new_height, 40.0f);
-        m_v_max_x        = conversion_manager->GetVMaxX();
-        m_v_min_x        = conversion_manager->GetVMinX();
-        return true;
-    }
-
-    if(m_resizing && mouse_released)
-    {
-        m_resizing = false;
-    }
-
-    return m_resizing;
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -71,6 +71,27 @@ StickyNote::ResolveAnchorY(const TrackLayout& layout) const
     return m_y_offset;
 }
 
+void
+StickyNote::RenderTimeIndicator(ImDrawList*                         draw_list,
+                                const ImVec2&                       window_position,
+                                std::shared_ptr<TimePixelTransform> tpt) const
+{
+    if(!draw_list || !tpt) return;
+
+    constexpr float kLineThickness = 1.5f;
+    constexpr float kLineAlpha     = 0.85f;
+
+    SettingsManager& settings = SettingsManager::GetInstance();
+    ImU32            color =
+        ApplyAlpha(settings.GetColor(Colors::kStickyNoteAccent), kLineAlpha);
+
+    const float line_x   = window_position.x + tpt->TimeToPixel(m_time_ns);
+    const float y_top    = window_position.y;
+    const float y_bottom = window_position.y + tpt->GetGraphSizeY();
+    draw_list->AddLine(ImVec2(line_x, y_top), ImVec2(line_x, y_bottom), color,
+                       kLineThickness);
+}
+
 double
 StickyNote::GetTimeNs() const
 {
@@ -186,6 +207,11 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
             std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
         ImVec2 btn_max = ImVec2(sticky_pos.x + minimized_btn_size,
                                 sticky_pos.y + minimized_btn_size);
+        bool hovered = ImGui::IsMouseHoveringRect(sticky_pos, btn_max);
+        if((hovered || m_dragging) && draw_list)
+        {
+            RenderTimeIndicator(draw_list, window_position, tpt);
+        }
         if(draw_list)
         {
             draw_list->AddRectFilled(ImVec2(sticky_pos.x + 2.0f, sticky_pos.y + 3.0f),
@@ -209,7 +235,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         ImGui::PopStyleColor(4);
         ImGui::PopFont();
 
-        bool blocks_timeline_input = ImGui::IsMouseHoveringRect(sticky_pos, btn_max);
+        bool blocks_timeline_input = hovered;
         if(blocks_timeline_input)
         {
             TimelineFocusManager::GetInstance().RequestLayerFocus(
@@ -255,6 +281,14 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
         sticky_pos = ImVec2(window_position.x + adjusted_x, window_position.y + adjusted_y);
         ImGui::SetCursorPos(ImVec2(adjusted_x, adjusted_y));
+
+        ImVec2 expanded_max =
+            ImVec2(sticky_pos.x + sticky_size.x, sticky_pos.y + sticky_size.y);
+        if((ImGui::IsMouseHoveringRect(sticky_pos, expanded_max) || m_dragging) &&
+           draw_list)
+        {
+            RenderTimeIndicator(draw_list, window_position, tpt);
+        }
 
         if(draw_list)
         {

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -638,8 +638,21 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     bool   mouse_down     = ImGui::IsMouseDown(ImGuiMouseButton_Left);
     bool   mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
 
+    // A click inside the expanded window must move only the window, not the
+    // anchor it overlaps.
+    bool over_expanded_window = false;
+    if(!m_is_minimized && IsExpandedPlaced())
+    {
+        const ImVec2 win_max = ImVec2(m_expanded_screen_pos.x + m_size.x,
+                                      m_expanded_screen_pos.y + m_size.y);
+        over_expanded_window = mouse_pos.x >= m_expanded_screen_pos.x &&
+                               mouse_pos.x <= win_max.x &&
+                               mouse_pos.y >= m_expanded_screen_pos.y &&
+                               mouse_pos.y <= win_max.y;
+    }
+
     if((dragged_id == INVALID_STICKY_ID || dragged_id == m_id) && !m_dragging &&
-       ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
+       !over_expanded_window && ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
        ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
        !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
     {

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -37,10 +37,6 @@ constexpr float kIconActiveAlpha      = 0.22f;
 constexpr float kMarkerRoundingScale  = 0.6f;
 constexpr float kMarkerShadowOffsetX  = 2.0f;
 constexpr float kMarkerShadowOffsetY  = 3.0f;
-constexpr int   kGlowLayers           = 3;
-constexpr float kGlowSpread           = 2.5f;
-constexpr float kGlowAlpha            = 0.5f;
-constexpr float kGlowThickness        = 2.0f;
 constexpr float kUnplacedCoord        = -1.0f;
 }  // namespace
 
@@ -196,24 +192,15 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 
     // The anchor marker is always shown so the note's timeline location stays
     // visible even when expanded.
-    ImVec2 marker_max;
-    bool   marker_hovered = RenderAnchorMarker(draw_list, anchor_pos, marker_max);
+    bool marker_hovered = RenderAnchorMarker(draw_list, anchor_pos);
 
     bool window_hovered = false;
     if(!m_is_minimized)
     {
-        window_hovered = RenderExpandedWindow(anchor_pos, marker_hovered);
+        window_hovered = RenderExpandedWindow(anchor_pos);
     }
 
-    // Hovering either half lights both so the pair is easy to spot.
     bool pair_hovered = marker_hovered || window_hovered;
-    if(pair_hovered)
-    {
-        const float marker_rounding =
-            SettingsManager::GetInstance().GetDefaultStyle().ChildRounding *
-            kMarkerRoundingScale;
-        DrawGlow(draw_list, anchor_pos, marker_max, marker_rounding);
-    }
 
     if((pair_hovered || m_dragging) && draw_list)
     {
@@ -226,8 +213,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 }
 
 bool
-StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
-                               ImVec2& out_marker_max)
+StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
 {
     SettingsManager& settings     = SettingsManager::GetInstance();
     ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
@@ -251,19 +237,18 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
     ImVec2      padding   = ImGui::GetStyle().FramePadding;
     const float btn_size =
         std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
-    out_marker_max = ImVec2(marker_pos.x + btn_size, marker_pos.y + btn_size);
-    bool hovered   = ImGui::IsMouseHoveringRect(marker_pos, out_marker_max);
+    ImVec2 btn_max = ImVec2(marker_pos.x + btn_size, marker_pos.y + btn_size);
+    bool   hovered = ImGui::IsMouseHoveringRect(marker_pos, btn_max);
 
     if(draw_list)
     {
         draw_list->AddRectFilled(
             ImVec2(marker_pos.x + kMarkerShadowOffsetX,
                    marker_pos.y + kMarkerShadowOffsetY),
-            ImVec2(out_marker_max.x + kMarkerShadowOffsetX,
-                   out_marker_max.y + kMarkerShadowOffsetY),
+            ImVec2(btn_max.x + kMarkerShadowOffsetX, btn_max.y + kMarkerShadowOffsetY),
             shadow_color, rounding);
-        draw_list->AddRectFilled(marker_pos, out_marker_max, bg_color, rounding);
-        draw_list->AddRect(marker_pos, out_marker_max, border_color, rounding);
+        draw_list->AddRectFilled(marker_pos, btn_max, bg_color, rounding);
+        draw_list->AddRect(marker_pos, btn_max, border_color, rounding);
     }
 
     ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
@@ -292,7 +277,7 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
 }
 
 bool
-StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered)
+StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
 {
     SettingsManager& settings     = SettingsManager::GetInstance();
     ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
@@ -426,11 +411,6 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered)
         ImGui::PopStyleColor();
 
         hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
-        if(marker_hovered || hovered)
-        {
-            DrawGlow(ImGui::GetForegroundDrawList(), win_pos,
-                     ImVec2(win_pos.x + win_size.x, win_pos.y + win_size.y), rounding);
-        }
 
         m_expanded_screen_pos = win_pos;
         m_size                = win_size;
@@ -440,25 +420,6 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered)
     ImGui::PopStyleColor(2);
     ImGui::PopStyleVar(3);
     return hovered;
-}
-
-void
-StickyNote::DrawGlow(ImDrawList* draw_list, const ImVec2& min, const ImVec2& max,
-                     float rounding) const
-{
-    if(!draw_list) return;
-
-    ImU32 glow = SettingsManager::GetInstance().GetColor(Colors::kStickyNoteAccent);
-    for(int i = kGlowLayers; i >= 1; --i)
-    {
-        float spread = kGlowSpread * static_cast<float>(i);
-        float alpha  = kGlowAlpha *
-                      (1.0f - static_cast<float>(i - 1) / static_cast<float>(kGlowLayers));
-        draw_list->AddRect(ImVec2(min.x - spread, min.y - spread),
-                           ImVec2(max.x + spread, max.y + spread),
-                           ApplyAlpha(glow, alpha), rounding + spread, ImDrawFlags_None,
-                           kGlowThickness);
-    }
 }
 
 void

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -5,14 +5,13 @@
 #include "icons/rocprovfis_icon_defines.h"
 #include "imgui.h"
 #include "rocprofvis_click_manager.h"
-#include "rocprofvis_event_manager.h"
-#include "rocprofvis_events.h"
 #include "rocprofvis_hotkey_manager.h"
 #include "rocprofvis_settings_manager.h"
 #include "widgets/rocprofvis_gui_helpers.h"
 #include <algorithm>
 #include <cfloat>
 #include <spdlog/spdlog.h>
+#include <string>
 
 namespace RocProfVis
 {
@@ -38,27 +37,76 @@ constexpr float kMarkerRoundingScale  = 0.6f;
 constexpr float kMarkerShadowOffsetX  = 2.0f;
 constexpr float kMarkerShadowOffsetY  = 3.0f;
 constexpr float kUnplacedCoord        = -1.0f;
+constexpr float kTitleInputPadX       = 4.0f;
+
+// Grows the backing std::string on demand so ImGui input fields can edit it in
+// place without a fixed char buffer.
+int
+GrowStringCallback(ImGuiInputTextCallbackData* data)
+{
+    if(data->EventFlag == ImGuiInputTextFlags_CallbackResize)
+    {
+        std::string* str = static_cast<std::string*>(data->UserData);
+        str->resize(static_cast<size_t>(data->BufTextLen));
+        data->Buf = str->data();
+    }
+    return 0;
+}
+
+bool
+InlineInputText(const char* id, const char* hint, std::string& str,
+                ImGuiInputTextFlags flags)
+{
+    flags |= ImGuiInputTextFlags_CallbackResize;
+    return ImGui::InputTextWithHint(id, hint, str.data(), str.capacity() + 1, flags,
+                                    GrowStringCallback, &str);
+}
+
+bool
+InlineInputTextMultiline(const char* id, std::string& str, const ImVec2& size,
+                         ImGuiInputTextFlags flags)
+{
+    flags |= ImGuiInputTextFlags_CallbackResize;
+    return ImGui::InputTextMultiline(id, str.data(), str.capacity() + 1, size, flags,
+                                     GrowStringCallback, &str);
+}
+
+// Styles an input to read like plain text: no frame, no background.
+void
+PushPlainTextInputStyle(SettingsManager& settings)
+{
+    ImU32 transparent = settings.GetColor(Colors::kTransparent);
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, transparent);
+    ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, transparent);
+    ImGui::PushStyleColor(ImGuiCol_FrameBgActive, transparent);
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 0.0f);
+}
+
+void
+PopPlainTextInputStyle()
+{
+    ImGui::PopStyleVar(1);
+    ImGui::PopStyleColor(3);
+}
 }  // namespace
 
 static int s_unique_id_counter = 0;
 StickyNote::StickyNote(double time_ns, float y_offset, const ImVec2& size,
-                       const std::string& text, const std::string& title,
-                       const std::string& project_id, double v_min, double v_max,
-                       uint64_t track_id, bool is_minimized)
+                       const std::string& text, const std::string& title, double v_min,
+                       double v_max, uint64_t track_id, bool is_minimized)
 : m_time_ns(time_ns)
 , m_y_offset(y_offset)
 , m_track_id(track_id)
 , m_size(size)
 , m_text(text)
 , m_title(title)
-, m_project_id(project_id)
 , m_id(s_unique_id_counter)
 , m_is_visible(true)
 , m_v_min_x(v_min)
 , m_v_max_x(v_max)
 , m_is_minimized(is_minimized)
 {
-    s_unique_id_counter = s_unique_id_counter + 1;
+    ++s_unique_id_counter;
 }
 
 void
@@ -102,10 +150,12 @@ StickyNote::RenderTimeIndicator(ImDrawList*                         draw_list,
     ImU32            color =
         ApplyAlpha(settings.GetColor(Colors::kStickyNoteAccent), kLineAlpha);
 
-    const float line_x   = window_position.x + tpt->TimeToPixel(m_time_ns);
-    const float y_top    = window_position.y;
-    const float y_bottom = window_position.y + tpt->GetGraphSizeY();
-    draw_list->AddLine(ImVec2(line_x, y_top), ImVec2(line_x, y_bottom), color,
+    // Span the full visible track area (the draw list's clip rect) rather than
+    // keying off the scrolled content origin, which only covers the top sliver.
+    const float  line_x   = window_position.x + tpt->TimeToPixel(m_time_ns);
+    const ImVec2 clip_min = draw_list->GetClipRectMin();
+    const ImVec2 clip_max = draw_list->GetClipRectMax();
+    draw_list->AddLine(ImVec2(line_x, clip_min.y), ImVec2(line_x, clip_max.y), color,
                        kLineThickness);
 }
 
@@ -165,14 +215,25 @@ StickyNote::IsVisible() const
 }
 
 void
-StickyNote::SetText(std::string title)
+StickyNote::SetText(std::string text)
 {
-    m_text = title;
+    m_text = std::move(text);
 }
 void
 StickyNote::SetTitle(std::string title)
 {
-    m_title = title;
+    m_title = std::move(title);
+}
+void
+StickyNote::BeginInlineEdit()
+{
+    m_is_minimized        = false;
+    m_request_focus       = true;
+    m_focus_input         = true;
+    m_editing_title       = true;
+    m_provisional         = true;
+    m_seen_focus          = false;
+    m_expanded_screen_pos = ImVec2(kUnplacedCoord, kUnplacedCoord);
 }
 bool
 StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
@@ -257,17 +318,18 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
     ImGui::PushStyleColor(ImGuiCol_Text, text_color);
     ImGui::Button((std::string(ICON_STICKY_NOTE) + "##" + std::to_string(m_id)).c_str(),
                   ImVec2(btn_size, btn_size));
-    if(ImGui::IsItemHovered() && IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
+    // Clicking a minimized marker expands the note; re-seed its window position.
+    if(m_is_minimized && ImGui::IsItemHovered() &&
+       IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
     {
-        if(m_is_minimized)
-        {
-            m_expanded_screen_pos = ImVec2(kUnplacedCoord, kUnplacedCoord);
-            m_is_minimized        = false;
-        }
-        else
-        {
-            m_request_focus = true;
-        }
+        m_expanded_screen_pos = ImVec2(kUnplacedCoord, kUnplacedCoord);
+        m_is_minimized        = false;
+    }
+    // Pressing an expanded note's marker steals window focus on mouse-down;
+    // request refocus while held so the empty-note auto-discard doesn't fire.
+    if(!m_is_minimized && ImGui::IsItemActive())
+    {
+        m_request_focus = true;
     }
     ImGui::PopStyleColor(4);
     ImGui::PopFont();
@@ -306,6 +368,9 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         m_expanded_screen_pos = anchor;
     }
 
+    // A pending focus request (e.g. clicking the note's own anchor) refocuses
+    // the window next frame, so it must not count as abandoning the note.
+    const bool refocusing = m_request_focus;
     if(m_request_focus)
     {
         ImGui::SetNextWindowFocus();
@@ -349,68 +414,147 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
                                 ImVec2(win_pos.x + win_size.x, header_max.y),
                                 ApplyAlpha(border_color, kHeaderSeparatorAlpha));
 
-        ImGui::SetCursorPos(ImVec2(
-            kNoteMargin, (kExpandedHeaderHeight - ImGui::GetTextLineHeight()) * 0.5f));
-        ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-        ImGui::TextUnformatted(m_title.c_str());
-        ImGui::PopStyleColor();
-
         ImFont* action_icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
         ImGui::PushFont(action_icon_font);
-        ImVec2      edit_icon_size  = ImGui::CalcTextSize(ICON_EDIT);
-        ImVec2      close_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
-        const float action_btn_size =
-            std::max({kHeaderButtonMinSize, edit_icon_size.x + kHeaderButtonPadding,
-                      close_icon_size.x + kHeaderButtonPadding});
+        ImVec2 close_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
+        ImVec2 trash_icon_size = ImGui::CalcTextSize(ICON_TRASH_CAN);
+        ImGui::PopFont();
+        const float action_btn_size = std::max(
+            {kHeaderButtonMinSize, close_icon_size.x + kHeaderButtonPadding,
+             trash_icon_size.x + kHeaderButtonPadding});
         const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
 
-        ImGui::SetCursorPos(ImVec2(
-            win_size.x - action_btn_size * 2.0f - kNoteMargin - kHeaderButtonGap,
-            action_btn_y));
+        // The title is plain text by default so the header stays draggable;
+        // a click (not a drag) on it switches to an inline input.
+        const float buttons_width = action_btn_size * 2.0f + kHeaderButtonGap;
+        const float title_width   = std::max(
+            0.0f, win_size.x - buttons_width - kHeaderButtonGap - kNoteMargin * 2.0f);
+        ImGui::PushStyleColor(ImGuiCol_Text, text_color);
+        if(m_editing_title)
+        {
+            ImGui::SetCursorPos(ImVec2(
+                kNoteMargin - kTitleInputPadX,
+                (kExpandedHeaderHeight - ImGui::GetFrameHeight()) * 0.5f));
+            ImGui::SetNextItemWidth(title_width + kTitleInputPadX);
+            PushPlainTextInputStyle(settings);
+            if(m_focus_input)
+            {
+                ImGui::SetKeyboardFocusHere();
+                m_focus_input = false;
+            }
+            InlineInputText(("##title_" + std::to_string(m_id)).c_str(), "Title", m_title,
+                            ImGuiInputTextFlags_EnterReturnsTrue);
+            if(ImGui::IsItemDeactivated())
+            {
+                m_editing_title = false;
+            }
+            PopPlainTextInputStyle();
+        }
+        else
+        {
+            ImGui::SetCursorPos(ImVec2(
+                kNoteMargin, (kExpandedHeaderHeight - ImGui::GetTextLineHeight()) * 0.5f));
+            if(m_title.empty())
+            {
+                ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
+                ImGui::TextUnformatted("Title");
+                ImGui::PopStyleColor();
+            }
+            else
+            {
+                ElidedText(m_title.c_str(), title_width);
+            }
+
+            const ImVec2 title_min(win_pos.x + kNoteMargin, win_pos.y);
+            const ImVec2 title_max(title_min.x + title_width,
+                                   win_pos.y + kExpandedHeaderHeight);
+            if(ImGui::IsMouseHoveringRect(title_min, title_max) &&
+               IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
+            {
+                m_editing_title = true;
+                m_focus_input   = true;
+            }
+        }
+        ImGui::PopStyleColor();
+
+        ImGui::PushFont(action_icon_font);
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
         ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
+
+        ImGui::SetCursorPos(ImVec2(
+            win_size.x - action_btn_size * 2.0f - kHeaderButtonGap - kNoteMargin,
+            action_btn_y));
         if(ImGui::Button(
-               (std::string(ICON_EDIT) + "##edit_" + std::to_string(m_id)).c_str(),
+               (std::string(ICON_TRASH_CAN) + "##delete_" + std::to_string(m_id)).c_str(),
                ImVec2(action_btn_size, action_btn_size)))
         {
-            EventManager::GetInstance()->AddEvent(
-                std::make_shared<StickyNoteEvent>(m_id, m_project_id));
+            m_pending_delete = true;
         }
-        ImGui::PopStyleColor(4);
 
         ImGui::SetCursorPos(
             ImVec2(win_size.x - action_btn_size - kNoteMargin, action_btn_y));
-        ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
-        ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
         if(ImGui::Button(
                (std::string(ICON_X_CIRCLED) + "##close_" + std::to_string(m_id)).c_str(),
                ImVec2(action_btn_size, action_btn_size)))
         {
-            m_is_minimized = true;
+            if(m_provisional && m_title.empty() && m_text.empty())
+            {
+                m_pending_delete = true;
+            }
+            else
+            {
+                m_is_minimized = true;
+            }
         }
         ImGui::PopStyleColor(4);
         ImGui::PopFont();
 
-        // Scroll only the note body; the header/actions stay pinned.
+        // Inline-editable body filling the remaining space.
         const float body_y      = kExpandedHeaderHeight + kNoteMargin;
         const float body_height = std::max(0.0f, win_size.y - body_y - kNoteMargin);
         ImGui::SetCursorPos(ImVec2(kNoteMargin, body_y));
-        ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kTransparent));
-        ImGui::BeginChild("StickyNoteBody",
-                          ImVec2(win_size.x - kNoteMargin * 2.0f, body_height), false);
         ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
-        ImGui::TextUnformatted(m_text.c_str());
-        ImGui::PopTextWrapPos();
-        ImGui::PopStyleColor();
-        ImGui::EndChild();
+        PushPlainTextInputStyle(settings);
+        InlineInputTextMultiline(
+            ("##body_" + std::to_string(m_id)).c_str(), m_text,
+            ImVec2(win_size.x - kNoteMargin * 2.0f, body_height),
+            ImGuiInputTextFlags_AllowTabInput);
+        bool body_active = ImGui::IsItemActive();
+        PopPlainTextInputStyle();
         ImGui::PopStyleColor();
 
+        // Placeholder hint while the body is empty and not being edited.
+        if(m_text.empty() && !body_active)
+        {
+            note_draw_list->AddText(
+                ImVec2(win_pos.x + kNoteMargin + ImGui::GetStyle().FramePadding.x,
+                       win_pos.y + body_y + ImGui::GetStyle().FramePadding.y),
+                muted_text_color, "Write a note...");
+        }
+
         hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+
+        // A provisional (just-created) note commits once anything is typed, and
+        // is discarded if the user clicks away while it is still empty.
+        if(m_provisional)
+        {
+            bool focused = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
+            if(focused)
+            {
+                m_seen_focus = true;
+            }
+
+            if(!m_title.empty() || !m_text.empty())
+            {
+                m_provisional = false;
+            }
+            else if(m_seen_focus && !focused && !refocusing)
+            {
+                m_pending_delete = true;
+            }
+        }
 
         m_expanded_screen_pos = win_pos;
         m_size                = win_size;
@@ -470,9 +614,9 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         spdlog::error("StickyNote::HandleDrag: conversion_manager shared_ptr is null");
         return false;
     }
-    // Expanded notes live in their own floating window, which owns move/resize.
-    if(!m_is_minimized) return false;
-
+    // The anchor marker can be dragged whether the note is minimized or expanded;
+    // it moves the note's timeline position, independent of the expanded window's
+    // own screen position.
     EnsureBound(layout);
 
     float x = conversion_manager->TimeToPixel(m_time_ns);
@@ -494,7 +638,7 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     bool   mouse_down     = ImGui::IsMouseDown(ImGuiMouseButton_Left);
     bool   mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
 
-    if((dragged_id == -1 || dragged_id == m_id) && !m_dragging &&
+    if((dragged_id == INVALID_STICKY_ID || dragged_id == m_id) && !m_dragging &&
        ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
        ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
        !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
@@ -511,7 +655,17 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         float  new_y       = mouse_pos.y - window_position.y - m_drag_offset.y;
         ImVec2 window_size = ImGui::GetWindowSize();
         new_x = std::clamp(new_x, 0.0f, window_size.x - drag_w);
-        new_y = std::clamp(new_y, 0.0f, window_size.y - drag_h);
+
+        // Keep the anchor inside the visible track viewport so it cannot be
+        // dragged off-screen; the timeline auto-scrolls to reveal more instead.
+        float min_y = 0.0f;
+        float max_y = window_size.y - drag_h;
+        if(layout.view_max_y > layout.view_min_y)
+        {
+            min_y = layout.view_min_y;
+            max_y = layout.view_max_y - drag_h;
+        }
+        new_y = std::clamp(new_y, min_y, std::max(min_y, max_y));
 
         m_time_ns = conversion_manager->PixelToTime(new_x);
         // Re-anchor to the track under the cursor, storing a track-relative
@@ -535,7 +689,7 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     if(m_dragging && mouse_released)
     {
         m_dragging = false;
-        dragged_id = -1;
+        dragged_id = INVALID_STICKY_ID;
         TimelineFocusManager::GetInstance().RequestLayerFocus(Layer::kNone);
     }
 

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -34,6 +34,14 @@ constexpr float kAccentStripeAlpha    = 0.78f;
 constexpr float kHeaderSeparatorAlpha = 0.42f;
 constexpr float kIconHoverAlpha       = 0.12f;
 constexpr float kIconActiveAlpha      = 0.22f;
+constexpr float kMarkerRoundingScale  = 0.6f;
+constexpr float kMarkerShadowOffsetX  = 2.0f;
+constexpr float kMarkerShadowOffsetY  = 3.0f;
+constexpr int   kGlowLayers           = 3;
+constexpr float kGlowSpread           = 2.5f;
+constexpr float kGlowAlpha            = 0.5f;
+constexpr float kGlowThickness        = 2.0f;
+constexpr float kUnplacedCoord        = -1.0f;
 }  // namespace
 
 static int s_unique_id_counter = 0;
@@ -181,13 +189,116 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         return false;
     }
     EnsureBound(layout);
+
+    float  x          = tpt->TimeToPixel(m_time_ns);
+    float  y          = ResolveAnchorY(layout);
+    ImVec2 anchor_pos = ImVec2(window_position.x + x, window_position.y + y);
+
+    // The anchor marker is always shown so the note's timeline location stays
+    // visible even when expanded.
+    ImVec2 marker_max;
+    bool   marker_hovered = RenderAnchorMarker(draw_list, anchor_pos, marker_max);
+
+    bool window_hovered = false;
+    if(!m_is_minimized)
+    {
+        window_hovered = RenderExpandedWindow(anchor_pos, marker_hovered);
+    }
+
+    // Hovering either half lights both so the pair is easy to spot.
+    bool pair_hovered = marker_hovered || window_hovered;
+    if(pair_hovered)
+    {
+        const float marker_rounding =
+            SettingsManager::GetInstance().GetDefaultStyle().ChildRounding *
+            kMarkerRoundingScale;
+        DrawGlow(ImGui::GetForegroundDrawList(), anchor_pos, marker_max, marker_rounding);
+    }
+
+    if((pair_hovered || m_dragging) && draw_list)
+    {
+        RenderTimeIndicator(draw_list, window_position, tpt);
+    }
+
+    TimelineFocusManager::GetInstance().RequestLayerFocus(
+        pair_hovered ? Layer::kInteractiveLayer : Layer::kNone);
+    return pair_hovered;
+}
+
+bool
+StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
+                               ImVec2& out_marker_max)
+{
+    SettingsManager& settings     = SettingsManager::GetInstance();
+    ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
+    ImU32            border_color = settings.GetColor(Colors::kStickyNoteBorder);
+    ImU32            shadow_color = settings.GetColor(Colors::kStickyNoteShadow);
+    ImU32            text_color   = settings.GetColor(Colors::kStickyNoteText);
+    ImU32            icon_hover_color =
+        ApplyAlpha(settings.GetColor(Colors::kStickyNoteText), kIconHoverAlpha);
+    ImU32 icon_active_color =
+        ApplyAlpha(settings.GetColor(Colors::kStickyNoteText), kIconActiveAlpha);
+    const float rounding =
+        settings.GetDefaultStyle().ChildRounding * kMarkerRoundingScale;
+
+    ImGui::SetCursorScreenPos(marker_pos);
+    std::string child_id = "StickyButtonArea##" + std::to_string(m_id);
+    ImGui::BeginChild(child_id.c_str(), m_size, false, ImGuiWindowFlags_None);
+
+    ImFont* icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
+    ImGui::PushFont(icon_font);
+    ImVec2      icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
+    ImVec2      padding   = ImGui::GetStyle().FramePadding;
+    const float btn_size =
+        std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
+    out_marker_max = ImVec2(marker_pos.x + btn_size, marker_pos.y + btn_size);
+    bool hovered   = ImGui::IsMouseHoveringRect(marker_pos, out_marker_max);
+
+    if(draw_list)
+    {
+        draw_list->AddRectFilled(
+            ImVec2(marker_pos.x + kMarkerShadowOffsetX,
+                   marker_pos.y + kMarkerShadowOffsetY),
+            ImVec2(out_marker_max.x + kMarkerShadowOffsetX,
+                   out_marker_max.y + kMarkerShadowOffsetY),
+            shadow_color, rounding);
+        draw_list->AddRectFilled(marker_pos, out_marker_max, bg_color, rounding);
+        draw_list->AddRect(marker_pos, out_marker_max, border_color, rounding);
+    }
+
+    ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
+    ImGui::PushStyleColor(ImGuiCol_Text, text_color);
+    ImGui::Button((std::string(ICON_STICKY_NOTE) + "##" + std::to_string(m_id)).c_str(),
+                  ImVec2(btn_size, btn_size));
+    if(ImGui::IsItemHovered() && IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
+    {
+        if(m_is_minimized)
+        {
+            m_expanded_screen_pos = ImVec2(kUnplacedCoord, kUnplacedCoord);
+            m_is_minimized        = false;
+        }
+        else
+        {
+            m_request_focus = true;
+        }
+    }
+    ImGui::PopStyleColor(4);
+    ImGui::PopFont();
+    ImGui::EndChild();
+
+    return hovered;
+}
+
+bool
+StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered)
+{
     SettingsManager& settings     = SettingsManager::GetInstance();
     ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
     ImU32            border_color = settings.GetColor(Colors::kStickyNoteBorder);
     ImU32            header_color = settings.GetColor(Colors::kStickyNoteHeader);
-    ImU32            shadow_color = settings.GetColor(Colors::kStickyNoteShadow);
-    // Overlay derived from the note text color so hover/active stays in palette.
-    ImU32 icon_hover_color =
+    ImU32            icon_hover_color =
         ApplyAlpha(settings.GetColor(Colors::kStickyNoteText), kIconHoverAlpha);
     ImU32 icon_active_color =
         ApplyAlpha(settings.GetColor(Colors::kStickyNoteText), kIconActiveAlpha);
@@ -195,205 +306,158 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     ImU32 muted_text_color = settings.GetColor(Colors::kStickyNoteTextMuted);
     ImU32 accent_color     = settings.GetColor(Colors::kStickyNoteAccent);
 
-    const float rounding = settings.GetDefaultStyle().ChildRounding;
+    const float  rounding    = settings.GetDefaultStyle().ChildRounding;
+    const ImVec2 sticky_size = m_size;
 
-    float  x           = tpt->TimeToPixel(m_time_ns);
-    float  y           = ResolveAnchorY(layout);
-    ImVec2 sticky_pos  = ImVec2(window_position.x + x, window_position.y + y);
-    ImVec2 sticky_size = m_size;
-
-    if(m_is_minimized)
+    // Seed the first position from the marker anchor, then ImGui owns it.
+    if(!IsExpandedPlaced())
     {
-        ImGui::SetCursorScreenPos(sticky_pos);
-        std::string child_id = "StickyButtonArea##" + std::to_string(m_id);
-        ImGui::BeginChild(child_id.c_str(), m_size, false, ImGuiWindowFlags_None);
+        const ImGuiViewport* viewport = ImGui::GetMainViewport();
+        ImVec2               anchor   = anchor_pos;
+        anchor.x = std::clamp(anchor.x, viewport->WorkPos.x,
+                              viewport->WorkPos.x + viewport->WorkSize.x - sticky_size.x);
+        anchor.y = std::clamp(anchor.y, viewport->WorkPos.y,
+                              viewport->WorkPos.y + viewport->WorkSize.y - sticky_size.y);
+        m_expanded_screen_pos = anchor;
+    }
 
-        ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(
-            FontType::kIcon);
-        ImGui::PushFont(icon_font);
-        ImVec2 icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
-        ImVec2 padding   = ImGui::GetStyle().FramePadding;
-        const float minimized_btn_size =
-            std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
-        ImVec2 btn_max = ImVec2(sticky_pos.x + minimized_btn_size,
-                                sticky_pos.y + minimized_btn_size);
-        bool hovered = ImGui::IsMouseHoveringRect(sticky_pos, btn_max);
-        if((hovered || m_dragging) && draw_list)
-        {
-            RenderTimeIndicator(draw_list, window_position, tpt);
-        }
-        if(draw_list)
-        {
-            draw_list->AddRectFilled(ImVec2(sticky_pos.x + 2.0f, sticky_pos.y + 3.0f),
-                                     ImVec2(btn_max.x + 2.0f, btn_max.y + 3.0f),
-                                     shadow_color, rounding * 0.6f);
-            draw_list->AddRectFilled(sticky_pos, btn_max, bg_color, rounding * 0.6f);
-            draw_list->AddRect(sticky_pos, btn_max, border_color, rounding * 0.6f);
-        }
+    if(m_request_focus)
+    {
+        ImGui::SetNextWindowFocus();
+        m_request_focus = false;
+    }
+    ImGui::SetNextWindowPos(m_expanded_screen_pos, ImGuiCond_Appearing);
+    ImGui::SetNextWindowSize(sticky_size, ImGuiCond_Appearing);
+    ImGui::SetNextWindowSizeConstraints(ImVec2(kExpandedMinWidth, kExpandedMinHeight),
+                                        ImVec2(FLT_MAX, FLT_MAX));
+
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, rounding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, kWindowBorderSize);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, bg_color);
+    ImGui::PushStyleColor(ImGuiCol_Border, border_color);
+
+    const ImGuiWindowFlags window_flags =
+        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse |
+        ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse |
+        ImGuiWindowFlags_NoSavedSettings;
+
+    std::string window_id = "StickyNoteWindow##" + std::to_string(m_id);
+    bool        visible   = ImGui::Begin(window_id.c_str(), nullptr, window_flags);
+
+    bool hovered = false;
+    if(visible)
+    {
+        const ImVec2 win_pos  = ImGui::GetWindowPos();
+        const ImVec2 win_size = ImGui::GetWindowSize();
+
+        ImDrawList*  note_draw_list = ImGui::GetWindowDrawList();
+        const ImVec2 header_max =
+            ImVec2(win_pos.x + win_size.x, win_pos.y + kExpandedHeaderHeight);
+        note_draw_list->AddRectFilled(win_pos, header_max, header_color, rounding,
+                                      ImDrawFlags_RoundCornersTop);
+        note_draw_list->AddRectFilled(
+            win_pos, ImVec2(win_pos.x + kAccentStripeWidth, win_pos.y + win_size.y),
+            ApplyAlpha(accent_color, kAccentStripeAlpha), rounding,
+            ImDrawFlags_RoundCornersLeft);
+        note_draw_list->AddLine(ImVec2(win_pos.x, header_max.y),
+                                ImVec2(win_pos.x + win_size.x, header_max.y),
+                                ApplyAlpha(border_color, kHeaderSeparatorAlpha));
+
+        ImGui::SetCursorPos(ImVec2(
+            kNoteMargin, (kExpandedHeaderHeight - ImGui::GetTextLineHeight()) * 0.5f));
+        ImGui::PushStyleColor(ImGuiCol_Text, text_color);
+        ImGui::TextUnformatted(m_title.c_str());
+        ImGui::PopStyleColor();
+
+        ImFont* action_icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
+        ImGui::PushFont(action_icon_font);
+        ImVec2      edit_icon_size  = ImGui::CalcTextSize(ICON_EDIT);
+        ImVec2      close_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
+        const float action_btn_size =
+            std::max({kHeaderButtonMinSize, edit_icon_size.x + kHeaderButtonPadding,
+                      close_icon_size.x + kHeaderButtonPadding});
+        const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
+
+        ImGui::SetCursorPos(ImVec2(
+            win_size.x - action_btn_size * 2.0f - kNoteMargin - kHeaderButtonGap,
+            action_btn_y));
         ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
-        ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-        ImGui::Button(
-            (std::string(ICON_STICKY_NOTE) + "##" + std::to_string(m_id)).c_str(),
-            ImVec2(minimized_btn_size, minimized_btn_size));
-        if(ImGui::IsItemHovered() && IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
+        ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
+        if(ImGui::Button(
+               (std::string(ICON_EDIT) + "##edit_" + std::to_string(m_id)).c_str(),
+               ImVec2(action_btn_size, action_btn_size)))
         {
-            m_expanded_screen_pos = ImVec2(-1, -1);
-            m_is_minimized        = false;
+            EventManager::GetInstance()->AddEvent(
+                std::make_shared<StickyNoteEvent>(m_id, m_project_id));
+        }
+        ImGui::PopStyleColor(4);
+
+        ImGui::SetCursorPos(
+            ImVec2(win_size.x - action_btn_size - kNoteMargin, action_btn_y));
+        ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
+        ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
+        if(ImGui::Button(
+               (std::string(ICON_X_CIRCLED) + "##close_" + std::to_string(m_id)).c_str(),
+               ImVec2(action_btn_size, action_btn_size)))
+        {
+            m_is_minimized = true;
         }
         ImGui::PopStyleColor(4);
         ImGui::PopFont();
 
-        bool blocks_timeline_input = hovered;
-        if(blocks_timeline_input)
-        {
-            TimelineFocusManager::GetInstance().RequestLayerFocus(
-                Layer::kInteractiveLayer);
-        }
-        else
-        {
-            TimelineFocusManager::GetInstance().RequestLayerFocus(Layer::kNone);
-        }
-
+        // Scroll only the note body; the header/actions stay pinned.
+        const float body_y      = kExpandedHeaderHeight + kNoteMargin;
+        const float body_height = std::max(0.0f, win_size.y - body_y - kNoteMargin);
+        ImGui::SetCursorPos(ImVec2(kNoteMargin, body_y));
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kTransparent));
+        ImGui::BeginChild("StickyNoteBody",
+                          ImVec2(win_size.x - kNoteMargin * 2.0f, body_height), false);
+        ImGui::PushStyleColor(ImGuiCol_Text, text_color);
+        ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x);
+        ImGui::TextUnformatted(m_text.c_str());
+        ImGui::PopTextWrapPos();
+        ImGui::PopStyleColor();
         ImGui::EndChild();
-        return blocks_timeline_input;
+        ImGui::PopStyleColor();
+
+        hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+        if(marker_hovered || hovered)
+        {
+            DrawGlow(ImGui::GetForegroundDrawList(), win_pos,
+                     ImVec2(win_pos.x + win_size.x, win_pos.y + win_size.y), rounding);
+        }
+
+        m_expanded_screen_pos = win_pos;
+        m_size                = win_size;
     }
-    else
+    ImGui::End();
+
+    ImGui::PopStyleColor(2);
+    ImGui::PopStyleVar(3);
+    return hovered;
+}
+
+void
+StickyNote::DrawGlow(ImDrawList* draw_list, const ImVec2& min, const ImVec2& max,
+                     float rounding) const
+{
+    if(!draw_list) return;
+
+    ImU32 glow = SettingsManager::GetInstance().GetColor(Colors::kStickyNoteAccent);
+    for(int i = kGlowLayers; i >= 1; --i)
     {
-        // Floating window: ImGui owns move/resize; we only seed the first
-        // position from the marker anchor, then track it live.
-        if(m_expanded_screen_pos.x < 0 || m_expanded_screen_pos.y < 0)
-        {
-            const ImGuiViewport* viewport = ImGui::GetMainViewport();
-            ImVec2               anchor   = sticky_pos;
-            anchor.x = std::clamp(anchor.x, viewport->WorkPos.x,
-                                  viewport->WorkPos.x + viewport->WorkSize.x - sticky_size.x);
-            anchor.y = std::clamp(anchor.y, viewport->WorkPos.y,
-                                  viewport->WorkPos.y + viewport->WorkSize.y - sticky_size.y);
-            m_expanded_screen_pos = anchor;
-        }
-
-        ImGui::SetNextWindowPos(m_expanded_screen_pos, ImGuiCond_Appearing);
-        ImGui::SetNextWindowSize(sticky_size, ImGuiCond_Appearing);
-        ImGui::SetNextWindowSizeConstraints(
-            ImVec2(kExpandedMinWidth, kExpandedMinHeight), ImVec2(FLT_MAX, FLT_MAX));
-
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, rounding);
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, kWindowBorderSize);
-        ImGui::PushStyleColor(ImGuiCol_WindowBg, bg_color);
-        ImGui::PushStyleColor(ImGuiCol_Border, border_color);
-
-        const ImGuiWindowFlags window_flags =
-            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse |
-            ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse |
-            ImGuiWindowFlags_NoSavedSettings;
-
-        std::string window_id = "StickyNoteWindow##" + std::to_string(m_id);
-        bool        visible   = ImGui::Begin(window_id.c_str(), nullptr, window_flags);
-
-        bool blocks_timeline_input = false;
-        if(visible)
-        {
-            const ImVec2 win_pos  = ImGui::GetWindowPos();
-            const ImVec2 win_size = ImGui::GetWindowSize();
-
-            ImDrawList*  note_draw_list = ImGui::GetWindowDrawList();
-            const ImVec2 header_max     = ImVec2(win_pos.x + win_size.x,
-                                                 win_pos.y + kExpandedHeaderHeight);
-            note_draw_list->AddRectFilled(win_pos, header_max, header_color, rounding,
-                                          ImDrawFlags_RoundCornersTop);
-            note_draw_list->AddRectFilled(
-                win_pos, ImVec2(win_pos.x + kAccentStripeWidth, win_pos.y + win_size.y),
-                ApplyAlpha(accent_color, kAccentStripeAlpha), rounding,
-                ImDrawFlags_RoundCornersLeft);
-            note_draw_list->AddLine(ImVec2(win_pos.x, header_max.y),
-                                    ImVec2(win_pos.x + win_size.x, header_max.y),
-                                    ApplyAlpha(border_color, kHeaderSeparatorAlpha));
-
-            ImGui::SetCursorPos(
-                ImVec2(kNoteMargin,
-                       (kExpandedHeaderHeight - ImGui::GetTextLineHeight()) * 0.5f));
-            ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-            ImGui::TextUnformatted(m_title.c_str());
-            ImGui::PopStyleColor();
-
-            ImFont* action_icon_font =
-                SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-            ImGui::PushFont(action_icon_font);
-            ImVec2      edit_icon_size  = ImGui::CalcTextSize(ICON_EDIT);
-            ImVec2      close_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
-            const float action_btn_size =
-                std::max({kHeaderButtonMinSize, edit_icon_size.x + kHeaderButtonPadding,
-                          close_icon_size.x + kHeaderButtonPadding});
-            const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
-
-            ImGui::SetCursorPos(ImVec2(win_size.x - action_btn_size * 2.0f - kNoteMargin -
-                                           kHeaderButtonGap,
-                                       action_btn_y));
-            ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
-            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
-            ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
-            ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
-            if(ImGui::Button((std::string(ICON_EDIT) + "##edit_" + std::to_string(m_id))
-                                 .c_str(),
-                             ImVec2(action_btn_size, action_btn_size)))
-            {
-                EventManager::GetInstance()->AddEvent(
-                    std::make_shared<StickyNoteEvent>(m_id, m_project_id));
-            }
-            ImGui::PopStyleColor(4);
-
-            ImGui::SetCursorPos(
-                ImVec2(win_size.x - action_btn_size - kNoteMargin, action_btn_y));
-            ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
-            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
-            ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
-            ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
-            if(ImGui::Button(
-                   (std::string(ICON_X_CIRCLED) + "##close_" + std::to_string(m_id)).c_str(),
-                   ImVec2(action_btn_size, action_btn_size)))
-            {
-                m_is_minimized = true;
-            }
-            ImGui::PopStyleColor(4);
-            ImGui::PopFont();
-
-            // Scroll only the note body; the header/actions stay pinned.
-            const float body_y      = kExpandedHeaderHeight + kNoteMargin;
-            const float body_height = std::max(0.0f, win_size.y - body_y - kNoteMargin);
-            ImGui::SetCursorPos(ImVec2(kNoteMargin, body_y));
-            ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kTransparent));
-            ImGui::BeginChild("StickyNoteBody",
-                              ImVec2(win_size.x - kNoteMargin * 2.0f, body_height), false);
-            ImGui::PushStyleColor(ImGuiCol_Text, text_color);
-            ImGui::PushTextWrapPos(ImGui::GetCursorPosX() +
-                                   ImGui::GetContentRegionAvail().x);
-            ImGui::TextUnformatted(m_text.c_str());
-            ImGui::PopTextWrapPos();
-            ImGui::PopStyleColor();
-            ImGui::EndChild();
-            ImGui::PopStyleColor();
-
-            blocks_timeline_input =
-                ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
-            if(blocks_timeline_input && draw_list)
-            {
-                RenderTimeIndicator(draw_list, window_position, tpt);
-            }
-
-            m_expanded_screen_pos = win_pos;
-            m_size                = win_size;
-        }
-        ImGui::End();
-
-        ImGui::PopStyleColor(2);
-        ImGui::PopStyleVar(3);
-
-        TimelineFocusManager::GetInstance().RequestLayerFocus(
-            blocks_timeline_input ? Layer::kInteractiveLayer : Layer::kNone);
-        return blocks_timeline_input;
+        float spread = kGlowSpread * static_cast<float>(i);
+        float alpha  = kGlowAlpha *
+                      (1.0f - static_cast<float>(i - 1) / static_cast<float>(kGlowLayers));
+        draw_list->AddRect(ImVec2(min.x - spread, min.y - spread),
+                           ImVec2(max.x + spread, max.y + spread),
+                           ApplyAlpha(glow, alpha), rounding + spread, ImDrawFlags_None,
+                           kGlowThickness);
     }
 }
 
@@ -403,16 +467,13 @@ StickyNote::RenderDragGhost(ImDrawList* draw_list, const ImVec2& screen_pos) con
     if(!draw_list) return;
 
     // Mirrors the minimized-note marker drawn in Render().
-    constexpr float kShadowOffsetX = 2.0f;
-    constexpr float kShadowOffsetY = 3.0f;
-    constexpr float kRoundingScale = 0.6f;
-
     SettingsManager& settings     = SettingsManager::GetInstance();
     ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
     ImU32            border_color = settings.GetColor(Colors::kStickyNoteBorder);
     ImU32            shadow_color = settings.GetColor(Colors::kStickyNoteShadow);
     ImU32            text_color   = settings.GetColor(Colors::kStickyNoteText);
-    const float rounding = settings.GetDefaultStyle().ChildRounding * kRoundingScale;
+    const float rounding =
+        settings.GetDefaultStyle().ChildRounding * kMarkerRoundingScale;
 
     ImFont* icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
     ImGui::PushFont(icon_font);
@@ -426,9 +487,9 @@ StickyNote::RenderDragGhost(ImDrawList* draw_list, const ImVec2& screen_pos) con
     ImVec2 box_max = ImVec2(screen_pos.x + btn_size, screen_pos.y + btn_size);
 
     draw_list->AddRectFilled(
-        ImVec2(screen_pos.x + kShadowOffsetX, screen_pos.y + kShadowOffsetY),
-        ImVec2(box_max.x + kShadowOffsetX, box_max.y + kShadowOffsetY), shadow_color,
-        rounding);
+        ImVec2(screen_pos.x + kMarkerShadowOffsetX, screen_pos.y + kMarkerShadowOffsetY),
+        ImVec2(box_max.x + kMarkerShadowOffsetX, box_max.y + kMarkerShadowOffsetY),
+        shadow_color, rounding);
     draw_list->AddRectFilled(screen_pos, box_max, bg_color, rounding);
     draw_list->AddRect(screen_pos, box_max, border_color, rounding);
 

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -301,7 +301,6 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
     const float btn_size =
         std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
     ImVec2 btn_max = ImVec2(marker_pos.x + btn_size, marker_pos.y + btn_size);
-    bool   hovered = ImGui::IsMouseHoveringRect(marker_pos, btn_max);
 
     if(draw_list)
     {
@@ -320,6 +319,8 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
     ImGui::PushStyleColor(ImGuiCol_Text, text_color);
     ImGui::Button((std::string(ICON_STICKY_NOTE) + "##" + std::to_string(m_id)).c_str(),
                   ImVec2(btn_size, btn_size));
+    // IsItemHovered respects z-order, so a covered marker won't show the time line.
+    bool hovered = ImGui::IsItemHovered();
     // Clicking a minimized marker expands the note; re-seed its window position.
     if(m_is_minimized && ImGui::IsItemHovered() &&
        IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -253,9 +253,39 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     float  y          = ResolveAnchorY(layout);
     ImVec2 anchor_pos = ImVec2(window_position.x + x, window_position.y + y);
 
-    // The anchor marker is always shown so the note's timeline location stays
-    // visible even when expanded.
-    bool marker_hovered = RenderAnchorMarker(draw_list, anchor_pos);
+    // Clip the anchor to its track's vertical span so a shrunk track cuts the
+    // marker off (or hides it) instead of letting it spill onto another track.
+    // While dragging the marker follows the cursor freely, so skip clipping.
+    bool   use_clip            = false;
+    bool   marker_fully_hidden = false;
+    ImVec2 clip_min;
+    ImVec2 clip_max;
+    float  track_top    = 0.0f;
+    float  track_height = 0.0f;
+    if(!m_dragging && m_track_id != INVALID_TRACK_ID && layout.top_of &&
+       layout.height_of && layout.top_of(m_track_id, track_top) &&
+       layout.height_of(m_track_id, track_height) && draw_list)
+    {
+        const ImVec2 draw_clip_min = draw_list->GetClipRectMin();
+        const ImVec2 draw_clip_max = draw_list->GetClipRectMax();
+        clip_min = ImVec2(draw_clip_min.x,
+                          std::max(draw_clip_min.y, window_position.y + track_top));
+        clip_max = ImVec2(
+            draw_clip_max.x,
+            std::min(draw_clip_max.y, window_position.y + track_top + track_height));
+        use_clip            = true;
+        marker_fully_hidden = clip_min.y >= clip_max.y || anchor_pos.y >= clip_max.y;
+    }
+
+    // Shown unless the track shrank below the anchor; the expanded window floats
+    // independently and stays regardless.
+    bool marker_hovered = false;
+    if(!marker_fully_hidden)
+    {
+        marker_hovered = RenderAnchorMarker(draw_list, anchor_pos,
+                                            use_clip ? &clip_min : nullptr,
+                                            use_clip ? &clip_max : nullptr);
+    }
 
     bool window_hovered = false;
     if(!m_is_minimized)
@@ -276,7 +306,8 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 }
 
 bool
-StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
+StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
+                               const ImVec2* clip_min, const ImVec2* clip_max)
 {
     SettingsManager& settings     = SettingsManager::GetInstance();
     ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
@@ -301,6 +332,14 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
     const float btn_size =
         std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
     ImVec2 btn_max = ImVec2(marker_pos.x + btn_size, marker_pos.y + btn_size);
+
+    // Clip the draw list (marker background) and ImGui (button hover/click).
+    const bool clipped = clip_min && clip_max;
+    if(clipped)
+    {
+        if(draw_list) draw_list->PushClipRect(*clip_min, *clip_max, true);
+        ImGui::PushClipRect(*clip_min, *clip_max, true);
+    }
 
     if(draw_list)
     {
@@ -336,6 +375,12 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
     }
     ImGui::PopStyleColor(4);
     ImGui::PopFont();
+
+    if(clipped)
+    {
+        ImGui::PopClipRect();
+        if(draw_list) draw_list->PopClipRect();
+    }
     ImGui::EndChild();
 
     return hovered;
@@ -649,8 +694,23 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     const bool timeline_hovered =
         ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
 
+    // A shrunk track cuts its anchor off, so don't let a marker that no longer
+    // fits within its track's bounds start a drag.
+    bool  anchor_in_track = true;
+    float track_top       = 0.0f;
+    float track_height    = 0.0f;
+    if(m_track_id != INVALID_TRACK_ID && layout.top_of && layout.height_of &&
+       layout.top_of(m_track_id, track_top) &&
+       layout.height_of(m_track_id, track_height))
+    {
+        const float top    = window_position.y + track_top;
+        const float bottom = top + track_height;
+        anchor_in_track    = mouse_pos.y >= top && mouse_pos.y < bottom;
+    }
+
     if((dragged_id == INVALID_STICKY_ID || dragged_id == m_id) && !m_dragging &&
-       timeline_hovered && ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
+       anchor_in_track && timeline_hovered &&
+       ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
        ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
        !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
     {

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -477,27 +477,29 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         }
         ImGui::PopStyleColor();
 
-        ImGui::PushFont(action_icon_font);
-        ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
+        // Glyph color for the header buttons; IconButton handles the (transparent)
+        // frame and hover/active backgrounds, with zero frame padding so the icon
+        // stays centered as the font scales.
         ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
+        const ImU32 transparent = settings.GetColor(Colors::kTransparent);
+        const ImVec2 action_btn(action_btn_size, action_btn_size);
 
         ImGui::SetCursorPos(ImVec2(
             win_size.x - action_btn_size * 2.0f - kHeaderButtonGap - kNoteMargin,
             action_btn_y));
-        if(ImGui::Button(
-               (std::string(ICON_TRASH_CAN) + "##delete_" + std::to_string(m_id)).c_str(),
-               ImVec2(action_btn_size, action_btn_size)))
+        if(IconButton(ICON_TRASH_CAN, action_icon_font, action_btn, nullptr, false,
+                      ImVec2(0.0f, 0.0f), transparent, icon_hover_color,
+                      icon_active_color,
+                      ("delete_" + std::to_string(m_id)).c_str()))
         {
             m_pending_delete = true;
         }
 
         ImGui::SetCursorPos(
             ImVec2(win_size.x - action_btn_size - kNoteMargin, action_btn_y));
-        if(ImGui::Button(
-               (std::string(ICON_X_CIRCLED) + "##close_" + std::to_string(m_id)).c_str(),
-               ImVec2(action_btn_size, action_btn_size)))
+        if(IconButton(ICON_X_CIRCLED, action_icon_font, action_btn, nullptr, false,
+                      ImVec2(0.0f, 0.0f), transparent, icon_hover_color,
+                      icon_active_color, ("close_" + std::to_string(m_id)).c_str()))
         {
             if(m_provisional && m_title.empty() && m_text.empty())
             {
@@ -508,8 +510,7 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
                 m_is_minimized = true;
             }
         }
-        ImGui::PopStyleColor(4);
-        ImGui::PopFont();
+        ImGui::PopStyleColor();
 
         // Inline-editable body filling the remaining space.
         const float body_y      = kExpandedHeaderHeight + kNoteMargin;

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -27,9 +27,10 @@ static int s_unique_id_counter = 0;
 StickyNote::StickyNote(double time_ns, float y_offset, const ImVec2& size,
                        const std::string& text, const std::string& title,
                        const std::string& project_id, double v_min, double v_max,
-                       bool is_minimized)
+                       uint64_t track_id, bool is_minimized)
 : m_time_ns(time_ns)
 , m_y_offset(y_offset)
+, m_track_id(track_id)
 , m_size(size)
 , m_text(text)
 , m_title(title)
@@ -41,6 +42,33 @@ StickyNote::StickyNote(double time_ns, float y_offset, const ImVec2& size,
 , m_is_minimized(is_minimized)
 {
     s_unique_id_counter = s_unique_id_counter + 1;
+}
+
+void
+StickyNote::EnsureBound(const TrackLayout& layout)
+{
+    if(m_track_id != INVALID_TRACK_ID || !layout.track_at) return;
+
+    // In the unbound state m_y_offset is an absolute Y; convert it to relative.
+    uint64_t track_id    = INVALID_TRACK_ID;
+    float    track_top_y = 0.0f;
+    if(layout.track_at(m_y_offset, track_id, track_top_y))
+    {
+        m_track_id = track_id;
+        m_y_offset -= track_top_y;
+    }
+}
+
+float
+StickyNote::ResolveAnchorY(const TrackLayout& layout) const
+{
+    float track_top_y = 0.0f;
+    if(m_track_id != INVALID_TRACK_ID && layout.top_of &&
+       layout.top_of(m_track_id, track_top_y))
+    {
+        return track_top_y + m_y_offset;
+    }
+    return m_y_offset;
 }
 
 double
@@ -110,7 +138,7 @@ StickyNote::SetTitle(std::string title)
 }
 bool
 StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
-                   std::shared_ptr<TimePixelTransform> tpt)
+                   std::shared_ptr<TimePixelTransform> tpt, const TrackLayout& layout)
 {
     if(!tpt)
     {
@@ -118,6 +146,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
             "StickyNote::Render: conversion_manager shared_ptr is null, cannot render");
         return false;
     }
+    EnsureBound(layout);
     SettingsManager& settings      = SettingsManager::GetInstance();
     ImU32            bg_color          = settings.GetColor(Colors::kStickyNoteBg);
     ImU32            border_color      = settings.GetColor(Colors::kStickyNoteBorder);
@@ -136,7 +165,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     const float icon_btn_gap  = 8.0f;
 
     float  x           = tpt->TimeToPixel(m_time_ns);
-    float  y           = m_y_offset;
+    float  y           = ResolveAnchorY(layout);
     ImVec2 sticky_pos  = ImVec2(window_position.x + x, window_position.y + y);
     ImVec2 sticky_size = m_size;
 
@@ -353,10 +382,52 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     }
 }
 
+void
+StickyNote::RenderDragGhost(ImDrawList* draw_list, const ImVec2& screen_pos) const
+{
+    if(!draw_list) return;
+
+    // Mirrors the minimized-note marker drawn in Render(): a drop shadow offset
+    // by a couple of pixels and corners at a fraction of the panel rounding.
+    constexpr float kShadowOffsetX = 2.0f;
+    constexpr float kShadowOffsetY = 3.0f;
+    constexpr float kRoundingScale = 0.6f;
+
+    SettingsManager& settings     = SettingsManager::GetInstance();
+    ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
+    ImU32            border_color = settings.GetColor(Colors::kStickyNoteBorder);
+    ImU32            shadow_color = settings.GetColor(Colors::kStickyNoteShadow);
+    ImU32            text_color   = settings.GetColor(Colors::kStickyNoteText);
+    const float rounding = settings.GetDefaultStyle().ChildRounding * kRoundingScale;
+
+    ImFont* icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
+    ImGui::PushFont(icon_font);
+    ImVec2 icon_size      = ImGui::CalcTextSize(ICON_STICKY_NOTE);
+    float  icon_font_size = ImGui::GetFontSize();
+    ImGui::PopFont();
+
+    ImVec2      padding = ImGui::GetStyle().FramePadding;
+    const float btn_size =
+        std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
+    ImVec2 box_max = ImVec2(screen_pos.x + btn_size, screen_pos.y + btn_size);
+
+    draw_list->AddRectFilled(
+        ImVec2(screen_pos.x + kShadowOffsetX, screen_pos.y + kShadowOffsetY),
+        ImVec2(box_max.x + kShadowOffsetX, box_max.y + kShadowOffsetY), shadow_color,
+        rounding);
+    draw_list->AddRectFilled(screen_pos, box_max, bg_color, rounding);
+    draw_list->AddRect(screen_pos, box_max, border_color, rounding);
+
+    ImVec2 text_pos = ImVec2(screen_pos.x + (btn_size - icon_size.x) * 0.5f,
+                             screen_pos.y + (btn_size - icon_size.y) * 0.5f);
+    draw_list->AddText(icon_font, icon_font_size, text_pos, text_color,
+                       ICON_STICKY_NOTE);
+}
+
 bool
 StickyNote::HandleDrag(const ImVec2&                       window_position,
                        std::shared_ptr<TimePixelTransform> conversion_manager,
-                       int&                                dragged_id)
+                       int& dragged_id, const TrackLayout& layout)
 {
     if(!conversion_manager)
     {
@@ -365,13 +436,15 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     }
     if(m_resizing) return false;
 
+    EnsureBound(layout);
+
     ImVec2 drag_pos;
     ImVec2 drag_max;
-    float  drag_w;
-    float  drag_h;
+    float  drag_w = 0.0f;
+    float  drag_h = 0.0f;
 
     float x = conversion_manager->TimeToPixel(m_time_ns);
-    float y = m_y_offset;
+    float y = ResolveAnchorY(layout);
 
     if(m_is_minimized)
     {
@@ -443,8 +516,20 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
 
         if(m_is_minimized)
         {
-            m_time_ns  = conversion_manager->PixelToTime(new_x);
-            m_y_offset = new_y;
+            m_time_ns = conversion_manager->PixelToTime(new_x);
+            // Re-anchor to the track under the cursor, storing a track-relative
+            // offset so the note follows reorder / collapse / resize.
+            uint64_t track_id    = INVALID_TRACK_ID;
+            float    track_top_y = 0.0f;
+            if(layout.track_at && layout.track_at(new_y, track_id, track_top_y))
+            {
+                m_track_id = track_id;
+                m_y_offset = new_y - track_top_y;
+            }
+            else
+            {
+                m_y_offset = new_y;
+            }
             m_v_max_x  = conversion_manager->GetVMaxX();
             m_v_min_x  = conversion_manager->GetVMinX();
         }
@@ -468,7 +553,8 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
 
 bool
 StickyNote::HandleResize(const ImVec2&                       window_position,
-                         std::shared_ptr<TimePixelTransform> conversion_manager)
+                         std::shared_ptr<TimePixelTransform> conversion_manager,
+                         const TrackLayout&                  layout)
 {
     if(!conversion_manager)
     {
@@ -487,7 +573,7 @@ StickyNote::HandleResize(const ImVec2&                       window_position,
     else
     {
         float x = conversion_manager->TimeToPixel(m_time_ns);
-        float y = m_y_offset;
+        float y = ResolveAnchorY(layout);
         sticky_pos = ImVec2(window_position.x + x, window_position.y + y);
     }
     ImVec2 sticky_max = ImVec2(sticky_pos.x + m_size.x, sticky_pos.y + m_size.y);

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -25,9 +25,9 @@ constexpr float kExpandedMinWidth     = 160.0f;
 constexpr float kExpandedMinHeight    = 96.0f;
 constexpr float kWindowBorderSize     = 1.0f;
 constexpr float kNoteMargin           = 14.0f;
-constexpr float kHeaderButtonGap      = 8.0f;
-constexpr float kHeaderButtonMinSize  = 34.0f;
-constexpr float kHeaderButtonPadding  = 14.0f;
+constexpr float kHeaderButtonGap      = 2.0f;
+constexpr float kHeaderButtonMinSize  = 24.0f;
+constexpr float kHeaderButtonPadding  = 6.0f;
 constexpr float kAccentStripeWidth    = 3.0f;
 constexpr float kAccentStripeAlpha    = 0.78f;
 constexpr float kHeaderSeparatorAlpha = 0.42f;
@@ -522,8 +522,8 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         ImGui::SetCursorPos(ImVec2(
             win_size.x - action_btn_size * 2.0f - kHeaderButtonGap - kNoteMargin,
             action_btn_y));
-        if(IconButton(ICON_TRASH_CAN, action_icon_font, action_btn, nullptr, false,
-                      ImVec2(0.0f, 0.0f), transparent, icon_hover_color,
+        if(IconButton(ICON_TRASH_CAN, action_icon_font, action_btn, "Delete Annotation",
+                      false, ImVec2(0.0f, 0.0f), transparent, icon_hover_color,
                       icon_active_color,
                       ("delete_" + std::to_string(m_id)).c_str()))
         {
@@ -532,7 +532,7 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
 
         ImGui::SetCursorPos(
             ImVec2(win_size.x - action_btn_size - kNoteMargin, action_btn_y));
-        if(IconButton(ICON_X_CIRCLED, action_icon_font, action_btn, nullptr, false,
+        if(IconButton(ICON_X_CIRCLED, action_icon_font, action_btn, "Close Note", false,
                       ImVec2(0.0f, 0.0f), transparent, icon_hover_color,
                       icon_active_color, ("close_" + std::to_string(m_id)).c_str()))
         {

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -38,9 +38,10 @@ constexpr float kMarkerShadowOffsetX  = 2.0f;
 constexpr float kMarkerShadowOffsetY  = 3.0f;
 constexpr float kUnplacedCoord        = -1.0f;
 constexpr float kTitleInputPadX       = 4.0f;
+constexpr float kTimeIndicatorWidth   = 1.5f;
+constexpr float kTimeIndicatorAlpha   = 0.85f;
 
-// Grows the backing std::string on demand so ImGui input fields can edit it in
-// place without a fixed char buffer.
+// Grows the backing std::string so ImGui can edit it in place.
 int
 GrowStringCallback(ImGuiInputTextCallbackData* data)
 {
@@ -138,6 +139,37 @@ StickyNote::ResolveAnchorY(const TrackLayout& layout) const
     return m_y_offset;
 }
 
+float
+StickyNote::MarkerSize()
+{
+    SettingsManager& settings   = SettingsManager::GetInstance();
+    ImFont*          icon_font  = settings.GetFontManager().GetFont(FontType::kIcon);
+    ImGui::PushFont(icon_font);
+    ImVec2 icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
+    ImGui::PopFont();
+    ImVec2 padding = ImGui::GetStyle().FramePadding;
+    return std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
+}
+
+bool
+StickyNote::IsMarkerOnTrack(const ImVec2& marker_pos, float marker_size,
+                            float window_top_y, const TrackLayout& layout) const
+{
+    float track_top    = 0.0f;
+    float track_height = 0.0f;
+    if(m_track_id == INVALID_TRACK_ID || !layout.top_of || !layout.height_of ||
+       !layout.top_of(m_track_id, track_top) ||
+       !layout.height_of(m_track_id, track_height))
+    {
+        return true;
+    }
+
+    // Visible while the badge overlaps the track band; gone once shrunk past it.
+    const float top    = window_top_y + track_top;
+    const float bottom = top + track_height;
+    return marker_pos.y < bottom && marker_pos.y + marker_size > top;
+}
+
 void
 StickyNote::RenderTimeIndicator(ImDrawList*                         draw_list,
                                 const ImVec2&                       window_position,
@@ -145,20 +177,16 @@ StickyNote::RenderTimeIndicator(ImDrawList*                         draw_list,
 {
     if(!draw_list || !tpt) return;
 
-    constexpr float kLineThickness = 1.5f;
-    constexpr float kLineAlpha     = 0.85f;
-
     SettingsManager& settings = SettingsManager::GetInstance();
     ImU32            color =
-        ApplyAlpha(settings.GetColor(Colors::kStickyNoteAccent), kLineAlpha);
+        ApplyAlpha(settings.GetColor(Colors::kStickyNoteAccent), kTimeIndicatorAlpha);
 
-    // Span the full visible track area (the draw list's clip rect) rather than
-    // keying off the scrolled content origin, which only covers the top sliver.
+    // Use the clip rect so the line spans the full visible track area.
     const float  line_x   = window_position.x + tpt->TimeToPixel(m_time_ns);
     const ImVec2 clip_min = draw_list->GetClipRectMin();
     const ImVec2 clip_max = draw_list->GetClipRectMax();
     draw_list->AddLine(ImVec2(line_x, clip_min.y), ImVec2(line_x, clip_max.y), color,
-                       kLineThickness);
+                       kTimeIndicatorWidth);
 }
 
 double
@@ -243,8 +271,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 {
     if(!tpt)
     {
-        spdlog::error(
-            "StickyNote::Render: conversion_manager shared_ptr is null, cannot render");
+        spdlog::error("StickyNote::Render: tpt shared_ptr is null");
         return false;
     }
     EnsureBound(layout);
@@ -253,39 +280,19 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     float  y          = ResolveAnchorY(layout);
     ImVec2 anchor_pos = ImVec2(window_position.x + x, window_position.y + y);
 
-    // Clip the anchor to its track's vertical span so a shrunk track cuts the
-    // marker off (or hides it) instead of letting it spill onto another track.
-    // While dragging the marker follows the cursor freely, so skip clipping.
-    bool   use_clip            = false;
-    bool   marker_fully_hidden = false;
-    ImVec2 clip_min;
-    ImVec2 clip_max;
-    float  track_top    = 0.0f;
-    float  track_height = 0.0f;
-    if(!m_dragging && m_track_id != INVALID_TRACK_ID && layout.top_of &&
-       layout.height_of && layout.top_of(m_track_id, track_top) &&
-       layout.height_of(m_track_id, track_height) && draw_list)
-    {
-        const ImVec2 draw_clip_min = draw_list->GetClipRectMin();
-        const ImVec2 draw_clip_max = draw_list->GetClipRectMax();
-        clip_min = ImVec2(draw_clip_min.x,
-                          std::max(draw_clip_min.y, window_position.y + track_top));
-        clip_max = ImVec2(
-            draw_clip_max.x,
-            std::min(draw_clip_max.y, window_position.y + track_top + track_height));
-        use_clip            = true;
-        marker_fully_hidden = clip_min.y >= clip_max.y || anchor_pos.y >= clip_max.y;
-    }
+    // Hide a minimized anchor once its track shrinks past it so it can't strand
+    // on a neighbour; expanded or dragging notes always keep it.
+    bool marker_hidden = m_is_minimized && !m_dragging &&
+                         !IsMarkerOnTrack(anchor_pos, MarkerSize(), window_position.y,
+                                          layout);
 
-    // Shown unless the track shrank below the anchor; the expanded window floats
-    // independently and stays regardless.
     bool marker_hovered = false;
-    if(!marker_fully_hidden)
+    if(!marker_hidden)
     {
-        marker_hovered = RenderAnchorMarker(draw_list, anchor_pos,
-                                            use_clip ? &clip_min : nullptr,
-                                            use_clip ? &clip_max : nullptr);
+        marker_hovered = RenderAnchorMarker(draw_list, anchor_pos);
     }
+    // Cached for next frame's HandleDrag (which runs before this render pass).
+    m_marker_hovered = marker_hovered;
 
     bool window_hovered = false;
     if(!m_is_minimized)
@@ -306,8 +313,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
 }
 
 bool
-StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
-                               const ImVec2* clip_min, const ImVec2* clip_max)
+StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
 {
     SettingsManager& settings     = SettingsManager::GetInstance();
     ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
@@ -320,26 +326,16 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
         ApplyAlpha(settings.GetColor(Colors::kStickyNoteText), kIconActiveAlpha);
     const float rounding =
         settings.GetDefaultStyle().ChildRounding * kMarkerRoundingScale;
+    const float  btn_size = MarkerSize();
+    const ImVec2 btn_max  = ImVec2(marker_pos.x + btn_size, marker_pos.y + btn_size);
 
+    // Marker-sized child (no padding) so it doesn't block track resize below it.
     ImGui::SetCursorScreenPos(marker_pos);
     std::string child_id = "StickyButtonArea##" + std::to_string(m_id);
-    ImGui::BeginChild(child_id.c_str(), m_size, false, ImGuiWindowFlags_None);
-
-    ImFont* icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
-    ImGui::PushFont(icon_font);
-    ImVec2      icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
-    ImVec2      padding   = ImGui::GetStyle().FramePadding;
-    const float btn_size =
-        std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
-    ImVec2 btn_max = ImVec2(marker_pos.x + btn_size, marker_pos.y + btn_size);
-
-    // Clip the draw list (marker background) and ImGui (button hover/click).
-    const bool clipped = clip_min && clip_max;
-    if(clipped)
-    {
-        if(draw_list) draw_list->PushClipRect(*clip_min, *clip_max, true);
-        ImGui::PushClipRect(*clip_min, *clip_max, true);
-    }
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+    ImGui::BeginChild(child_id.c_str(), ImVec2(btn_size, btn_size), false,
+                      ImGuiWindowFlags_None);
+    ImGui::PopStyleVar();
 
     if(draw_list)
     {
@@ -352,6 +348,7 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
         draw_list->AddRect(marker_pos, btn_max, border_color, rounding);
     }
 
+    ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kIcon));
     ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, icon_hover_color);
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, icon_active_color);
@@ -361,26 +358,18 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
     // IsItemHovered respects z-order, so a covered marker won't show the time line.
     bool hovered = ImGui::IsItemHovered();
     // Clicking a minimized marker expands the note; re-seed its window position.
-    if(m_is_minimized && ImGui::IsItemHovered() &&
-       IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
+    if(m_is_minimized && hovered && IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
     {
         m_expanded_screen_pos = ImVec2(kUnplacedCoord, kUnplacedCoord);
         m_is_minimized        = false;
     }
-    // Pressing an expanded note's marker steals window focus on mouse-down;
-    // request refocus while held so the empty-note auto-discard doesn't fire.
+    // Marker press steals focus; request refocus so auto-discard doesn't fire.
     if(!m_is_minimized && ImGui::IsItemActive())
     {
         m_request_focus = true;
     }
     ImGui::PopStyleColor(4);
     ImGui::PopFont();
-
-    if(clipped)
-    {
-        ImGui::PopClipRect();
-        if(draw_list) draw_list->PopClipRect();
-    }
     ImGui::EndChild();
 
     return hovered;
@@ -416,8 +405,7 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         m_expanded_screen_pos = anchor;
     }
 
-    // A pending focus request (e.g. clicking the note's own anchor) refocuses
-    // the window next frame, so it must not count as abandoning the note.
+    // A pending refocus (e.g. clicking the anchor) isn't abandoning the note.
     const bool refocusing = m_request_focus;
     if(m_request_focus)
     {
@@ -472,8 +460,7 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
              trash_icon_size.x + kHeaderButtonPadding});
         const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
 
-        // The title is plain text by default so the header stays draggable;
-        // a click (not a drag) on it switches to an inline input.
+        // Title is plain text so the header stays draggable; click to edit.
         const float buttons_width = action_btn_size * 2.0f + kHeaderButtonGap;
         const float title_width   = std::max(
             0.0f, win_size.x - buttons_width - kHeaderButtonGap - kNoteMargin * 2.0f);
@@ -527,9 +514,7 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         }
         ImGui::PopStyleColor();
 
-        // Glyph color for the header buttons; IconButton handles the (transparent)
-        // frame and hover/active backgrounds, with zero frame padding so the icon
-        // stays centered as the font scales.
+        // Header buttons: set glyph color; IconButton draws the frame and hover.
         ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
         const ImU32 transparent = settings.GetColor(Colors::kTransparent);
         const ImVec2 action_btn(action_btn_size, action_btn_size);
@@ -562,7 +547,6 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         }
         ImGui::PopStyleColor();
 
-        // Inline-editable body filling the remaining space.
         const float body_y      = kExpandedHeaderHeight + kNoteMargin;
         const float body_height = std::max(0.0f, win_size.y - body_y - kNoteMargin);
         ImGui::SetCursorPos(ImVec2(kNoteMargin, body_y));
@@ -576,7 +560,6 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         PopPlainTextInputStyle();
         ImGui::PopStyleColor();
 
-        // Placeholder hint while the body is empty and not being edited.
         if(m_text.empty() && !body_active)
         {
             note_draw_list->AddText(
@@ -587,8 +570,7 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
 
         hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
 
-        // A provisional (just-created) note commits once anything is typed, and
-        // is discarded if the user clicks away while it is still empty.
+        // Provisional note commits on first input, discarded if abandoned empty.
         if(m_provisional)
         {
             bool focused = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
@@ -637,10 +619,8 @@ StickyNote::RenderDragGhost(ImDrawList* draw_list, const ImVec2& screen_pos) con
     float  icon_font_size = ImGui::GetFontSize();
     ImGui::PopFont();
 
-    ImVec2      padding = ImGui::GetStyle().FramePadding;
-    const float btn_size =
-        std::max(icon_size.x + padding.x * 2.0f, icon_size.y + padding.y * 2.0f);
-    ImVec2 box_max = ImVec2(screen_pos.x + btn_size, screen_pos.y + btn_size);
+    const float  btn_size = MarkerSize();
+    const ImVec2 box_max  = ImVec2(screen_pos.x + btn_size, screen_pos.y + btn_size);
 
     draw_list->AddRectFilled(
         ImVec2(screen_pos.x + kMarkerShadowOffsetX, screen_pos.y + kMarkerShadowOffsetY),
@@ -665,53 +645,23 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         spdlog::error("StickyNote::HandleDrag: conversion_manager shared_ptr is null");
         return false;
     }
-    // The anchor marker can be dragged whether the note is minimized or expanded;
-    // it moves the note's timeline position, independent of the expanded window's
-    // own screen position.
+    // Dragging the anchor moves the note's timeline position, not the window's.
     EnsureBound(layout);
 
     float x = conversion_manager->TimeToPixel(m_time_ns);
     float y = ResolveAnchorY(layout);
 
-    ImVec2  icon_pos  = ImVec2(window_position.x + x, window_position.y + y);
-    ImFont* icon_font =
-        SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-    ImGui::PushFont(icon_font, 0.0f);
-    ImVec2 icon_size = ImGui::CalcTextSize(ICON_STICKY_NOTE);
-    ImGui::PopFont();
+    ImVec2 icon_pos = ImVec2(window_position.x + x, window_position.y + y);
 
-    ImVec2 padding  = ImGui::GetStyle().FramePadding;
-    float  drag_w   = icon_size.x + padding.x * 2.0f;
-    float  drag_h   = icon_size.y + padding.y * 2.0f;
-    ImVec2 drag_max = ImVec2(icon_pos.x + drag_w, icon_pos.y + drag_h);
+    const float marker_size    = MarkerSize();
+    ImVec2      mouse_pos      = ImGui::GetMousePos();
+    bool        mouse_down     = ImGui::IsMouseDown(ImGuiMouseButton_Left);
+    bool        mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
 
-    ImVec2 mouse_pos      = ImGui::GetMousePos();
-    bool   mouse_down     = ImGui::IsMouseDown(ImGuiMouseButton_Left);
-    bool   mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
-
-    // The anchor draws to the timeline draw list, so gate it on the timeline
-    // being hovered; this is false when a window or popup covers the cursor.
-    const bool timeline_hovered =
-        ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
-
-    // A shrunk track cuts its anchor off, so don't let a marker that no longer
-    // fits within its track's bounds start a drag.
-    bool  anchor_in_track = true;
-    float track_top       = 0.0f;
-    float track_height    = 0.0f;
-    if(m_track_id != INVALID_TRACK_ID && layout.top_of && layout.height_of &&
-       layout.top_of(m_track_id, track_top) &&
-       layout.height_of(m_track_id, track_height))
-    {
-        const float top    = window_position.y + track_top;
-        const float bottom = top + track_height;
-        anchor_in_track    = mouse_pos.y >= top && mouse_pos.y < bottom;
-    }
-
+    // Drag-start uses the marker's own hover (last frame), which respects z-order
+    // and popups; an anchor overhanging onto a neighbour track still grabs.
     if((dragged_id == INVALID_STICKY_ID || dragged_id == m_id) && !m_dragging &&
-       anchor_in_track && timeline_hovered &&
-       ImGui::IsMouseHoveringRect(icon_pos, drag_max) &&
-       ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
+       m_marker_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
        !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
     {
         m_dragging    = true;
@@ -726,16 +676,15 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
         float  new_x       = mouse_pos.x - window_position.x - m_drag_offset.x;
         float  new_y       = mouse_pos.y - window_position.y - m_drag_offset.y;
         ImVec2 window_size = ImGui::GetWindowSize();
-        new_x = std::clamp(new_x, 0.0f, window_size.x - drag_w);
+        new_x = std::clamp(new_x, 0.0f, window_size.x - marker_size);
 
-        // Keep the anchor inside the visible track viewport so it cannot be
-        // dragged off-screen; the timeline auto-scrolls to reveal more instead.
+        // Clamp to the visible viewport; auto-scroll reveals the rest.
         float min_y = 0.0f;
-        float max_y = window_size.y - drag_h;
+        float max_y = window_size.y - marker_size;
         if(layout.view_max_y > layout.view_min_y)
         {
             min_y = layout.view_min_y;
-            max_y = layout.view_max_y - drag_h;
+            max_y = layout.view_max_y - marker_size;
         }
         new_y = std::clamp(new_y, min_y, std::max(min_y, max_y));
 

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -81,6 +81,7 @@ public:
     uint64_t           GetTrackId() const { return m_track_id; }
     void               SetTrackHidden(bool hidden) { m_track_hidden = hidden; }
     bool               IsTrackHidden() const { return m_track_hidden; }
+    bool               IsDragging() const { return m_dragging; }
 
     // True after the user hit the delete button; the owner sweeps these notes.
     bool               WantsDelete() const { return m_pending_delete; }
@@ -118,6 +119,7 @@ private:
     std::string m_title;
     bool        m_dragging     = false;
     bool        m_track_hidden = false;
+    float       m_drag_abs_y   = 0.0f;  // Anchor Y during a drag; bound on drop.
     ImVec2      m_drag_offset  = ImVec2(0, 0);
     bool        m_is_visible;
     double      m_v_min_x;

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -20,6 +20,9 @@ class TimePixelTransform;
 // Sentinel for an unbound note (e.g. legacy project).
 inline constexpr uint64_t INVALID_TRACK_ID = INVALID_UINT64_INDEX;
 
+// Sentinel for "no note is currently being dragged".
+inline constexpr int INVALID_STICKY_ID = -1;
+
 // Per-frame track layout used to anchor notes to their track.
 struct TrackLayout
 {
@@ -28,15 +31,20 @@ struct TrackLayout
     // track_at clamps to the first/last track so notes stay draggable anywhere.
     std::function<bool(float abs_y, uint64_t& out_track_id, float& out_top_y)>
         track_at;
+
+    // Visible track viewport in content-space Y; a dragged anchor is clamped to
+    // this range so it stays on-screen (auto-scroll reveals the rest).
+    float view_min_y = 0.0f;
+    float view_max_y = 0.0f;
 };
 
 class StickyNote
 {
 public:
     StickyNote(double time_ns, float y_offset, const ImVec2& size,
-               const std::string& text, const std::string& title,
-               const std::string& project_id, double v_min, double v_max,
-               uint64_t track_id = INVALID_TRACK_ID, bool is_minimized = true);
+               const std::string& text, const std::string& title, double v_min,
+               double v_max, uint64_t track_id = INVALID_TRACK_ID,
+               bool is_minimized = true);
 
     bool Render(ImDrawList* draw_list, const ImVec2& window_position,
                 std::shared_ptr<TimePixelTransform> conversion_manager,
@@ -45,13 +53,17 @@ public:
     // Draws a non-interactive marker, used above a track's reorder preview.
     void RenderDragGhost(ImDrawList* draw_list, const ImVec2& screen_pos) const;
 
-    // Drag interaction (minimized marker only; the expanded note is a floating
-    // window that owns its own move/resize).
+    // Drags the timeline anchor marker (minimized or expanded), moving the note's
+    // timeline position. The expanded window keeps its own screen position.
     bool HandleDrag(const ImVec2&                       window_position,
                     std::shared_ptr<TimePixelTransform> conversion_manager,
                     int& dragged_id, const TrackLayout& layout);
     void SetTitle(std::string title);
-    void SetText(std::string title);
+    void SetText(std::string text);
+
+    // Opens the note expanded and focused for inline creation. Provisional until
+    // the user types; an empty note abandoned this way is auto-discarded.
+    void BeginInlineEdit();
 
     double             GetTimeNs() const;
     float              GetYOffset() const;
@@ -67,6 +79,9 @@ public:
     double             GetVMaxX() const;
     bool               IsMinimized() const { return m_is_minimized; }
     uint64_t           GetTrackId() const { return m_track_id; }
+
+    // True after the user hit the delete button; the owner sweeps these notes.
+    bool               WantsDelete() const { return m_pending_delete; }
 
 private:
     // Binds an unbound note to a track, making its offset track-relative.
@@ -99,14 +114,18 @@ private:
     ImVec2      m_size;
     std::string m_text;
     std::string m_title;
-    std::string m_project_id;
     bool        m_dragging    = false;
     ImVec2      m_drag_offset = ImVec2(0, 0);
     bool        m_is_visible;
     double      m_v_min_x;
     double      m_v_max_x;
     bool        m_is_minimized;
-    bool        m_request_focus = false;  // Raise the expanded window next frame.
+    bool        m_pending_delete = false;
+    bool        m_request_focus  = false;
+    bool        m_focus_input    = false;  // Focus the title field next frame.
+    bool        m_editing_title  = false;
+    bool        m_provisional    = false;  // Freshly created; discard if left empty.
+    bool        m_seen_focus     = false;
     // Absolute screen position of the floating expanded window; (-1, -1) until
     // first placed. Tracked live so the window stays where the user moved it.
     // Not persisted to the project.

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -80,6 +80,25 @@ private:
                              const ImVec2&                       window_position,
                              std::shared_ptr<TimePixelTransform> tpt) const;
 
+    // Always-visible timeline anchor. Returns true if hovered; reports the
+    // marker's bottom-right corner via out_marker_max.
+    bool RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
+                            ImVec2& out_marker_max);
+
+    // Floating expanded window. Returns true if hovered. marker_hovered links
+    // the pair glow so hovering the marker also lights the window.
+    bool RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered);
+
+    // Soft accent halo drawn just outside the given rect.
+    void DrawGlow(ImDrawList* draw_list, const ImVec2& min, const ImVec2& max,
+                  float rounding) const;
+
+    // True once the floating window has a real stored position.
+    bool IsExpandedPlaced() const
+    {
+        return m_expanded_screen_pos.x >= 0.0f && m_expanded_screen_pos.y >= 0.0f;
+    }
+
     double      m_time_ns;
     float       m_y_offset;  // Relative to m_track_id's top.
     uint64_t    m_track_id;
@@ -94,6 +113,7 @@ private:
     double      m_v_min_x;
     double      m_v_max_x;
     bool        m_is_minimized;
+    bool        m_request_focus = false;  // Raise the expanded window next frame.
     // Absolute screen position of the floating expanded window; (-1, -1) until
     // first placed. Tracked live so the window stays where the user moved it.
     // Not persisted to the project.

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -3,7 +3,10 @@
 
 #pragma once
 #include "imgui.h"
+#include "model/rocprofvis_common_defs.h"
 #include "rocprofvis_time_to_pixel.h"
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -14,21 +17,41 @@ namespace View
 
 class TimePixelTransform;
 
+// Sentinel for an unbound note (e.g. legacy project).
+inline constexpr uint64_t INVALID_TRACK_ID = INVALID_UINT64_INDEX;
+
+// Per-frame track layout used to anchor notes to their track.
+struct TrackLayout
+{
+    std::function<bool(uint64_t track_id, float& out_top_y)> top_of;
+
+    // track_at clamps to the first/last track so notes stay draggable anywhere.
+    std::function<bool(float abs_y, uint64_t& out_track_id, float& out_top_y)>
+        track_at;
+};
+
 class StickyNote
 {
 public:
     StickyNote(double time_ns, float y_offset, const ImVec2& size,
                const std::string& text, const std::string& title,
-               const std::string& project_id, double v_min, double v_max, bool is_minimized = true);
+               const std::string& project_id, double v_min, double v_max,
+               uint64_t track_id = INVALID_TRACK_ID, bool is_minimized = true);
 
     bool Render(ImDrawList* draw_list, const ImVec2& window_position,
-                std::shared_ptr<TimePixelTransform> conversion_manager);
-    bool HandleResize(const ImVec2&       window_position,
-                      std::shared_ptr<TimePixelTransform> conversion_manager);
+                std::shared_ptr<TimePixelTransform> conversion_manager,
+                const TrackLayout& layout);
+
+    // Draws a non-interactive marker, used above a track's reorder preview.
+    void RenderDragGhost(ImDrawList* draw_list, const ImVec2& screen_pos) const;
+    bool HandleResize(const ImVec2&                       window_position,
+                      std::shared_ptr<TimePixelTransform> conversion_manager,
+                      const TrackLayout&                  layout);
 
     // Drag interaction
-    bool HandleDrag(const ImVec2& window_position, std::shared_ptr<TimePixelTransform> conversion_manager,
-                    int& dragged_id);
+    bool HandleDrag(const ImVec2&                       window_position,
+                    std::shared_ptr<TimePixelTransform> conversion_manager,
+                    int& dragged_id, const TrackLayout& layout);
     void SetTitle(std::string title);
     void SetText(std::string title);
 
@@ -45,10 +68,18 @@ public:
     double             GetVMinX() const;
     double             GetVMaxX() const;
     bool               IsMinimized() const { return m_is_minimized; }
+    uint64_t           GetTrackId() const { return m_track_id; }
 
 private:
+    // Binds an unbound note to a track, making its offset track-relative.
+    void EnsureBound(const TrackLayout& layout);
+
+    // Absolute Y from the bound track top plus offset (raw offset if unbound).
+    float ResolveAnchorY(const TrackLayout& layout) const;
+
     double      m_time_ns;
-    float       m_y_offset;
+    float       m_y_offset;  // Relative to m_track_id's top.
+    uint64_t    m_track_id;
     int         m_id;
     ImVec2      m_size;
     std::string m_text;

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -77,6 +77,11 @@ private:
     // Absolute Y from the bound track top plus offset (raw offset if unbound).
     float ResolveAnchorY(const TrackLayout& layout) const;
 
+    // Vertical guide at the note's time, spanning the graph height.
+    void RenderTimeIndicator(ImDrawList*                         draw_list,
+                             const ImVec2&                       window_position,
+                             std::shared_ptr<TimePixelTransform> tpt) const;
+
     double      m_time_ns;
     float       m_y_offset;  // Relative to m_track_id's top.
     uint64_t    m_track_id;

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -28,6 +28,10 @@ struct TrackLayout
 {
     std::function<bool(uint64_t track_id, float& out_top_y)> top_of;
 
+    // Current height of a track, used to cut off / hide an anchor whose offset
+    // no longer fits after the track is shrunk.
+    std::function<bool(uint64_t track_id, float& out_height)> height_of;
+
     // track_at clamps to the first/last track so notes stay draggable anywhere.
     std::function<bool(float abs_y, uint64_t& out_track_id, float& out_top_y)>
         track_at;
@@ -98,8 +102,10 @@ private:
                              const ImVec2&                       window_position,
                              std::shared_ptr<TimePixelTransform> tpt) const;
 
-    // Always-visible timeline anchor. Returns true if hovered.
-    bool RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos);
+    // Always-visible timeline anchor; clipped to clip rect when non-null.
+    // Returns true if hovered.
+    bool RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
+                            const ImVec2* clip_min, const ImVec2* clip_max);
 
     // Floating expanded window. Returns true if hovered.
     bool RenderExpandedWindow(const ImVec2& anchor_pos);

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -44,11 +44,9 @@ public:
 
     // Draws a non-interactive marker, used above a track's reorder preview.
     void RenderDragGhost(ImDrawList* draw_list, const ImVec2& screen_pos) const;
-    bool HandleResize(const ImVec2&                       window_position,
-                      std::shared_ptr<TimePixelTransform> conversion_manager,
-                      const TrackLayout&                  layout);
 
-    // Drag interaction
+    // Drag interaction (minimized marker only; the expanded note is a floating
+    // window that owns its own move/resize).
     bool HandleDrag(const ImVec2&                       window_position,
                     std::shared_ptr<TimePixelTransform> conversion_manager,
                     int& dragged_id, const TrackLayout& layout);
@@ -90,15 +88,16 @@ private:
     std::string m_text;
     std::string m_title;
     std::string m_project_id;
-    bool        m_dragging      = false;
-    ImVec2      m_drag_offset   = ImVec2(0, 0);
-    ImVec2      m_resize_offset = ImVec2(0, 0);
+    bool        m_dragging    = false;
+    ImVec2      m_drag_offset = ImVec2(0, 0);
     bool        m_is_visible;
     double      m_v_min_x;
     double      m_v_max_x;
-    bool        m_resizing = false;
     bool        m_is_minimized;
-    ImVec2      m_expanded_screen_pos = ImVec2(-1, -1);  // Temporary position for expanded note (not saved)
+    // Absolute screen position of the floating expanded window; (-1, -1) until
+    // first placed. Tracked live so the window stays where the user moved it.
+    // Not persisted to the project.
+    ImVec2      m_expanded_screen_pos = ImVec2(-1, -1);
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -79,6 +79,8 @@ public:
     double             GetVMaxX() const;
     bool               IsMinimized() const { return m_is_minimized; }
     uint64_t           GetTrackId() const { return m_track_id; }
+    void               SetTrackHidden(bool hidden) { m_track_hidden = hidden; }
+    bool               IsTrackHidden() const { return m_track_hidden; }
 
     // True after the user hit the delete button; the owner sweeps these notes.
     bool               WantsDelete() const { return m_pending_delete; }
@@ -114,8 +116,9 @@ private:
     ImVec2      m_size;
     std::string m_text;
     std::string m_title;
-    bool        m_dragging    = false;
-    ImVec2      m_drag_offset = ImVec2(0, 0);
+    bool        m_dragging     = false;
+    bool        m_track_hidden = false;
+    ImVec2      m_drag_offset  = ImVec2(0, 0);
     bool        m_is_visible;
     double      m_v_min_x;
     double      m_v_max_x;

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -80,18 +80,11 @@ private:
                              const ImVec2&                       window_position,
                              std::shared_ptr<TimePixelTransform> tpt) const;
 
-    // Always-visible timeline anchor. Returns true if hovered; reports the
-    // marker's bottom-right corner via out_marker_max.
-    bool RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
-                            ImVec2& out_marker_max);
+    // Always-visible timeline anchor. Returns true if hovered.
+    bool RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos);
 
-    // Floating expanded window. Returns true if hovered. marker_hovered links
-    // the pair glow so hovering the marker also lights the window.
-    bool RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered);
-
-    // Soft accent halo drawn just outside the given rect.
-    void DrawGlow(ImDrawList* draw_list, const ImVec2& min, const ImVec2& max,
-                  float rounding) const;
+    // Floating expanded window. Returns true if hovered.
+    bool RenderExpandedWindow(const ImVec2& anchor_pos);
 
     // True once the floating window has a real stored position.
     bool IsExpandedPlaced() const

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -28,16 +28,14 @@ struct TrackLayout
 {
     std::function<bool(uint64_t track_id, float& out_top_y)> top_of;
 
-    // Current height of a track, used to cut off / hide an anchor whose offset
-    // no longer fits after the track is shrunk.
+    // Track height; used to hide an anchor once its track shrinks past it.
     std::function<bool(uint64_t track_id, float& out_height)> height_of;
 
     // track_at clamps to the first/last track so notes stay draggable anywhere.
     std::function<bool(float abs_y, uint64_t& out_track_id, float& out_top_y)>
         track_at;
 
-    // Visible track viewport in content-space Y; a dragged anchor is clamped to
-    // this range so it stays on-screen (auto-scroll reveals the rest).
+    // Visible track viewport (content-space Y); clamps a dragged anchor on-screen.
     float view_min_y = 0.0f;
     float view_max_y = 0.0f;
 };
@@ -97,15 +95,21 @@ private:
     // Absolute Y from the bound track top plus offset (raw offset if unbound).
     float ResolveAnchorY(const TrackLayout& layout) const;
 
+    // Whether the marker still overlaps its bound track's vertical span (always
+    // true when unbound). window_top_y is the timeline content origin.
+    bool IsMarkerOnTrack(const ImVec2& marker_pos, float marker_size,
+                         float window_top_y, const TrackLayout& layout) const;
+
+    // Square side length of the anchor marker (icon plus frame padding).
+    static float MarkerSize();
+
     // Vertical guide at the note's time, spanning the graph height.
     void RenderTimeIndicator(ImDrawList*                         draw_list,
                              const ImVec2&                       window_position,
                              std::shared_ptr<TimePixelTransform> tpt) const;
 
-    // Always-visible timeline anchor; clipped to clip rect when non-null.
-    // Returns true if hovered.
-    bool RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos,
-                            const ImVec2* clip_min, const ImVec2* clip_max);
+    // Always-visible timeline anchor. Returns true if hovered.
+    bool RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos);
 
     // Floating expanded window. Returns true if hovered.
     bool RenderExpandedWindow(const ImVec2& anchor_pos);
@@ -123,10 +127,11 @@ private:
     ImVec2      m_size;
     std::string m_text;
     std::string m_title;
-    bool        m_dragging     = false;
-    bool        m_track_hidden = false;
-    float       m_drag_abs_y   = 0.0f;  // Anchor Y during a drag; bound on drop.
-    ImVec2      m_drag_offset  = ImVec2(0, 0);
+    bool        m_dragging       = false;
+    bool        m_track_hidden   = false;
+    bool        m_marker_hovered = false;  // Hovered last frame; drives drag-start.
+    float       m_drag_abs_y     = 0.0f;   // Anchor Y during a drag; bound on drop.
+    ImVec2      m_drag_offset    = ImVec2(0, 0);
     bool        m_is_visible;
     double      m_v_min_x;
     double      m_v_max_x;

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -98,6 +98,8 @@ TimelineView::TimelineView(DataProvider&                          dp,
 , m_project_settings(m_data_provider.GetTraceFilePath(), *this)
 , m_annotations(annotations)
 , m_dragged_sticky_id(-1)
+, m_reordering_track_id(INVALID_TRACK_ID)
+, m_reorder_preview_screen_top_y(0.0f)
 , m_histogram(nullptr)
 , m_pseudo_focus(false)
 , m_histogram_pseudo_focus(false)
@@ -162,8 +164,20 @@ TimelineView::TimelineView(DataProvider&                          dp,
     // This is used for navigation from other views like the annotation view.
     auto navigation_handler = [this](std::shared_ptr<RocEvent> e) {
         auto evt = std::dynamic_pointer_cast<NavigationEvent>(e);
-        MoveToPosition(evt->GetVMin(), evt->GetVMax(), evt->GetYPosition(),
-                       evt->GetCenter());
+        if(!evt) return;
+        // Track-bound annotations pass a track-relative y; resolve it to an
+        // absolute Y. Other sources already pass an absolute Y.
+        double y_position = evt->GetYPosition();
+        if(evt->GetTrackId() != INVALID_TRACK_ID)
+        {
+            TrackLayout layout      = BuildTrackLayout();
+            float       track_top_y = 0.0f;
+            if(layout.top_of && layout.top_of(evt->GetTrackId(), track_top_y))
+            {
+                y_position = track_top_y + evt->GetYPosition();
+            }
+        }
+        MoveToPosition(evt->GetVMin(), evt->GetVMax(), y_position, evt->GetCenter());
     };
     m_navigation_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kGoToTimelineSpot), navigation_handler);
@@ -223,6 +237,66 @@ TimelineView::RenderInteractiveUI()
     ImGui::EndChild();
 }
 
+TrackLayout
+TimelineView::BuildTrackLayout()
+{
+    TrackLayout layout;
+
+    layout.top_of = [this](uint64_t track_id, float& out_top_y) -> bool {
+        auto it = m_track_position_y.find(track_id);
+        if(it == m_track_position_y.end()) return false;
+        out_top_y = it->second;
+        return true;
+    };
+
+    layout.track_at = [this](float abs_y, uint64_t& out_track_id,
+                             float& out_top_y) -> bool {
+        if(!m_graphs || m_graphs->empty()) return false;
+
+        bool     have_first = false;
+        uint64_t first_id   = 0;
+        float    first_top  = 0.0f;
+        uint64_t last_id    = 0;
+        float    last_top   = 0.0f;
+
+        for(const TrackGraph& graph : *m_graphs)
+        {
+            if(!graph.display) continue;
+            const uint64_t track_id = graph.chart->GetID();
+            auto           pos      = m_track_position_y.find(track_id);
+            if(pos == m_track_position_y.end()) continue;
+            const float top    = pos->second;
+            const float height = graph.chart->GetTrackHeight();
+
+            if(!have_first)
+            {
+                have_first = true;
+                first_id   = track_id;
+                first_top  = top;
+            }
+            last_id  = track_id;
+            last_top = top;
+
+            if(abs_y >= top && abs_y < top + height)
+            {
+                out_track_id = track_id;
+                out_top_y    = top;
+                return true;
+            }
+        }
+
+        if(!have_first) return false;
+
+        // Outside all tracks: clamp to the nearest end so the note stays
+        // anchored while keeping the user's vertical offset.
+        out_track_id = (abs_y < first_top) ? first_id : last_id;
+        out_top_y    = (abs_y < first_top) ? first_top : last_top;
+        return true;
+    };
+
+    return layout;
+}
+
 void
 TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
 {
@@ -230,21 +304,29 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
     bool movement_resize = false;
     // m_visible_center     = current_center;
 
+    TrackLayout layout = BuildTrackLayout();
+
     if(m_annotations->IsVisibile())
     {
         // Interaction --> top-most gets priority
         for(int i = static_cast<int>(m_annotations->GetStickyNotes().size()) - 1; i >= 0;
             --i)
         {
-            if(!m_annotations->GetStickyNotes()[i].IsVisible() ||
+            StickyNote& note = m_annotations->GetStickyNotes()[i];
+            if(!note.IsVisible() ||
                TimelineFocusManager::GetInstance().GetFocusedLayer() ==
                    Layer::kScrubberLayer)
                 continue;
 
-            movement_drag |= m_annotations->GetStickyNotes()[i].HandleDrag(
-                window_position, m_tpt, m_dragged_sticky_id);
-            movement_resize |=
-                m_annotations->GetStickyNotes()[i].HandleResize(window_position, m_tpt);
+            // The note on the reordering track is drawn as a foreground ghost
+            // below; skip its interaction so it doesn't fight the track drag.
+            if(m_reordering_track_id != INVALID_TRACK_ID &&
+               note.GetTrackId() == m_reordering_track_id)
+                continue;
+
+            movement_drag |=
+                note.HandleDrag(window_position, m_tpt, m_dragged_sticky_id, layout);
+            movement_resize |= note.HandleResize(window_position, m_tpt, layout);
         }
 
         bool annotation_blocks_timeline_input = false;
@@ -252,11 +334,24 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
         // Rendering --> based on added order (old bottom new on top)
         for(size_t i = 0; i < m_annotations->GetStickyNotes().size(); ++i)
         {
-            if(!m_annotations->GetStickyNotes()[i].IsVisible()) continue;
+            StickyNote& note = m_annotations->GetStickyNotes()[i];
+            if(!note.IsVisible()) continue;
+
+            // A note on the reordering track rides the floating preview, which
+            // is an opaque foreground window, so draw it on the foreground draw
+            // list to keep it visible above the preview.
+            if(m_reordering_track_id != INVALID_TRACK_ID &&
+               note.GetTrackId() == m_reordering_track_id)
+            {
+                ImVec2 ghost_pos = ImVec2(
+                    window_position.x + m_tpt->TimeToPixel(note.GetTimeNs()),
+                    m_reorder_preview_screen_top_y + note.GetYOffset());
+                note.RenderDragGhost(ImGui::GetForegroundDrawList(), ghost_pos);
+                continue;
+            }
 
             annotation_blocks_timeline_input |=
-                m_annotations->GetStickyNotes()[i].Render(draw_list, window_position,
-                                                          m_tpt);
+                note.Render(draw_list, window_position, m_tpt, layout);
         }
         m_stop_user_interaction |= annotation_blocks_timeline_input;
     }
@@ -465,9 +560,20 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
         {
             float  x_in_chart = rel_mouse_pos.x;
             double time_ns    = m_tpt->PixelToTime(x_in_chart);
-            float  y_offset   = rel_mouse_pos.y;
+            // Anchor the new note to the track under the cursor, storing a
+            // track-relative click offset.
+            TrackLayout layout      = BuildTrackLayout();
+            uint64_t    track_id    = INVALID_TRACK_ID;
+            float       track_top_y = 0.0f;
+            float       y_offset    = rel_mouse_pos.y;
+            if(layout.track_at &&
+               layout.track_at(rel_mouse_pos.y, track_id, track_top_y))
+            {
+                y_offset = rel_mouse_pos.y - track_top_y;
+            }
             m_annotations->OpenStickyNotePopup(time_ns, y_offset, m_tpt->GetVMinX(),
-                                               m_tpt->GetVMaxX(), m_tpt->GetGraphSize());
+                                               m_tpt->GetVMaxX(), m_tpt->GetGraphSize(),
+                                               track_id);
         }
 
         ImGui::Separator();
@@ -1298,6 +1404,9 @@ TimelineView::RenderGraphView()
 
     bool request_data = IsRequestDataNeeded();
 
+    // Reset per frame; set by RenderReorderingTrack while a track drag is active.
+    m_reordering_track_id = INVALID_TRACK_ID;
+
     for(int index = 0; index < m_graphs->size(); index++)
     {
         RenderTrack(index, request_data, window_flags, container_size);
@@ -1657,9 +1766,13 @@ TimelineView::RenderReorderingTrack(TrackItem* track_item, ImVec2 container_size
     ImVec2 mouse_pos          = ImGui::GetMousePos();
     ImVec2 mouse_relative_pos = mouse_pos - graph_view_pos;
 
-    ImGui::SetNextWindowPos(
-        ImVec2(graph_view_pos.x, mouse_pos.y - ImGui::GetFrameHeight() / 2),
-        ImGuiCond_Always);
+    const float preview_top_y = mouse_pos.y - ImGui::GetFrameHeight() / 2;
+
+    // Expose the live preview top so annotations on this track follow it.
+    m_reordering_track_id          = track_item->GetID();
+    m_reorder_preview_screen_top_y = preview_top_y;
+
+    ImGui::SetNextWindowPos(ImVec2(graph_view_pos.x, preview_top_y), ImGuiCond_Always);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
     if(ImGui::Begin(
            "##ReorderPreview", nullptr,

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -330,6 +330,14 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
 
     TrackLayout layout = BuildTrackLayout();
 
+    // Refresh every note's cached track-hidden state (even when annotations are
+    // globally hidden) so the annotation table can grey out the visibility
+    // toggle for notes whose track is hidden.
+    for(StickyNote& note : m_annotations->GetStickyNotes())
+    {
+        note.SetTrackHidden(!IsAnnotationTrackVisible(note.GetTrackId()));
+    }
+
     if(m_annotations->IsVisibile())
     {
         // Interaction --> top-most gets priority

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -97,7 +97,7 @@ TimelineView::TimelineView(DataProvider&                          dp,
 , m_measurement(measurement)
 , m_project_settings(m_data_provider.GetTraceFilePath(), *this)
 , m_annotations(annotations)
-, m_dragged_sticky_id(-1)
+, m_dragged_sticky_id(INVALID_STICKY_ID)
 , m_reordering_track_id(INVALID_TRACK_ID)
 , m_reorder_preview_screen_top_y(0.0f)
 , m_histogram(nullptr)
@@ -294,6 +294,11 @@ TimelineView::BuildTrackLayout()
         return true;
     };
 
+    // Visible track viewport in content-space Y, used to keep a dragged anchor
+    // on-screen (see StickyNote::HandleDrag).
+    layout.view_min_y = m_scroll_position_y;
+    layout.view_max_y = m_scroll_position_y + GetTrackViewportHeight();
+
     return layout;
 }
 
@@ -326,6 +331,13 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
                 note.HandleDrag(window_position, m_tpt, m_dragged_sticky_id, layout);
         }
 
+        // While an anchor is dragged toward an edge, scroll the view that way so
+        // the note can be moved beyond the currently visible range.
+        if(m_dragged_sticky_id != INVALID_STICKY_ID)
+        {
+            AutoScrollForAnnotationDrag(window_position);
+        }
+
         bool annotation_blocks_timeline_input = false;
 
         // Rendering --> based on added order (old bottom new on top)
@@ -355,9 +367,66 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
     m_stop_user_interaction |= movement_drag;
 
     RenderTimelineViewOptionsMenu(window_position);
-    m_annotations->ShowStickyNotePopup();
-    m_annotations->ShowStickyNoteEditPopup();
+    m_annotations->RemoveNotesPendingDelete();
 }
+
+void
+TimelineView::AutoScrollForAnnotationDrag(ImVec2 content_origin)
+{
+    // Distance from a viewport edge that begins scrolling, and the maximum
+    // per-frame scroll applied right at the edge (scaled by how deep in we are).
+    constexpr float kEdgeMargin  = 36.0f;
+    constexpr float kMaxScrollPx = 16.0f;
+
+    const float graph_w = m_tpt->GetGraphSizeX();
+    if(graph_w <= 0.0f) return;
+
+    const ImVec2 mouse     = ImGui::GetMousePos();
+    const float  vp_left   = content_origin.x;
+    const float  vp_right  = content_origin.x + graph_w;
+    const float  vp_top    = content_origin.y + m_scroll_position_y;
+    const float  vp_bottom = vp_top + GetTrackViewportHeight();
+
+    // Scroll speed ramped by how far the cursor has crossed into the margin.
+    auto edge_speed = [kEdgeMargin, kMaxScrollPx](float distance_into_margin) {
+        return kMaxScrollPx * std::clamp(distance_into_margin / kEdgeMargin, 0.0f, 1.0f);
+    };
+
+    float horizontal_px = 0.0f;
+    if(mouse.x < vp_left + kEdgeMargin)
+    {
+        horizontal_px = -edge_speed(vp_left + kEdgeMargin - mouse.x);
+    }
+    else if(mouse.x > vp_right - kEdgeMargin)
+    {
+        horizontal_px = edge_speed(mouse.x - (vp_right - kEdgeMargin));
+    }
+    if(horizontal_px != 0.0f)
+    {
+        const double view_width = m_tpt->GetRangeX() / m_tpt->GetZoom();
+        const double move_ns    = (horizontal_px / graph_w) * view_width;
+        const double max_offset =
+            std::max(0.0, m_tpt->GetRangeX() - m_tpt->GetVWidth());
+        m_tpt->SetViewTimeOffsetNs(
+            std::clamp(m_tpt->GetViewTimeOffsetNs() + move_ns, 0.0, max_offset));
+    }
+
+    float vertical_px = 0.0f;
+    if(mouse.y < vp_top + kEdgeMargin)
+    {
+        vertical_px = -edge_speed(vp_top + kEdgeMargin - mouse.y);
+    }
+    else if(mouse.y > vp_bottom - kEdgeMargin)
+    {
+        vertical_px = edge_speed(mouse.y - (vp_bottom - kEdgeMargin));
+    }
+    if(vertical_px != 0.0f)
+    {
+        m_scroll_position_y = std::clamp(m_scroll_position_y + vertical_px, 0.0f,
+                                         m_content_max_y_scroll);
+    }
+}
+
 void
 TimelineView::RenderMeasurement(ImDrawList* draw_list, ImVec2 window_position)
 {
@@ -568,9 +637,9 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
             {
                 y_offset = rel_mouse_pos.y - track_top_y;
             }
-            m_annotations->OpenStickyNotePopup(time_ns, y_offset, m_tpt->GetVMinX(),
-                                               m_tpt->GetVMaxX(), m_tpt->GetGraphSize(),
-                                               track_id);
+            m_annotations->CreateStickyNote(time_ns, y_offset, m_tpt->GetVMinX(),
+                                            m_tpt->GetVMaxX(), m_tpt->GetGraphSize(),
+                                            track_id);
         }
 
         ImGui::Separator();
@@ -1419,7 +1488,9 @@ TimelineView::WantsContinuousRender() const
 {
     // The loading-timer debounce gates track-data requests and only advances
     // while rendering, so keep rendering until it expires or the load stalls.
-    return m_loading_timer.IsRunning();
+    // Dragging an anchor also needs frames so edge auto-scroll keeps advancing
+    // when the cursor is held still.
+    return m_loading_timer.IsRunning() || m_dragged_sticky_id != INVALID_STICKY_ID;
 }
 
 bool

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -250,6 +250,19 @@ TimelineView::BuildTrackLayout()
         return true;
     };
 
+    layout.height_of = [this](uint64_t track_id, float& out_height) -> bool {
+        if(!m_graphs) return false;
+        for(const TrackGraph& graph : *m_graphs)
+        {
+            if(graph.chart && graph.chart->GetID() == track_id)
+            {
+                out_height = graph.chart->GetTrackHeight();
+                return true;
+            }
+        }
+        return false;
+    };
+
     layout.track_at = [this](float abs_y, uint64_t& out_track_id,
                              float& out_top_y) -> bool {
         if(!m_graphs || m_graphs->empty()) return false;

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -300,9 +300,7 @@ TimelineView::BuildTrackLayout()
 void
 TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
 {
-    bool movement_drag   = false;
-    bool movement_resize = false;
-    // m_visible_center     = current_center;
+    bool movement_drag = false;
 
     TrackLayout layout = BuildTrackLayout();
 
@@ -326,7 +324,6 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
 
             movement_drag |=
                 note.HandleDrag(window_position, m_tpt, m_dragged_sticky_id, layout);
-            movement_resize |= note.HandleResize(window_position, m_tpt, layout);
         }
 
         bool annotation_blocks_timeline_input = false;
@@ -355,7 +352,7 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
         }
         m_stop_user_interaction |= annotation_blocks_timeline_input;
     }
-    m_stop_user_interaction |= movement_drag || movement_resize;
+    m_stop_user_interaction |= movement_drag;
 
     RenderTimelineViewOptionsMenu(window_position);
     m_annotations->ShowStickyNotePopup();

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -303,6 +303,26 @@ TimelineView::BuildTrackLayout()
     return layout;
 }
 
+bool
+TimelineView::IsAnnotationTrackVisible(uint64_t track_id) const
+{
+    // Notes that aren't bound to a track (legacy / free-floating) always show.
+    if(track_id == INVALID_TRACK_ID || !m_graphs) return true;
+
+    for(const TrackGraph& graph : *m_graphs)
+    {
+        if(graph.chart && graph.chart->GetID() == track_id)
+        {
+            // A note follows its track's eye-toggle: hidden track, hidden note.
+            return graph.display;
+        }
+    }
+
+    // Bound track is no longer present in the current view; keep the note so it
+    // isn't silently lost.
+    return true;
+}
+
 void
 TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
 {
@@ -321,6 +341,10 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
                TimelineFocusManager::GetInstance().GetFocusedLayer() ==
                    Layer::kScrubberLayer)
                 continue;
+
+            // A note whose track is hidden is hidden too: don't let it grab
+            // input over whatever visible track now occupies that row.
+            if(!IsAnnotationTrackVisible(note.GetTrackId())) continue;
 
             // The note on the reordering track is drawn as a foreground ghost
             // below; skip its interaction so it doesn't fight the track drag.
@@ -346,6 +370,9 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
         {
             StickyNote& note = m_annotations->GetStickyNotes()[i];
             if(!note.IsVisible()) continue;
+
+            // Hide the note on the timeline when its bound track is hidden.
+            if(!IsAnnotationTrackVisible(note.GetTrackId())) continue;
 
             // A note on the reordering track rides the floating preview, which
             // is an opaque foreground window, so draw it on the foreground draw

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -250,17 +250,24 @@ TimelineView::BuildTrackLayout()
         return true;
     };
 
-    layout.height_of = [this](uint64_t track_id, float& out_height) -> bool {
-        if(!m_graphs) return false;
+    // Snapshot heights once so per-note lookups are O(1), not a per-note rescan.
+    std::unordered_map<uint64_t, float> track_heights;
+    if(m_graphs)
+    {
         for(const TrackGraph& graph : *m_graphs)
         {
-            if(graph.chart && graph.chart->GetID() == track_id)
+            if(graph.chart)
             {
-                out_height = graph.chart->GetTrackHeight();
-                return true;
+                track_heights[graph.chart->GetID()] = graph.chart->GetTrackHeight();
             }
         }
-        return false;
+    }
+    layout.height_of = [heights = std::move(track_heights)](
+                           uint64_t track_id, float& out_height) -> bool {
+        auto it = heights.find(track_id);
+        if(it == heights.end()) return false;
+        out_height = it->second;
+        return true;
     };
 
     layout.track_at = [this](float abs_y, uint64_t& out_track_id,

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -113,6 +113,8 @@ public:
     void           CalculateGridInterval();
     ImVec2         GetGraphSize();
     void           RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position);
+
+    void           AutoScrollForAnnotationDrag(ImVec2 content_origin);
     void           RenderMeasurement(ImDrawList* draw_list, ImVec2 window_position);
     ViewCoords                          GetViewCoords() const;
     std::shared_ptr<TimePixelTransform> GetTransform() const;

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -113,6 +113,7 @@ public:
     void           CalculateGridInterval();
     ImVec2         GetGraphSize();
     void           RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position);
+    bool           IsAnnotationTrackVisible(uint64_t track_id) const;
 
     void           AutoScrollForAnnotationDrag(ImVec2 content_origin);
     void           RenderMeasurement(ImDrawList* draw_list, ImVec2 window_position);

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -170,6 +170,8 @@ private:
     void                            ClearTimeRangeSelection();
     void                            CopySelectedEventNames();
     void                            CopySelectedEventDetails();
+
+    TrackLayout                     BuildTrackLayout();
     EventManager::SubscriptionToken m_scroll_to_track_token;
     EventManager::SubscriptionToken m_navigation_token;
     EventManager::SubscriptionToken m_new_track_token;
@@ -178,6 +180,8 @@ private:
     EventManager::SubscriptionToken m_timeline_time_range_changed_token;
 
     int                                 m_dragged_sticky_id;
+    uint64_t                            m_reordering_track_id;  // INVALID_TRACK_ID when idle
+    float                               m_reorder_preview_screen_top_y;
     const std::vector<double>*          m_histogram;
     float                               m_ruler_height;
     float                               m_ruler_padding;

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 #include <chrono>

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -884,10 +884,8 @@ TraceView::RenderAnnotationControls()
             ImVec2     graph_size   = m_timeline_view->GetGraphSize();
             double     center_time  = tpt->PixelToTime(graph_size.x * 0.5f);
             float      center_y     = m_timeline_view->GetScrollPosition() + graph_size.y * 0.5f;
-            m_annotations->OpenStickyNotePopup(
-                center_time, center_y, coords.v_min_x,
-                coords.v_max_x, graph_size);
-            m_annotations->ShowStickyNotePopup();
+            m_annotations->CreateStickyNote(center_time, center_y, coords.v_min_x,
+                                            coords.v_max_x, graph_size);
         }
     }
     ImGui::PopStyleColor();

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -302,6 +302,7 @@ BeginTooltipStyled()
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
                         settings.GetDefaultStyle().FrameRounding);
     ImGui::PushStyleColor(ImGuiCol_WindowBg, settings.GetColor(Colors::kBgFrame));
+    ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextMain));
     ImGui::BeginTooltip();
 }
 
@@ -314,12 +315,13 @@ BeginItemTooltipStyled()
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
                         settings.GetDefaultStyle().FrameRounding);
     ImGui::PushStyleColor(ImGuiCol_WindowBg, settings.GetColor(Colors::kBgFrame));
+    ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextMain));
     if(ImGui::BeginItemTooltip())
     {
         return true;
     }
     ImGui::PopStyleVar(2);
-    ImGui::PopStyleColor();
+    ImGui::PopStyleColor(2);
     return false;
 }
 
@@ -328,7 +330,7 @@ EndTooltipStyled()
 {
     ImGui::EndTooltip();
     ImGui::PopStyleVar(2);
-    ImGui::PopStyleColor();
+    ImGui::PopStyleColor(2);
 }
 
 void


### PR DESCRIPTION
## Motivation

Timeline annotations (sticky notes) were clunky to use. Creating and editing
a note required separate "Add" and "Edit" modal popups, notes floated free in
content space rather than belonging to any track, and the timeline anchor was
hard to place — it couldn't be moved while a note was expanded and couldn't be
dragged past the visible range. This PR reworks annotations end-to-end into a
direct, inline experience and ties each note to the track it describes.

## Technical Details

- **Track-bound notes:** Annotations are now anchored to a specific track,
  with their Y position stored relative to that track's top. The bound
  `track_id` is persisted (`JSON_KEY_ANNOTATION_TRACK_ID`) and `NavigationEvent`
  carries it so "go to note" lands on the right track. The annotation list
  gains a Track column showing the bound track's name, or "Unbound" for legacy
  notes saved before this change.
- **Inline create/edit:** Removed the Add/Edit modal dialogs (and the
  `kStickyNoteEdited` round-trip). A new note opens expanded and focused,
  commits on the first keystroke, and auto-discards if left empty. The
  expanded note's title is click-to-edit and the body is inline-editable, with
  trash/close buttons in the window.
- **Floating expanded window:** The expanded note is now a movable floating
  window that stays where the user drags it (position tracked live, not
  persisted).
- **Draggable anchor + edge auto-scroll:** The timeline anchor can be dragged
  whether the note is minimized or expanded. It is clamped to the visible
  track viewport, and the timeline pans/scrolls when the anchor nears a
  viewport edge so it can be placed beyond the currently visible range
  (rendering stays continuous during the drag for smooth motion).
- **Time guide line:** A hovered/dragged note draws a time indicator line
  spanning the full visible track area.
- **Restyle:** Reworked the sticky-note color palette (dark and light themes)
  to a warmer amber look with better contrast.
- **Cleanup:** Removed dead annotation code (modal/edit paths, unused members,
  empty destructor, stale includes), added an `INVALID_STICKY_ID` sentinel,
  and updated the agent docs in `.agents/AGENTS.md`.