### PR TITLE
Always show Node ID and Process ID in track tooltip

### DIFF
--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -740,14 +740,8 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
 
     std::string meta_lines;
     meta_lines += "Track ID: " + std::to_string(track_info->id) + "\n";
-    if(show_node_id)
-    {
-        meta_lines += "Node ID: " + node_id_str + "\n";
-    }
-    if(show_process_id)
-    {
-        meta_lines += "Process ID: " + process_id_str + "\n";
-    }
+    meta_lines += "Node ID: " + node_id_str + "\n";
+    meta_lines += "Process ID: " + process_id_str + "\n";
     meta_lines += std::string(count_label) + ": ";
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     meta_lines += std::to_string(track_info->num_entries);


### PR DESCRIPTION
## Motivation

The track meta-area tooltip only displayed the Node ID and Process ID
when a trace contained more than one node or process. For single-node /
single-process traces these fields were hidden, so the tooltip didn't
consistently surface a track's full identifying info. This makes the
tooltip always show all info (e.g. Node, Process Id) regardless of the
trace topology.

## Technical Details

- Updated `TrackItem::SetMetaAreaLabel` in
  `src/view/src/rocprofvis_track_item.cpp` to always append `Node ID`
  and `Process ID` to the tooltip (`meta_lines`), dropping the
  `show_node_id` / `show_process_id` conditions that previously gated
  them.
- The visible track label is intentionally left unchanged: it still
  omits the `(NID:)` / `(PID:)` suffixes in the single-node /
  single-process case to avoid cluttering the timeline labels. Only the
  hover tooltip now always shows the complete info.