### PR TITLE
Remove TrackGraph + Misc.

### DIFF
--- a/src/view/src/model/rocprofvis_model_types.h
+++ b/src/view/src/model/rocprofvis_model_types.h
@@ -20,24 +20,6 @@ namespace View
 
 // Forward declarations
 class TableRequestParams;
-class TrackItem;
-
-enum class GraphType
-{
-    TYPE_LINECHART,
-    TYPE_FLAMECHART
-};
-
-// Track Graph Information
-struct TrackGraph
-{
-    GraphType  graph_type;
-    bool       display;
-    bool       display_changed;
-    TrackItem* chart;
-    bool       selected;
-
-};
 
 union TopologyId
 {

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -159,7 +159,7 @@ AppWindow::Init()
 
     m_welcome_page = std::make_unique<WelcomePage>(
         [this]() { HandleOpenFile(); },
-        [this](const std::string& file_path) { HandleOpenRecentFile(file_path); });
+        [this](const std::string& file_path) { OpenFile(file_path); });
 
     constexpr float initial_status_bar_height = 30.0f;
     LayoutItem status_bar_item(-1, initial_status_bar_height);
@@ -838,20 +838,6 @@ AppWindow::OpenFile(std::string file_path)
 }
 
 void
-AppWindow::HandleOpenRecentFile(const std::string& file_path)
-{
-    if(!std::filesystem::exists(file_path))
-    {
-        SettingsManager::GetInstance().RemoveRecentFile(file_path);
-        ShowMessageDialog("Recent File Not Found",
-                          "This recent file could not be found and was removed from the list:\n\n" +
-                              file_path);
-        return;
-    }
-    OpenFile(file_path);
-}
-
-void
 AppWindow::RenderDisableScreen()
 {
     if(m_shutdown_requested)
@@ -964,7 +950,7 @@ AppWindow::RenderFileMenu(Project* project)
             {
                 if(ImGui::MenuItem(file.c_str(), nullptr))
                 {
-                    HandleOpenRecentFile(file);
+                    OpenFile(file);
                     break;
                 }
             }

--- a/src/view/src/rocprofvis_appwindow.h
+++ b/src/view/src/rocprofvis_appwindow.h
@@ -115,7 +115,6 @@ private:
     void HandleTabSelectionChanged(std::shared_ptr<RocEvent> e);
     void HandleFontChanged();
     void HandleOpenFile();
-    void HandleOpenRecentFile(const std::string& file_path);
     void HandleSaveAsFile();
     void ConfigureFileDialogBackend();
     void BeginAppShutdown();

--- a/src/view/src/rocprofvis_events.h
+++ b/src/view/src/rocprofvis_events.h
@@ -55,7 +55,6 @@ enum class RocEventType
     kNavigationEvent,
     kRequestProgressUpdateEvent,
 #ifdef COMPUTE_UI_SUPPORT
-    kComputeTableSearchEvent,
     kComputeSelectionChangedEvent,
     kComputeMetricsFetchedEvent,
     kComputeAddMetricToKernelDetailsEvent,

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -46,11 +46,11 @@ FlameTrackItem::CalculateMaxEventLabelWidth()
     s_max_event_label_width = ImGui::CalcTextSize("W").x * MAX_CHARACTERS_PER_LINE;
 }
 
-FlameTrackItem::FlameTrackItem(DataProvider&                          dp,
-                               std::shared_ptr<TimelineSelection>     timeline_selection,
-                               std::shared_ptr<MeasurementController> measurement,
-                               uint64_t track_id, std::shared_ptr<TimePixelTransform> tpt)
-: TrackItem(dp, track_id, tpt, timeline_selection)
+FlameTrackItem::FlameTrackItem(DataProvider& dp, uint64_t track_id, bool display,
+                               std::shared_ptr<TimePixelTransform>    tpt,
+                               std::shared_ptr<TimelineSelection>     timeline_selection,                               
+                               std::shared_ptr<MeasurementController> measurement)
+: TrackItem(dp, track_id, display, tpt, timeline_selection)
 , m_text_padding(SettingsManager::GetInstance().GetDefaultIMGUIStyle().FramePadding)
 , m_level_height(SettingsManager::GetInstance().GetEventLevelHeight())
 , m_measurement(measurement)

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -49,11 +49,10 @@ class FlameTrackItem : public TrackItem
     friend FlameTrackProjectSettings;
 
 public:
-    FlameTrackItem(DataProvider&                          dp,
-                   std::shared_ptr<TimelineSelection>     timeline_selection,
-                   std::shared_ptr<MeasurementController> measurement,
-                   uint64_t                               track_id,
-                   std::shared_ptr<TimePixelTransform>    time_to_pixel_manager);
+    FlameTrackItem(DataProvider& dp, uint64_t track_id, bool display,
+                   std::shared_ptr<TimePixelTransform>    time_to_pixel_manager,
+                   std::shared_ptr<TimelineSelection>     timeline_selection,                   
+                   std::shared_ptr<MeasurementController> measurement);
     ~FlameTrackItem();
 
     void Update() override;

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -20,10 +20,10 @@ namespace View
 constexpr float DEFAULT_VERTICAL_PADDING = 2.0f;
 constexpr float DEFAULT_LINE_THICKNESS   = 1.0f;
 
-LineTrackItem::LineTrackItem(DataProvider& dp, uint64_t track_id,
+LineTrackItem::LineTrackItem(DataProvider& dp, uint64_t track_id, bool display,
                              std::shared_ptr<TimePixelTransform> tpt,
                              std::shared_ptr<TimelineSelection>  timeline_selection)
-: TrackItem(dp, track_id, tpt, timeline_selection)
+: TrackItem(dp, track_id, display, tpt, timeline_selection)
 , m_data({})
 , m_min_y("edit_min")
 , m_max_y("edit_max")

--- a/src/view/src/rocprofvis_line_track_item.h
+++ b/src/view/src/rocprofvis_line_track_item.h
@@ -77,7 +77,7 @@ class LineTrackItem : public TrackItem
     };
 
 public:
-    LineTrackItem(DataProvider& dp, uint64_t track_id,
+    LineTrackItem(DataProvider& dp, uint64_t track_id, bool display,
                   std::shared_ptr<TimePixelTransform> time_to_pixel_manager,
                   std::shared_ptr<TimelineSelection>  timeline_selection);
     ~LineTrackItem();

--- a/src/view/src/rocprofvis_project.cpp
+++ b/src/view/src/rocprofvis_project.cpp
@@ -87,9 +87,11 @@ Project::Open(std::string& file_path)
     }
     else
     {
-        AppWindow::GetInstance()->ShowMessageDialog("Error",
-                                                    "File does not exist: " + file_path);
-        spdlog::error("Failed to open file: {}, file does not exist", file_path);                                                    
+        AppWindow::GetInstance()->ShowMessageDialog(
+            "Recent File Not Found",
+            "This recent file could not be found and was removed from the list:\n\n" +
+                file_path);
+        spdlog::error("Failed to open file: {}, file does not exist", file_path);
     }
     return result;
 }
@@ -99,6 +101,7 @@ Project::Save()
 {
     if(IsProject() && SaveSetttingsJson())
     {
+        SettingsManager::GetInstance().AddRecentFile(m_project_file_path);
         NotificationManager::GetInstance().Show("Saved " + m_project_file_path + ".",
                                                 NotificationLevel::Success);
     }

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -54,12 +54,12 @@ private:
 
 SideBar::SideBar(std::shared_ptr<TrackTopology>         topology,
                  std::shared_ptr<TimelineSelection>     timeline_selection,
-                 std::shared_ptr<std::vector<TrackGraph>> graphs,
+                 std::shared_ptr<std::vector<TrackItem*>> tracks,
                  DataProvider&                          dp)
 : m_settings(SettingsManager::GetInstance())
 , m_track_topology(topology)
 , m_timeline_selection(timeline_selection)
-, m_graphs(graphs)
+, m_tracks(tracks)
 , m_data_provider(dp)
 {}
 
@@ -132,30 +132,29 @@ SideBar::Update()
 void
 SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
 {
-    if(!m_graphs || index >= m_graphs->size())
+    if(!m_tracks || index >= m_tracks->size() || !(*m_tracks)[index])
     {
         return;
     }
 
-    TrackGraph& graph = (*m_graphs)[index];
+    TrackItem& track = *(*m_tracks)[index];
 
-    ImGui::PushID(static_cast<int>(graph.chart->GetID()));
+    ImGui::PushID(static_cast<int>(track.GetID()));
     ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, m_settings.GetColor(Colors::kHighlightChart));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, m_settings.GetColor(Colors::kHighlightChart));
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(2, 0));
 
-    bool display = graph.display;
+    bool display = track.IsDisplayed();
     if(show_eye_button)
     {
         ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
         if(ImGui::Button(display ? ICON_EYE : ICON_EYE_SLASH))
         {
-            graph.display         = !graph.display;
-            graph.display_changed = true;
+            track.SetDisplay(!track.IsDisplayed());
             m_eye_state_dirty     = true;
             m_data_provider.DataModel().GetTimeline().UpdateHistogram(
-                { graph.chart->GetID() }, graph.display);
+                { track.GetID() }, track.IsDisplayed());
         }
         ImGui::PopFont();
         if(ImGui::IsItemHovered())
@@ -167,7 +166,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
         {
             EventManager::GetInstance()->AddEvent(std::make_shared<ScrollToTrackEvent>(
                 static_cast<int>(RocEvents::kHandleUserGraphNavigationEvent),
-                graph.chart->GetID(), m_data_provider.GetTraceFilePath()));
+                track.GetID(), m_data_provider.GetTraceFilePath()));
         }
         ImGui::PopFont();
         if(ImGui::IsItemHovered())
@@ -183,15 +182,15 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
 
     ImGui::PushStyleColor(
         ImGuiCol_Button,
-        m_settings.GetColor(graph.selected ? Colors::kSelection : Colors::kTransparent));
+        m_settings.GetColor(track.IsSelected() ? Colors::kSelection : Colors::kTransparent));
     if(!display)
     {
         ImGui::PushStyleColor(ImGuiCol_Text,
                               ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
     }
-    if(ImGui::Button(graph.chart->GetName().c_str()))
+    if(ImGui::Button(track.GetName().c_str()))
     {
-        m_timeline_selection->ToggleSelectTrack(graph);
+        m_timeline_selection->ToggleSelectTrack(track);
     }
     if(!display)
     {
@@ -215,12 +214,12 @@ SideBar::MergeEyeButtonState(EyeButtonState lhs, EyeButtonState rhs) const
 SideBar::EyeButtonState
 SideBar::GetLeafState(const LeafNode& leaf) const
 {
-    if(!m_graphs || leaf.graph_index >= m_graphs->size())
+    if(!m_tracks || leaf.graph_index >= m_tracks->size())
     {
         return EyeButtonState::kAllHidden;
     }
 
-    return (*m_graphs)[leaf.graph_index].display
+    return (*m_tracks)[leaf.graph_index]->IsDisplayed()
                ? EyeButtonState::kAllVisible
                : EyeButtonState::kAllHidden;
 }
@@ -278,7 +277,7 @@ SideBar::GetSubtreeEyeState(const TreeNode& node, bool cross_boundaries) const
 void
 SideBar::ApplyVisibility(const TreeNode& node, bool visible)
 {
-    if(!m_graphs || m_graphs->empty())
+    if(!m_tracks || m_tracks->empty())
     {
         return;
     }
@@ -306,15 +305,14 @@ SideBar::ApplyVisibility(const TreeNode& node, bool visible)
         if(current->IsLeaf())
         {
             const LeafNode& leaf = static_cast<const LeafNode&>(*current);
-            if(leaf.graph_index < m_graphs->size() &&
+            if(leaf.graph_index < m_tracks->size() &&
                visited_graphs.insert(leaf.graph_index).second)
             {
-                TrackGraph& graph = (*m_graphs)[leaf.graph_index];
-                if(graph.display != visible)
+                TrackItem* track = (*m_tracks)[leaf.graph_index];
+                if(track && track->IsDisplayed() != visible)
                 {
-                    graph.display         = visible;
-                    graph.display_changed = true;
-                    chart_ids.push_back(graph.chart->GetID());
+                    track->SetDisplay(visible);
+                    chart_ids.push_back(track->GetID());
                 }
             }
         }

--- a/src/view/src/rocprofvis_sidebar.h
+++ b/src/view/src/rocprofvis_sidebar.h
@@ -16,13 +16,14 @@ class SettingsManager;
 class TrackTopology;
 class TimelineSelection;
 class DataProvider;
+class TrackItem;
 
 class SideBar : public RocWidget
 {
 public:
     SideBar(std::shared_ptr<TrackTopology>         topology,
             std::shared_ptr<TimelineSelection>     timeline_selection,
-            std::shared_ptr<std::vector<TrackGraph>> graphs,
+            std::shared_ptr<std::vector<TrackItem*>> tracks,
             DataProvider&                          dp);
     ~SideBar();
     virtual void Render() override;
@@ -57,7 +58,7 @@ private:
     SettingsManager&                         m_settings;
     std::shared_ptr<TrackTopology>           m_track_topology;
     std::shared_ptr<TimelineSelection>       m_timeline_selection;
-    std::shared_ptr<std::vector<TrackGraph>> m_graphs;
+    std::shared_ptr<std::vector<TrackItem*>> m_tracks;
     DataProvider&                            m_data_provider;
     bool                                     m_eye_state_dirty = false;
 };

--- a/src/view/src/rocprofvis_timeline_arrow.cpp
+++ b/src/view/src/rocprofvis_timeline_arrow.cpp
@@ -44,7 +44,7 @@ TimelineArrow::SetRenderStyle(RenderStyle style)
 void
 TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
                       const std::unordered_map<uint64_t, float>& track_position_y,
-                      const std::shared_ptr<std::vector<TrackGraph>> graphs,
+                      const std::shared_ptr<std::vector<TrackItem*>> tracks,
                       std::shared_ptr<TimePixelTransform>                    tpt) const
 {
     if(m_flow_display_mode == FlowDisplayMode::kHide) return;
@@ -72,13 +72,13 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
             // True view: origin + multiple targets
             const EventFlowData& origin = flows[0];
             const TrackInfo*      origin_track_info = tlm.GetTrack(origin.track_id);
-            if(!origin_track_info) continue;
-            const TrackGraph& origin_track = (*graphs)[origin_track_info->index];
-            if(!origin_track.display)
+            if(!origin_track_info || !(*tracks)[origin_track_info->index]) continue;
+            const TrackItem& origin_track = *(*tracks)[origin_track_info->index];
+            if(!origin_track.IsDisplayed())
             {
                 continue;
             }
-            if(origin_track.chart->IsCompactMode())
+            if(origin_track.IsCompactMode())
             {
                 level_height = settings.GetEventLevelCompactHeight();
             }
@@ -90,19 +90,19 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
             float origin_x = tpt->RawTimeToPixel(static_cast<double>(origin.end_timestamp));
             float origin_y = track_position_y.at(origin.track_id) +
                              std::min(level_height * origin.level + level_height / 2,
-                                      origin_track.chart->GetTrackHeight());
+                                      origin_track.GetTrackHeight());
             ImVec2 p_origin = ImVec2(window.x + origin_x, window.y + origin_y);
 
             for(size_t i = 1; i < flows.size(); ++i)
             {
                 const EventFlowData& target = flows[i];
                 const TrackInfo*     target_track_info = tlm.GetTrack(target.track_id);
-                if(!target_track_info) continue;
-                const TrackGraph& target_track =
-                    (*graphs)[target_track_info->index];
-                if(!target_track.display) continue;
+                if(!target_track_info || !(*tracks)[target_track_info->index]) continue;
+                const TrackItem& target_track =
+                    *(*tracks)[target_track_info->index];
+                if(!target_track.IsDisplayed()) continue;
 
-                if(target_track.chart->IsCompactMode())
+                if(target_track.IsCompactMode())
                 {
                     level_height = settings.GetEventLevelCompactHeight();
                 }
@@ -114,7 +114,7 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
                 float target_x = tpt->RawTimeToPixel(static_cast<double>(target.start_timestamp));
                 float target_y = track_position_y.at(target.track_id) +
                                  std::min(level_height * target.level + level_height / 2,
-                                          target_track.chart->GetTrackHeight());
+                                          target_track.GetTrackHeight());
                 ImVec2 p_target = ImVec2(window.x + target_x, window.y + target_y);
 
                 if(p_origin.x == p_target.x && p_origin.y == p_target.y) continue;
@@ -169,14 +169,14 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
 
                 const TrackInfo* from_track_info = tlm.GetTrack(from.track_id);
                 const TrackInfo* to_track_info   = tlm.GetTrack(to.track_id);
-                if(!from_track_info || !to_track_info) continue;
+                if(!from_track_info || !(*tracks)[from_track_info->index] || !to_track_info || !(*tracks)[to_track_info->index]) continue;
 
-                const TrackGraph& from_track = (*graphs)[from_track_info->index];
-                const TrackGraph& to_track   = (*graphs)[to_track_info->index];
+                const TrackItem& from_track = *(*tracks)[from_track_info->index];
+                const TrackItem& to_track   = *(*tracks)[to_track_info->index];
 
-                if(!from_track.display || !to_track.display) continue;
+                if(!from_track.IsDisplayed() || !to_track.IsDisplayed()) continue;
 
-                if(from_track.chart->IsCompactMode())
+                if(from_track.IsCompactMode())
                 {
                     level_height = settings.GetEventLevelCompactHeight();
                 }
@@ -188,10 +188,10 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
                 float from_x = tpt->RawTimeToPixel(static_cast<double>(from.end_timestamp));
                 float from_y = track_position_y.at(from.track_id) +
                                std::min(level_height * from.level + level_height / 2,
-                                        from_track.chart->GetTrackHeight());
+                                        from_track.GetTrackHeight());
                 ImVec2 p_from = ImVec2(window.x + from_x, window.y + from_y);
 
-                if(to_track.chart->IsCompactMode())
+                if(to_track.IsCompactMode())
                 {
                     level_height = settings.GetEventLevelCompactHeight();
                 }
@@ -203,7 +203,7 @@ TimelineArrow::Render(ImDrawList* draw_list, const ImVec2 window,
                 float to_x = tpt->RawTimeToPixel(static_cast<double>(to.start_timestamp));
                 float to_y = track_position_y.at(to.track_id) +
                              std::min(level_height * to.level + level_height / 2,
-                                      to_track.chart->GetTrackHeight());
+                                      to_track.GetTrackHeight());
                 ImVec2 p_to = ImVec2(window.x + to_x, window.y + to_y);
 
                 if(p_from.x == p_to.x && p_from.y == p_to.y) continue;

--- a/src/view/src/rocprofvis_timeline_arrow.h
+++ b/src/view/src/rocprofvis_timeline_arrow.h
@@ -6,7 +6,6 @@
 #include "imgui.h"
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_event_manager.h"
-#include "rocprofvis_time_to_pixel.h"
 
 #include <memory>
 
@@ -24,8 +23,8 @@ enum class FlowDisplayMode
 
 class DataProvider;
 class TimelineSelection;
-struct event_info_t;
 class TimePixelTransform;
+class TrackItem;
 
 class TimelineArrow
 {
@@ -47,7 +46,7 @@ public:
     // mapping
     void Render(ImDrawList* draw_list, const ImVec2 window,
                 const std::unordered_map<uint64_t, float>&             track_position_y,
-                const std::shared_ptr<std::vector<TrackGraph>> graphs,
+                const std::shared_ptr<std::vector<TrackItem*>>         tracks,
                 std::shared_ptr<TimePixelTransform>                    tpt) const;
 
 private:

--- a/src/view/src/rocprofvis_timeline_selection.cpp
+++ b/src/view/src/rocprofvis_timeline_selection.cpp
@@ -23,56 +23,42 @@ TimelineSelection::TimelineSelection(DataProvider& dp)
 TimelineSelection::~TimelineSelection() {}
 
 void
-TimelineSelection::SelectTrack(TrackGraph& graph)
+TimelineSelection::SelectTrack(TrackItem& track)
 {
-    if(!graph.selected && graph.chart && !graph.chart->IsSelected() &&
-       m_selected_track_ids.count(graph.chart->GetID()) == 0)
+    if(!IsTrackSelected(track))
     {
-        graph.selected = true;
-        graph.chart->SetSelected(true);
-        m_selected_track_ids.insert(graph.chart->GetID());
-        SendTrackSelectionChanged(graph.chart->GetID(), true);
+        m_selected_track_ids.insert(track.GetID());
+        SendTrackSelectionChanged(track.GetID(), true);
     }
 }
 
 void
-TimelineSelection::UnselectTrack(TrackGraph& graph)
+TimelineSelection::UnselectTrack(TrackItem& track)
 {
-    if(graph.selected && graph.chart && graph.chart->IsSelected() &&
-       m_selected_track_ids.count(graph.chart->GetID()) > 0)
+    if(IsTrackSelected(track))
     {
-        graph.selected = false;
-        graph.chart->SetSelected(false);
-        m_selected_track_ids.erase(graph.chart->GetID());
-        SendTrackSelectionChanged(graph.chart->GetID(), false);
+        m_selected_track_ids.erase(track.GetID());
+        SendTrackSelectionChanged(track.GetID(), false);
     }
 }
 
 void
-TimelineSelection::UnselectAllTracks(std::vector<TrackGraph>& graphs)
+TimelineSelection::UnselectAllTracks()
 {
-    for(auto& graph : graphs)
-    {
-        graph.selected = false;
-        if(graph.chart)
-        {
-            graph.chart->SetSelected(false);
-        }
-    }
     m_selected_track_ids.clear();
     SendTrackSelectionChanged(INVALID_SELECTION_ID, false);
 }
 
 void
-TimelineSelection::ToggleSelectTrack(TrackGraph& graph)
+TimelineSelection::ToggleSelectTrack(TrackItem& track)
 {
-    if(graph.selected)
+    if(IsTrackSelected(track))
     {
-        UnselectTrack(graph);
+        UnselectTrack(track);
     }
     else
     {
-        SelectTrack(graph);
+        SelectTrack(track);
     }
 }
 
@@ -93,6 +79,12 @@ bool
 TimelineSelection::HasSelectedTracks() const
 {
     return !m_selected_track_ids.empty();
+}
+
+bool
+TimelineSelection::IsTrackSelected(TrackItem& track) const
+{
+    return m_selected_track_ids.count(track.GetID()) > 0;
 }
 
 void

--- a/src/view/src/rocprofvis_timeline_selection.h
+++ b/src/view/src/rocprofvis_timeline_selection.h
@@ -30,7 +30,7 @@ namespace View
 {
 
 class DataProvider;
-struct TrackGraph;
+class TrackItem;
 
 class TimelineSelection
 {
@@ -38,12 +38,13 @@ public:
     TimelineSelection(DataProvider& dp);
     ~TimelineSelection();
 
-    void SelectTrack(TrackGraph& graph);
-    void UnselectTrack(TrackGraph& graph);
-    void ToggleSelectTrack(TrackGraph& graph);
-    void UnselectAllTracks(std::vector<TrackGraph>& graphs);
+    void SelectTrack(TrackItem& track);
+    void UnselectTrack(TrackItem& track);
+    void ToggleSelectTrack(TrackItem& track);
+    void UnselectAllTracks();
     bool GetSelectedTracks(std::vector<uint64_t>& track_ids) const;
     bool HasSelectedTracks() const;
+    bool IsTrackSelected(TrackItem& track) const;
 
     void SelectTimeRange(double start_ts, double end_ts);
     bool GetSelectedTimeRange(double& start_ts_out, double& end_ts_out) const;

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -7,7 +7,6 @@
 #include "rocprofvis_annotations.h"
 #include "rocprofvis_click_manager.h"
 #include "rocprofvis_hotkey_manager.h"
-#include "rocprofvis_controller.h"
 #include "rocprofvis_core_assert.h"
 #include "rocprofvis_flame_track_item.h"
 #include "rocprofvis_font_manager.h"
@@ -18,9 +17,7 @@
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_notification_manager.h"
-#include "widgets/rocprofvis_debug_window.h"
 #include "widgets/rocprofvis_gui_helpers.h"
-#include <GLFW/glfw3.h>
 #include <algorithm>
 #include <sstream>
 
@@ -180,7 +177,7 @@ TimelineView::TimelineView(DataProvider&                          dp,
     m_timeline_time_range_changed_token = EventManager::GetInstance()->Subscribe(
         static_cast<int>(RocEvents::kTimelineTimeRangeChanged), time_range_changed_handler);
 
-    m_graphs = std::make_shared<std::vector<TrackGraph>>();
+    m_tracks = std::make_shared<std::vector<TrackItem*>>();
 
     // force initial calculation of flame track label width
     FlameTrackItem::CalculateMaxEventLabelWidth();
@@ -212,7 +209,7 @@ TimelineView::RenderInteractiveUI()
     ImDrawList* draw_list       = ImGui::GetWindowDrawList();
     ImVec2      window_position = ImGui::GetWindowPos();
 
-    m_arrow_layer.Render(draw_list, window_position, m_track_position_y, m_graphs, m_tpt);
+    m_arrow_layer.Render(draw_list, window_position, m_track_position_y, m_tracks, m_tpt);
 
     RenderMeasurement(draw_list, window_position);
 
@@ -731,11 +728,11 @@ TimelineView::HandleNewTrackData(std::shared_ptr<RocEvent> e)
         }
 
         uint64_t track_index = metadata->index;
-        if(track_index < m_graphs->size())
+        if(track_index < m_tracks->size())
         {
-            if((*m_graphs)[track_index].chart)
+            if((*m_tracks)[track_index])
             {
-                (*m_graphs)[track_index].chart->HandleTrackDataChanged(
+                (*m_tracks)[track_index]->HandleTrackDataChanged(
                     tde->GetRequestID(), tde->GetResponseCode());
             }
             else
@@ -764,16 +761,19 @@ TimelineView::Update()
             if(m_data_provider.SetGraphIndex(m_reorder_request.track_id,
                                              m_reorder_request.new_index))
             {
-                std::vector<TrackGraph> graphs_reordered;
+                std::vector<TrackItem*> tracks_reordered;
                 TimelineModel&          tlm = m_data_provider.DataModel().GetTimeline();
-                graphs_reordered.resize(tlm.GetTrackCount());
-                for(TrackGraph& graph : *m_graphs)
+                tracks_reordered.resize(tlm.GetTrackCount());
+                for(TrackItem* track : *m_tracks)
                 {
-                    const TrackInfo* metadata = tlm.GetTrack(graph.chart->GetID());
-                    ROCPROFVIS_ASSERT(metadata);
-                    graphs_reordered[metadata->index] = std::move(graph);
+                    if(track)
+                    {
+                        const TrackInfo* metadata = tlm.GetTrack(track->GetID());
+                        ROCPROFVIS_ASSERT(metadata);
+                        tracks_reordered[metadata->index] = track;
+                    }
                 }
-                *m_graphs = std::move(graphs_reordered);
+                *m_tracks = std::move(tracks_reordered);
             }
         }
         // Rebuild the positioning map.
@@ -781,22 +781,27 @@ TimelineView::Update()
         {
             m_track_position_y.clear();
             m_track_height_sum = 0;
-            for(int i = 0; i < m_graphs->size(); i++)
+            for(int i = 0; i < m_tracks->size(); i++)
             {
-                m_track_position_y[(*m_graphs)[i].chart->GetID()] = m_track_height_sum;
-                m_track_height_sum +=
-                    (*m_graphs)[i].display
-                        ? (*m_graphs)[i]
-                              .chart->GetTrackHeight()  // Get the height of the track.
-                        : 0;
-                (*m_graphs)[i].display_changed = false;
+                if((*m_tracks)[i])
+                {
+                    m_track_position_y[(*m_tracks)[i]->GetID()] = m_track_height_sum;
+                    m_track_height_sum +=
+                        (*m_tracks)[i]->IsDisplayed()
+                            ? (*m_tracks)[i]
+                                  ->GetTrackHeight()  // Get the height of the track.
+                            : 0;
+                }
             }
         }
         m_reorder_request.handled = true;
         m_resize_activity         = false;
-        for(const TrackGraph& track : *m_graphs)
+        for(TrackItem* track : *m_tracks)
         {
-            track.chart->Update();
+            if(track)
+            {
+                track->Update();
+            }
         }
     }
 }
@@ -1155,10 +1160,10 @@ TimelineView::RenderScrubber(ImVec2 screen_pos)
     ImGui::PopStyleColor();
 }
 
-std::shared_ptr<std::vector<TrackGraph>>
-TimelineView::GetGraphs()
+std::shared_ptr<std::vector<TrackItem*>>
+TimelineView::GetTracks()
 {
-    return m_graphs;
+    return m_tracks;
 }
 
 void
@@ -1305,7 +1310,7 @@ TimelineView::RenderGraphView()
     // Re-set each frame by RenderReorderingTrack while in the auto-scroll zone.
     m_reorder_auto_scrolling = false;
 
-    for(int index = 0; index < m_graphs->size(); index++)
+    for(int index = 0; index < m_tracks->size(); index++)
     {
         RenderTrack(index, request_data, window_flags, container_size);
     }
@@ -1374,72 +1379,70 @@ void
 TimelineView::RenderTrack(int track_index, bool request_data,
                           ImGuiWindowFlags window_flags, ImVec2 container_size)
 {
-    TrackGraph& track_graph = (*m_graphs)[track_index];
-    m_resize_activity |= track_graph.display_changed;
-
-    if(track_graph.display)
+    TrackItem* track_item = (*m_tracks)[track_index];
+    if(track_item)
     {
-        TrackItem* track_item = track_graph.chart;
-        ROCPROFVIS_ASSERT(track_item);
-
-        // Get track height and position to check if the track is in view
-        float  track_height = track_item->GetTrackHeight();
-        ImVec2 track_pos    = ImGui::GetCursorPos();
-
-        // Calculate the track's position in the scrollable area
-        float track_top    = track_pos.y;
-        float track_bottom = track_top + track_height;
-
-        // Calculate deltas for out-of-view tracks
-        float delta_top = m_scroll_position_y -
-                          track_bottom;  // Positive if the track is above the view
-        float delta_bottom =
-            track_top -
-            (m_scroll_position_y +
-             m_tpt->GetGraphSizeY());  // Positive if the track is below the view
-
-        // Save distance for book keeping
-        track_item->SetDistanceToView(std::max(std::max(delta_bottom, delta_top), 0.0f));
-
-        // This item is being reordered if there is an active payload and its id
-        // matches the payload's id.
-        bool is_reordering = ImGui::GetDragDropPayload() &&
-                             m_reorder_request.track_id == track_item->GetID();
-
-        // Check if the track is visible
-        bool is_visible = (track_bottom >= m_scroll_position_y &&
-                           track_top <= m_scroll_position_y + m_tpt->GetGraphSizeY()) ||
-                          is_reordering;
-
-        track_item->SetInViewVertical(is_visible);
-
         m_resize_activity |= track_item->TrackHeightChanged();
 
-        if(m_loading_timer.IsExpired())
+        if(track_item->IsDisplayed())
         {
-            if(is_visible || track_item->GetDistanceToView() <= m_unload_track_distance)
-            {
-                RequestDataIfEmpty(track_item, request_data);
-                track_item->RequestAnalysis();
-            }
-            else if(track_item->IsSelected())
-            {
-                track_item->RequestAnalysis();
-            }
-        }
+            // Get track height and position to check if the track is in view
+            float  track_height = track_item->GetTrackHeight();
+            ImVec2 track_pos    = ImGui::GetCursorPos();
 
-        if(is_visible)
-        {
-            RenderNormalTrack(track_graph, track_index, window_flags, is_reordering);
-        }
-        else
-        {
-            RenderEmptyTrack(track_item);
-        }
+            // Calculate the track's position in the scrollable area
+            float track_top    = track_pos.y;
+            float track_bottom = track_top + track_height;
 
-        if(is_reordering)
-        {
-            RenderReorderingTrack(track_item, container_size);
+            // Calculate deltas for out-of-view tracks
+            float delta_top = m_scroll_position_y -
+                              track_bottom;  // Positive if the track is above the view
+            float delta_bottom =
+                track_top -
+                (m_scroll_position_y +
+                 m_tpt->GetGraphSizeY());  // Positive if the track is below the view
+
+            // Save distance for book keeping
+            track_item->SetDistanceToView(std::max(std::max(delta_bottom, delta_top), 0.0f));
+
+            // This item is being reordered if there is an active payload and its id
+            // matches the payload's id.
+            bool is_reordering = ImGui::GetDragDropPayload() &&
+                                 m_reorder_request.track_id == track_item->GetID();
+
+            // Check if the track is visible
+            bool is_visible = (track_bottom >= m_scroll_position_y &&
+                               track_top <= m_scroll_position_y + m_tpt->GetGraphSizeY()) ||
+                              is_reordering;
+
+            track_item->SetInViewVertical(is_visible);
+
+            if(m_loading_timer.IsExpired())
+            {
+                if(is_visible || track_item->GetDistanceToView() <= m_unload_track_distance)
+                {
+                    RequestDataIfEmpty(track_item, request_data);
+                    track_item->RequestAnalysis();
+                }
+                else if(track_item->IsSelected())
+                {
+                    track_item->RequestAnalysis();
+                }
+            }
+
+            if(is_visible)
+            {
+                RenderNormalTrack(track_item, track_index, window_flags, is_reordering);
+            }
+            else
+            {
+                RenderEmptyTrack(track_item);
+            }
+
+            if(is_reordering)
+            {
+                RenderReorderingTrack(track_item, container_size);
+            }
         }
     }
 }
@@ -1465,15 +1468,13 @@ TimelineView::RequestDataIfEmpty(TrackItem* track_item, bool request_data)
 }
 
 void
-TimelineView::RenderNormalTrack(TrackGraph& track_graph, int track_index,
+TimelineView::RenderNormalTrack(TrackItem* track_item, int track_index,
                         ImGuiWindowFlags window_flags, bool is_reordering)
 {
-    TrackItem* track_item = track_graph.chart;
-    ROCPROFVIS_ASSERT(track_item);
     float track_height = track_item->GetTrackHeight();
 
     ImU32 selection_color = m_settings.GetColor(Colors::kTransparent);
-    if(track_graph.selected)
+    if(track_item->IsSelected())
     {
         selection_color = m_settings.GetColor(Colors::kHighlightChart);
     }
@@ -1523,7 +1524,7 @@ TimelineView::RenderNormalTrack(TrackGraph& track_graph, int track_index,
 
     RenderTimeRangeSelectionFill(lane_dl, lane_min, lane_max);
 
-    if(track_graph.selected)
+    if(track_item->IsSelected())
     {
         // Mark the selected lane without covering the track contents.
         lane_dl->AddRectFilled(
@@ -1598,7 +1599,7 @@ TimelineView::RenderNormalTrack(TrackGraph& track_graph, int track_index,
         // check for mouse click
         if(track_item->IsMetaAreaClicked())
         {
-            m_timeline_selection->ToggleSelectTrack(track_graph);
+            m_timeline_selection->ToggleSelectTrack(*track_item);
         }
     }
     ImGui::EndChild();
@@ -1722,14 +1723,13 @@ TimelineView::RenderReorderingTrack(TrackItem* track_item, ImVec2 container_size
 void
 TimelineView::DestroyGraphs()
 {
-    if(m_graphs)
+    if(m_tracks)
     {
-        for(TrackGraph& graph : *m_graphs)
+        for(TrackItem* track : *m_tracks)
         {
-            delete graph.chart;
+            delete track;
         }
-
-        m_graphs->clear();
+        m_tracks->clear();
     }
     m_meta_map_made = false;
 }
@@ -1754,7 +1754,7 @@ TimelineView::MakeGraphView()
 
     /*This section makes the charts both line and flamechart are constructed here*/
     uint64_t num_graphs = tlm.GetTrackCount();
-    m_graphs->resize(num_graphs);
+    m_tracks->resize(num_graphs);
 
     std::vector<const TrackInfo*> track_list    = tlm.GetTrackList();
     bool                          project_valid = m_project_settings.Valid();
@@ -1791,24 +1791,21 @@ TimelineView::MakeGraphView()
             continue;
         }
 
-        TrackGraph graph = { GraphType::TYPE_FLAMECHART, display, false, nullptr, false };
+        TrackItem* track = nullptr;
         switch(track_info->track_type)
         {
             case kRPVControllerTrackTypeEvents:
             {
                 // Create FlameChart
-                graph.chart = new FlameTrackItem(
-                    m_data_provider, m_timeline_selection, m_measurement,
-                    track_info->id, m_tpt);
-                graph.graph_type = GraphType::TYPE_FLAMECHART;
+                track = new FlameTrackItem(m_data_provider, track_info->id, display,
+                                           m_tpt, m_timeline_selection, m_measurement);
                 break;
             }
             case kRPVControllerTrackTypeSamples:
             {
                 // Linechart
-                graph.chart = new LineTrackItem(m_data_provider, track_info->id, m_tpt,
-                                                m_timeline_selection);
-                graph.graph_type = GraphType::TYPE_LINECHART;
+                track = new LineTrackItem(m_data_provider, track_info->id, display, m_tpt,
+                                          m_timeline_selection);
                 break;
             }
             default:
@@ -1816,12 +1813,12 @@ TimelineView::MakeGraphView()
                 break;
             }
         }
-        if(graph.chart)
+        if(track)
         {
             m_tpt->SetMinMaxX(std::min(track_info->min_ts, m_tpt->GetMinX()),
                               std::max(track_info->max_ts, m_tpt->GetMaxX()));
 
-            (*m_graphs)[track_info->index] = std::move(graph);
+            (*m_tracks)[track_info->index] = track;
         }
     }
 
@@ -2811,7 +2808,7 @@ TimelineView::GetVisibleTrackFractions(float& start_fraction, float& end_fractio
     start_fraction = 0.0f;
     end_fraction   = 1.0f;
 
-    if(!m_graphs || m_graphs->empty()) return;
+    if(!m_tracks || m_tracks->empty()) return;
 
     // Count displayed tracks and find visible range
     int   displayed_count = 0;
@@ -2821,12 +2818,12 @@ TimelineView::GetVisibleTrackFractions(float& start_fraction, float& end_fractio
     float view_bottom     = view_top + GetTrackViewportHeight();
     float cumulative_y    = 0.0f;
 
-    for(int i = 0; i < static_cast<int>(m_graphs->size()); i++)
+    for(int i = 0; i < static_cast<int>(m_tracks->size()); i++)
     {
-        const auto& graph = (*m_graphs)[i];
-        if(!graph.display) continue;
+        const auto& track = (*m_tracks)[i];
+        if(!track || !track->IsDisplayed()) continue;
 
-        float track_height = graph.chart->GetTrackHeight();
+        float track_height = track->GetTrackHeight();
         float track_top    = cumulative_y;
         float track_bottom = cumulative_y + track_height;
 
@@ -2869,15 +2866,15 @@ void
 TimelineView::UpdateMaxMetaAreaSize(bool update_tracks)
 {
     m_max_meta_scale_area_size = 0.0f;
-    for(TrackGraph& track : (*m_graphs))
+    for(TrackItem* track : (*m_tracks))
     {
-        if(track.chart)
+        if(track)
         {
             if(update_tracks)
             {
-                track.chart->UpdateMaxMetaScaleAreaSize();
+                track->UpdateMaxMetaScaleAreaSize();
             }
-            m_max_meta_scale_area_size = std::max(track.chart->GetMaxMetaAreaScaleWidth(),
+            m_max_meta_scale_area_size = std::max(track->GetMaxMetaAreaScaleWidth(),
                                                   m_max_meta_scale_area_size);
         }
     }
@@ -2894,13 +2891,13 @@ TimelineViewProjectSettings::~TimelineViewProjectSettings() {}
 void
 TimelineViewProjectSettings::ToJson()
 {
-    const std::vector<TrackGraph>& graphs = *m_timeline_view.GetGraphs();
-    for(int i = 0; i < graphs.size(); i++)
+    const std::vector<TrackItem*>& tracks = *m_timeline_view.GetTracks();
+    for(int i = 0; i < tracks.size(); i++)
     {
-        uint64_t id = graphs[i].chart->GetID();
+        uint64_t id = tracks[i]->GetID();
         m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER][i] = id;
         m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK][id]
-                       [JSON_KEY_TIMELINE_TRACK_DISPLAY] = graphs[i].display;
+                       [JSON_KEY_TIMELINE_TRACK_DISPLAY] = tracks[i]->IsDisplayed();
     }
 }
 
@@ -2913,7 +2910,7 @@ TimelineViewProjectSettings::Valid() const
         std::vector<jt::Json>& track_order =
             m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER]
                 .getArray();
-        if(track_order.size() == m_timeline_view.m_graphs->size())
+        if(track_order.size() == m_timeline_view.m_tracks->size())
         {
             int valid_count = 0;
             for(jt::Json& track_id : track_order)
@@ -2938,7 +2935,7 @@ TimelineViewProjectSettings::Valid() const
             std::vector<jt::Json>& tracks =
                 m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK]
                     .getArray();
-            if(tracks.size() == m_timeline_view.m_graphs->size())
+            if(tracks.size() == m_timeline_view.m_tracks->size())
             {
                 int valid_count = 0;
                 for(jt::Json& track_id : tracks)

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -91,7 +91,7 @@ public:
     void                                             MakeGraphView();
     void                                             ResetView();
     void                                             DestroyGraphs();
-    std::shared_ptr<std::vector<TrackGraph>> GetGraphs();
+    std::shared_ptr<std::vector<TrackItem*>>         GetTracks();
     void                                             RenderInteractiveUI();
     void ScrollToTrack(const uint64_t& track_id);
     void SetViewableRangeNS(double start_ns, double end_ns);
@@ -158,7 +158,7 @@ private:
                      ImVec2 container_size);
     bool IsRequestDataNeeded();
     void RequestDataIfEmpty(TrackItem* track_item, bool request_data);
-    void RenderNormalTrack(TrackGraph& track_graph, int track_index, ImGuiWindowFlags window_flags,
+    void RenderNormalTrack(TrackItem* track_item, int track_index, ImGuiWindowFlags window_flags,
                    bool is_reordering);
     void RenderTimeRangeSelectionFill(ImDrawList* draw_list, ImVec2 lane_min,
                                       ImVec2 lane_max);
@@ -209,7 +209,7 @@ private:
     bool                                m_pseudo_focus;
     bool                                m_histogram_pseudo_focus;
     float                               m_max_meta_scale_area_size;
-    std::shared_ptr<std::vector<TrackGraph>> m_graphs;
+    std::shared_ptr<std::vector<TrackItem*>>          m_tracks;
     std::shared_ptr<TimePixelTransform>               m_tpt;
     struct
     {

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -290,7 +290,7 @@ TraceView::CreateView()
 
     auto sidebar =
         std::make_shared<SideBar>(m_track_topology, m_timeline_selection,
-                                  m_timeline_view->GetGraphs(), m_data_provider);
+                                  m_timeline_view->GetTracks(), m_data_provider);
     auto analysis = std::make_shared<AnalysisView>(m_data_provider, m_track_topology,
                                                    m_timeline_selection, m_annotations);
 
@@ -610,11 +610,7 @@ TraceView::RenderEditMenuOptions()
     {
         if(m_timeline_selection)
         {
-            std::shared_ptr<std::vector<TrackGraph>> graphs = m_timeline_view->GetGraphs();
-            if(graphs)
-            {
-                m_timeline_selection->UnselectAllTracks(*graphs);
-            }
+            m_timeline_selection->UnselectAllTracks();
         }
     }
     if(ImGui::MenuItem("Unselect All Events", nullptr, false,

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -30,7 +30,7 @@ constexpr const char*     TRACK_COPY_MENU_POPUP_NAME     = "TrackCopyMenu";
 
 float TrackItem::s_metadata_width = 400.0f;
 
-TrackItem::TrackItem(DataProvider& dp, uint64_t id,
+TrackItem::TrackItem(DataProvider& dp, uint64_t id, bool display,
                      std::shared_ptr<TimePixelTransform> tpt,
                      std::shared_ptr<TimelineSelection>  timeline_selection)
 : m_track_metadata(nullptr)
@@ -51,13 +51,15 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id,
 , m_meta_area_clicked(false)
 , m_meta_area_scale_width(0.0f)
 , m_max_meta_area_scale_width(0.0f)
-, m_selected(false)
+, m_display(display)
 , m_reorder_grip_width(DEFAULT_GRIP_WIDTH)
 , m_tpt(tpt)
 , m_timeline_selection(timeline_selection)
 , m_chunk_duration_ns(DEFAULT_CHUNK_DURATION)
 , m_group_id_counter(0)
 , m_meta_area_label("")
+, m_selected(false)
+, m_selected_changed_token(EventManager::InvalidSubscriptionToken)
 , m_track_project_settings(m_data_provider.GetTraceFilePath(), *this)
 {
     if(m_track_project_settings.Valid())
@@ -77,6 +79,28 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id,
     m_name = m_data_provider.DataModel().BuildTrackName(m_track_id);
     SetMetaAreaLabel(track_info);
     SetDefaultPillLabel(track_info);
+
+    EventManager::EventHandler selected_changed_handler =
+        [this](std::shared_ptr<RocEvent> e) {
+            std::shared_ptr<TrackSelectionChangedEvent> evt =
+                std::dynamic_pointer_cast<TrackSelectionChangedEvent>(e);
+            if(evt && evt->GetSourceId() == m_data_provider.GetTraceFilePath() &&
+               (evt->GetTrackID() == m_track_id ||
+                evt->GetTrackID() == TimelineSelection::INVALID_SELECTION_ID))
+            {
+                m_selected = evt->TrackSelected();
+            }
+        };
+    m_selected_changed_token = EventManager::GetInstance()->Subscribe(
+        static_cast<int>(RocEvents::kTimelineTrackSelectionChanged),
+        selected_changed_handler);
+}
+
+TrackItem::~TrackItem()
+{
+    EventManager::GetInstance()->Unsubscribe(
+        static_cast<int>(RocEvents::kTimelineTrackSelectionChanged),
+        m_selected_changed_token);
 }
 
 bool
@@ -88,7 +112,7 @@ TrackItem::TrackHeightChanged()
 }
 
 float
-TrackItem::GetTrackHeight()
+TrackItem::GetTrackHeight() const
 {
     return m_track_height;
 }
@@ -100,7 +124,7 @@ TrackItem::GetName()
 }
 
 uint64_t
-TrackItem::GetID()
+TrackItem::GetID() const
 {
     return m_track_id;
 }
@@ -112,7 +136,7 @@ TrackItem::SetSidebarSize(float sidebar_size)
 }
 
 bool
-TrackItem::IsInViewVertical()
+TrackItem::IsInViewVertical() const
 {
     return m_is_in_view_vertical;
 }
@@ -124,7 +148,7 @@ TrackItem::SetDistanceToView(float distance)
 }
 
 float
-TrackItem::GetDistanceToView()
+TrackItem::GetDistanceToView() const
 {
     return m_distance_to_view_y;
 }
@@ -141,19 +165,27 @@ TrackItem::SetID(uint64_t id)
     m_track_id = id;
 }
 
-
 bool
 TrackItem::IsSelected() const
 {
     return m_selected;
 }
 
-void
-TrackItem::SetSelected(bool selected)
+bool
+TrackItem::IsDisplayed() const
 {
-    m_selected = selected;
+    return m_display;
 }
 
+void
+TrackItem::SetDisplay(bool display)
+{
+    if(display != m_display)
+    {
+        m_display              = display;
+        m_track_height_changed = true;
+    }
+}
 
 void
 TrackItem::Render(float width)
@@ -212,7 +244,7 @@ void
 TrackItem::RenderMetaArea()
 {
     ImVec2 outer_container_size = ImGui::GetContentRegionAvail();
-    m_track_content_height      = m_track_height;
+    m_track_content_height      = m_track_height - 0.5f * m_resize_grip_thickness;
 
     ImVec2 name_label_min(0.0f, 0.0f);
     ImVec2 name_label_max(0.0f, 0.0f);
@@ -232,12 +264,10 @@ TrackItem::RenderMetaArea()
                               : (m_request_state == TrackDataRequestState::kError
                                      ? m_settings.GetColor(Colors::kGridRed)
                                      : m_settings.GetColor(Colors::kMetaDataColor)));
-    ImGui::SetCursorPos(ImVec2(0.0f, 0.0f));
-    if(ImGui::BeginChild("MetaData Area",
-                         ImVec2(s_metadata_width, outer_container_size.y),
-                         ImGuiChildFlags_None,
-                         ImGuiWindowFlags_NoScrollbar |
-                             ImGuiWindowFlags_NoScrollWithMouse))
+    if(ImGui::BeginChild(
+           "MetaData Area", ImVec2(s_metadata_width, outer_container_size.y),
+           ImGuiChildFlags_None,
+           ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse))
     {
         ImVec2 content_size = ImGui::GetContentRegionAvail();
 
@@ -323,16 +353,12 @@ TrackItem::RenderMetaArea()
         RenderMetaAreaScale();
         RenderMetaAreaExpand();
         RenderPills(ImVec2(available_for_text, content_size.y));
+        ImGui::GetWindowDrawList()->AddLine(
+            ImGui::GetWindowPos() + ImVec2(0.0f, ImGui::GetWindowSize().y),
+            ImGui::GetWindowPos() + ImGui::GetWindowSize(),
+            m_settings.GetColor(Colors::kMetaDataSeparator), m_resize_grip_thickness);
     }
     ImGui::EndChild();  // end metadata area
-
-    ImVec2      meta_min = ImGui::GetItemRectMin();
-    ImVec2      meta_max = ImGui::GetItemRectMax();
-    ImDrawList* dl       = ImGui::GetWindowDrawList();
-    dl->AddLine(ImVec2(meta_max.x - 1.0f, meta_min.y),
-                ImVec2(meta_max.x - 1.0f, meta_max.y),
-                m_settings.GetColor(Colors::kMetaDataSeparator), 1.0f);
-
     ImGui::PopStyleColor();
     ImGui::PopStyleVar(5);
     if(ImGui::IsItemClicked(ImGuiMouseButton_Left))
@@ -404,12 +430,13 @@ TrackItem::RenderResizeBar(const ImVec2& parent_size)
     ImGui::PushStyleColor(ImGuiCol_ChildBg, m_settings.GetColor(Colors::kTransparent));
     ImGui::BeginChild("Resize Bar", ImVec2(parent_size.x, m_resize_grip_thickness),
                       false);
-
-    ImGui::Selectable(("##MovePositionLine" + std::to_string(m_track_id)).c_str(), false,
-                      ImGuiSelectableFlags_AllowDoubleClick,
-                      ImVec2(0, m_resize_grip_thickness));
-    if(ImGui::IsItemHovered())
+    ImGui::InvisibleButton("##MovePositionLine", ImVec2(0, m_resize_grip_thickness));
+    if(ImGui::IsItemHovered() || ImGui::IsItemActive())
     {
+        ImGui::GetWindowDrawList()->AddLine(
+            ImGui::GetItemRectMin(),
+            ImVec2(ImGui::GetItemRectMax().x, ImGui::GetItemRectMin().y),
+            m_settings.GetColor(Colors::kAccent), m_resize_grip_thickness);
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeNS);
     }
 

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -91,23 +91,26 @@ private:
 class TrackItem
 {
 public:
-    TrackItem(DataProvider& dp, uint64_t id, std::shared_ptr<TimePixelTransform> tpt,
+    TrackItem(DataProvider& dp, uint64_t id, bool diplay, 
+              std::shared_ptr<TimePixelTransform> tpt,
               std::shared_ptr<TimelineSelection> timeline_selection = nullptr);
-    virtual ~TrackItem() {}
+    virtual ~TrackItem();
     void               SetID(uint64_t id);
-    uint64_t           GetID();
-    virtual float      GetTrackHeight();
+    uint64_t           GetID() const;
+    virtual float      GetTrackHeight() const;
     virtual void       Render(float width);
     virtual void       Update();
     const std::string& GetName();
-    bool IsInViewVertical();
+    bool IsInViewVertical() const;
     void SetInViewVertical(bool in_view);
 
     bool  IsSelected() const;
-    void  SetSelected(bool selected);
-    void  SetDistanceToView(float distance);
 
-    float GetDistanceToView();
+    bool IsDisplayed() const;
+    void SetDisplay(bool display);
+
+    void  SetDistanceToView(float distance);
+    float GetDistanceToView() const;
 
     bool        TrackHeightChanged();
     static void SetSidebarSize(float sidebar_size);
@@ -163,7 +166,7 @@ protected:
     bool                                m_meta_area_clicked;
     float                               m_meta_area_scale_width;
     float                               m_max_meta_area_scale_width;
-    bool                                m_selected;
+    bool                                m_display;
     float                               m_reorder_grip_width;
     std::shared_ptr<TimePixelTransform> m_tpt;
     std::shared_ptr<TimelineSelection>  m_timeline_selection;
@@ -178,6 +181,9 @@ protected:
 
 private:
     void RenderPills(ImVec2 region);
+
+    bool                            m_selected;
+    EventManager::SubscriptionToken m_selected_changed_token;
 
     std::vector<std::unique_ptr<Pill>> m_pills;
     TrackProjectSettings               m_track_project_settings;

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -223,7 +223,6 @@ TrackTopology::UpdateTopology()
         m_topology.node_lut.clear();
         std::vector<const NodeInfo*> node_infos = topology_data.GetNodeList();
         m_topology.nodes.resize(node_infos.size());
-        std::vector<std::vector<TrackGraph*>> graph_categories(node_infos.size());
         m_topology.node_header = "Nodes (" + std::to_string(node_infos.size()) + ")";
         for(int i = 0; i < node_infos.size(); i++)
         {


### PR DESCRIPTION
- Remove `TrackGraph`
  - `Selection` - `TimelineSelection` made sole owner. `TrackItem` maintains read-only cached value updated via event to avoid querying `TimelineSelection` (`set` look up) constantly in render loop.
  - `Display` - Moved to `TrackItem`.
  - Others removed.
- Restore `TrackItem` vertical resize grip visibility + apply accent on hover like other grips.
- Add project to recent files on Save/Save As.
