### PR TITLE
Fixed missing RPD trace reverse data flow arrows

### DIFF
--- a/src/controller/src/rocprofvis_controller_analysis.cpp
+++ b/src/controller/src/rocprofvis_controller_analysis.cpp
@@ -205,9 +205,13 @@ rocprofvis_result_t Analysis::AsyncFetchQueueUtilization(SystemTrace* trace, Tra
             ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess);
             future->AddDependentFuture(object2wait);
             dm_result = rocprofvis_db_future_wait(object2wait, UINT64_MAX);
-            ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess);
-            rocprofvis_dm_slice_t slice = rocprofvis_dm_get_property_as_handle(dm_track, kRPVDMSliceHandleTimed, rocprofvis_dm_hash_combine_timestamp(range_start, range_end, kRocProfVisDmHashedTimestampTagAnalysis));
-            ROCPROFVIS_ASSERT(slice);
+            ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess || dm_result == kRocProfVisDmResultDbAbort);
+            rocprofvis_dm_slice_t slice = nullptr;
+            if (dm_result == kRocProfVisDmResultSuccess)
+            {
+                slice = rocprofvis_dm_get_property_as_handle(dm_track, kRPVDMSliceHandleTimed, rocprofvis_dm_hash_combine_timestamp(range_start, range_end, kRocProfVisDmHashedTimestampTagAnalysis));
+                ROCPROFVIS_ASSERT(slice);
+            }         
             if(slice && !future->IsCancelled())
             {
                 uint64_t num_records = rocprofvis_dm_get_property_as_uint64(slice, kRPVDMNumberOfRecordsUInt64, 0);
@@ -265,9 +269,9 @@ rocprofvis_result_t Analysis::AsyncFetchQueueUtilization(SystemTrace* trace, Tra
                 {
                     *output = (double)busy_duration / (double)(range_end - range_start) * 100.0;
                 }
+                dm_result = rocprofvis_dm_delete_time_slice_handle(trace->GetDMHandle(), track_id, slice);
+                ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess);
             }
-            dm_result = rocprofvis_dm_delete_time_slice_handle(trace->GetDMHandle(), track_id, slice);
-            ROCPROFVIS_ASSERT(dm_result == kRocProfVisDmResultSuccess);
             future->RemoveDependentFuture(object2wait);
             rocprofvis_db_future_free(object2wait);
         }

--- a/src/model/src/database/rocprofvis_db_rocpd.cpp
+++ b/src/model/src/database/rocprofvis_db_rocpd.cpp
@@ -816,7 +816,7 @@ rocprofvis_dm_result_t  RocpdDatabase::ReadFlowTraceInfo(
         } else
         if (event_id.bitfield.event_op == kRocProfVisDmOperationDispatch)
         {
-            query << "select 1, rocpd_api_ops.op_id, rocpd_api_ops.api_id, 0, pid, tid, rocpd_api.apiName_id, rocpd_api.args_id, " << Builder::LevelTable("api") << ".level, rocpd_api.end "
+            query << "select 1, rocpd_api_ops.op_id, rocpd_api_ops.api_id, 0, pid, tid, rocpd_api.start, rocpd_api.apiName_id, rocpd_api.args_id, " << Builder::LevelTable("api") << ".level, rocpd_api.end "
                 "from rocpd_api_ops "
                 "INNER JOIN rocpd_api on rocpd_api_ops.api_id = rocpd_api.id "
                 "INNER JOIN rocpd_op on rocpd_api_ops.op_id = rocpd_op.id "

--- a/src/model/src/database/rocprofvis_db_rocpd.cpp
+++ b/src/model/src/database/rocprofvis_db_rocpd.cpp
@@ -980,6 +980,9 @@ rocprofvis_dm_result_t  RocpdDatabase::ReadExtEventInfo(
                         Builder::LeftJoin(Builder::LevelTable("op"), "L", "id = L.eid", MultiNode::No) },
                       { Builder::Where(
                           "id", "==", std::to_string(event_id.bitfield.event_id)) } }));
+            if(kRocProfVisDmResultSuccess !=
+                ExecuteSQLQuery(future, DbInstancePtrAt(0), level_query.c_str(), extdata, &CallbackAddEssentialInfo))
+                break;
         } else    
         {
             ShowProgress(0, "Extended data not available for specified operation type!", kRPVDbError, future );


### PR DESCRIPTION
## Motivation

Missing data flow arrow, when kernel dispatch event selected in RPD trace

## Technical Details

There were two separate issues:
1. Flow trace query for RPD kernel dispatch event was missing start time column.
2. Essential info collection method was not called for RPD kernel dispatch event.