### PR TITLE
Add right-click copy to Kernel Selection Table

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -692,18 +692,6 @@ KernelMetricTable::Render()
                     ImGui::EndDisabled();
                 }
 
-                // Collect visible columns here; TableGetColumnFlags is invalid once
-                // the popup window is open.
-                std::vector<int> visible_cols;
-                visible_cols.reserve(column_count);
-                for(int c = 0; c < column_count; c++)
-                {
-                    if(ImGui::TableGetColumnFlags(c) & ImGuiTableColumnFlags_IsEnabled)
-                    {
-                        visible_cols.push_back(c);
-                    }
-                }
-
                 if(open_menu)
                 {
                     ImGui::OpenPopup(CELL_CONTEXT_MENU_ID);
@@ -715,21 +703,24 @@ KernelMetricTable::Render()
                     {
                         const std::vector<std::string>& menu_row = data[m_cell_menu.row];
                         std::vector<std::string>        row_cells;
-                        row_cells.reserve(visible_cols.size());
-                        // Remap the data-column index to its visible-list position.
+                        row_cells.reserve(header.size());
+                        // Hidden columns have a header name starting with '_'. Remap
+                        // the data-column index to its visible-list position.
                         int cell_index = 0;
-                        for(int c : visible_cols)
+                        for(int col = 0; col < static_cast<int>(header.size()) &&
+                                         col < static_cast<int>(menu_row.size());
+                            col++)
                         {
-                            if(c >= static_cast<int>(menu_row.size()))
+                            if(!header[col].empty() && header[col][0] == '_')
                             {
                                 continue;
                             }
-                            if(c == m_cell_menu.column)
+                            if(col == m_cell_menu.column)
                             {
                                 cell_index = static_cast<int>(row_cells.size());
                             }
-                            row_cells.push_back(menu_row[c].empty() ? "N/A"
-                                                                    : menu_row[c]);
+                            row_cells.push_back(menu_row[col].empty() ? "N/A"
+                                                                      : menu_row[col]);
                         }
                         AddCopyRowCellMenuItems(row_cells.data(),
                                                 static_cast<int>(row_cells.size()),

--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -49,6 +49,8 @@ constexpr const char* JSON_KEY_SELECTION_ID         = "id";
 constexpr const char* JSON_KEY_SELECTION_NAME       = "name";
 constexpr const char* JSON_KEY_SELECTION_VALUE_NAME = "value";
 
+constexpr const char* CELL_CONTEXT_MENU_ID = "##kernel_table_cell_menu";
+
 KernelMetricTable::KernelMetricTable(DataProvider&                     data_provider,
                                      std::shared_ptr<ComputeSelection> compute_selection)
 : RocWidget()
@@ -545,6 +547,8 @@ KernelMetricTable::Render()
                     ImGui::BeginDisabled();
                 }
 
+                bool open_menu = false;
+
                 ImGuiListClipper clipper;
                 clipper.Begin(static_cast<int>(data.size()));
                 while(clipper.Step())
@@ -668,6 +672,16 @@ KernelMetricTable::Render()
                                 ImGui::PopTextWrapPos();
                                 EndTooltipStyled();
                             }
+
+                            // Resolve the column from the cell rect; the row-spanning
+                            // selectable and frozen column make item hover unreliable.
+                            if(cell_hovered &&
+                               ImGui::IsMouseClicked(ImGuiMouseButton_Right))
+                            {
+                                m_cell_menu.row    = row;
+                                m_cell_menu.column = col;
+                                open_menu          = true;
+                            }
                         }
                         ImGui::PopID();  // Pop row ID
                     }
@@ -676,6 +690,52 @@ KernelMetricTable::Render()
                 if(request_pending)
                 {
                     ImGui::EndDisabled();
+                }
+
+                // Collect visible columns here; TableGetColumnFlags is invalid once
+                // the popup window is open.
+                std::vector<int> visible_cols;
+                visible_cols.reserve(column_count);
+                for(int c = 0; c < column_count; c++)
+                {
+                    if(ImGui::TableGetColumnFlags(c) & ImGuiTableColumnFlags_IsEnabled)
+                    {
+                        visible_cols.push_back(c);
+                    }
+                }
+
+                if(open_menu)
+                {
+                    ImGui::OpenPopup(CELL_CONTEXT_MENU_ID);
+                }
+                if(BeginCellContextMenu(CELL_CONTEXT_MENU_ID))
+                {
+                    if(m_cell_menu.row >= 0 &&
+                       m_cell_menu.row < static_cast<int>(data.size()))
+                    {
+                        const std::vector<std::string>& menu_row = data[m_cell_menu.row];
+                        std::vector<std::string>        row_cells;
+                        row_cells.reserve(visible_cols.size());
+                        // Remap the data-column index to its visible-list position.
+                        int cell_index = 0;
+                        for(int c : visible_cols)
+                        {
+                            if(c >= static_cast<int>(menu_row.size()))
+                            {
+                                continue;
+                            }
+                            if(c == m_cell_menu.column)
+                            {
+                                cell_index = static_cast<int>(row_cells.size());
+                            }
+                            row_cells.push_back(menu_row[c].empty() ? "N/A"
+                                                                    : menu_row[c]);
+                        }
+                        AddCopyRowCellMenuItems(row_cells.data(),
+                                                static_cast<int>(row_cells.size()),
+                                                cell_index);
+                    }
+                    EndCellContextMenu();
                 }
 
                 ImGui::PopStyleColor(3);

--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.h
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "model/compute/rocprofvis_compute_model_types.h"
 #include "rocprofvis_presets.h"
+#include "widgets/rocprofvis_gui_helpers.h"
 #include "widgets/rocprofvis_query_builder.h"
 #include "widgets/rocprofvis_widget.h"
 #include <memory>
@@ -105,6 +106,9 @@ private:
 
     std::set<int>                   m_bar_chart_columns;
     std::unordered_map<int, double> m_column_max_values;
+
+    // Row/column whose right-click opened the copy context menu.
+    CellMenuTarget m_cell_menu;
 
     std::unique_ptr<Preset> m_preset;
 };


### PR DESCRIPTION
## Motivation

The Kernel Selection Table (a.k.a. Kernel Pivot Table) in the Compute view did not support copying data, unlike the other tables in the app (Event Details, Track Details, etc.). Users had no quick way to pull a kernel's metric values out of the table for sharing, notes, or comparison. This PR brings the Kernel Selection Table in line with the rest of the app's copy behavior.

## Technical Details

- Added right-click **Copy Row Data** / **Copy Cell Data** context menu support to the Kernel Selection Table, reusing the shared copy helpers (`CellMenuTarget`, `BeginCellContextMenu` / `AddCopyRowCellMenuItems` / `EndCellContextMenu`) so behavior and copy notifications match the other tables.
- The column under the cursor is resolved geometrically from each cell's rectangle bounds rather than `TableGetHoveredColumn()`, which is unreliable with frozen columns and a `SpanAllColumns` selectable. This ensures the correct column's value is copied (previously, copying a cell like Duration could copy the Name column).
- Row and cell copies exclude hidden/disabled columns (e.g. the internal ID column), with the cell index remapped to the visible column set. Visible-column info is captured before the popup opens to avoid reading table state in an invalid context.
- Empty cells copy as `N/A`; copied row values are comma-separated for consistency with the other tables.
- Existing left-click kernel selection behavior is unchanged.