### PR TITLE
Stop treating NULL agent type as NIC from 3.0.1

### DIFF
--- a/src/controller/src/system/rocprofvis_controller_topology.cpp
+++ b/src/controller/src/system/rocprofvis_controller_topology.cpp
@@ -195,7 +195,8 @@ TopologyNode::GetUInt64(rocprofvis_property_t property, uint64_t index, uint64_t
                 }
                 else
                 {
-                    result = kRocProfVisResultUnknownError;
+                    *value = kRPVControllerProcessorTypeUndefined;
+                    result = kRocProfVisResultSuccess;
                 }
             }
             else

--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -701,10 +701,11 @@ rocprofvis_dm_result_t RocprofDatabase::GenerateInterdependencyTables(Future* fu
 rocprofvis_dm_result_t RocprofDatabase::LoadInformationTables(Future* future) {
 
     std::vector<std::thread> threads;
+    std::string agent_type = m_query_factory.IsVersionGreaterOrEqual("3.0.1") ? "type" : "coalesce(type, 'NIC') as type";
 
     std::vector<std::pair<std::string, std::string>> info_table_list = {
         {"Node", "SELECT * from rocpd_info_node_%GUID%;"},
-        {"Agent", "SELECT id,guid,nid,pid,coalesce(type,'NIC') as type,absolute_index,logical_index,type_index,uuid,name,model_name,vendor_name,product_name,extdata from rocpd_info_agent_%GUID%;"},
+        {"Agent", "SELECT id,guid,nid,pid,"+agent_type+",absolute_index,logical_index,type_index,uuid,name,model_name,vendor_name,product_name,extdata from rocpd_info_agent_%GUID%;"},
         {"Queue", "SELECT * from rocpd_info_queue_%GUID%;"},
         {"Stream", "SELECT * from rocpd_info_stream_%GUID%;"},
         {"Process", "SELECT * from rocpd_info_process_%GUID%;"},

--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -701,11 +701,10 @@ rocprofvis_dm_result_t RocprofDatabase::GenerateInterdependencyTables(Future* fu
 rocprofvis_dm_result_t RocprofDatabase::LoadInformationTables(Future* future) {
 
     std::vector<std::thread> threads;
-    std::string agent_type = m_query_factory.IsVersionGreaterOrEqual("3.0.1") ? "type" : "coalesce(type, 'NIC') as type";
 
     std::vector<std::pair<std::string, std::string>> info_table_list = {
         {"Node", "SELECT * from rocpd_info_node_%GUID%;"},
-        {"Agent", "SELECT id,guid,nid,pid,"+agent_type+",absolute_index,logical_index,type_index,uuid,name,model_name,vendor_name,product_name,extdata from rocpd_info_agent_%GUID%;"},
+        {"Agent", "SELECT id,guid,nid,pid,type,absolute_index,logical_index,type_index,uuid,name,model_name,vendor_name,product_name,extdata from rocpd_info_agent_%GUID%;"},
         {"Queue", "SELECT * from rocpd_info_queue_%GUID%;"},
         {"Stream", "SELECT * from rocpd_info_stream_%GUID%;"},
         {"Process", "SELECT * from rocpd_info_process_%GUID%;"},


### PR DESCRIPTION
## Motivation

NIC agent type added to 3.0.1 schema

## Technical Details

NULL agent type was treated as NIC by default. Adding versioning logic to the agent type ingestion since 3.0.1 schema has NIC type added.
