### PR TITLE
Fix event callstack retrieval crash.

### DIFF
--- a/src/controller/src/rocprofvis_controller_data.cpp
+++ b/src/controller/src/rocprofvis_controller_data.cpp
@@ -59,7 +59,7 @@ Data::Data(Data const& other)
     operator=(other);
 }
 
-Data::Data(Data&& other)
+Data::Data(Data&& other) noexcept
 : m_type(other.m_type)
 {
     m_uint64 = 0;
@@ -105,7 +105,7 @@ Data& Data::operator=(Data const& other)
     return *this;
 }
 
-Data& Data::operator=(Data&& other)
+Data& Data::operator=(Data&& other) noexcept
 {
     if (this == &other)
     {

--- a/src/controller/src/rocprofvis_controller_data.h
+++ b/src/controller/src/rocprofvis_controller_data.h
@@ -19,11 +19,11 @@ public:
 
     Data(Data const& other);
 
-    Data(Data&& other);
+    Data(Data&& other) noexcept;
 
     Data& operator=(Data const& other);
 
-    Data& operator=(Data&& other);
+    Data& operator=(Data&& other) noexcept;
 
     Data(rocprofvis_controller_primitive_type_t type);
 

--- a/src/controller/src/system/rocprofvis_controller_event.cpp
+++ b/src/controller/src/system/rocprofvis_controller_event.cpp
@@ -226,7 +226,12 @@ Event::FetchDataModelStackTraceProperty(uint64_t event_id, Array& array,
                                    (uint64_t*) &records_count))
                             {
                                 uint64_t entry_counter = 0;
-                                for(int index = 0; index < records_count; index++)
+                                result = array.SetUInt64(kRPVControllerArrayNumEntries, 0,
+                                                         records_count);
+                                for(int index = 0;
+                                    result == kRocProfVisResultSuccess &&
+                                    index < records_count;
+                                    index++)
                                 {
                                     char* symbol = nullptr;
                                     char* codeline    = nullptr;
@@ -276,17 +281,25 @@ Event::FetchDataModelStackTraceProperty(uint64_t event_id, Array& array,
                                         if(!name.empty())
                                         {
                                             CallStack* call_stack = new CallStack(id, depth, file.c_str(), pc.c_str(), name.c_str(), line_name.c_str(), line_address.c_str());
-                                            result = array.SetUInt64(kRPVControllerArrayNumEntries, 0, entry_counter + 1);
+                                            result = array.SetOwnedObject(
+                                                kRPVControllerArrayEntryIndexed, entry_counter,
+                                                (rocprofvis_handle_t*) call_stack);
                                             if(result == kRocProfVisResultSuccess)
                                             {
-                                                result = array.SetOwnedObject(kRPVControllerArrayEntryIndexed, entry_counter++, (rocprofvis_handle_t*) call_stack);
+                                                entry_counter++;
                                             }
-                                            if(result != kRocProfVisResultSuccess)
+                                            else
                                             {
                                                 delete call_stack;
                                             }
                                         }
                                     }
+                                }
+                                if(result == kRocProfVisResultSuccess &&
+                                   entry_counter != records_count)
+                                {
+                                    result = array.SetUInt64(kRPVControllerArrayNumEntries, 0,
+                                                             entry_counter);
                                 }
                             }
                             result = kRocProfVisResultSuccess;


### PR DESCRIPTION
## Motivation

Selecting an event in the GUI could crash inside `DataProvider::ProcessEventCallStackRequest` due to heap corruption originating in the controller. Introduced by df4d9851 ("Add SetOwnedObject methods for Array and Data classes").

## Technical Details

Data's move constructor and move assignment operator were not marked `noexcept`. As a result, `std::vector<Data>` falls back to copying (instead of moving) its elements on reallocation (std::move_if_noexcept).

For owned objects, a copy is intentionally a borrow (`m_owns_object = false`) while the original remains the owner. So when `FetchDataModelStackTraceProperty` grew the call stack array one frame at a time, each reallocation:

- Copied existing owned Data entries into new storage (copies are borrowers),
- Destroyed the old storage, whose entries were still owners and deleted their CallStack objects,
- Left the new storage holding dangling pointers → double-free / heap corruption.

The corruption surfaced later as a crash in the View layer when reading` req.request_array`.
This only affected call stacks because extended-data and table fetches pre-size their arrays once and never reallocate mid-fill.

### Fix

Marked `Data`'s move constructor and move assignment operator `noexcept`, so `std::vector<Data>` reallocation always moves (transferring ownership) instead of copying. This removes the entire class of bug for any current or future array-growth path.

Pre-size the call stack array once before the fill loop (matching the extended-data pattern) to avoid mid-fill reallocation, and trim to the actual entry count when frames are skipped.
