### PR TITLE
Fix: Custom metrics show as N/A in kernel pivot table (compute analysis)

### DIFF
--- a/src/controller/src/compute/rocprofvis_controller_table_compute_pivot.cpp
+++ b/src/controller/src/compute/rocprofvis_controller_table_compute_pivot.cpp
@@ -65,7 +65,7 @@ ComputePivotTable::Setup(rocprofvis_dm_trace_t dm_handle, Arguments& args, Futur
             if(args.GetString(kRPVControllerCPTArgsMetricSelectorIndexed, i,
                               buffer, &length) == kRocProfVisResultSuccess)
             {
-                m_metric_selectors.push_back(std::string(buffer));
+                m_metric_selectors.emplace_back(buffer, length);
             }
         }
 
@@ -105,7 +105,7 @@ ComputePivotTable::Setup(rocprofvis_dm_trace_t dm_handle, Arguments& args, Futur
                               filter_expr, &expr_length) != kRocProfVisResultSuccess)
                 continue;
 
-            m_column_filters[column_index] = std::string(filter_expr);
+            m_column_filters[column_index] = std::string(filter_expr, expr_length);
         }
     }
     else

--- a/src/controller/src/rocprofvis_controller_data.cpp
+++ b/src/controller/src/rocprofvis_controller_data.cpp
@@ -338,10 +338,19 @@ rocprofvis_result_t Data::GetString(char* string, uint32_t* length)
             }
             else if (length && string && (*length > 0))
             {
-                const size_t src_len = m_string ? strlen(m_string) : 0;
-                const size_t copy    = std::min(src_len, static_cast<size_t>(*length));
+                // *length is the capacity of the caller's buffer. Copy as many bytes
+                // as fit, and null-terminate only when there is spare room. This keeps
+                // the exact-fit caller (resize(strlen) then pass strlen) working while
+                // ensuring oversized buffers (e.g. a fixed char buf[256] later wrapped
+                // in std::string(buffer)) get a terminator instead of reading past the
+                // copied data into uninitialized memory.
+                const size_t src_len  = m_string ? strlen(m_string) : 0;
+                const size_t capacity = static_cast<size_t>(*length);
+                const size_t copy     = std::min(src_len, capacity);
                 if (copy > 0) std::memcpy(string, m_string, copy);
-                result = kRocProfVisResultSuccess;
+                if (copy < capacity) string[copy] = '\0';
+                *length = static_cast<uint32_t>(copy);
+                result  = kRocProfVisResultSuccess;
             }
             break;
         }

--- a/src/view/src/compute/rocprofvis_compute_memory_chart.cpp
+++ b/src/view/src/compute/rocprofvis_compute_memory_chart.cpp
@@ -892,7 +892,7 @@ ComputeMemoryChartView::DrawVectorL1(ImDrawList* draw_list, ImVec2 origin)
     cursor_y = DrawMetricRow(draw_list, block_x, cursor_y, block.w,
                              "Coalescing:", VL1_COALESCE, "%");
     cursor_y =
-        DrawMetricRow(draw_list, block_x, cursor_y, block.w, "Stall:", VL1_STALL, "%");
+        DrawMetricRow(draw_list, block_x, cursor_y, block.w, "Stall:", VL1_STALL, "cycles");
 }
 
 void

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -4933,12 +4933,39 @@ DataProvider::ProcessMetricPivotTable(RequestInfo& req)
                 row_values.resize(num_columns);
                 for (uint64_t col = 0; col < num_columns; col++)
                 {
-                    if (column_types[col] == kRPVControllerPrimitiveTypeString)
+                    std::string value;
+                    switch(column_types[col])
                     {
-                        std::string value =
-                            GetString(row_handle, kRPVControllerArrayEntryIndexed, col);
-                        row_values[col] = value;
+                        case kRPVControllerPrimitiveTypeUInt64:
+                        {
+                            uint64_t cell_value = 0;
+                            result = rocprofvis_controller_get_uint64(
+                                row_handle, kRPVControllerArrayEntryIndexed, col,
+                                &cell_value);
+                            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                            value = std::to_string(cell_value);
+                            break;
+                        }
+                        case kRPVControllerPrimitiveTypeDouble:
+                        {
+                            double cell_value = 0;
+                            result = rocprofvis_controller_get_double(
+                                row_handle, kRPVControllerArrayEntryIndexed, col,
+                                &cell_value);
+                            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                            value = std::to_string(cell_value);
+                            break;
+                        }
+                        case kRPVControllerPrimitiveTypeString:
+                        {
+                            value =
+                                GetString(row_handle, kRPVControllerArrayEntryIndexed, col);
+                            break;
+                        }
+                        default:
+                            break;
                     }
+                    row_values[col] = std::move(value);
                 }
 
                 kernel_pivot_table.table_data.push_back(row_values);

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -4933,39 +4933,12 @@ DataProvider::ProcessMetricPivotTable(RequestInfo& req)
                 row_values.resize(num_columns);
                 for (uint64_t col = 0; col < num_columns; col++)
                 {
-                    std::string value;
-                    switch(column_types[col])
+                    if (column_types[col] == kRPVControllerPrimitiveTypeString)
                     {
-                        case kRPVControllerPrimitiveTypeUInt64:
-                        {
-                            uint64_t cell_value = 0;
-                            result = rocprofvis_controller_get_uint64(
-                                row_handle, kRPVControllerArrayEntryIndexed, col,
-                                &cell_value);
-                            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-                            value = std::to_string(cell_value);
-                            break;
-                        }
-                        case kRPVControllerPrimitiveTypeDouble:
-                        {
-                            double cell_value = 0;
-                            result = rocprofvis_controller_get_double(
-                                row_handle, kRPVControllerArrayEntryIndexed, col,
-                                &cell_value);
-                            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-                            value = std::to_string(cell_value);
-                            break;
-                        }
-                        case kRPVControllerPrimitiveTypeString:
-                        {
-                            value =
-                                GetString(row_handle, kRPVControllerArrayEntryIndexed, col);
-                            break;
-                        }
-                        default:
-                            break;
+                        std::string value =
+                            GetString(row_handle, kRPVControllerArrayEntryIndexed, col);
+                        row_values[col] = value;
                     }
-                    row_values[col] = std::move(value);
                 }
 
                 kernel_pivot_table.table_data.push_back(row_values);


### PR DESCRIPTION
## Motivation

Custom metrics added to pivot table do not display values.  Every value is N/A.

<img width="800" height="269" alt="image" src="https://github.com/user-attachments/assets/9723c845-f6d2-45f7-87cc-0acea63ee303" />

## Technical Details

This is a regression. 

### Problem

In the Kernel Selection Table ("kernel pivot") on the kernel details screen, all custom-added metric columns (e.g. VALU Stall Value, VALU FLOPs Avg) rendered as N/A, even though the values exist in the database. This was a regression — the feature worked previously.

### Root cause

A buffer-handling regression introduced in PR 844 ("Warning Fixes"). That change rewrote Data::GetString in src/controller/src/rocprofvis_controller_data.cpp, replacing strncpy with a raw memcpy that copies the string bytes but never null-terminates the destination buffer:

```
const size_t copy = std::min(src_len, static_cast<size_t>(*length));
if (copy > 0) std::memcpy(string, m_string, copy);   // no '\0' written
```

The old strncpy happened to null-terminate in the relevant case (short string into a large fixed buffer, with zero-padding), which is why it worked before.

The break surfaces in ComputePivotTable::Setup, which reads each metric selector into a fixed char buffer[256] and then wraps it with std::string(buffer). Without a terminator, that constructor reads past the real data (e.g. "2.1.2:peak") into uninitialized stack memory. Downstream, the model's SanitizeMetricValueName turns the trailing garbage into a long run of _, producing corrupted column names like metric_2_1_2_peak______… and — critically — a corrupted value_name. The model matches metric values by value_name, so the corrupted selector never matches any row, leaving every metric cell empty, which the UI renders as N/A.

### Fix

Data::GetString now guarantees a valid C-string: it null-terminates when the buffer has spare capacity and writes the actual copied length back to *length. The exact-fit pattern used throughout the codebase (resize(strlen) then pass strlen) is preserved (no terminator written / no truncation when copied == capacity), so all other string-reading callers are unaffected.

### Misc

Updated the unit from % to cycles for the Vector L1 Cache Stalls field.