### PR TITLE
Block app launch on Intel Macs with a native alert

### DIFF
--- a/src/app/src/main.cpp
+++ b/src/app/src/main.cpp
@@ -240,6 +240,16 @@ main(int argc, char** argv)
         return app_result_code;
     }
 
+#ifdef __APPLE__
+    // Bail out early on Intel Macs: the app is built for / tested on Apple
+    // Silicon only. This shows a native alert and exits before any GLFW/Vulkan
+    // init that would otherwise fail or behave unpredictably.
+    if(!RocProfVis::Platform::check_supported_mac_hardware())
+    {
+        return 1;
+    }
+#endif
+
     std::string log_dir = rocprofvis_get_application_log_path();
 #ifndef NDEBUG
     std::filesystem::path log_path =

--- a/src/app/src/rocprofvis_platform_helpers.h
+++ b/src/app/src/rocprofvis_platform_helpers.h
@@ -37,5 +37,12 @@ get_os_modifier_state();
 void
 configure_bundled_vulkan_icd();
 
+// macOS only. Returns true when running on supported hardware (Apple Silicon).
+// On an Intel Mac it presents a blocking native alert explaining that the app
+// is not compatible or tested on Intel and returns false; the caller should
+// then exit. Call once at startup, before creating any windows.
+bool
+check_supported_mac_hardware();
+
 }  // namespace Platform
 }  // namespace RocProfVis

--- a/src/app/src/rocprofvis_platform_helpers_macos.mm
+++ b/src/app/src/rocprofvis_platform_helpers_macos.mm
@@ -7,6 +7,7 @@
 #import <Foundation/Foundation.h>
 
 #include <cstdlib>
+#include <sys/sysctl.h>
 
 namespace RocProfVis
 {
@@ -55,6 +56,44 @@ configure_bundled_vulkan_icd()
 
         setenv("VK_ICD_FILENAMES", path, 1);
         setenv("VK_DRIVER_FILES", path, 1);
+    }
+}
+
+bool
+check_supported_mac_hardware()
+{
+    @autoreleasepool
+    {
+        // "hw.optional.arm64" is 1 on Apple Silicon and absent/0 on Intel.
+        // This reports the real CPU even when the process runs under Rosetta.
+        int    is_arm64 = 0;
+        size_t size     = sizeof(is_arm64);
+        if(sysctlbyname("hw.optional.arm64", &is_arm64, &size, nullptr, 0) == 0 &&
+           is_arm64 == 1)
+        {
+            return true;
+        }
+
+        // This runs before GLFW/NSApplication init, so bootstrap the shared
+        // application and bring it to the foreground; otherwise the alert can
+        // appear behind other windows or without focus.
+        [NSApplication sharedApplication];
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [NSApp activateIgnoringOtherApps:YES];
+
+        NSAlert* alert = [[NSAlert alloc] init];
+        [alert setAlertStyle:NSAlertStyleCritical];
+        [alert setMessageText:@"Unsupported Mac"];
+        [alert setInformativeText:
+                   @"ROCm\u2122 Optiq runs only on Apple Silicon (M-series) Macs. "
+                   @"It is not compatible with, nor tested on, Intel-based Macs and "
+                   @"cannot be opened on this machine."];
+        [alert addButtonWithTitle:@"Quit"];
+
+        [[alert window] setLevel:NSModalPanelWindowLevel];
+        [alert runModal];
+
+        return false;
     }
 }
 


### PR DESCRIPTION
Display error message when app is opened on x86 based mac systems. We do not officially support this. 