### PR TITLE
Fix flow mem leak

### DIFF
--- a/src/controller/src/system/rocprofvis_controller_event.cpp
+++ b/src/controller/src/system/rocprofvis_controller_event.cpp
@@ -164,10 +164,14 @@ Event::FetchDataModelFlowTraceProperty(uint64_t event_id, Array& array,
                                                 category, symbol);
                                         if(result == kRocProfVisResultSuccess)
                                         {
-                                            result = array.SetObject(
+                                            result = array.SetOwnedObject(
                                                 kRPVControllerArrayEntryIndexed,
                                                 entry_counter++,
                                                 (rocprofvis_handle_t*) flow_control);
+                                        }
+                                        if(result != kRocProfVisResultSuccess)
+                                        {
+                                            delete flow_control;
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Motivation

Fix mem leak that occurs when fetching flow information.

## Technical Details

`Event::FetchDataModelFlowTraceProperty` allocated a `FlowControl `object but stored it via `Array::SetObject`, which does not take ownership — so the objects were never freed (ASan: "Direct leak of 88 byte(s)" at rocprofvis_controller_event.cpp:164).

Switched to `Array::SetOwnedObject` so the array owns and frees each `FlowControl `on destruction, and added a delete on the failure path so nothing leaks if the store fails.

Mirrors the existing ownership/cleanup pattern already used in the stack-trace fetch path (`FetchDataModelStackTraceProperty`).


