### PR TITLE
Counter Stats

### DIFF
--- a/src/controller/src/rocprofvis_controller_analysis.cpp
+++ b/src/controller/src/rocprofvis_controller_analysis.cpp
@@ -41,6 +41,19 @@ rocprofvis_result_t rocprofvis_analysis_fetch_queue_utilization(rocprofvis_contr
     return error;
 }
 
+rocprofvis_result_t rocprofvis_analysis_fetch_counter_statistics(rocprofvis_controller_t* controller, rocprofvis_controller_track_t* track, double start_time, double end_time, rocprofvis_controller_future_t* result, rocprofvis_analysis_counter_statistics_t* output)
+{
+    rocprofvis_result_t error = kRocProfVisResultInvalidArgument;
+    RocProfVis::Controller::SystemTraceRef trace(controller);
+    RocProfVis::Controller::TrackRef track_ref(track);
+    RocProfVis::Controller::FutureRef future(result);
+    if(trace.IsValid() && future.IsValid() && track_ref.IsValid() && output)
+    {
+        error = RocProfVis::Controller::Analysis::GetInstance().AsyncFetchCounterStatistics(trace.Get(), track_ref.Get(), start_time, end_time, output, future.Get());
+    }
+    return error;
+}
+
 rocprofvis_result_t rocprofvis_analysis_get_instrumented_events_table(rocprofvis_controller_t* controller, rocprofvis_handle_t** table)
 {
     rocprofvis_result_t error = kRocProfVisResultInvalidArgument;
@@ -206,14 +219,10 @@ rocprofvis_result_t Analysis::AsyncFetchQueueUtilization(SystemTrace* trace, Tra
             future->AddDependentFuture(object2wait);
             dm_result = rocprofvis_db_future_wait(object2wait, UINT64_MAX);
             ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess || dm_result == kRocProfVisDmResultDbAbort);
-            rocprofvis_dm_slice_t slice = nullptr;
-            if (dm_result == kRocProfVisDmResultSuccess)
+            rocprofvis_dm_slice_t slice = rocprofvis_dm_get_property_as_handle(dm_track, kRPVDMSliceHandleTimed, rocprofvis_dm_hash_combine_timestamp(range_start, range_end, kRocProfVisDmHashedTimestampTagAnalysis));
+            if(!future->IsCancelled())
             {
-                slice = rocprofvis_dm_get_property_as_handle(dm_track, kRPVDMSliceHandleTimed, rocprofvis_dm_hash_combine_timestamp(range_start, range_end, kRocProfVisDmHashedTimestampTagAnalysis));
                 ROCPROFVIS_ASSERT(slice);
-            }         
-            if(slice && !future->IsCancelled())
-            {
                 uint64_t num_records = rocprofvis_dm_get_property_as_uint64(slice, kRPVDMNumberOfRecordsUInt64, 0);
                 uint64_t busy_duration = 0;
                 uint64_t busy_start = 0;
@@ -268,8 +277,116 @@ rocprofvis_result_t Analysis::AsyncFetchQueueUtilization(SystemTrace* trace, Tra
                 else
                 {
                     *output = (double)busy_duration / (double)(range_end - range_start) * 100.0;
+                }           
+            }
+            dm_result = rocprofvis_dm_delete_time_slice_handle(trace->GetDMHandle(), track_id, slice);
+            if(!future->IsCancelled())
+            {
+                ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess);
+            }
+            future->RemoveDependentFuture(object2wait);
+            rocprofvis_db_future_free(object2wait);
+        }
+        return future->IsCancelled() ? kRocProfVisResultCancelled : result;
+    }, future));
+    if(future->IsValid())
+    {
+        result = kRocProfVisResultSuccess;
+    }
+    return result;
+}
+
+rocprofvis_result_t Analysis::AsyncFetchCounterStatistics(SystemTrace* trace, Track* track, double start, double end, rocprofvis_analysis_counter_statistics_t* output, Future* future) const
+{
+    rocprofvis_result_t result = kRocProfVisResultUnknownError;
+    future->Set(JobSystem::Get().IssueJob([this, trace, track, start, end, output](Future* future) -> rocprofvis_result_t {
+        rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
+        rocprofvis_handle_t* counter_handle = nullptr;
+        result = track->GetObject(kRPVControllerTrackCounter, 0, &counter_handle);
+        ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+        if(counter_handle)
+        {
+            rocprofvis_dm_result_t dm_result = kRocProfVisDmResultUnknownError;
+            uint64_t track_id = 0;
+            result = track->GetUInt64(kRPVControllerTrackId, 0, &track_id);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            rocprofvis_dm_track_t dm_track = track->GetDmHandle();
+            rocprofvis_dm_database_t db = rocprofvis_dm_get_property_as_handle(dm_track, kRPVDMTrackDatabaseHandle, 0);
+            ROCPROFVIS_ASSERT(db);
+            rocprofvis_db_future_t object2wait = rocprofvis_db_future_alloc(nullptr);
+            ROCPROFVIS_ASSERT(object2wait);
+            uint64_t range_start = (uint64_t)floor(start);
+            uint64_t range_end = (uint64_t)ceil(end);
+            dm_result = rocprofvis_db_read_trace_pmc_slice_async(db, range_start, range_end, kRocProfVisDmHashedTimestampTagAnalysis, (rocprofvis_db_track_selection_t)&track_id, true, false, object2wait);
+            ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess);
+            future->AddDependentFuture(object2wait);
+            dm_result = rocprofvis_db_future_wait(object2wait, UINT64_MAX);
+            ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess || dm_result == kRocProfVisDmResultDbAbort);
+            rocprofvis_dm_slice_t slice = rocprofvis_dm_get_property_as_handle(dm_track, kRPVDMSliceHandleTimed, rocprofvis_dm_hash_combine_timestamp(range_start, range_end, kRocProfVisDmHashedTimestampTagAnalysis));
+            if(!future->IsCancelled())
+            {                
+                ROCPROFVIS_ASSERT(slice);
+                uint64_t num_records = rocprofvis_dm_get_property_as_uint64(slice, kRPVDMNumberOfRecordsUInt64, 0);
+                double min_value = 0.0;
+                double max_value = 0.0;
+                double mean_value = 0.0;
+                double std_dev = 0.0;
+                double sum = 0.0;
+                double sum_sq = 0.0;
+                double total_duration = 0.0;
+                bool range_empty = true;
+                for(uint64_t i = 0; i < num_records; i++)
+                {
+                    double value = rocprofvis_dm_get_property_as_double(slice, kRPVDMPmcValueDoubleIndexed, i);
+                    uint64_t sample_start = rocprofvis_dm_get_property_as_uint64(slice, kRPVDMTimestampUInt64Indexed, i);
+                    uint64_t sample_end = (i + 1 < num_records) ? rocprofvis_dm_get_property_as_uint64(slice, kRPVDMTimestampUInt64Indexed, i + 1) : range_end;
+                    if(sample_start < range_start)
+                    {
+                        sample_start = range_start;
+                    }
+                    if(sample_end > range_end)
+                    {
+                        sample_end = range_end;
+                    }
+                    if(sample_end > sample_start)
+                    {
+                        double duration = (double)(sample_end - sample_start);
+                        sum += value * duration;
+                        sum_sq += value * value * duration;
+                        total_duration += duration;
+                        if(range_empty)
+                        {
+                            min_value = value;
+                            max_value = value;
+                            range_empty = false;
+                        }
+                        else
+                        {
+                            if(value < min_value)
+                            {
+                                min_value = value;
+                            }
+                            if(value > max_value)
+                            {
+                                max_value = value;
+                            }
+                        }
+                    }
                 }
-                dm_result = rocprofvis_dm_delete_time_slice_handle(trace->GetDMHandle(), track_id, slice);
+                if(total_duration > 0.0)
+                {
+                    mean_value = sum / total_duration;
+                    double variance = sum_sq / total_duration - mean_value * mean_value;
+                    std_dev = (variance > 0.0) ? sqrt(variance) : 0.0;
+                }
+                output->min_value = min_value;
+                output->max_value = max_value;
+                output->mean_value = mean_value;
+                output->std_dev = std_dev;           
+            }            
+            dm_result = rocprofvis_dm_delete_time_slice_handle(trace->GetDMHandle(), track_id, slice);
+            if(!future->IsCancelled())
+            {
                 ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess);
             }
             future->RemoveDependentFuture(object2wait);

--- a/src/controller/src/rocprofvis_controller_analysis.h
+++ b/src/controller/src/rocprofvis_controller_analysis.h
@@ -16,6 +16,29 @@ extern "C"
 #endif
 
 /*
+* Duration-weighted statistics for a counter track over a time range.
+*/
+typedef struct rocprofvis_analysis_counter_statistics_t
+{
+    double min_value;   // minimum counter value over the range
+    double max_value;   // maximum counter value over the range
+    double mean_value;  // duration-weighted mean counter value over the range
+    double std_dev;     // duration-weighted standard deviation over the range
+} rocprofvis_analysis_counter_statistics_t;
+
+/*
+* Calculates duration-weighted statistics for the specified counter track within the given time range.
+* @param controller The system trace controller instance.
+* @param track The handle track to analyze.
+* @param start_time The start time in ns of the analysis range.
+* @param end_time The end time in ns of the analysis range.
+* @param result The future object to store the result.
+* @param output The output struct to write the counter statistics.
+* @returns kRocProfVisResultSuccess or an error code.
+*/
+rocprofvis_result_t rocprofvis_analysis_fetch_counter_statistics(rocprofvis_controller_t* controller, rocprofvis_controller_track_t* track, double start_time, double end_time, rocprofvis_controller_future_t* result, rocprofvis_analysis_counter_statistics_t* output);
+
+/*
 * Calculates the queue utilization for the specified track within the given time range.
 * @param controller The system trace controller instance.
 * @param track The handle track to analyze.
@@ -122,6 +145,8 @@ public:
     rocprofvis_result_t AsyncTableExportCSV(SystemTrace* trace, Table& table, Arguments& args, Future& future, const char* path) const;
 
     rocprofvis_result_t AsyncFetchQueueUtilization(SystemTrace* trace, Track* track, double start, double end, double* output, Future* future) const;
+
+    rocprofvis_result_t AsyncFetchCounterStatistics(SystemTrace* trace, Track* track, double start, double end, rocprofvis_analysis_counter_statistics_t* output, Future* future) const;
 
     rocprofvis_result_t GetInstrumentedThreadEventsTable(SystemTrace* trace, rocprofvis_handle_t** table);
     rocprofvis_result_t GetDispatchEventsTable(SystemTrace* trace, rocprofvis_handle_t** table);

--- a/src/model/inc/rocprofvis_interface.h
+++ b/src/model/inc/rocprofvis_interface.h
@@ -138,6 +138,16 @@ rocprofvis_dm_result_t rocprofvis_db_read_trace_slice_async(
                                     rocprofvis_db_track_selection_t,
                                     rocprofvis_db_future_t);    
 
+rocprofvis_dm_result_t rocprofvis_db_read_trace_pmc_slice_async(
+                                    rocprofvis_dm_database_t,
+                                    rocprofvis_dm_timestamp_t,
+                                    rocprofvis_dm_timestamp_t,
+                                    rocprofvis_dm_hashed_timestamp_tag_t,
+                                    rocprofvis_db_track_selection_t,
+                                    bool,
+                                    bool,
+                                    rocprofvis_db_future_t);  
+
 /****************************************************************************************************
 * @brief method to build compute database query based on use case and set of parameters
 *

--- a/src/model/src/common/rocprofvis_c_interface.cpp
+++ b/src/model/src/common/rocprofvis_c_interface.cpp
@@ -296,6 +296,24 @@ rocprofvis_dm_result_t rocprofvis_db_read_trace_slice_async(
     return db->ReadTraceSliceAsync(start,end,tag,num,tracks,object);
 }
 
+rocprofvis_dm_result_t
+rocprofvis_db_read_trace_pmc_slice_async(                                        
+                                        rocprofvis_dm_database_t database,
+                                        rocprofvis_dm_timestamp_t start,
+                                        rocprofvis_dm_timestamp_t end,
+                                        rocprofvis_dm_hashed_timestamp_tag_t tag,
+                                        rocprofvis_db_track_selection_t track,
+                                        bool left_neighbor,
+                                        bool right_neighbor,
+                                        rocprofvis_db_future_t object){
+    PROFILE;
+    ROCPROFVIS_ASSERT_MSG_RETURN(database,
+                                 RocProfVis::DataModel::ERROR_DATABASE_CANNOT_BE_NULL,
+                                 kRocProfVisDmResultInvalidParameter);
+    RocProfVis::DataModel::Database* db = (RocProfVis::DataModel::Database*) database;
+    return db->ReadTracePMCSliceAsync(start,end,tag,track,left_neighbor,right_neighbor,object);
+}
+
 rocprofvis_dm_result_t rocprofvis_db_build_table_query(
     rocprofvis_dm_database_t database, rocprofvis_dm_table_use_case_enum_t use_case,
     rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end, 

--- a/src/model/src/database/rocprofvis_db.cpp
+++ b/src/model/src/database/rocprofvis_db.cpp
@@ -102,7 +102,35 @@ rocprofvis_dm_result_t  Database::ReadTraceSliceAsync(
     try {
         future->SetWorker(std::move(std::thread(Database::ReadTraceSliceStatic, this, start, end, tag, num, tracks, future)));
     }
-    catch (std::exception ex)
+    catch (const std::exception& ex)
+    {
+        ROCPROFVIS_ASSERT_ALWAYS_MSG_RETURN(ex.what(), kRocProfVisDmResultUnknownError);
+    }
+    return kRocProfVisDmResultSuccess;
+}
+
+rocprofvis_dm_result_t
+Database::ReadTracePMCSliceAsync(
+                                                    rocprofvis_dm_timestamp_t start,
+                                                    rocprofvis_dm_timestamp_t end,
+                                                    rocprofvis_dm_hashed_timestamp_tag_t tag,
+                                                    rocprofvis_db_track_selection_t track,
+                                                    bool left_neighbor, 
+                                                    bool right_neighbor,
+                                                    rocprofvis_db_future_t object){
+    Future* future = (Future*) object;
+    ROCPROFVIS_ASSERT_MSG_RETURN(future, ERROR_FUTURE_CANNOT_BE_NULL, kRocProfVisDmResultInvalidParameter);
+    ROCPROFVIS_ASSERT_MSG_RETURN(!future->IsWorking(), ERROR_FUTURE_CANNOT_BE_USED, kRocProfVisDmResultResourceBusy);
+    rocprofvis_dm_result_t result = BindObject()->FuncCheckSliceExists(BindObject()->trace_object, start, end, tag, 1, track);
+    if(result != kRocProfVisDmResultNotLoaded)
+    {
+        spdlog::debug("Slice ({},{}) exists!", start, end);
+        return future->SetPromise(result);
+    }
+    try {
+        future->SetWorker(std::move(std::thread(Database::ReadTracePMCSliceStatic, this, start, end, tag, track, left_neighbor, right_neighbor, future)));
+    }
+    catch (const std::exception& ex)
     {
         ROCPROFVIS_ASSERT_ALWAYS_MSG_RETURN(ex.what(), kRocProfVisDmResultUnknownError);
     }
@@ -298,6 +326,35 @@ rocprofvis_dm_result_t  Database::ReadTraceSliceStatic(
     return db->ReadTraceSlice(start, end, tag, num, tracks, object);
 }
 
+rocprofvis_dm_result_t  Database::ReadTracePMCSliceStatic(
+                                                    Database* db, 
+                                                    rocprofvis_dm_timestamp_t start,
+                                                    rocprofvis_dm_timestamp_t            end,
+                                                    rocprofvis_dm_hashed_timestamp_tag_t tag,
+                                                    rocprofvis_db_track_selection_t      track,
+                                                    bool left_neighbor, 
+                                                    bool right_neighbor, 
+                                                    Future* object){
+    return db->ReadTracePMCSlice(start, end, tag, track, left_neighbor, right_neighbor, object);
+}
+
+rocprofvis_dm_result_t  Database::ReadTracePMCSlice(
+                                                    rocprofvis_dm_timestamp_t start,
+                                                    rocprofvis_dm_timestamp_t end,
+                                                    rocprofvis_dm_hashed_timestamp_tag_t tag,
+                                                    rocprofvis_db_track_selection_t track, 
+                                                    bool left_neighbor,
+                                                    bool right_neighbor, 
+                                                    Future* object){
+    (void) start;
+    (void) end;
+    (void) tag;
+    (void) track;
+    (void) left_neighbor;
+    (void) right_neighbor;
+    object->SetPromise(kRocProfVisDmResultNotSupported);
+    return kRocProfVisDmResultNotSupported;
+}
 
 rocprofvis_dm_result_t   Database::ReadEventPropertyStatic(
                                                     Database* db, 

--- a/src/model/src/database/rocprofvis_db.h
+++ b/src/model/src/database/rocprofvis_db.h
@@ -140,6 +140,24 @@ class Database
                                                                 rocprofvis_db_num_of_tracks_t num,
                                                                 rocprofvis_db_track_selection_t tracks,
                                                                 rocprofvis_db_future_t object);
+
+        // Asynchronously read a PMC time slice (records from specified track for specified time frame) from database  
+        // @param start - start timestamp of time slice 
+        // @param end - end timestamp of time slice 
+        // @param track - track ID  
+        // @param left_neighbor - include the left neighbor of the time range
+        // @param right_neighbor - include the right neighbor of the time range
+        // @param object - future object providing asynchronous execution mechanism         
+        // @return status of operation
+        rocprofvis_dm_result_t          ReadTracePMCSliceAsync( 
+                                                                rocprofvis_dm_timestamp_t start,
+                                                                rocprofvis_dm_timestamp_t end,
+                                                                rocprofvis_dm_hashed_timestamp_tag_t tag,
+                                                                rocprofvis_db_track_selection_t track,
+                                                                bool left_neighbor,
+                                                                bool right_neighbor,
+                                                                rocprofvis_db_future_t object);
+
         // Asynchronously read different types of event properties (flowtrace, stacktrace, extdata) for event ID
         // @param type - event property type (flowtrace, stacktrace, extdata) 
         // @param event_id - 60-bit event id and 4-bit operation type  
@@ -274,6 +292,25 @@ class Database
                                                                 rocprofvis_db_num_of_tracks_t num,
                                                                 rocprofvis_db_track_selection_t tracks,
                                                                 Future* object);
+
+        //static method to read PMC time slice. Required to launch a unique thread for asynchronous time slice read
+        // @param db - pointer to database object 
+        // @param start - start timestamp of time slice 
+        // @param end - end timestamp of time slice 
+        // @param track - track ID
+        // @param left_neighbor - include the left neighbor of the time range
+        // @param right_neighbor - include the right neighbor of the time range 
+        // @param object - future object providing asynchronous execution mechanism   
+        // @return status of operation
+        static rocprofvis_dm_result_t   ReadTracePMCSliceStatic(
+                                                                Database* db,
+                                                                rocprofvis_dm_timestamp_t start,
+                                                                rocprofvis_dm_timestamp_t end,
+                                                                rocprofvis_dm_hashed_timestamp_tag_t tag,
+                                                                rocprofvis_db_track_selection_t track,
+                                                                bool left_neighbor,
+                                                                bool right_neighbor,
+                                                                Future* object);
         //static method to read Event properties. Required to launch a unique thread for asynchronous event properties read
         // @param db - pointer to database object
         // @param type - event property type (flowtrace, stacktrace, extdata) 
@@ -356,6 +393,16 @@ class Database
                                                                 rocprofvis_db_num_of_tracks_t num,
                                                                 rocprofvis_db_track_selection_t tracks,
                                                                 Future* object) = 0;
+
+        virtual rocprofvis_dm_result_t  ReadTracePMCSlice(
+                                                                rocprofvis_dm_timestamp_t start,
+                                                                rocprofvis_dm_timestamp_t end,
+                                                                rocprofvis_dm_hashed_timestamp_tag_t tag,
+                                                                rocprofvis_db_track_selection_t track,
+                                                                bool left_neighbor,
+                                                                bool right_neighbor,
+                                                                Future* object);
+
         // worker method to read flow trace info, called from ReadEventPropertyStatic
         // @param event_id - 60-bit event id and 4-bit operation type  
         // @param object - future object providing asynchronous execution mechanism 

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -1428,80 +1428,124 @@ rocprofvis_dm_result_t  ProfileDatabase::ReadTraceSlice(
                                                     rocprofvis_db_track_selection_t tracks,
                                                     Future* future) {
     ROCPROFVIS_ASSERT_MSG_RETURN(future, ERROR_FUTURE_CANNOT_BE_NULL, kRocProfVisDmResultInvalidParameter);
-    while (true)
+    ROCPROFVIS_ASSERT_MSG(BindObject()->trace_properties, ERROR_TRACE_PROPERTIES_CANNOT_BE_NULL);
+    ROCPROFVIS_ASSERT_MSG(BindObject()->trace_properties->metadata_loaded, ERROR_METADATA_IS_NOT_LOADED);
+    // We never used multiple tracks request for single slice. And with multinode support it becomes very cumbersome. 
+    // Disabling this feature, but leave the interface untouched for now
+    ROCPROFVIS_ASSERT_MSG(num == 1, ERROR_UNSUPPORTED_FEATURE);
+    
+    rocprofvis_dm_track_params_t* props = TrackPropertiesAt(*tracks);
+    if(props->track_indentifiers.category == kRocProfVisDmPmcTrack)
     {
-        ROCPROFVIS_ASSERT_MSG_BREAK(BindObject()->trace_properties, ERROR_TRACE_PROPERTIES_CANNOT_BE_NULL);
-        ROCPROFVIS_ASSERT_MSG_BREAK(BindObject()->trace_properties->metadata_loaded, ERROR_METADATA_IS_NOT_LOADED);
-        // We never used multiple tracks request for single slice. And with multinode support it becomes very cumbersome. 
-        // Disabling this feature, but leave the interface untouched for now
-        ROCPROFVIS_ASSERT_MSG_BREAK(num == 1, ERROR_UNSUPPORTED_FEATURE);
-
-        std::string slice_query;
-        slice_array_t slices;
-
-        slices[*tracks]=BindObject()->FuncAddSlice(BindObject()->trace_object, *tracks, start, end, tag);
-        rocprofvis_dm_result_t result = BuildSliceQuery(start, end, num, tracks, slice_query, slices);
-        std::string query;
-
-        if (result == kRocProfVisDmResultSuccess)
+        return ReadTracePMCSlice(start, end, tag, tracks, true, true, future);
+    }
+    else
+    {
+        while (true)
         {
-            rocprofvis_dm_track_params_t* props = TrackPropertiesAt(*tracks);
-            if (props->track_indentifiers.category == kRocProfVisDmPmcTrack)
-            {
-                result = BuildCounterSliceLeftNeighbourQuery(start, end, *tracks, query);
-                if (result != kRocProfVisDmResultSuccess) break;
-                result = ExecuteSQLQuery(future,(DbInstance*)props->track_indentifiers.db_instance, query.c_str(), &slices, &CallbackAddAnyRecord);
-                if (result != kRocProfVisDmResultSuccess) break;
-            }
+            std::string slice_query;
+            slice_array_t slices;
+
+            slices[*tracks]=BindObject()->FuncAddSlice(BindObject()->trace_object, *tracks, start, end, tag);
+            rocprofvis_dm_result_t result = BuildSliceQuery(start, end, num, tracks, slice_query, slices);
+            std::string query;
 
             if (result == kRocProfVisDmResultSuccess)
             {
                 result = ExecuteSQLQuery(future, (DbInstance*)props->track_indentifiers.db_instance, slice_query.c_str(), &slices, &CallbackAddAnyRecord);
+                BindObject()->FuncCompleteSlice(slices[*tracks]);
+            }
+
+            if(kRocProfVisDmResultSuccess != result)
+            {
+                BindObject()->FuncRemoveSlice(BindObject()->trace_object, *tracks, slices[*tracks]);
+                break;
+            }
+            ShowProgress(100 - future->Progress(), "Time slice successfully loaded!", kRPVDbSuccess, future);
+            return future->SetPromise(kRocProfVisDmResultSuccess);
+        }
+    }
+    
+    ShowProgress(0, "Not all tracks are loaded!", kRPVDbError, future );
+    return future->SetPromise(future->Interrupted() ? kRocProfVisDmResultDbAbort : kRocProfVisDmResultDbAccessFailed);    
+}
+
+rocprofvis_dm_result_t
+ProfileDatabase::ReadTracePMCSlice(rocprofvis_dm_timestamp_t            start,
+                                   rocprofvis_dm_timestamp_t            end,
+                                   rocprofvis_dm_hashed_timestamp_tag_t tag,
+                                   rocprofvis_db_track_selection_t      track,
+                                   bool left_neighbor, bool right_neighbor,
+                                   Future* future){
+    ROCPROFVIS_ASSERT_MSG_RETURN(future, ERROR_FUTURE_CANNOT_BE_NULL, kRocProfVisDmResultInvalidParameter);
+    ROCPROFVIS_ASSERT_MSG(BindObject()->trace_properties, ERROR_TRACE_PROPERTIES_CANNOT_BE_NULL);
+    ROCPROFVIS_ASSERT_MSG(BindObject()->trace_properties->metadata_loaded, ERROR_METADATA_IS_NOT_LOADED);
+    
+    rocprofvis_dm_track_params_t* props = TrackPropertiesAt(*track);
+    if(props->track_indentifiers.category == kRocProfVisDmPmcTrack)
+    {
+        while (true)
+        {
+            std::string slice_query;
+            slice_array_t slices;
+
+            slices[*track]=BindObject()->FuncAddSlice(BindObject()->trace_object, *track, start, end, tag);
+            rocprofvis_dm_result_t result = BuildSliceQuery(start, end, 1, track, slice_query, slices);
+            std::string query;
+
+            if (result == kRocProfVisDmResultSuccess)
+            {
+                if (left_neighbor)
+                {
+                    result = BuildCounterSliceLeftNeighbourQuery(start, end, *track, query);
+                    if (result != kRocProfVisDmResultSuccess) break;
+                    result = ExecuteSQLQuery(future,(DbInstance*)props->track_indentifiers.db_instance, query.c_str(), &slices, &CallbackAddAnyRecord);
+                    if (result != kRocProfVisDmResultSuccess) break;
+                }
 
                 if (result == kRocProfVisDmResultSuccess)
                 {
-                    query = "";
-                    if (props->track_indentifiers.category == kRocProfVisDmPmcTrack)
+                    result = ExecuteSQLQuery(future, (DbInstance*)props->track_indentifiers.db_instance, slice_query.c_str(), &slices, &CallbackAddAnyRecord);
+
+                    if (result == kRocProfVisDmResultSuccess && right_neighbor)
                     {
-                        if (props->track_indentifiers.category == kRocProfVisDmPmcTrack)
+                        query = "";
+                        future->ResetRowCount();
+                        if (BuildCounterSliceRightNeighbourQuery(start, end, *track, query) != kRocProfVisDmResultSuccess) break;
+                        if (ExecuteSQLQuery(future, (DbInstance*)props->track_indentifiers.db_instance, query.c_str(), &slices, &CallbackAddAnyRecord) != kRocProfVisDmResultSuccess) break;
+
+                        if (future->GetProcessedRowsCount() == 0)
                         {
-                            future->ResetRowCount();
-                            if (BuildCounterSliceRightNeighbourQuery(start, end, *tracks, query) != kRocProfVisDmResultSuccess) break;
-                            if (ExecuteSQLQuery(future, (DbInstance*)props->track_indentifiers.db_instance, query.c_str(), &slices, &CallbackAddAnyRecord) != kRocProfVisDmResultSuccess) break;
+                            rocprofvis_db_record_data_t record; 
+                            auto db_instance = (DbInstance*)props->track_indentifiers.db_instance;
+                            record.pmc.timestamp = TraceProperties()->db_inst_end_time[db_instance->GuidIndex()]-TraceProperties()->db_inst_start_time[db_instance->GuidIndex()];
+                            record.pmc.value = future->GetRuntimeStorageValue<double>(kRPVFutureStorageSampleValue,0);
 
-                            if (future->GetProcessedRowsCount() == 0)
-                            {
-                                rocprofvis_db_record_data_t record; 
-                                auto db_instance = (DbInstance*)props->track_indentifiers.db_instance;
-                                record.pmc.timestamp = TraceProperties()->db_inst_end_time[db_instance->GuidIndex()]-TraceProperties()->db_inst_start_time[db_instance->GuidIndex()];
-                                record.pmc.value = future->GetRuntimeStorageValue<double>(kRPVFutureStorageSampleValue,0);
+                            if (BindObject()->FuncAddRecord(slices[*track], record) != kRocProfVisDmResultSuccess)
+                            break;
 
-                                if (BindObject()->FuncAddRecord(slices[*tracks], record) != kRocProfVisDmResultSuccess)
-                                break;
-
-                            }
                         }
                     }
+
+
+                    BindObject()->FuncCompleteSlice(slices[*track]);
+
                 }
-
-
-                BindObject()->FuncCompleteSlice(slices[*tracks]);
-
             }
-        }
 
-        if(kRocProfVisDmResultSuccess != result)
-        {
-            BindObject()->FuncRemoveSlice(BindObject()->trace_object, *tracks, slices[*tracks]);
-            break;
-        }
-        ShowProgress(100 - future->Progress(), "Time slice successfully loaded!", kRPVDbSuccess, future);
-        return future->SetPromise(kRocProfVisDmResultSuccess);
-
+            if(kRocProfVisDmResultSuccess != result)
+            {
+                BindObject()->FuncRemoveSlice(BindObject()->trace_object, *track, slices[*track]);
+                break;
+            }
+            ShowProgress(100 - future->Progress(), "Time slice successfully loaded!", kRPVDbSuccess, future);
+            return future->SetPromise(kRocProfVisDmResultSuccess);
+        }    
     }
 
     ShowProgress(0, "Not all tracks are loaded!", kRPVDbError, future );
     return future->SetPromise(future->Interrupted() ? kRocProfVisDmResultDbAbort : kRocProfVisDmResultDbAccessFailed);
+    
 }
 
 rocprofvis_dm_result_t  ProfileDatabase::ExecuteQuery(

--- a/src/model/src/database/rocprofvis_db_profile.h
+++ b/src/model/src/database/rocprofvis_db_profile.h
@@ -89,6 +89,22 @@ class ProfileDatabase : public SqliteDatabase
                         rocprofvis_db_num_of_tracks_t num,
                         rocprofvis_db_track_selection_t tracks,
                         Future* object) override;
+        // worker method to read PMC time slice
+        // @param start - start timestamp of time slice 
+        // @param end - end timestamp of time slice 
+        // @param track - track ID
+        // @param left_neighbor - include the left neighbor of the time range
+        // @param right_neighbor - include the right neighbor of the time range 
+        // @param object - future object providing asynchronous execution mechanism   
+        // @return status of operation 
+        rocprofvis_dm_result_t  ReadTracePMCSlice(
+                        rocprofvis_dm_timestamp_t start,
+                        rocprofvis_dm_timestamp_t end,
+                        rocprofvis_dm_hashed_timestamp_tag_t tag,
+                        rocprofvis_db_track_selection_t track,
+                        bool left_neighbor,
+                        bool right_neighbor,
+                        Future* object) override;
         // worker method to execute database query
         // @param query - database query 
         // @param description - database description

--- a/src/view/src/model/rocprofvis_analysis_model.cpp
+++ b/src/view/src/model/rocprofvis_analysis_model.cpp
@@ -2,16 +2,38 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_analysis_model.h"
+#include "../rocprofvis_utils.h"
+#include "rocprofvis_topology_model.h"
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <tuple>
 
 namespace RocProfVis
 {
 namespace View
 {
 
-AnalysisModel::AnalysisModel()
+constexpr int SIGNIFICANT_DIGITS = 1;
+const double  ROUND_FACTOR       = std::pow(10.0, SIGNIFICANT_DIGITS);
+// Name, compact name, accent color index
+constexpr std::array<std::tuple<const char*, const char*, size_t>,
+                     AnalysisTrackStatistics::Queue::kQueueCount>
+    DISPLAY_PROPS_QUEUE = { { { "Utilization", "Util", 2 } } };
+constexpr std::array<std::tuple<const char*, const char*, size_t>,
+                     AnalysisTrackStatistics::Counter::kCounterCount>
+    DISPLAY_PROPS_COUNTER = { { { "Minimum", "Min", 0 },
+                                { "Maximum", "Max", 5 },
+                                { "Mean", "Avg", 3 },
+                                { "Standard Deviation", "Std Dev", 8 } } };
+
+AnalysisModel::AnalysisModel(const TopologyDataModel& topology)
 : m_analysis_range_start_ns(0.0)
 , m_analysis_range_end_ns(0.0)
+, m_topology(topology)
 {}
+
 void
 AnalysisModel::SetAnalysisRange(double start_ns, double end_ns)
 {
@@ -19,43 +41,156 @@ AnalysisModel::SetAnalysisRange(double start_ns, double end_ns)
     {
         m_analysis_range_start_ns = start_ns;
         m_analysis_range_end_ns   = end_ns;
-        for(std::pair<const uint64_t, AnalysisQueueUtilization>& queue :
-            m_per_track_queue_utilization)
+        for(std::pair<const uint64_t, AnalysisTrackStatistics>& stats : m_track_stats)
         {
-            queue.second.state = AnalysisQueueUtilization::kStale;
+            stats.second.state = AnalysisTrackStatistics::kStale;
         }
     }
 }
 
-const AnalysisQueueUtilization*
-AnalysisModel::GetPerTrackQueueUtilization(const TrackInfo& track)
+const AnalysisTrackStatistics*
+AnalysisModel::RegisterTrack(const TrackInfo& track)
 {
-    if(track.topology.type == TrackInfo::TrackType::Queue)
+    AnalysisTrackStatistics* store = nullptr;
+    if(m_track_stats.count(track.id) == 0)
     {
-        if(m_per_track_queue_utilization.count(track.id) == 0)
+        switch(track.topology.type)
         {
-            AnalysisQueueUtilization* queue = &m_per_track_queue_utilization[track.id];
-            m_per_track_queue_utilization[track.id].track = &track;
-            queue->util_pct                               = 0.0;
-            queue->state = AnalysisQueueUtilization::kReady;
+            case TrackInfo::TrackType::Queue:
+            {
+                store = &m_track_stats[track.id];
+                store->stats.resize(AnalysisTrackStatistics::Queue::kQueueCount);
+                store->stats[AnalysisTrackStatistics::Queue::kQueueUtilization].name =
+                    std::get<0>(DISPLAY_PROPS_QUEUE
+                                    [AnalysisTrackStatistics::Queue::kQueueUtilization]);
+                store->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
+                    .compact_name =
+                    std::get<1>(DISPLAY_PROPS_QUEUE
+                                    [AnalysisTrackStatistics::Queue::kQueueUtilization]);
+                store->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
+                    .accent_color =
+                    std::get<2>(DISPLAY_PROPS_QUEUE
+                                    [AnalysisTrackStatistics::Queue::kQueueUtilization]);
+                break;
+            }
+            case TrackInfo::TrackType::Counter:
+            {
+                store = &m_track_stats[track.id];
+                store->stats.resize(AnalysisTrackStatistics::Counter::kCounterCount);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMin]
+                    .name = std::get<0>(
+                    DISPLAY_PROPS_COUNTER[AnalysisTrackStatistics::Counter::kCounterMin]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMin]
+                    .compact_name = std::get<1>(
+                    DISPLAY_PROPS_COUNTER[AnalysisTrackStatistics::Counter::kCounterMin]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMin]
+                    .accent_color = std::get<2>(
+                    DISPLAY_PROPS_COUNTER[AnalysisTrackStatistics::Counter::kCounterMin]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMax]
+                    .name = std::get<0>(
+                    DISPLAY_PROPS_COUNTER[AnalysisTrackStatistics::Counter::kCounterMax]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMax]
+                    .compact_name = std::get<1>(
+                    DISPLAY_PROPS_COUNTER[AnalysisTrackStatistics::Counter::kCounterMax]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMax]
+                    .accent_color = std::get<2>(
+                    DISPLAY_PROPS_COUNTER[AnalysisTrackStatistics::Counter::kCounterMax]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMean].name =
+                    std::get<0>(DISPLAY_PROPS_COUNTER
+                                    [AnalysisTrackStatistics::Counter::kCounterMean]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMean]
+                    .compact_name =
+                    std::get<1>(DISPLAY_PROPS_COUNTER
+                                    [AnalysisTrackStatistics::Counter::kCounterMean]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterMean]
+                    .accent_color =
+                    std::get<2>(DISPLAY_PROPS_COUNTER
+                                    [AnalysisTrackStatistics::Counter::kCounterMean]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterStandardDeviation]
+                    .name = std::get<0>(
+                    DISPLAY_PROPS_COUNTER
+                        [AnalysisTrackStatistics::Counter::kCounterStandardDeviation]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterStandardDeviation]
+                    .compact_name = std::get<1>(
+                    DISPLAY_PROPS_COUNTER
+                        [AnalysisTrackStatistics::Counter::kCounterStandardDeviation]);
+                store->stats[AnalysisTrackStatistics::Counter::kCounterStandardDeviation]
+                    .accent_color = std::get<2>(
+                    DISPLAY_PROPS_COUNTER
+                        [AnalysisTrackStatistics::Counter::kCounterStandardDeviation]);
+                break;
+            }
         }
-        return &m_per_track_queue_utilization.at(track.id);
+        if(store)
+        {
+            store->track = &track;
+            store->state = AnalysisTrackStatistics::kReady;
+        }
     }
     else
     {
-        return nullptr;
+        store = &m_track_stats.at(track.id);
+    }
+    return store;
+}
+
+void
+AnalysisModel::SetQueueUtilization(uint64_t track_id, const double& util_pct)
+{
+    AnalysisTrackStatistics& store = m_track_stats.at(track_id);
+    if(store.track->topology.type == TrackInfo::TrackType::Queue &&
+       store.state == AnalysisTrackStatistics::State::kRequested)
+    {
+        store.stats[AnalysisTrackStatistics::Queue::kQueueUtilization].value =
+            Round(util_pct);
+        ToString(store.track,
+                 store.stats[AnalysisTrackStatistics::Queue::kQueueUtilization], "%");
+        store.state = AnalysisTrackStatistics::State::kReady;
     }
 }
 
 void
-AnalysisModel::SetPerTrackQueueUtilizationValue(uint64_t track_id, double util_pct)
+AnalysisModel::SetCounterStatistics(uint64_t track_id,
+                                    const rocprofvis_analysis_counter_statistics_t& stats)
 {
-    AnalysisQueueUtilization& data = m_per_track_queue_utilization.at(track_id);
-    if(data.state == AnalysisQueueUtilization::State::kRequested)
+    AnalysisTrackStatistics& store = m_track_stats.at(track_id);
+    if(store.track->topology.type == TrackInfo::TrackType::Counter &&
+       store.state == AnalysisTrackStatistics::State::kRequested)
     {
-        data.util_pct = util_pct;
-        data.state    = AnalysisQueueUtilization::State::kReady;
+        store.stats[AnalysisTrackStatistics::Counter::kCounterMin].value =
+            Round(stats.min_value);
+        store.stats[AnalysisTrackStatistics::Counter::kCounterMax].value =
+            Round(stats.max_value);
+        store.stats[AnalysisTrackStatistics::Counter::kCounterMean].value =
+            Round(stats.mean_value);
+        store.stats[AnalysisTrackStatistics::Counter::kCounterStandardDeviation].value =
+            Round(stats.std_dev);
+        const CounterInfo* counter =
+            m_topology.GetCounter(store.track->topology.id.value);
+        if(counter)
+        {
+            ToString(store.track,
+                     store.stats[AnalysisTrackStatistics::Counter::kCounterMin],
+                     counter->units);
+            ToString(store.track,
+                     store.stats[AnalysisTrackStatistics::Counter::kCounterMax],
+                     counter->units);
+            ToString(store.track,
+                     store.stats[AnalysisTrackStatistics::Counter::kCounterMean],
+                     counter->units);
+            ToString(
+                store.track,
+                store.stats[AnalysisTrackStatistics::Counter::kCounterStandardDeviation],
+                counter->units);
+        }
+        store.state = AnalysisTrackStatistics::State::kReady;
     }
+}
+
+const std::unordered_map<uint64_t, AnalysisTrackStatistics>&
+AnalysisModel::GetTrackStatistics() const
+{
+    return m_track_stats;
 }
 
 const TablesModel&
@@ -71,16 +206,44 @@ AnalysisModel::GetTables()
 }
 
 void
-AnalysisModel::ClearPerTrackQueueUtilization()
-{
-    m_per_track_queue_utilization.clear();
-}
-
-void
 AnalysisModel::Clear()
 {
     m_tables.ClearAllTables();
-    ClearPerTrackQueueUtilization();
+    m_track_stats.clear();
+}
+
+void
+AnalysisModel::ToString(const TrackInfo* track, AnalysisTrackStatistics::Stat& stat,
+                        const std::string& units)
+{
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(SIGNIFICANT_DIGITS) << stat.value;
+    switch(track->topology.type)
+    {
+        case TrackInfo::Queue:
+        {
+            stat.compact  = oss.str() + (units.empty() ? "" : " " + units);
+            stat.extended = std::string(stat.compact_name) + ": " + stat.compact;
+            stat.full     = std::string(stat.name) + ": " + oss.str() +
+                            (units.empty() ? "" : " " + units);
+            break;
+        }
+        case TrackInfo::Counter:
+        {
+            stat.compact =
+                compact_number_format(stat.value) + (units.empty() ? "" : " " + units);
+            stat.extended = std::string(stat.compact_name) + ": " + stat.compact;
+            stat.full     = std::string(stat.name) + ": " + oss.str() +
+                            (units.empty() ? "" : " " + units);
+            break;
+        }
+    }
+}
+
+double
+AnalysisModel::Round(double d) const
+{
+    return std::round(d * ROUND_FACTOR) / ROUND_FACTOR;
 }
 
 }  // namespace View

--- a/src/view/src/model/rocprofvis_analysis_model.cpp
+++ b/src/view/src/model/rocprofvis_analysis_model.cpp
@@ -187,12 +187,6 @@ AnalysisModel::SetCounterStatistics(uint64_t track_id,
     }
 }
 
-const std::unordered_map<uint64_t, AnalysisTrackStatistics>&
-AnalysisModel::GetTrackStatistics() const
-{
-    return m_track_stats;
-}
-
 const TablesModel&
 AnalysisModel::GetTables() const
 {

--- a/src/view/src/model/rocprofvis_analysis_model.h
+++ b/src/view/src/model/rocprofvis_analysis_model.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "rocprofvis_controller_analysis.h"
 #include "rocprofvis_model_types.h"
 #include "rocprofvis_tables_model.h"
 #include <cstdint>
@@ -12,29 +13,41 @@ namespace RocProfVis
 namespace View
 {
 
+class TopologyDataModel;
+
 class AnalysisModel
 {
 public:
-    AnalysisModel();
+    AnalysisModel(const TopologyDataModel& topology);
     ~AnalysisModel() = default;
 
     void SetAnalysisRange(double start_ns, double end_ns);
 
-    const AnalysisQueueUtilization* GetPerTrackQueueUtilization(const TrackInfo& track);
-    void SetPerTrackQueueUtilizationValue(uint64_t track_id, double util_pct);
+    const AnalysisTrackStatistics* RegisterTrack(const TrackInfo& track);
+
+    void SetQueueUtilization(uint64_t track_id, const double& util_pct);
+    void SetCounterStatistics(uint64_t                                        track_id,
+                              const rocprofvis_analysis_counter_statistics_t& stats);
+
+    const std::unordered_map<uint64_t, AnalysisTrackStatistics>& GetTrackStatistics()
+        const;
 
     const TablesModel& GetTables() const;
     TablesModel&       GetTables();
 
-    void ClearPerTrackQueueUtilization();
     void Clear();
 
 private:
+    void   ToString(const TrackInfo* track, AnalysisTrackStatistics::Stat& stat,
+                    const std::string& units);
+    double Round(double d) const;
+
     double m_analysis_range_start_ns;
     double m_analysis_range_end_ns;
 
-    TablesModel                                            m_tables;
-    std::unordered_map<uint64_t, AnalysisQueueUtilization> m_per_track_queue_utilization;
+    TablesModel                                           m_tables;
+    std::unordered_map<uint64_t, AnalysisTrackStatistics> m_track_stats;
+    const TopologyDataModel&                              m_topology;
 };
 
 }  // namespace View

--- a/src/view/src/model/rocprofvis_analysis_model.h
+++ b/src/view/src/model/rocprofvis_analysis_model.h
@@ -29,9 +29,6 @@ public:
     void SetCounterStatistics(uint64_t                                        track_id,
                               const rocprofvis_analysis_counter_statistics_t& stats);
 
-    const std::unordered_map<uint64_t, AnalysisTrackStatistics>& GetTrackStatistics()
-        const;
-
     const TablesModel& GetTables() const;
     TablesModel&       GetTables();
 

--- a/src/view/src/model/rocprofvis_model_types.h
+++ b/src/view/src/model/rocprofvis_model_types.h
@@ -285,7 +285,7 @@ struct TableInfo
     uint64_t                              total_row_count;
 };
 
-struct AnalysisQueueUtilization
+struct AnalysisTrackStatistics
 {
     enum State
     {
@@ -294,9 +294,32 @@ struct AnalysisQueueUtilization
         kRequested,  // Pending fetch completion
         kReady,
     };
-    const TrackInfo* track;
-    double           util_pct;
-    mutable State    state;
+    struct Stat
+    {
+        const char* name;
+        const char* compact_name;
+        size_t      accent_color;
+        double      value;
+        std::string compact;
+        std::string extended;
+        std::string full;
+    };
+    enum Queue : size_t
+    {
+        kQueueUtilization = 0,
+        kQueueCount,
+    };
+    enum Counter : size_t
+    {
+        kCounterMin = 0,
+        kCounterMax,
+        kCounterMean,
+        kCounterStandardDeviation,
+        kCounterCount
+    };
+    const TrackInfo*  track;
+    mutable State     state;
+    std::vector<Stat> stats;
 };
 
 }  // namespace View

--- a/src/view/src/model/rocprofvis_trace_data_model.cpp
+++ b/src/view/src/model/rocprofvis_trace_data_model.cpp
@@ -8,7 +8,9 @@ namespace RocProfVis
 namespace View
 {
 
-TraceDataModel::TraceDataModel() {}
+TraceDataModel::TraceDataModel()
+: m_analysis(m_topology)
+{}
 
 std::string
 TraceDataModel::BuildTrackName(uint64_t track_id) const

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -2271,8 +2271,8 @@ DataProvider::FetchSummary()
 }
 
 bool
-DataProvider::FetchAnalysisQueueUtilization(
-    const AnalysisQueueUtilizationRequestParams& params)
+DataProvider::FetchAnalysisTrackStatistics(
+    const AnalysisTrackStatisticsRequestParams& params)
 {
     if(m_state != ProviderState::kReady)
     {
@@ -2284,13 +2284,12 @@ DataProvider::FetchAnalysisQueueUtilization(
     {
         uint64_t request_id = RequestIdBuilder::MakeTrackDataRequestId(
             static_cast<uint32_t>(params.m_track_id), 0, 0,
-            RequestType::kFetchAnalysisQueueUtilization);
+            RequestType::kFetchAnalysisTrackStatistics);
         auto it = m_requests.find(request_id);
         if(it != m_requests.end())
         {
-            spdlog::debug(
-                "Per-track queue utilization request for track {} is already pending",
-                params.m_track_id);
+            spdlog::debug("Track statistics request for track {} is already pending",
+                          params.m_track_id);
             return false;
         }
         else
@@ -2303,18 +2302,40 @@ DataProvider::FetchAnalysisQueueUtilization(
             ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess && track_handle);
             rocprofvis_controller_future_t* future = rocprofvis_controller_future_alloc();
             ROCPROFVIS_ASSERT(future);
-            std::shared_ptr<AnalysisQueueUtilizationRequestParams> stored_params =
-                std::make_shared<AnalysisQueueUtilizationRequestParams>(params);
+            std::shared_ptr<AnalysisTrackStatisticsRequestParams> stored_params =
+                std::make_shared<AnalysisTrackStatisticsRequestParams>(params);
             m_requests.emplace(request_id,
                                RequestInfo{ request_id, future, nullptr, nullptr, nullptr,
                                             RequestState::kLoading,
-                                            RequestType::kFetchAnalysisQueueUtilization,
+                                            RequestType::kFetchAnalysisTrackStatistics,
                                             stored_params });
-            result = rocprofvis_analysis_fetch_queue_utilization(
-                m_trace_controller, track_handle, stored_params->m_start_ts,
-                stored_params->m_end_ts, future, &stored_params->m_result);
+            switch(metadata->topology.type)
+            {
+                case TrackInfo::TrackType::Queue:
+                {
+                    result = rocprofvis_analysis_fetch_queue_utilization(
+                        m_trace_controller, track_handle, stored_params->m_start_ts,
+                        stored_params->m_end_ts, future,
+                        &stored_params->m_output.queue_util);
+                    break;
+                }
+                case TrackInfo::TrackType::Counter:
+                {
+                    result = rocprofvis_analysis_fetch_counter_statistics(
+                        m_trace_controller, track_handle, stored_params->m_start_ts,
+                        stored_params->m_end_ts, future,
+                        &stored_params->m_output.counter_stats);
+                    break;
+                }
+                default:
+                {
+                    result = kRocProfVisResultNotSupported;
+                    break;
+                }
+            }
+
             ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            spdlog::debug("Fetching per-track queue utilization for track {}",
+            spdlog::debug("Fetching track statistics for track {}",
                           stored_params->m_track_id);
             return true;
         }
@@ -2933,9 +2954,9 @@ DataProvider::ProcessRequest(RequestInfo& req)
             ProcessSummaryRequest(req);
             break;
         }
-        case RequestType::kFetchAnalysisQueueUtilization:
+        case RequestType::kFetchAnalysisTrackStatistics:
         {
-            ProcessAnalysisQueueUtilizationRequest(req);
+            ProcessAnalysisTrackStatisticsRequest(req);
             break;
         }
 #ifdef COMPUTE_UI_SUPPORT
@@ -3018,23 +3039,39 @@ DataProvider::ProcessSummaryRequest(RequestInfo& req)
 }
 
 void
-DataProvider::ProcessAnalysisQueueUtilizationRequest(RequestInfo& req)
+DataProvider::ProcessAnalysisTrackStatisticsRequest(RequestInfo& req)
 {
-    std::shared_ptr<AnalysisQueueUtilizationRequestParams> params =
-        std::dynamic_pointer_cast<AnalysisQueueUtilizationRequestParams>(req.custom_params);
+    std::shared_ptr<AnalysisTrackStatisticsRequestParams> params =
+        std::dynamic_pointer_cast<AnalysisTrackStatisticsRequestParams>(
+            req.custom_params);
     if(!params)
     {
-        spdlog::error("Queue utilization params missing or invalid");
+        spdlog::error("Track statistics params missing or invalid");
     }
     else if(req.response_code != kRocProfVisResultSuccess)
     {
-        spdlog::debug("Queue utilization request for track {} failed with code {}",
+        spdlog::debug("Track statistics request for track {} failed with code {}",
                       params->m_track_id, req.response_code);
     }
     else
     {
-        m_model.GetAnalysis().SetPerTrackQueueUtilizationValue(params->m_track_id,
-                                                               params->m_result);
+        const TrackInfo* metadata = m_model.GetTimeline().GetTrack(params->m_track_id);
+        ROCPROFVIS_ASSERT(metadata);
+        switch(metadata->topology.type)
+        {
+            case TrackInfo::TrackType::Queue:
+            {
+                m_model.GetAnalysis().SetQueueUtilization(params->m_track_id,
+                                                          params->m_output.queue_util);
+                break;
+            }
+            case TrackInfo::TrackType::Counter:
+            {
+                m_model.GetAnalysis().SetCounterStatistics(
+                    params->m_track_id, params->m_output.counter_stats);
+                break;
+            }
+        }
     }
 }
 

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -194,8 +194,7 @@ public:
 
     bool FetchSummary();
 
-    bool FetchAnalysisQueueUtilization(
-        const AnalysisQueueUtilizationRequestParams& params);
+    bool FetchAnalysisTrackStatistics(const AnalysisTrackStatisticsRequestParams& params);
 
     bool IsRequestPending(uint64_t request_id) const;
 
@@ -296,7 +295,7 @@ private:
     void ProcessSaveTrimmedTraceRequest(RequestInfo& req);
     void ProcessCleanupDatabaseRequest(RequestInfo& req);
     void ProcessSummaryRequest(RequestInfo& req);
-    void ProcessAnalysisQueueUtilizationRequest(RequestInfo& req);
+    void ProcessAnalysisTrackStatisticsRequest(RequestInfo& req);
 
     bool SetupCommonTableArguments(rocprofvis_controller_arguments_t* args,
                                    const TableRequestParams&          table_params);

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -14,11 +14,9 @@
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_gui_helpers.h"
 #include <cmath>
-#include <cstdio>
 #include <limits>
 #include <sstream>
 #include <string>
-#include <unordered_set>
 
 namespace RocProfVis
 {
@@ -31,7 +29,6 @@ inline constexpr float HIGHLIGHT_THICKNESS_HALF  = HIGHLIGHT_THICKNESS / 2;
 inline constexpr float TOOLTIP_OFFSET            = 16.0f;
 inline constexpr int   MAX_CHARACTERS_PER_LINE   = 40;
 inline constexpr float MAX_TABLE_HEIGHT          = 300.0f;
-inline constexpr float PILL_SPACING              = 4.0f;
 
 /*
 For IMGUI rectangle borders ANTI_ALIASING_WORKAROUND is needed to avoid anti-aliasing
@@ -52,23 +49,21 @@ FlameTrackItem::CalculateMaxEventLabelWidth()
 FlameTrackItem::FlameTrackItem(DataProvider&                          dp,
                                std::shared_ptr<TimelineSelection>     timeline_selection,
                                std::shared_ptr<MeasurementController> measurement,
-                               uint64_t                               track_id,
-                               std::shared_ptr<TimePixelTransform>    tpt)
-: TrackItem(dp, track_id, tpt)
-, m_event_color_mode(EventColorMode::kByEventName)
+                               uint64_t track_id, std::shared_ptr<TimePixelTransform> tpt)
+: TrackItem(dp, track_id, tpt, timeline_selection)
 , m_text_padding(SettingsManager::GetInstance().GetDefaultIMGUIStyle().FramePadding)
 , m_level_height(SettingsManager::GetInstance().GetEventLevelHeight())
-, m_timeline_selection(timeline_selection)
 , m_measurement(measurement)
 , m_deferred_click_handled(false)
 , m_has_drawn_tool_tip(false)
-, m_flame_track_project_settings(dp.GetTraceFilePath(), *this)
 , m_selected_chart_items({})
 , m_tooltip_size(0.0f, 0.0f)
 , m_is_expanded(false)
+, m_pill_analysis_queue(nullptr)
+, m_flame_track_project_settings(dp.GetTraceFilePath(), *this)
+, m_show_pill_analysis_queue(true)
+, m_event_color_mode(EventColorMode::kByEventName)
 , m_compact_mode(false)
-, m_queue_utilization(nullptr)
-, m_queue_utilization_pill("", false, false)
 {
     if(!m_tpt)
     {
@@ -80,12 +75,16 @@ FlameTrackItem::FlameTrackItem(DataProvider&                          dp,
     {
         m_min_level = static_cast<float>(m_track_metadata->min_value);
         m_max_level = static_cast<float>(m_track_metadata->max_value);
-
+        m_track_statistics =
+            m_data_provider.DataModel().GetAnalysis().RegisterTrack(*m_track_metadata);
         if(m_track_metadata->topology.type == TrackInfo::TrackType::Queue)
         {
-            m_queue_utilization =
-                m_data_provider.DataModel().GetAnalysis().GetPerTrackQueueUtilization(
-                    *m_track_metadata);
+            m_pill_analysis_queue = AddPill();
+            m_pill_analysis_queue->SetVisible(m_show_pill_analysis_queue);
+            m_pill_analysis_queue->SetAccentColor(
+                m_track_statistics
+                    ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
+                    .accent_color);
         }
     }
 
@@ -113,6 +112,13 @@ FlameTrackItem::FlameTrackItem(DataProvider&                          dp,
         if(m_compact_mode)
         {
             m_level_height = m_settings.GetEventLevelCompactHeight();
+        }
+        m_show_pill_analysis_queue =
+            m_flame_track_project_settings
+                .ShowAnalysis()[AnalysisTrackStatistics::Queue::kQueueUtilization];
+        if(m_pill_analysis_queue)
+        {
+            m_pill_analysis_queue->SetVisible(m_show_pill_analysis_queue);
         }
     }
 }
@@ -166,6 +172,38 @@ FlameTrackItem::~FlameTrackItem()
     EventManager::GetInstance()->Unsubscribe(
         static_cast<int>(RocEvents::kTimelineEventHighlightChanged),
         m_timeline_event_highlight_changed_token);
+}
+
+void
+FlameTrackItem::Update()
+{
+    if(m_track_statistics && m_pill_analysis_queue)
+    {
+        if(m_track_statistics->state == AnalysisTrackStatistics::kReady &&
+           m_track_statistics_dirty)
+        {
+            m_pill_analysis_queue->Activate();
+            m_pill_analysis_queue->SetLabel(
+                m_track_statistics
+                    ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
+                    .compact,
+                Pill::kCompact);
+            m_pill_analysis_queue->SetLabel(
+                m_track_statistics
+                    ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
+                    .extended,
+                Pill::kExtended);
+            m_pill_analysis_queue->SetTooltip(
+                m_track_statistics
+                    ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
+                    .full);
+        }
+        else if(m_track_statistics->state < AnalysisTrackStatistics::kReady)
+        {
+            m_pill_analysis_queue->Deactivate();
+        }
+    }
+    TrackItem::Update();
 }
 
 bool
@@ -782,64 +820,40 @@ FlameTrackItem::RenderChart(float graph_width)
 }
 
 void
-FlameTrackItem::RenderSecondaryMetaPill(const ImVec2& content_size)
-{
-    if(!(m_track_metadata &&
-         m_track_metadata->topology.type == TrackInfo::TrackType::Queue &&
-         m_queue_utilization))
-    {
-        return;
-    }
-
-    // Keep the two pills grouped: only show utilization when the QUEUE pill is
-    // visible, so a cramped meta area never shows a lone, overflowing pill.
-    if(!m_pill.IsShown())
-    {
-        m_queue_utilization_pill.Hide();
-        return;
-    }
-
-    char util_text[16];
-    std::snprintf(util_text, sizeof(util_text), "%.1f %%",
-                  m_queue_utilization->util_pct);
-    m_queue_utilization_pill.SetLabel(util_text);
-    m_queue_utilization_pill.SetTooltipLabel(std::string("Queue Utilization: ") +
-                                             util_text);
-
-    // A ready value is shown as an active (prominent) pill; a stale/pending
-    // value is shown dimmed until the analysis fetch completes.
-    if(m_queue_utilization->state == AnalysisQueueUtilization::kReady)
-    {
-        m_queue_utilization_pill.Activate();
-    }
-    else
-    {
-        m_queue_utilization_pill.Deactivate();
-    }
-    m_queue_utilization_pill.Show();
-
-    // Sit immediately to the right of the QUEUE pill, sharing its bottom row.
-    ImVec2 util_pill_size = m_queue_utilization_pill.GetPillSize();
-    ImVec2 pill_pos(m_reorder_grip_width + m_pill.GetPillSize().x + PILL_SPACING,
-                    content_size.y - util_pill_size.y - 2.0f);
-    m_queue_utilization_pill.RenderPillLabelAt(pill_pos, m_settings);
-}
-
-void
 FlameTrackItem::RenderMetaAreaOptions()
 {
+    if(m_track_statistics &&
+       m_track_metadata->topology.type == TrackInfo::TrackType::Queue)
+    {
+        ImGui::SeparatorText("Metrics");
+        ImGui::PushStyleColor(
+            ImGuiCol_CheckMark,
+            (m_settings.GetColorWheel()
+                 [m_track_statistics
+                      ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
+                      .accent_color]) |
+                IM_COL32_A_MASK);
+        if(ImGui::Checkbox("##queue_util", &m_show_pill_analysis_queue))
+        {
+            m_pill_analysis_queue->SetVisible(m_show_pill_analysis_queue);
+        }
+        ImGui::PopStyleColor();
+        ImGui::SameLine();
+        ImGui::Text(
+            "Show %s",
+            m_track_statistics->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
+                .name);
+    }
+    ImGui::SeparatorText("Appearance");
     EventColorMode mode = m_event_color_mode;
-
     if(ImGui::RadioButton("Color by Name", mode == EventColorMode::kByEventName))
         mode = EventColorMode::kByEventName;
-    ImGui::SameLine();
     if(ImGui::RadioButton("Color by Time Level", mode == EventColorMode::kByTimeLevel))
         mode = EventColorMode::kByTimeLevel;
-    ImGui::SameLine();
     if(ImGui::RadioButton("No Color", mode == EventColorMode::kNone))
         mode = EventColorMode::kNone;
     m_event_color_mode = mode;
-
+    ImGui::Separator();
     if(ImGui::Checkbox("Compact Mode", &m_compact_mode))
     {
         if(m_compact_mode)
@@ -857,46 +871,6 @@ FlameTrackItem::RenderMetaAreaOptions()
         if(m_track_height > std::max(m_max_level * m_level_height + m_level_height, DEFAULT_TRACK_HEIGHT))
         {
             RecalculateTrackHeight();
-        }
-    }
-}
-
-void
-FlameTrackItem::RequestAnalysis()
-{
-    if(m_track_metadata &&
-       m_track_metadata->topology.type == TrackInfo::TrackType::Queue &&
-       m_queue_utilization &&
-       (m_queue_utilization->state == AnalysisQueueUtilization::kStale ||
-        m_queue_utilization->state == AnalysisQueueUtilization::kPending))
-    {
-        uint64_t request_id = RequestIdBuilder::MakeTrackDataRequestId(
-            static_cast<uint32_t>(m_track_id), 0, 0,
-            RequestType::kFetchAnalysisQueueUtilization);
-        if(m_data_provider.IsRequestPending(request_id))
-        {
-            m_data_provider.CancelRequest(request_id);
-            m_queue_utilization->state = AnalysisQueueUtilization::kPending;
-        }
-        else
-        {
-            double start_ts;
-            double end_ts;
-            if(m_timeline_selection && m_timeline_selection->HasValidTimeRangeSelection())
-            {
-                m_timeline_selection->GetSelectedTimeRange(start_ts, end_ts);
-            }
-            else
-            {
-                start_ts = m_tpt->GetVMinX();
-                end_ts   = m_tpt->GetVMaxX();
-            }
-            m_queue_utilization->state =
-                (start_ts < end_ts &&
-                 m_data_provider.FetchAnalysisQueueUtilization(
-                     AnalysisQueueUtilizationRequestParams(m_track_id, start_ts, end_ts)))
-                    ? AnalysisQueueUtilization::kRequested
-                    : AnalysisQueueUtilization::kPending;
         }
     }
 }
@@ -919,6 +893,10 @@ FlameTrackProjectSettings::ToJson()
     m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK]
                    [m_track_item.GetID()][JSON_KEY_TIMELINE_TRACK_COMPACT_MODE] =
                        m_track_item.m_compact_mode;
+
+    m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK]
+                   [m_track_item.GetID()][JSON_KEY_TRACK_QUEUE_UTILIZATION] =
+                       m_track_item.m_show_pill_analysis_queue;
 }
 
 bool
@@ -933,6 +911,13 @@ FlameTrackProjectSettings::Valid() const
 
     if(!m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK]
                        [m_track_item.GetID()][JSON_KEY_TIMELINE_TRACK_COMPACT_MODE]
+                           .isBool())
+    {
+        return false;
+    }
+
+    if(!m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK]
+                       [m_track_item.GetID()][JSON_KEY_TRACK_QUEUE_UTILIZATION]
                            .isBool())
     {
         return false;
@@ -963,6 +948,17 @@ FlameTrackProjectSettings::CompactMode() const
     return m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK]
                           [m_track_item.GetID()][JSON_KEY_TIMELINE_TRACK_COMPACT_MODE]
                               .getBool();
+}
+
+std::array<bool, AnalysisTrackStatistics::Queue::kQueueCount>
+FlameTrackProjectSettings::ShowAnalysis() const
+{
+    std::array<bool, AnalysisTrackStatistics::Queue::kQueueCount> show_analysis;
+    show_analysis[AnalysisTrackStatistics::Queue::kQueueUtilization] =
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK]
+                       [m_track_item.GetID()][JSON_KEY_TRACK_QUEUE_UTILIZATION]
+                           .getBool();
+    return show_analysis;
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include "rocprofvis_time_to_pixel.h"
 
 namespace RocProfVis
 {
@@ -39,6 +38,7 @@ public:
 
     EventColorMode ColorEvents() const;
     bool           CompactMode() const;
+    std::array<bool, AnalysisTrackStatistics::Queue::kQueueCount> ShowAnalysis() const;
 
 private:
     FlameTrackItem& m_track_item;
@@ -56,6 +56,7 @@ public:
                    std::shared_ptr<TimePixelTransform>    time_to_pixel_manager);
     ~FlameTrackItem();
 
+    void Update() override;
     bool ReleaseData() override;
 
     // Called to calculate max event label width for all flame track items.
@@ -67,7 +68,6 @@ protected:
     void  RenderChart(float graph_width) override;
     void  RenderMetaAreaOptions() override;
     void  RenderMetaAreaExpand() override;
-    void  RenderSecondaryMetaPill(const ImVec2& content_size) override;
 
 private:
     struct ChildEventInfo
@@ -99,19 +99,14 @@ private:
 
     void RenderTooltip(ChartItem& chart_item, int color_index);
     void RecalculateTrackHeight();
-    
-    void RequestAnalysis() override;
 
-    std::vector<ChartItem>             m_chart_items;
-    EventColorMode                     m_event_color_mode;
-    ImVec2                             m_text_padding;
-    float                              m_level_height;
-    std::vector<uint64_t>              m_selected_event_id;
-    std::shared_ptr<TimelineSelection> m_timeline_selection;
+    std::vector<ChartItem>                 m_chart_items;
+    ImVec2                                 m_text_padding;
+    float                                  m_level_height;
+    std::vector<uint64_t>                  m_selected_event_id;
     std::shared_ptr<MeasurementController> m_measurement;
-    FlameTrackProjectSettings          m_flame_track_project_settings;
-    float                              m_min_level;
-    float                              m_max_level;
+    float                                  m_min_level;
+    float                                  m_max_level;
     // Used to enforce one click handling per render cycle.
     bool                            m_deferred_click_handled;
     bool                            m_has_drawn_tool_tip;
@@ -123,10 +118,13 @@ private:
     static float             s_max_event_label_width;
     static const std::string s_child_info_separator;
     bool                     m_is_expanded;
-    bool                     m_compact_mode;
 
-    const AnalysisQueueUtilization* m_queue_utilization;
-    Pill                            m_queue_utilization_pill;
+    Pill* m_pill_analysis_queue;
+
+    FlameTrackProjectSettings m_flame_track_project_settings;
+    bool                      m_show_pill_analysis_queue;
+    EventColorMode            m_event_color_mode;
+    bool                      m_compact_mode;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -21,26 +21,40 @@ constexpr float DEFAULT_VERTICAL_PADDING = 2.0f;
 constexpr float DEFAULT_LINE_THICKNESS   = 1.0f;
 
 LineTrackItem::LineTrackItem(DataProvider& dp, uint64_t track_id,
-                             std::shared_ptr<TimePixelTransform> tpt)
-: TrackItem(dp, track_id, tpt)
+                             std::shared_ptr<TimePixelTransform> tpt,
+                             std::shared_ptr<TimelineSelection>  timeline_selection)
+: TrackItem(dp, track_id, tpt, timeline_selection)
 , m_data({})
-, m_highlight_y_limits()
-, m_highlight_y_range(false)
-, m_dp(dp)
-, m_show_boxplot(true)
-, m_show_boxplot_stripes(false)
-, m_linetrack_project_settings(dp.GetTraceFilePath(), *this)
 , m_min_y("edit_min")
 , m_max_y("edit_max")
+, m_dp(dp)
 , m_vertical_padding(DEFAULT_VERTICAL_PADDING)
+, m_pills_analysis({})
+, m_linetrack_project_settings(dp.GetTraceFilePath(), *this)
+, m_show_analysis({ false, false, true, true })
+, m_highlight_y_range(false)
+, m_highlight_y_limits()
+, m_show_boxplot(true)
+, m_show_boxplot_stripes(false)
 {
     if(!m_tpt)
     {
         spdlog::error("LineTrackItem: m_tpt shared_ptr is null, cannot construct");
         return;
     }
-    m_meta_area_scale_width = CalculateNewMetaAreaSize();
     UpdateMetadata();
+
+    if(m_track_metadata)
+    {
+        m_track_statistics =
+            m_data_provider.DataModel().GetAnalysis().RegisterTrack(*m_track_metadata);
+        for(int i = 0; i < AnalysisTrackStatistics::Counter::kCounterCount; i++)
+        {
+            m_pills_analysis[i] = AddPill();
+            m_pills_analysis[i]->SetVisible(m_show_analysis[i]);
+            m_pills_analysis[i]->SetAccentColor(m_track_statistics->stats[i].accent_color);
+        }
+    }
 
     if(m_linetrack_project_settings.Valid())
     {
@@ -48,6 +62,14 @@ LineTrackItem::LineTrackItem(DataProvider& dp, uint64_t track_id,
         m_show_boxplot_stripes = m_linetrack_project_settings.BoxPlotStripes();
         m_highlight_y_range    = m_linetrack_project_settings.Highlight();
         m_highlight_y_limits   = m_linetrack_project_settings.HighlightRange();
+        m_show_analysis        = m_linetrack_project_settings.ShowAnalysis();
+        for(int i = 0; i < AnalysisTrackStatistics::Counter::kCounterCount; i++)
+        {
+            if(m_pills_analysis[i])
+            {
+                m_pills_analysis[i]->SetVisible(m_show_analysis[i]);
+            }
+        }
     }
 }
 
@@ -76,7 +98,8 @@ LineTrackItem::UpdateMetadata()
     {
         m_max_y.Init(m_min_y.Value() + 1.0, m_units);
     }
-    m_meta_area_scale_width = CalculateNewMetaAreaSize();
+    UpdateMetaScaleAreaSize();
+    UpdateMaxMetaScaleAreaSize();
 }
 
 void
@@ -201,18 +224,53 @@ LineTrackItem::BoxPlotRender(float graph_width)
     ImGui::EndChild();
 }
 
-float
-LineTrackItem::CalculateNewMetaAreaSize()
+void
+LineTrackItem::UpdateMetaScaleAreaSize()
 {
-    ImVec2 max_size = ImGui::CalcTextSize(m_max_y.CompactValue().c_str());
+    m_meta_area_scale_width =
+        std::max({ ImGui::CalcTextSize(m_max_y.CompactValue().c_str()).x +
+                       m_max_y.ButtonSize(),
+                   ImGui::CalcTextSize(m_min_y.CompactValue().c_str()).x +
+                       m_min_y.ButtonSize() }) +
+        ImGui::GetStyle().ItemSpacing.x;
+}
 
-    ImVec2 min_size = ImGui::CalcTextSize(m_min_y.CompactValue().c_str());
+void
+LineTrackItem::UpdateMaxMetaScaleAreaSize()
+{
+    // compact_number_format() will return no more than 8 characters...
+    m_max_meta_area_scale_width = m_max_y.ButtonSize() +
+                                  ImGui::CalcTextSize("XXXXXXXX").x +
+                                  ImGui::GetStyle().ItemSpacing.x;
+}
 
-    return std::max(
-               { max_size.x + m_max_y.ButtonSize(), min_size.x + m_min_y.ButtonSize() }) +
-           6 * m_metadata_padding
-                   .x;  // TODO: Hardcoded padding for posible label size
-                        // Think later how it can be calculated or store as default values
+void
+LineTrackItem::Update()
+{
+    if(m_track_statistics)
+    {
+        for(size_t i = 0; i < m_pills_analysis.size(); i++)
+        {
+            if(m_pills_analysis[i])
+            {
+                if(m_track_statistics->state == AnalysisTrackStatistics::kReady &&
+                   m_track_statistics_dirty)
+                {
+                    m_pills_analysis[i]->Activate();
+                    m_pills_analysis[i]->SetLabel(m_track_statistics->stats[i].compact,
+                                                  Pill::kCompact);
+                    m_pills_analysis[i]->SetLabel(m_track_statistics->stats[i].extended,
+                                                  Pill::kExtended);
+                    m_pills_analysis[i]->SetTooltip(m_track_statistics->stats[i].full);
+                }
+                else if(m_track_statistics->state < AnalysisTrackStatistics::kReady)
+                {
+                    m_pills_analysis[i]->Deactivate();
+                }
+            }
+        }
+    }
+    TrackItem::Update();
 }
 
 bool
@@ -310,6 +368,30 @@ LineTrackItem::RenderChart(float graph_width)
 void
 LineTrackItem::RenderMetaAreaOptions()
 {
+    if(m_track_statistics)
+    {
+        ImGui::SeparatorText("Metrics");
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                            ImGui::GetStyle().ItemInnerSpacing);
+        for(int i = 0; i < AnalysisTrackStatistics::Counter::kCounterCount; i++)
+        {
+            ImGui::PushID(i);
+            ImGui::PushStyleColor(
+                ImGuiCol_CheckMark,
+                m_settings.GetColorWheel()[m_track_statistics->stats[i].accent_color] |
+                    IM_COL32_A_MASK);
+            if(ImGui::Checkbox("", &m_show_analysis[i]))
+            {
+                m_pills_analysis[i]->SetVisible(m_show_analysis[i]);
+            }
+            ImGui::PopStyleColor();
+            ImGui::SameLine();
+            ImGui::Text("Show %s", m_track_statistics->stats[i].name);
+            ImGui::PopID();
+        }
+        ImGui::PopStyleVar();
+    }
+    ImGui::SeparatorText("Appearance");
     ImGui::Checkbox("Show Counter Boxes", &m_show_boxplot);
     ImGui::Checkbox("Alternate Counter Coloring", &m_show_boxplot_stripes);
     if(ImGui::Checkbox("Highlight Y Range", &m_highlight_y_range))
@@ -422,6 +504,15 @@ LineTrackProjectSettings::ToJson()
     track[JSON_KEY_TIMELINE_TRACK_COLOR_RANGE_MAX] =
         m_track_item.m_highlight_y_limits.max_limit;
     track[JSON_KEY_TIMELINE_TRACK_STRIPES] = m_track_item.m_show_boxplot_stripes;
+    track[JSON_KEY_TRACK_MIN] =
+        m_track_item.m_show_analysis[AnalysisTrackStatistics::Counter::kCounterMin];
+    track[JSON_KEY_TRACK_MAX] =
+        m_track_item.m_show_analysis[AnalysisTrackStatistics::Counter::kCounterMax];
+    track[JSON_KEY_TRACK_MEAN] =
+        m_track_item.m_show_analysis[AnalysisTrackStatistics::Counter::kCounterMean];
+    track[JSON_KEY_TRACK_STANDARD_DEVIATION] =
+        m_track_item
+            .m_show_analysis[AnalysisTrackStatistics::Counter::kCounterStandardDeviation];
 }
 
 bool
@@ -433,7 +524,10 @@ LineTrackProjectSettings::Valid() const
            track[JSON_KEY_TIMELINE_TRACK_STRIPES].isBool() &&
            track[JSON_KEY_TIMELINE_TRACK_COLOR].isBool() &&
            track[JSON_KEY_TIMELINE_TRACK_COLOR_RANGE_MIN].isNumber() &&
-           track[JSON_KEY_TIMELINE_TRACK_COLOR_RANGE_MAX].isNumber();
+           track[JSON_KEY_TIMELINE_TRACK_COLOR_RANGE_MAX].isNumber() &&
+           track[JSON_KEY_TRACK_MIN].isBool() && track[JSON_KEY_TRACK_MAX].isBool() &&
+           track[JSON_KEY_TRACK_MEAN].isBool() &&
+           track[JSON_KEY_TRACK_STANDARD_DEVIATION].isBool();
 }
 
 bool
@@ -469,6 +563,23 @@ LineTrackProjectSettings::HighlightRange() const
         static_cast<float>(track[JSON_KEY_TIMELINE_TRACK_COLOR_RANGE_MAX].getNumber()),
         static_cast<float>(track[JSON_KEY_TIMELINE_TRACK_COLOR_RANGE_MIN].getNumber())
     };
+}
+
+std::array<bool, AnalysisTrackStatistics::Counter::kCounterCount>
+LineTrackProjectSettings::ShowAnalysis() const
+{
+    jt::Json& track = m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK]
+                                     [m_track_item.GetID()];
+    std::array<bool, AnalysisTrackStatistics::Counter::kCounterCount> show_analysis;
+    show_analysis[AnalysisTrackStatistics::Counter::kCounterMin] =
+        track[JSON_KEY_TRACK_MIN].getBool();
+    show_analysis[AnalysisTrackStatistics::Counter::kCounterMax] =
+        track[JSON_KEY_TRACK_MAX].getBool();
+    show_analysis[AnalysisTrackStatistics::Counter::kCounterMean] =
+        track[JSON_KEY_TRACK_MEAN].getBool();
+    show_analysis[AnalysisTrackStatistics::Counter::kCounterStandardDeviation] =
+        track[JSON_KEY_TRACK_STANDARD_DEVIATION].getBool();
+    return show_analysis;
 }
 
 LineTrackItem::VerticalLimits::VerticalLimits(std::string field_id)

--- a/src/view/src/rocprofvis_line_track_item.h
+++ b/src/view/src/rocprofvis_line_track_item.h
@@ -3,10 +3,8 @@
 
 #pragma once
 
-#include "rocprofvis_controller_types.h"
 #include "rocprofvis_raw_track_data.h"
 #include "rocprofvis_track_item.h"
-#include "widgets/rocprofvis_widget.h"
 #include "rocprofvis_time_to_pixel.h"
 #include <memory>
 #include "widgets/rocprofvis_editable_textfield.h"
@@ -20,6 +18,7 @@ namespace View
 
 class LineTrackItem;
 class TimePixelTransform;
+class TimelineSelection;
 
 struct HighlightYRange
 {
@@ -38,6 +37,7 @@ public:
     bool            BoxPlotStripes() const;
     bool            Highlight() const;
     HighlightYRange HighlightRange() const;
+    std::array<bool, AnalysisTrackStatistics::Counter::kCounterCount> ShowAnalysis() const;
 
 private:
     LineTrackItem& m_track_item;
@@ -78,11 +78,14 @@ class LineTrackItem : public TrackItem
 
 public:
     LineTrackItem(DataProvider& dp, uint64_t track_id,
-                  std::shared_ptr<TimePixelTransform> time_to_pixel_manager);
+                  std::shared_ptr<TimePixelTransform> time_to_pixel_manager,
+                  std::shared_ptr<TimelineSelection>  timeline_selection);
     ~LineTrackItem();
 
-    bool          ReleaseData() override;
-    virtual float CalculateNewMetaAreaSize() override;
+    void         Update() override;
+    bool         ReleaseData() override;
+    virtual void UpdateMetaScaleAreaSize() override;
+    virtual void UpdateMaxMetaScaleAreaSize() override;
 
 protected:
     virtual void RenderMetaAreaScale() override;
@@ -100,18 +103,23 @@ private:
                                const ImVec2& content_size, double scale_y);
 
     std::vector<TraceCounter> m_data;
-    HighlightYRange                         m_highlight_y_limits;
 
-    VerticalLimits           m_min_y;
-    VerticalLimits           m_max_y;
-    std::string              m_units;
-    bool                     m_highlight_y_range;
-    DataProvider&            m_dp;
-    bool                     m_show_boxplot;
-    bool                     m_show_boxplot_stripes;
+    VerticalLimits m_min_y;
+    VerticalLimits m_max_y;
+    std::string    m_units;
+
+    DataProvider& m_dp;
+    float         m_vertical_padding;
+
+    std::array<Pill*, AnalysisTrackStatistics::Counter::kCounterCount> m_pills_analysis;
+
     LineTrackProjectSettings m_linetrack_project_settings;
-    float                    m_vertical_padding;
- };
+    std::array<bool, AnalysisTrackStatistics::Counter::kCounterCount> m_show_analysis;
+    bool                                                              m_highlight_y_range;
+    HighlightYRange m_highlight_y_limits;
+    bool            m_show_boxplot;
+    bool            m_show_boxplot_stripes;
+};
 
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/rocprofvis_project.cpp
+++ b/src/view/src/rocprofvis_project.cpp
@@ -12,6 +12,8 @@
 #include "widgets/rocprofvis_notification_manager.h"
 #include <fstream>
 
+constexpr const char* PROJECT_VERSION = "1.0";
+
 namespace RocProfVis
 {
 namespace View
@@ -267,12 +269,9 @@ Project::GetSettingsJson()
 bool
 Project::SaveSetttingsJson()
 {
-    bool result     = false;
-    m_settings_json = "";
-    m_settings_json[JSON_KEY_GROUP_GENERAL][JSON_KEY_GENERAL_VERSION] =
-        std::to_string(ROCPROFVIS_VERSION_MAJOR) + "." +
-        std::to_string(ROCPROFVIS_VERSION_MINOR) + "." +
-        std::to_string(ROCPROFVIS_VERSION_PATCH);
+    bool result                                                       = false;
+    m_settings_json                                                   = "";
+    m_settings_json[JSON_KEY_GROUP_GENERAL][JSON_KEY_GENERAL_VERSION] = PROJECT_VERSION;
     m_settings_json[JSON_KEY_GROUP_GENERAL][JSON_KEY_GENERAL_TRACE_PATH] =
         std::filesystem::proximate(
             m_trace_file_path, std::filesystem::path(m_project_file_path).parent_path())

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -149,6 +149,11 @@ constexpr const char* JSON_KEY_TIMELINE_TRACK_COLOR_RANGE_MIN = "color_min";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_COLOR_RANGE_MAX = "color_max";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_BOX_PLOT        = "box_plot";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_STRIPES         = "box_plot_stripes";
+constexpr const char* JSON_KEY_TRACK_MIN                      = "min";
+constexpr const char* JSON_KEY_TRACK_MAX                      = "max";
+constexpr const char* JSON_KEY_TRACK_MEAN                     = "mean";
+constexpr const char* JSON_KEY_TRACK_STANDARD_DEVIATION       = "standard_deviation";
+constexpr const char* JSON_KEY_TRACK_QUEUE_UTILIZATION        = "queue_utilization";
 
 constexpr const char* JSON_KEY_ANNOTATIONS                 = "annotations";
 constexpr const char* JSON_KEY_ANNOTATION_TIME_NS          = "time_ns";

--- a/src/view/src/rocprofvis_requests.h
+++ b/src/view/src/rocprofvis_requests.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "rocprofvis_controller_analysis.h"
 #include "rocprofvis_controller_enums.h"
 #include "rocprofvis_controller_types.h"
 #include "rocprofvis_c_interface_types.h"
@@ -35,7 +36,7 @@ enum class RequestType
     kCleanupDatabase,
     kTableExport,
     kFetchSystemTrace,
-    kFetchAnalysisQueueUtilization,
+    kFetchAnalysisTrackStatistics,
     kFetchAnalysisTopEventsTable,
     kFetchAnalysisTopDispatchEventsTable,
     kFetchAnalysisTopMemoryAllocationEventsTable,
@@ -219,23 +220,30 @@ public:
     {}
 };
 
-// Queue utilization analysis request parameters
-class AnalysisQueueUtilizationRequestParams : public RequestParamsBase
+class AnalysisTrackStatisticsRequestParams : public RequestParamsBase
 {
 public:
+    union Output
+    {
+        double                                   queue_util;
+        rocprofvis_analysis_counter_statistics_t counter_stats;
+    };
+
     uint64_t m_track_id;
     double   m_start_ts;
     double   m_end_ts;
-    double   m_result;
+    Output   m_output;
 
-    AnalysisQueueUtilizationRequestParams(const AnalysisQueueUtilizationRequestParams& other)            = default;
-    AnalysisQueueUtilizationRequestParams& operator=(const AnalysisQueueUtilizationRequestParams& other) = default;
+    AnalysisTrackStatisticsRequestParams(
+        const AnalysisTrackStatisticsRequestParams& other) = default;
+    AnalysisTrackStatisticsRequestParams& operator=(
+        const AnalysisTrackStatisticsRequestParams& other) = default;
 
-    AnalysisQueueUtilizationRequestParams(uint64_t track_id, double start, double end)
+    AnalysisTrackStatisticsRequestParams(uint64_t track_id, double start, double end)
     : m_track_id(track_id)
     , m_start_ts(start)
     , m_end_ts(end)
-    , m_result(0.0)
+    , m_output{}
     {}
 };
 

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -102,7 +102,7 @@ TimelineView::TimelineView(DataProvider&                          dp,
 , m_histogram(nullptr)
 , m_pseudo_focus(false)
 , m_histogram_pseudo_focus(false)
-, m_max_meta_area_size(0.0f)
+, m_max_meta_scale_area_size(0.0f)
 , m_tpt(std::make_shared<TimePixelTransform>())
 , m_dragging_selection_start(false)
 , m_dragging_selection_end(false)
@@ -149,13 +149,12 @@ TimelineView::TimelineView(DataProvider&                          dp,
         (void) e;
         m_recalculate_grid_interval = true;
         m_ruler_height              = ImGui::GetTextLineHeightWithSpacing();
-        CalculateMaxMetaAreaSize();
-        UpdateAllMaxMetaAreaSizes();
+        UpdateMaxMetaAreaSize(true);
         FlameTrackItem::CalculateMaxEventLabelWidth();
-        m_sidebar_size =
-            std::clamp(static_cast<float>(m_sidebar_size),
-                       m_max_meta_area_size + 2 * ImGui::GetFrameHeightWithSpacing(),
-                       SIDEBAR_WIDTH_MAX);
+        m_sidebar_size = std::clamp(static_cast<float>(m_sidebar_size),
+                                    m_max_meta_scale_area_size +
+                                        2 * ImGui::GetFrameHeightWithSpacing(),
+                                    SIDEBAR_WIDTH_MAX);
     };
     m_font_changed_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kFontSizeChanged), font_changed_handler);
@@ -795,6 +794,10 @@ TimelineView::Update()
         }
         m_reorder_request.handled = true;
         m_resize_activity         = false;
+        for(const TrackGraph& track : *m_graphs)
+        {
+            track.chart->Update();
+        }
     }
 }
 
@@ -848,13 +851,13 @@ TimelineView::RenderSplitter()
             m_settings.GetColor(Colors::kAccent));
     }
 
-    if(ImGui::BeginDragDropSource(ImGuiDragDropFlags_None))
+    if(ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceNoPreviewTooltip))
     {
         ImVec2 drag_delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left);
-        m_sidebar_size =
-            std::clamp(m_sidebar_size + drag_delta.x,
-                       m_max_meta_area_size + 2 * ImGui::GetFrameHeightWithSpacing(),
-                       SIDEBAR_WIDTH_MAX);
+        m_sidebar_size    = std::clamp(m_sidebar_size + drag_delta.x,
+                                       m_max_meta_scale_area_size +
+                                           2 * ImGui::GetFrameHeightWithSpacing(),
+                                       SIDEBAR_WIDTH_MAX);
 
         m_tpt->SetViewTimeOffsetNs(
             m_tpt->GetViewTimeOffsetNs() -
@@ -1419,6 +1422,10 @@ TimelineView::RenderTrack(int track_index, bool request_data,
                 RequestDataIfEmpty(track_item, request_data);
                 track_item->RequestAnalysis();
             }
+            else if(track_item->IsSelected())
+            {
+                track_item->RequestAnalysis();
+            }
         }
 
         if(is_visible)
@@ -1534,10 +1541,6 @@ TimelineView::RenderNormalTrack(TrackGraph& track_graph, int track_index,
                          window_flags | ImGuiWindowFlags_NoScrollbar |
                              ImGuiWindowFlags_NoMouseInputs))
     {
-        // call update function (TODO: move this to timeline's update
-        // function?)
-        track_item->Update();
-
         if(is_reordering)
         {
             // Empty space if the track is being reordered
@@ -1803,7 +1806,8 @@ TimelineView::MakeGraphView()
             case kRPVControllerTrackTypeSamples:
             {
                 // Linechart
-                graph.chart = new LineTrackItem(m_data_provider, track_info->id, m_tpt);
+                graph.chart = new LineTrackItem(m_data_provider, track_info->id, m_tpt,
+                                                m_timeline_selection);
                 graph.graph_type = GraphType::TYPE_LINECHART;
                 break;
             }
@@ -1814,7 +1818,6 @@ TimelineView::MakeGraphView()
         }
         if(graph.chart)
         {
-            UpdateMaxMetaAreaSize(graph.chart->GetMetaAreaScaleWidth());
             m_tpt->SetMinMaxX(std::min(track_info->min_ts, m_tpt->GetMinX()),
                               std::max(track_info->max_ts, m_tpt->GetMaxX()));
 
@@ -1823,8 +1826,7 @@ TimelineView::MakeGraphView()
     }
 
     m_data_provider.DataModel().GetTimeline().UpdateHistogram(hidden_tracks, false);
-
-    UpdateAllMaxMetaAreaSizes();
+    UpdateMaxMetaAreaSize();
     m_histogram       = &tlm.GetHistogram();
     m_meta_map_made   = true;
     m_resize_activity = true;
@@ -2864,39 +2866,20 @@ TimelineView::GetArrowLayer()
 }
 
 void
-TimelineView::UpdateMaxMetaAreaSize(float new_size)
+TimelineView::UpdateMaxMetaAreaSize(bool update_tracks)
 {
-    m_max_meta_area_size =
-        new_size > m_max_meta_area_size ? new_size : m_max_meta_area_size;
-}
-
-void
-TimelineView::CalculateMaxMetaAreaSize()
-{
-    m_max_meta_area_size = 0.0f;
-    std::vector<const TrackInfo*> track_list =
-        m_data_provider.DataModel().GetTimeline().GetTrackList();
-
-    for(size_t i = 0; i < track_list.size(); i++)
+    m_max_meta_scale_area_size = 0.0f;
+    for(TrackGraph& track : (*m_graphs))
     {
-        const TrackInfo* track_info = track_list[i];
-        auto             graph      = (*m_graphs)[track_info->index];
-        m_max_meta_area_size =
-            std::max(graph.chart->CalculateNewMetaAreaSize(), m_max_meta_area_size);
-    }
-}
-
-void
-TimelineView::UpdateAllMaxMetaAreaSizes()
-{
-    std::vector<const TrackInfo*> track_list =
-        m_data_provider.DataModel().GetTimeline().GetTrackList();
-
-    for(size_t i = 0; i < track_list.size(); i++)
-    {
-        const TrackInfo* track_info = track_list[i];
-        auto             graph      = (*m_graphs)[track_info->index];
-        graph.chart->UpdateMaxMetaAreaSize(m_max_meta_area_size);
+        if(track.chart)
+        {
+            if(update_tracks)
+            {
+                track.chart->UpdateMaxMetaScaleAreaSize();
+            }
+            m_max_meta_scale_area_size = std::max(track.chart->GetMaxMetaAreaScaleWidth(),
+                                                  m_max_meta_scale_area_size);
+        }
     }
 }
 

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -152,9 +152,7 @@ private:
     void BuildTrackCountLabels();
     void RenderTrackStats(float available_width);
 
-    void UpdateMaxMetaAreaSize(float new_size);
-    void CalculateMaxMetaAreaSize();
-    void UpdateAllMaxMetaAreaSizes();
+    void UpdateMaxMetaAreaSize(bool update_tracks = false);
 
     void RenderTrack(int track_index, bool request_data, ImGuiWindowFlags window_flags,
                      ImVec2 container_size);
@@ -210,7 +208,7 @@ private:
     std::shared_ptr<AnnotationsManager> m_annotations;
     bool                                m_pseudo_focus;
     bool                                m_histogram_pseudo_focus;
-    float                               m_max_meta_area_size;
+    float                               m_max_meta_scale_area_size;
     std::shared_ptr<std::vector<TrackGraph>> m_graphs;
     std::shared_ptr<TimePixelTransform>               m_tpt;
     struct

--- a/src/view/src/rocprofvis_track_details.cpp
+++ b/src/view/src/rocprofvis_track_details.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_track_details.h"
+#include "icons/rocprovfis_icon_defines.h"
+#include "model/rocprofvis_model_types.h"
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_events.h"
 #include "rocprofvis_settings_manager.h"
@@ -15,16 +17,20 @@ namespace RocProfVis
 namespace View
 {
 
+// TrackInfo::TrackType
+constexpr const char* TRACK_PREFIX[] = { "Unknown", "Queue",  "Stream",
+                                         "Thread",  "Thread", "Counter" };
+
 TrackDetails::TrackDetails(DataProvider& dp, std::shared_ptr<TrackTopology> topology,
                            std::shared_ptr<TimelineSelection> timeline_selection)
-: m_data_provider(dp)
-, m_track_topology(topology)
+: m_track_topology(topology)
+, m_data_provider(dp)
 , m_timeline_selection(timeline_selection)
+, m_settings(SettingsManager::GetInstance())
 , m_selection_dirty(false)
-, m_detail_item_id(0)
+, m_data_valid(false)
 , m_topology_changed_event_token(EventManager::InvalidSubscriptionToken)
 , m_track_metadata_changed_event_token(EventManager::InvalidSubscriptionToken)
-, m_data_valid(false)
 {
     auto topology_changed_event_handler = [this](std::shared_ptr<RocEvent> event) {
         if(event)
@@ -69,12 +75,11 @@ TrackDetails::Render()
 {
     if(m_data_valid && !m_selection_dirty && !m_track_topology->Dirty())
     {
-        const SettingsManager& settings = SettingsManager::GetInstance();
-        const ImGuiStyle&      style    = settings.GetDefaultStyle();
+        const ImGuiStyle& style = m_settings.GetDefaultStyle();
         ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, style.ChildRounding);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
-        ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
-        ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kBorderColor));
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, m_settings.GetColor(Colors::kBgPanel));
+        ImGui::PushStyleColor(ImGuiCol_Border, m_settings.GetColor(Colors::kBorderColor));
         ImGui::BeginChild("track_details", ImVec2(0, 0),
                           ImGuiChildFlags_Borders |
                               ImGuiChildFlags_AlwaysUseWindowPadding);
@@ -87,55 +92,109 @@ TrackDetails::Render()
         }
         else
         {
+            ImFont* icons = m_settings.GetFontManager().GetFont(FontType::kIcon);
+            ImGui::PushFont(icons);
+            ImVec2 icon_size = ImGui::CalcTextSize(ICON_CHEVRON_DOWN);
+            ImGui::PopFont();
+            int id = 0;
             for(DetailItem& detail : m_track_details)
             {
-                ImGui::PushID(detail.id);
+                ImGui::PushID(id++);
                 if(ImGui::CollapsingHeader(detail.track_name.c_str(),
                                            ImGuiTreeNodeFlags_DefaultOpen))
                 {
-                    ImGui::TextUnformatted("Node: ");
-                    ImGui::SameLine();
-                    ImGui::TextUnformatted(detail.node->info->host_name.c_str());
-                    RenderTable(detail.node->info_table);
-                    ImGui::TextUnformatted("Process: ");
-                    ImGui::SameLine();
-                    ImGui::TextUnformatted(detail.process->header.c_str());
-                    RenderTable(detail.process->info_table);
-                    if(detail.queue)
+                    if(detail.parents.node || detail.parents.process || detail.track ||
+                       detail.stream_track)
                     {
-                        ImGui::TextUnformatted("Queue: ");
-                        ImGui::SameLine();
-                        ImGui::TextUnformatted(detail.queue->info->name.c_str());
-                        RenderTable(detail.queue->info_table);
+                        ImGui::BeginChild("topology", ImVec2(0.0f, 0.0f),
+                                          ImGuiChildFlags_Borders |
+                                              ImGuiChildFlags_AutoResizeY);
+                        ImGui::BeginGroup();
+                        IconButton(
+                            detail.parents.expand ? ICON_CHEVRON_DOWN
+                                                  : ICON_CHEVRON_RIGHT,
+                            icons,
+                            ImVec2(icon_size.x + style.FramePadding.x * 2.0f,
+                                   icon_size.y + style.FramePadding.y * 2.0f),
+                            nullptr, false, style.FramePadding,
+                            SettingsManager::GetInstance().GetColor(Colors::kTransparent),
+                            SettingsManager::GetInstance().GetColor(
+                                Colors::kButtonHovered),
+                            SettingsManager::GetInstance().GetColor(
+                                Colors::kTransparent));
+                        if(detail.parents.node)
+                        {
+                            ImGui::SameLine();
+                            ImGui::TextUnformatted(
+                                detail.parents.node->info->host_name.c_str());
+                        }
+                        if(detail.parents.process)
+                        {
+                            ImGui::PushFont(icons);
+                            ImGui::SameLine(0.0f, style.ItemSpacing.x);
+                            ImGui::TextUnformatted(ICON_ARROW_FORWARD);
+                            ImGui::PopFont();
+                            ImGui::SameLine(0.0f, style.ItemSpacing.x);
+                            ImGui::TextUnformatted(
+                                detail.parents.process->header.c_str());
+                        }
+                        if(detail.track || detail.stream_track)
+                        {
+                            ImGui::PushFont(icons);
+                            ImGui::SameLine(0.0f, style.ItemSpacing.x);
+                            ImGui::TextUnformatted(ICON_ARROW_FORWARD);
+                            ImGui::PopFont();
+                            ImGui::SameLine(0.0f, style.ItemSpacing.x);
+                            if(detail.track)
+                            {
+                                ImGui::TextUnformatted(detail.track->info->name.c_str());
+                            }
+                            else if(detail.stream_track)
+                            {
+                                ImGui::TextUnformatted(
+                                    detail.stream_track->info->name.c_str());
+                            }
+                        }
+                        ImGui::EndGroup();
+                        if(ImGui::IsItemClicked())
+                        {
+                            detail.parents.expand = !detail.parents.expand;
+                        }
+                        if(detail.parents.expand)
+                        {
+                            if(detail.parents.node)
+                            {
+                                ImGui::Text("Node: %s",
+                                            detail.parents.node->info->host_name.c_str());
+                                RenderTable(detail.parents.node->info_table);
+                            }
+                            if(detail.parents.process)
+                            {
+                                ImGui::Text("Process: %s",
+                                            detail.parents.process->header.c_str());
+                                RenderTable(detail.parents.process->info_table);
+                            }
+                        }
+                        ImGui::EndChild();
                     }
-                    else if(detail.instrumented_thread)
+                    if(detail.track || detail.stream_track)
                     {
-                        ImGui::TextUnformatted("Thread: ");
-                        ImGui::SameLine();
-                        ImGui::TextUnformatted(
-                            detail.instrumented_thread->info->name.c_str());
-                        RenderTable(detail.instrumented_thread->info_table);
-                    }
-                    else if(detail.sampled_thread)
-                    {
-                        ImGui::TextUnformatted("Thread: ");
-                        ImGui::SameLine();
-                        ImGui::TextUnformatted(detail.sampled_thread->info->name.c_str());
-                        RenderTable(detail.sampled_thread->info_table);
-                    }
-                    else if(detail.counter)
-                    {
-                        ImGui::TextUnformatted("Counter: ");
-                        ImGui::SameLine();
-                        ImGui::TextUnformatted(detail.counter->info->name.c_str());
-                        RenderTable(detail.counter->info_table);
-                    }
-                    else if(detail.stream)
-                    {
-                        ImGui::TextUnformatted("Stream: ");
-                        ImGui::SameLine();
-                        ImGui::TextUnformatted(detail.stream->info->name.c_str());
-                        RenderTable(detail.stream->info_table);
+                        ImGui::BeginChild("track", ImVec2(0.0f, 0.0f),
+                                          ImGuiChildFlags_Borders |
+                                              ImGuiChildFlags_AutoResizeY);
+                        if(detail.track)
+                        {
+                            ImGui::Text("%s: %s", TRACK_PREFIX[detail.track_type],
+                                        detail.track->info->name.c_str());
+                            RenderTable(detail.track->info_table, detail.stats);
+                        }
+                        else if(detail.stream_track)
+                        {
+                            ImGui::Text("%s: %s", TRACK_PREFIX[detail.track_type],
+                                        detail.stream_track->info->name.c_str());
+                            RenderTable(detail.stream_track->info_table, detail.stats);
+                        }
+                        ImGui::EndChild();
                     }
                 }
                 ImGui::PopID();
@@ -162,26 +221,26 @@ TrackDetails::Update()
             {
                 item.track_name =
                     m_data_provider.DataModel().BuildTrackName(item.track_id);
-
-                const uint64_t& node_id    = metadata->topology.node_id;
-                const uint64_t& process_id = metadata->topology.process_id;
+                item.track_type              = metadata->topology.type;
+                const uint64_t& node_id      = metadata->topology.node_id;
+                const uint64_t& process_id   = metadata->topology.process_id;
                 const uint64_t& processor_id = metadata->topology.device_id;
-                const uint64_t& type_id    = metadata->topology.id.value;
+                const uint64_t& type_id      = metadata->topology.id.value;
                 if(topology.node_lut.count(node_id) > 0)
                 {
-                    NodeModel& node = *topology.node_lut.at(node_id);
-                    item.node       = &node;
+                    NodeModel& node   = *topology.node_lut.at(node_id);
+                    item.parents.node = &node;
                     if(node.process_lut.count(process_id) > 0)
                     {
                         ProcessModel& process = *node.process_lut.at(process_id);
-                        item.process          = &process;
+                        item.parents.process  = &process;
                         switch(metadata->topology.type)
                         {
                             case TrackInfo::TrackType::InstrumentedThread:
                             {
                                 if(process.instrumented_thread_lut.count(type_id) > 0)
                                 {
-                                    item.instrumented_thread =
+                                    item.track =
                                         process.instrumented_thread_lut.at(type_id);
                                 }
                                 break;
@@ -190,8 +249,7 @@ TrackDetails::Update()
                             {
                                 if(process.sampled_thread_lut.count(type_id) > 0)
                                 {
-                                    item.sampled_thread =
-                                        process.sampled_thread_lut.at(type_id);
+                                    item.track = process.sampled_thread_lut.at(type_id);
                                 }
                                 break;
                             }
@@ -199,7 +257,7 @@ TrackDetails::Update()
                             {
                                 if(process.stream_lut.count(type_id) > 0)
                                 {
-                                    item.stream = process.stream_lut.at(type_id);
+                                    item.stream_track = process.stream_lut.at(type_id);
                                 }
                                 break;
                             }
@@ -208,14 +266,13 @@ TrackDetails::Update()
                     if(node.processor_lut.count(processor_id) > 0)
                     {
                         ProcessorModel& processor = *node.processor_lut.at(processor_id);
-                        item.processor          = &processor;
                         switch(metadata->topology.type)
                         {
                             case TrackInfo::TrackType::Queue:
                             {
                                 if(processor.queue_lut.count(type_id) > 0)
                                 {
-                                    item.queue = processor.queue_lut.at(type_id);
+                                    item.track = processor.queue_lut.at(type_id);
                                 }
                                 break;
                             }
@@ -223,13 +280,15 @@ TrackDetails::Update()
                             {
                                 if(processor.counter_lut.count(type_id) > 0)
                                 {
-                                    item.counter = processor.counter_lut.at(type_id);
+                                    item.track = processor.counter_lut.at(type_id);
                                 }
                                 break;
                             }
                         }
                     }
                 }
+                item.stats =
+                    m_data_provider.DataModel().GetAnalysis().RegisterTrack(*metadata);
             }
             else
             {
@@ -246,16 +305,23 @@ TrackDetails::Update()
 }
 
 void
-TrackDetails::RenderTable(InfoTable& table)
+TrackDetails::RenderTable(InfoTable& table, const AnalysisTrackStatistics* stats)
 {
-    if(!table.cells.empty() && !table.cells[0].empty())
+    if((!table.cells.empty() && table.cells[0].size() == 2) || stats)
     {
-        const int& rows = static_cast<int>(table.cells.size());
-        const int& cols = static_cast<int>(table.cells[0].size());
+        SettingsManager& settings = SettingsManager::GetInstance();
+        const int        rows     = static_cast<int>(table.cells.size());
+        const int        cols =
+            table.cells.empty() ? 2 : static_cast<int>(table.cells[0].size());
 
         float table_x_min = ImGui::GetCursorScreenPos().x;
         float table_width = ImGui::GetContentRegionAvail().x;
         float table_x_max = table_x_min + table_width;
+
+        ImGui::PushStyleColor(ImGuiCol_TableRowBg,
+                              settings.GetColor(Colors::kFillerColor));
+        ImGui::PushStyleColor(ImGuiCol_TableRowBgAlt,
+                              settings.GetColor(Colors::kFillerColor));
         if(ImGui::BeginTable("", cols,
                              ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersOuter |
                                  ImGuiTableFlags_BordersV |
@@ -330,8 +396,46 @@ TrackDetails::RenderTable(InfoTable& table)
                 }
                 ImGui::PopID();
             }
+            if(stats)
+            {
+                ImGui::TableNextRow();
+                switch(stats->track->topology.type)
+                {
+                    case TrackInfo::TrackType::Queue:
+                    {
+                        for(size_t i = 0; i < AnalysisTrackStatistics::Queue::kQueueCount;
+                            i++)
+                        {
+                            ImGui::TableNextColumn();
+                            ImGui::TextUnformatted(stats->stats[i].name);
+                            ImGui::TableNextColumn();
+                            ImGui::BeginDisabled(stats->state !=
+                                                 AnalysisTrackStatistics::kReady);
+                            ImGui::Text("%.1f", stats->stats[i].value);
+                            ImGui::EndDisabled();
+                        }
+                        break;
+                    }
+                    case TrackInfo::TrackType::Counter:
+                    {
+                        for(size_t i = 0;
+                            i < AnalysisTrackStatistics::Counter::kCounterCount; i++)
+                        {
+                            ImGui::TableNextColumn();
+                            ImGui::TextUnformatted(stats->stats[i].name);
+                            ImGui::TableNextColumn();
+                            ImGui::BeginDisabled(stats->state !=
+                                                 AnalysisTrackStatistics::kReady);
+                            ImGui::Text("%.1f", stats->stats[i].value);
+                            ImGui::EndDisabled();
+                        }
+                        break;
+                    }
+                }
+            }
             ImGui::EndTable();
         }
+        ImGui::PopStyleColor(2);
     }
 }
 
@@ -340,9 +444,7 @@ TrackDetails::HandleTrackSelectionChanged(const uint64_t track_id, const bool se
 {
     if(selected)
     {
-        m_track_details.emplace_front(DetailItem{ m_detail_item_id++, track_id, "",
-                                                  nullptr, nullptr, nullptr, nullptr,
-                                                  nullptr, nullptr, nullptr });
+        m_track_details.emplace_front(DetailItem{ track_id });
     }
     else if(track_id == TimelineSelection::INVALID_SELECTION_ID)
     {
@@ -350,8 +452,7 @@ TrackDetails::HandleTrackSelectionChanged(const uint64_t track_id, const bool se
     }
     else
     {
-        m_track_details.remove(DetailItem{ 0, track_id, "", nullptr, nullptr, nullptr,
-                                           nullptr, nullptr, nullptr, nullptr });
+        m_track_details.remove(DetailItem{ track_id });
     }
     m_selection_dirty = true;
 }

--- a/src/view/src/rocprofvis_track_details.h
+++ b/src/view/src/rocprofvis_track_details.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include "model/rocprofvis_model_types.h"
 #include "rocprofvis_event_manager.h"
 #include "widgets/rocprofvis_widget.h"
 #include <list>
@@ -13,13 +14,14 @@ namespace View
 {
 
 class DataProvider;
+class SettingsManager;
 class TrackTopology;
+class TimelineSelection;
 struct NodeModel;
 struct ProcessModel;
 struct ProcessorModel;
 struct IterableModel;
 struct StreamModel;
-class TimelineSelection;
 struct InfoTable;
 
 class TrackDetails : public RocWidget
@@ -36,17 +38,20 @@ public:
 private:
     struct DetailItem
     {
-        const int          id;
-        const uint64_t     track_id;
-        std::string        track_name;
-        NodeModel*         node;
-        ProcessModel*      process;
-        ProcessorModel*    processor;
-        IterableModel*     queue;
-        IterableModel*     instrumented_thread;
-        IterableModel*     sampled_thread;
-        IterableModel*     counter;
-        StreamModel*       stream;
+        struct Parents
+        {
+            NodeModel*    node;
+            ProcessModel* process;
+            bool          expand;
+        };
+
+        const uint64_t                 track_id;
+        TrackInfo::TrackType           track_type;
+        std::string                    track_name;
+        Parents                        parents;
+        IterableModel*                 track;
+        StreamModel*                   stream_track;
+        const AnalysisTrackStatistics* stats;
 
         bool operator==(const DetailItem& other) const
         {
@@ -54,14 +59,14 @@ private:
         }
     };
 
-    void RenderTable(InfoTable& table);
+    void RenderTable(InfoTable& table, const AnalysisTrackStatistics* = nullptr);
 
     std::shared_ptr<TrackTopology>     m_track_topology;
     DataProvider&                      m_data_provider;
     std::shared_ptr<TimelineSelection> m_timeline_selection;
+    SettingsManager&                   m_settings;
     bool                               m_selection_dirty;
     std::list<DetailItem>              m_track_details;
-    int                                m_detail_item_id;
     bool                               m_data_valid;
 
     EventManager::SubscriptionToken m_topology_changed_event_token;

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -5,6 +5,7 @@
 #include "icons/rocprovfis_icon_defines.h"
 #include "rocprofvis_font_manager.h"
 #include "rocprofvis_settings_manager.h"
+#include "rocprofvis_timeline_selection.h"
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_gui_helpers.h"
@@ -30,31 +31,34 @@ constexpr const char*     TRACK_COPY_MENU_POPUP_NAME     = "TrackCopyMenu";
 float TrackItem::s_metadata_width = 400.0f;
 
 TrackItem::TrackItem(DataProvider& dp, uint64_t id,
-                     std::shared_ptr<TimePixelTransform> tpt)
-: m_data_provider(dp)
-, m_track_metadata(nullptr)
+                     std::shared_ptr<TimePixelTransform> tpt,
+                     std::shared_ptr<TimelineSelection>  timeline_selection)
+: m_track_metadata(nullptr)
+, m_track_statistics(nullptr)
+, m_track_statistics_dirty(false)
 , m_track_id(id)
 , m_track_height(DEFAULT_TRACK_HEIGHT)
 , m_track_content_height(0.0f)
 , m_min_track_height(DEFAULT_MIN_TRACK_HEIGHT)
+, m_track_height_changed(false)
 , m_is_in_view_vertical(false)
+, m_distance_to_view_y(0.0f)
 , m_metadata_padding(ImVec2(8.0f, 5.0f))
 , m_resize_grip_thickness(4.0f)
+, m_data_provider(dp)
 , m_request_state(TrackDataRequestState::kIdle)
-, m_track_height_changed(false)
+, m_settings(SettingsManager::GetInstance())
 , m_meta_area_clicked(false)
 , m_meta_area_scale_width(0.0f)
-, m_settings(SettingsManager::GetInstance())
+, m_max_meta_area_scale_width(0.0f)
 , m_selected(false)
 , m_reorder_grip_width(DEFAULT_GRIP_WIDTH)
-, m_group_id_counter(0)
+, m_tpt(tpt)
+, m_timeline_selection(timeline_selection)
 , m_chunk_duration_ns(DEFAULT_CHUNK_DURATION)
-, m_tpt(tpt)  
-, m_track_project_settings(m_data_provider.GetTraceFilePath(), *this)
+, m_group_id_counter(0)
 , m_meta_area_label("")
-, m_pill("", false, false)
-, m_distance_to_view_y(0.0f)
-, m_analysis_request_pending(false)
+, m_track_project_settings(m_data_provider.GetTraceFilePath(), *this)
 {
     if(m_track_project_settings.Valid())
     {
@@ -181,17 +185,15 @@ TrackItem::GetReorderGripWidth()
 }
 
 void
-TrackItem::UpdateMaxMetaAreaSize(float new_size)
+TrackItem::UpdateMetaScaleAreaSize()
 {
-    m_meta_area_scale_width = m_meta_area_scale_width == 0.0
-                                  ? 0.0
-                                  : std::max(CalculateNewMetaAreaSize(), new_size);
+    // no-op;
 }
 
-float
-TrackItem::CalculateNewMetaAreaSize()
+void
+TrackItem::UpdateMaxMetaScaleAreaSize()
 {
-    return m_meta_area_scale_width;
+    // no-op;
 }
 
 void
@@ -203,13 +205,6 @@ TrackItem::RenderMetaAreaExpand()
 void
 TrackItem::RenderMetaAreaScale()
 {
-    // no-op
-}
-
-void
-TrackItem::RenderSecondaryMetaPill(const ImVec2& content_size)
-{
-    (void) content_size;
     // no-op
 }
 
@@ -299,16 +294,11 @@ TrackItem::RenderMetaArea()
         //     }
         // }
 
+        UpdateMetaScaleAreaSize();
         float available_for_text =
             content_size.x - m_meta_area_scale_width - m_reorder_grip_width;
 
-        ImVec2 text_size = ImGui::CalcTextSize(m_meta_area_label.c_str());
-
-        if(available_for_text < m_pill.GetPillSize().x ||
-           content_size.y - text_size.y < m_pill.GetPillSize().y)
-            m_pill.Hide();
-        else
-            m_pill.Show();
+        ImVec2 track_name_size = ImGui::CalcTextSize(m_meta_area_label.c_str());
 
         ImGui::BeginGroup();
         ImGui::PushStyleColor(ImGuiCol_Text, m_settings.GetColor(Colors::kTextMain));
@@ -319,11 +309,12 @@ TrackItem::RenderMetaArea()
             ElidedText(m_meta_area_label.c_str(), available_for_text);
             ImGui::PopID();
 
-            const float  label_width = std::min(text_size.x, available_for_text);
-            const ImVec2 hit_padding(NAME_LABEL_HITBOX_PADDING_X, NAME_LABEL_HITBOX_PADDING_Y);
+            const float  label_width = std::min(track_name_size.x, available_for_text);
+            const ImVec2 hit_padding(NAME_LABEL_HITBOX_PADDING_X,
+                                     NAME_LABEL_HITBOX_PADDING_Y);
             name_label_min = label_start - hit_padding;
             name_label_max = ImVec2(label_start.x + label_width + hit_padding.x,
-                                    label_start.y + text_size.y + hit_padding.y);
+                                    label_start.y + track_name_size.y + hit_padding.y);
             name_label_visible = true;
         }
         ImGui::PopStyleColor();
@@ -331,9 +322,7 @@ TrackItem::RenderMetaArea()
 
         RenderMetaAreaScale();
         RenderMetaAreaExpand();
-
-        m_pill.RenderPillLabel(content_size, m_settings, m_reorder_grip_width);
-        RenderSecondaryMetaPill(content_size);
+        RenderPills(ImVec2(available_for_text, content_size.y));
     }
     ImGui::EndChild();  // end metadata area
 
@@ -355,10 +344,7 @@ TrackItem::RenderMetaArea()
         m_meta_area_clicked = false;
     }
 
-    const bool meta_area_hovered = ImGui::IsItemHovered() &&
-                                   !ImGui::IsAnyItemHovered() &&
-                                   !m_pill.WasLastHovered();
-
+    const bool meta_area_hovered = ImGui::IsItemHovered() && !ImGui::IsAnyItemHovered();
     const bool name_label_hovered =
         name_label_visible && ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows) &&
         ImGui::IsMouseHoveringRect(name_label_min, name_label_max);
@@ -401,7 +387,9 @@ TrackItem::RenderMetaArea()
         ImGui::Separator();
         if(IconBeginMenu(ICON_GEAR, "Track Options"))
         {
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0.0f, 0.0f));
             RenderMetaAreaOptions();
+            ImGui::PopStyleVar();
             ImGui::EndMenu();
         }
         ImGui::EndPopup();
@@ -509,9 +497,20 @@ TrackItem::Update()
             FetchHelper();
         }
     }
-    if(m_analysis_request_pending)
+    if(m_track_statistics)
     {
-        RequestAnalysis();
+        if(m_track_statistics->state == AnalysisTrackStatistics::kPending)
+        {
+            RequestAnalysis();
+        }
+        if(m_track_statistics->state < AnalysisTrackStatistics::kReady)
+        {
+            m_track_statistics_dirty = true;
+        }
+        else
+        {
+            m_track_statistics_dirty = false;
+        }
     }
 }
 
@@ -555,31 +554,28 @@ TrackItem::SetDefaultPillLabel(const TrackInfo* track_info)
     {
         tdm.GetDeviceTypeLabel(*device_info, device_type_label);
     }
-
+    Pill* pill = AddPill(true, false);
     switch(track_info->topology.type)
     {
         case TrackInfo::TrackType::Queue:
         {
             std::string pill_label =
                 "QUEUE" + (device_type_label.empty() ? "" : " " + device_type_label);
-            m_pill.Show();
-            m_pill.SetLabel(pill_label);
+            pill->SetLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::Stream:
         {
             std::string pill_label =
                 "STREAM" + (device_type_label.empty() ? "" : " " + device_type_label);
-            m_pill.Show();
-            m_pill.SetLabel(pill_label);
+            pill->SetLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::Counter:
         {
             std::string pill_label =
                 "COUNTER" + (device_type_label.empty() ? "" : " " + device_type_label);
-            m_pill.Show();
-            m_pill.SetLabel(pill_label);
+            pill->SetLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::InstrumentedThread:
@@ -588,26 +584,23 @@ TrackItem::SetDefaultPillLabel(const TrackInfo* track_info)
                    tdm.GetInstrumentedThread(track_info->topology.id.value);
                thread_info && thread_info->tid == track_info->topology.process_id)
             {
-                m_pill.Show();
-                m_pill.Activate();
-                m_pill.SetLabel("MAIN THREAD");
+                pill->Activate();
+                pill->SetLabel("MAIN THREAD");
             }
             else
             {
-                m_pill.Show();
-                m_pill.SetLabel("THREAD");
+                pill->SetLabel("THREAD");
             }
             break;
         }
         case TrackInfo::TrackType::SampledThread:
         {
-            m_pill.Show();
-            m_pill.SetLabel("SAMPLED THREAD");
+            pill->SetLabel("SAMPLED THREAD");
             break;
         }
         default:
         {
-            m_pill.Hide();
+            pill->SetVisible(false);
             break;
         }
     }
@@ -622,7 +615,7 @@ TrackItem::SetDefaultPillLabel(const TrackInfo* track_info)
             // Get product label from topology model, ex: "AMD Radeon RX 6800 XT"
             if(device_info)
             {
-                m_pill.SetTooltipLabel(device_info->product_name);
+                pill->SetTooltip(device_info->product_name);
             }
             break;
         }
@@ -780,6 +773,13 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
     }
 }
 
+Pill*
+TrackItem::AddPill(bool shown, bool active)
+{
+    m_pills.emplace_back(std::make_unique<Pill>(shown, active));
+    return m_pills.back().get();
+}
+
 bool
 TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
 {
@@ -838,7 +838,100 @@ TrackItem::HasPendingRequests() const
 void
 TrackItem::RequestAnalysis()
 {
-    // no op
+    if(m_track_statistics && m_timeline_selection &&
+       (m_track_statistics->state == AnalysisTrackStatistics::kStale ||
+        m_track_statistics->state == AnalysisTrackStatistics::kPending))
+    {
+        uint64_t request_id = RequestIdBuilder::MakeTrackDataRequestId(
+            static_cast<uint32_t>(m_track_id), 0, 0,
+            RequestType::kFetchAnalysisTrackStatistics);
+        if(m_data_provider.IsRequestPending(request_id))
+        {
+            m_data_provider.CancelRequest(request_id);
+            m_track_statistics->state = AnalysisTrackStatistics::kPending;
+        }
+        else
+        {
+            double start_ts;
+            double end_ts;
+            if(m_timeline_selection->HasValidTimeRangeSelection())
+            {
+                m_timeline_selection->GetSelectedTimeRange(start_ts, end_ts);
+            }
+            else
+            {
+                start_ts = m_tpt->GetVMinX();
+                end_ts   = m_tpt->GetVMaxX();
+            }
+            m_track_statistics->state =
+                (start_ts < end_ts &&
+                 m_data_provider.FetchAnalysisTrackStatistics(
+                     AnalysisTrackStatisticsRequestParams(m_track_id, start_ts, end_ts)))
+                    ? AnalysisTrackStatistics::kRequested
+                    : AnalysisTrackStatistics::kPending;
+        }
+    }
+}
+
+void
+TrackItem::RenderPills(ImVec2 region)
+{
+    if(!m_pills.empty() &&
+       region.y - ImGui::GetFrameHeightWithSpacing() >= m_pills[0]->Size().y)
+    {
+        float   pill_x_pos     = 0;
+        uint8_t pills_visible  = 0;
+        uint8_t pills_extended = 0;
+        for(size_t i = 0; i < m_pills.size(); i++)
+        {
+            if(m_pills[i]->Visible())
+            {
+                pills_visible++;
+                if(pill_x_pos + m_pills[i]->ExtSize().x < region.x)
+                {
+                    pills_extended++;
+                    pill_x_pos += m_pills[i]->ExtSize().x +
+                                  m_settings.GetDefaultStyle().ItemSpacing.x;
+                }
+            }
+        }
+        pill_x_pos = m_reorder_grip_width;
+        for(size_t i = 0; i < m_pills.size(); i++)
+        {
+            if(m_pills[i]->Visible())
+            {
+                if(pills_visible == pills_extended)
+                {
+                    m_pills[i]->Render(
+                        ImVec2(pill_x_pos, region.y - m_pills[i]->Size().y), m_settings,
+                        Pill::kExtended);
+                    pill_x_pos +=
+                        m_pills[i]->Size().x + m_settings.GetDefaultStyle().ItemSpacing.x;
+                }
+                else if(pill_x_pos + m_pills[i]->CompactSize().x <
+                        region.x + m_reorder_grip_width)
+                {
+                    m_pills[i]->Render(
+                        ImVec2(pill_x_pos, region.y - m_pills[i]->Size().y), m_settings,
+                        Pill::kCompact);
+                    pill_x_pos +=
+                        m_pills[i]->Size().x + m_settings.GetDefaultStyle().ItemSpacing.x;
+                }
+                else if(pill_x_pos + m_pills[i]->ElidedSize().x <
+                        region.x + m_reorder_grip_width)
+                {
+                    m_pills[i]->Render(
+                        ImVec2(pill_x_pos, region.y - m_pills[i]->Size().y), m_settings,
+                        Pill::kElided);
+                    break;
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+    }
 }
 
 TrackProjectSettings::TrackProjectSettings(const std::string& project_id,
@@ -874,17 +967,23 @@ TrackProjectSettings::Height() const
                            .getNumber());
 }
 
-Pill::Pill(const std::string& label, bool shown, bool active)
-: m_pill_label(label)
-, m_show_pill_label(shown)
+Pill::Pill(bool shown, bool active)
+: m_show_pill_label(shown)
 , m_active(active)
+, m_accent_color(std::nullopt)
+, m_sizing(kCompact)
+, m_compact_label("")
+, m_ext_label("")
+, m_tooltip("")
+, m_widths({})
+, m_height(0.0f)
 , m_font_changed_token(EventManager::InvalidSubscriptionToken)
 {
-    CalculatePillSize();
+    CalculateSize();
 
     auto font_changed_handler = [this](std::shared_ptr<RocEvent> e) {
         (void) e;
-        CalculatePillSize();
+        CalculateSize();
     };
     m_font_changed_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kFontSizeChanged), font_changed_handler);
@@ -897,16 +996,34 @@ Pill::~Pill()
 }
 
 void
-Pill::SetLabel(const std::string& label)
+Pill::SetLabel(const std::string& label, Sizing sizing)
 {
-    m_pill_label = label;
-    CalculatePillSize();
+    switch(sizing)
+    {
+        case kCompact:
+        {
+            m_compact_label = label;
+            break;
+        }
+        case kExtended:
+        {
+            m_ext_label = label;
+            break;
+        }
+    }
+    CalculateSize();
 }
 
 void
-Pill::SetTooltipLabel(std::string label)
+Pill::SetTooltip(std::string label)
 {
-    m_tooltip_label = label;
+    m_tooltip = label;
+}
+
+void
+Pill::SetAccentColor(size_t accent_color)
+{
+    m_accent_color = accent_color;
 }
 
 void
@@ -921,87 +1038,116 @@ Pill::Deactivate()
     m_active = false;
 }
 
-void
-Pill::Show()
+ImVec2
+Pill::Size()
 {
-    m_show_pill_label = true;
+    return ImVec2(m_widths[m_sizing], m_height);
+}
+
+ImVec2
+Pill::CompactSize()
+{
+    return ImVec2(m_widths[kCompact], m_height);
+}
+
+ImVec2
+Pill::ExtSize()
+{
+    return ImVec2(m_widths[kExtended], m_height);
+}
+
+ImVec2
+Pill::ElidedSize()
+{
+    return ImVec2(m_widths[kElided], m_height);
+}
+
+bool
+Pill::Visible() const
+{
+    return m_show_pill_label;
 }
 
 void
-Pill::Hide()
+Pill::SetVisible(bool visible)
 {
-    m_show_pill_label = false;
+    m_show_pill_label = visible;
 }
 
 void
-Pill::RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
-                      float reorder_grip_width)
-{
-    ImVec2 pillbox_pos(reorder_grip_width, container_size.y - m_pillbox_size.y - 2.0f);
-    RenderPillLabelAt(pillbox_pos, settings);
-}
-
-void
-Pill::RenderPillLabelAt(ImVec2 pillbox_pos, SettingsManager& settings)
+Pill::Render(const ImVec2& pos, SettingsManager& settings, Sizing sizing)
 {
     if(m_show_pill_label == false)
     {
-        m_was_last_hovered = false;
         return;
+    }
+    m_sizing = sizing;
+    if(m_sizing == kExtended && m_ext_label.empty())
+    {
+        m_sizing = kCompact;
     }
     ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kDefault),
                     settings.GetFontManager().GetFontSize(FontSize::kSmall));
 
-    if (m_active)
+    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    ImVec2      win_pos   = ImGui::GetWindowPos();
+    if(m_active)
     {
-        ImDrawList* draw_list     = ImGui::GetWindowDrawList();
-        ImU32       pillbox_color = settings.GetColor(Colors::kBgFrame);
-        ImVec2      win_pos       = ImGui::GetWindowPos();
-        draw_list->AddRectFilled(win_pos + pillbox_pos,
-                                 win_pos + pillbox_pos + m_pillbox_size,
-                                 pillbox_color, m_pillbox_size.y * 0.5f);
-        draw_list->AddRect(win_pos + pillbox_pos,
-                           win_pos + pillbox_pos + m_pillbox_size,
-                           settings.GetColor(Colors::kBorderGray),
-                           m_pillbox_size.y * 0.5f, 0, 1.0f);
+        draw_list->AddRectFilled(win_pos + pos, win_pos + pos + Size(),
+                                 settings.GetColor(Colors::kBgFrame), m_height * 0.5f);
         ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextMain));
     }
     else
     {
-        ImDrawList* draw_list     = ImGui::GetWindowDrawList();
-        ImVec2      win_pos       = ImGui::GetWindowPos();
-        draw_list->AddRectFilled(win_pos + pillbox_pos,
-                                 win_pos + pillbox_pos + m_pillbox_size,
+        draw_list->AddRectFilled(win_pos + pos, win_pos + pos + Size(),
                                  settings.GetColor(Colors::kMetaDataColorSelected),
-                                 m_pillbox_size.y * 0.5f);
+                                 m_height * 0.5f);
         ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
     }
+    draw_list->AddRect(win_pos + pos, win_pos + pos + Size(),
+                       m_accent_color ? settings.GetColorWheel()[m_accent_color.value()]
+                                      : settings.GetColor(Colors::kTextDim),
+                       m_height * 0.5f, 0, 1.0f);
 
-    ImVec2 text_pos = pillbox_pos + ImVec2(m_padding_x, m_padding_y);
+    ImVec2 text_pos = pos + ImVec2(m_padding_x, m_padding_y);
     ImGui::SetCursorPos(text_pos);
-    ImGui::TextUnformatted(m_pill_label.c_str());
-    m_was_last_hovered =
-        ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled);
-    if(!m_tooltip_label.empty() && m_was_last_hovered)
+    switch(m_sizing)
     {
-        SetTooltipStyled("%s", m_tooltip_label.c_str());
+        case kElided:
+        {
+            ImGui::TextUnformatted("...");
+            break;
+        }
+        case kCompact:
+        {
+            ImGui::TextUnformatted(m_compact_label.c_str());
+            break;
+        }
+        case kExtended:
+        {
+            ImGui::TextUnformatted(m_ext_label.c_str());
+            break;
+        }
+    }
+    if(!m_tooltip.empty() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+    {
+        SetTooltipStyled("%s", m_tooltip.c_str());
     }
     ImGui::PopStyleColor();
 
     ImGui::PopFont();
 }
 
-ImVec2
-Pill::GetPillSize()
-{
-    return m_pillbox_size;
-}
-
 void
-Pill::CalculatePillSize()
+Pill::CalculateSize()
 {
-    ImVec2 text_size = ImGui::CalcTextSize(m_pill_label.c_str());
-    m_pillbox_size = ImVec2(text_size.x + 2 * m_padding_x, text_size.y + 2 * m_padding_y);
+    m_widths[kElided]  = ImGui::CalcTextSize("...").x + 2 * m_padding_x;
+    m_widths[kCompact] = ImGui::CalcTextSize(m_compact_label.c_str()).x + 2 * m_padding_x;
+    m_widths[kExtended] =
+        m_ext_label.empty()
+            ? m_widths[kCompact]
+            : ImGui::CalcTextSize(m_ext_label.c_str()).x + 2 * m_padding_x;
+    m_height = ImGui::GetTextLineHeight() + 2 * m_padding_y;
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -21,6 +21,7 @@ inline constexpr float DEFAULT_TRACK_HEIGHT = 75.0f;
 class SettingsManager;
 class TrackItem;
 class TimePixelTransform;
+class TimelineSelection;
 
 enum class TrackDataRequestState
 {
@@ -47,41 +48,51 @@ private:
 class Pill
 {
 public:
-    Pill(const std::string& label, bool shown, bool active);
+    enum Sizing : size_t
+    {
+        kElided,
+        kCompact,
+        kExtended,
+        kCount
+    };
+
+    Pill(bool shown, bool active);
     ~Pill();
-    void SetLabel(const std::string& label);
-    void SetTooltipLabel(std::string label);
-    void Activate();
-    void Deactivate();
-    void Show();
-    void Hide();
-    void RenderPillLabel(ImVec2 container_size, SettingsManager& settings,
-                         float reorder_grip_width);
-    // Render the pill at an explicit window-local top-left position. Lets callers
-    // place a pill somewhere other than the default bottom-left meta-area slot.
-    void RenderPillLabelAt(ImVec2 pillbox_pos, SettingsManager& settings);
-    ImVec2 GetPillSize();
-    bool   WasLastHovered() const { return m_was_last_hovered; }
-    bool   IsShown() const { return m_show_pill_label; }
+
+    void   SetLabel(const std::string& label, Sizing sizing = kCompact);
+    void   SetTooltip(std::string label);
+    void   SetAccentColor(size_t accent_color);
+    void   Activate();
+    void   Deactivate();
+    void   Render(const ImVec2& pos, SettingsManager& settings, Sizing sizing = kCompact);
+    ImVec2 Size();
+    ImVec2 CompactSize();
+    ImVec2 ExtSize();
+    ImVec2 ElidedSize();
+    bool   Visible() const;
+    void   SetVisible(bool visible);
 
 private:
-    void                            CalculatePillSize();
-    bool                            m_show_pill_label;
-    bool                            m_active;
-    bool                            m_was_last_hovered = false;
-    std::string                     m_pill_label;
-    std::string                     m_tooltip_label;
-    ImVec2                          m_pillbox_size;
-    const float                     m_padding_x = 8.0f;
-    const float                     m_padding_y = 2.0f;
-    EventManager::SubscriptionToken m_font_changed_token;
+    void                              CalculateSize();
+    bool                              m_show_pill_label;
+    bool                              m_active;
+    std::optional<size_t>             m_accent_color;
+    Sizing                            m_sizing;
+    std::string                       m_compact_label;
+    std::string                       m_ext_label;
+    std::string                       m_tooltip;
+    std::array<float, Sizing::kCount> m_widths;
+    float                             m_height;
+    const float                       m_padding_x = 8.0f;
+    const float                       m_padding_y = 2.0f;
+    EventManager::SubscriptionToken   m_font_changed_token;
 };
 
 class TrackItem
 {
 public:
-    TrackItem(DataProvider& dp, uint64_t id,
-              std::shared_ptr<TimePixelTransform> tpt);
+    TrackItem(DataProvider& dp, uint64_t id, std::shared_ptr<TimePixelTransform> tpt,
+              std::shared_ptr<TimelineSelection> timeline_selection = nullptr);
     virtual ~TrackItem() {}
     void               SetID(uint64_t id);
     uint64_t           GetID();
@@ -101,14 +112,15 @@ public:
     bool        TrackHeightChanged();
     static void SetSidebarSize(float sidebar_size);
 
-    virtual bool  HasData();
-    virtual bool  ReleaseData();
-    virtual void  RequestData(double min, double max, float width);
-    virtual void  RequestAnalysis();
-    virtual bool  HandleTrackDataChanged(uint64_t request_id, uint64_t response_code);
-    virtual bool  HasPendingRequests() const;
-    virtual float CalculateNewMetaAreaSize();
-    virtual bool  IsCompactMode() const { return false; }
+    virtual bool HasData();
+    virtual bool ReleaseData();
+    virtual void RequestData(double min, double max, float width);
+    void         RequestAnalysis();
+    virtual bool HandleTrackDataChanged(uint64_t request_id, uint64_t response_code);
+    virtual bool HasPendingRequests() const;
+    virtual void UpdateMetaScaleAreaSize();
+    virtual void UpdateMaxMetaScaleAreaSize();
+    virtual bool IsCompactMode() const { return false; }
 
     TrackDataRequestState GetRequestState() const { return m_request_state; }
 
@@ -116,26 +128,25 @@ public:
 
     float GetReorderGripWidth();
 
-    float GetMetaAreaScaleWidth() { return m_meta_area_scale_width; }
-    void  UpdateMaxMetaAreaSize(float newSize);
+    float GetMaxMetaAreaScaleWidth() { return m_max_meta_area_scale_width; }
 
 protected:
     virtual void RenderMetaArea();
     virtual void RenderMetaAreaScale();
     virtual void RenderMetaAreaOptions()        = 0;
     virtual void RenderMetaAreaExpand();
-    // Optional hook to render an extra pill beside the primary meta-area pill.
-    // Called right after the primary pill so subclasses share its bottom row.
-    virtual void RenderSecondaryMetaPill(const ImVec2& content_size);
     virtual void RenderChart(float graph_width) = 0;
     virtual void RenderResizeBar(const ImVec2& parent_size);
     virtual bool ExtractPointsFromData() = 0;
 
-    void FetchHelper();
-    void SetDefaultPillLabel(const TrackInfo* track_info);
-    void SetMetaAreaLabel(const TrackInfo* track_info);
+    void  FetchHelper();
+    void  SetDefaultPillLabel(const TrackInfo* track_info);
+    void  SetMetaAreaLabel(const TrackInfo* track_info);
+    Pill* AddPill(bool shown = true, bool active = true);
 
     const TrackInfo*                    m_track_metadata;
+    const AnalysisTrackStatistics*      m_track_statistics;
+    bool                                m_track_statistics_dirty;
     uint64_t                            m_track_id;
     float                               m_track_height;
     float                               m_track_content_height;
@@ -151,10 +162,11 @@ protected:
     SettingsManager&                    m_settings;
     bool                                m_meta_area_clicked;
     float                               m_meta_area_scale_width;
+    float                               m_max_meta_area_scale_width;
     bool                                m_selected;
     float                               m_reorder_grip_width;
-    bool                                m_analysis_request_pending;
     std::shared_ptr<TimePixelTransform> m_tpt;
+    std::shared_ptr<TimelineSelection>  m_timeline_selection;
     uint64_t m_chunk_duration_ns;  // Duration of each chunk in nanoseconds
     uint8_t  m_group_id_counter;   // Counter for grouping requests
 
@@ -163,10 +175,12 @@ protected:
     static float                                     s_metadata_width;
     std::string                                      m_meta_area_label;
     std::string                                      m_meta_area_tooltip;
-    Pill                                             m_pill;
 
 private:
-    TrackProjectSettings m_track_project_settings;
+    void RenderPills(ImVec2 region);
+
+    std::vector<std::unique_ptr<Pill>> m_pills;
+    TrackProjectSettings               m_track_project_settings;
 };
 
 }  // namespace View

--- a/src/view/src/widgets/rocprofvis_editable_textfield.cpp
+++ b/src/view/src/widgets/rocprofvis_editable_textfield.cpp
@@ -54,6 +54,10 @@ EditableTextField::DrawPlainText()
     SettingsManager& settings = SettingsManager::GetInstance();
     if(m_show_reset_button)
     {
+        ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x - ButtonSize() -
+                             ImGui::GetStyle().ItemSpacing.x -
+                             ImGui::CalcTextSize(m_text.c_str()).x -
+                             ImGui::GetStyle().WindowPadding.x);
         if(IconButton(ICON_ARROWS_CYCLE,
                       settings.GetFontManager().GetFont(FontType::kIcon)))
         {
@@ -63,16 +67,18 @@ EditableTextField::DrawPlainText()
             SetTooltipStyled("Revert To Default\n%s", m_reset_tooltip.c_str());
         ImGui::SameLine();
     }
+    else
+    {
+        ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x -
+                             ImGui::CalcTextSize(m_text.c_str()).x -
+                             ImGui::GetStyle().WindowPadding.x);
+    }
     // Draw the text as a button to avoid the background
     // and prevent clicks from being registered.
     ImGui::PushStyleColor(ImGuiCol_Button, 0);
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, 0);
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, 0);
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-
-    ImGui::SetCursorPosX(ImGui::GetContentRegionMax().x -
-                         ImGui::CalcTextSize(m_text.c_str()).x -
-                         ImGui::GetStyle().WindowPadding.x);
     if(ImGui::Button(m_text.c_str()))
     {
         m_editing_mode           = true;
@@ -151,11 +157,15 @@ EditableTextField::SetText(std::string text, std::string tooltip, std::string re
 float
 EditableTextField::ButtonSize() const
 {
-    ImFont* icon_font =
-        SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-    ImGui::PushFont(icon_font, 0.0f);
-    float size = ImGui::CalcTextSize(ICON_ARROWS_CYCLE).x;
-    ImGui::PopFont();
+    float size = 0.0f;
+    if(m_show_reset_button)
+    {
+        ImFont* icon_font =
+            SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
+        ImGui::PushFont(icon_font);
+        size = ImGui::CalcTextSize(ICON_ARROWS_CYCLE).x;
+        ImGui::PopFont();
+    }
     return size;
 }
 


### PR DESCRIPTION
## DM
  - Factored out PMC slice read from `rocprofvis_db_read_trace_slice_async` into `rocprofvis_db_read_trace_pmc_slice_async` (`left_neighbor`, `right_neighbor`).
  This is necessary because including both left and right neighbors like the rendering code causes incorrect stat
  calculations.
    - PMC data does not have duration. For plotting purposes, each data point is visually extended to their right
  neighbor. This means that inside a given time range, all line segments in a counter track belong to their left
  neighbor.
    - `rocprofvis_db_read_trace_slice_async` is unchanged and still supports both event and PMC tracks; it will
  internally call `rocprofvis_db_read_trace_pmc_slice_async` for both neighbors if the requested track is a PMC.

  ## Controller
  - Added `rocprofvis_analysis_fetch_counter_statistics` for calculating the min, max, mean, and standard deviation of a counter track within a time range.
    - All stats are calculated together as the cost is dominated by slice read. Performance profile is same as queue
  utilization (linear).

  ## View
  - Generalized request `kFetchAnalysisQueueUtilization` into `kFetchAnalysisTrackStatistics` to be shared by all
  timeline-driven analysis requests.
    - Requests of this type share parameters (track id + time range) and update condition (visible in timeline +
  timeline movement).
    - Additionally added update condition for not visible in timeline but track is selected for TrackDetails use case. 
  - `TrackItem`
    - `Pill`
      - Changed single instance to a list. List can be appended to via `Pill* AddPill()`. Render code will
  make best effort to fit list within available space.
      - Added variations/states (`Sizing`: `kElided`, `kCompact`, `kExtended`) configurable with distinct strings to
  make best use of available space.
      - Added configurable border color.
    - `MetaArea`
      - Maximize space available to track name and `Pill` list by allowing `MetaScaleArea` to differ in size among
  tracks.
      - Added display of min, max, mean, standard deviation to counter tracks. Visibility is configurable in track
  options, persistent in project settings.
      - Removed small white square appearing next to mouse when resizing horizontally.
    - Moved `Update()` out of `TimelineView::RenderNormalTrack` into `TimelineView::Update`.
      - This was done because track analysis must update for out-of-view tracks if they are selected.
  - `TrackDetails`
    - Redesigned topology information to be collapsable and be collapsed by default.
    - Added display of queue utilization to queue tracks, and min, max, mean, standard deviation to counter tracks.