### PR TITLE
Show units with track detail statistics

### DIFF
--- a/src/view/src/rocprofvis_track_details.cpp
+++ b/src/view/src/rocprofvis_track_details.cpp
@@ -12,7 +12,6 @@
 #include "widgets/rocprofvis_gui_helpers.h"
 #include "widgets/rocprofvis_widget.h"
 
-#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -456,7 +455,8 @@ TrackDetails::RenderTable(InfoTable& table, const char* table_id,
                     CaptureCellRightClick(0, stat_row, m_cell_menu, open_menu);
                     PositionCell(1);
                     ImGui::BeginDisabled(!stats_ready);
-                    ImGui::Text("%.1f", stats->stats[i].value);
+                    ImGui::TextUnformatted(stats_ready ? stats->stats[i].compact.c_str()
+                                                       : "--");
                     ImGui::EndDisabled();
                     CaptureCellRightClick(1, stat_row, m_cell_menu, open_menu);
                     ImGui::PopID();
@@ -486,10 +486,7 @@ TrackDetails::RenderTable(InfoTable& table, const char* table_id,
                 {
                     const AnalysisTrackStatistics::Stat& stat =
                         stats->stats[m_cell_menu.row - rows];
-                    char value_buf[32];
-                    std::snprintf(value_buf, sizeof(value_buf), "%.1f", stat.value);
-                    std::string stat_cells[2] = { std::string(stat.name),
-                                                  std::string(value_buf) };
+                    std::string stat_cells[2] = { std::string(stat.name), stat.compact };
                     AddCopyRowCellMenuItems(stat_cells, 2, m_cell_menu.column);
                 }
                 EndCellContextMenu();

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -323,13 +323,10 @@ TrackTopology::UpdateTopology()
                                         { { InfoTable::Cell{ "Description", false },
                                         InfoTable::Cell{ counter_info->description,
                                         false } },
-                                        { InfoTable::Cell{ "Units", false },
-                                        InfoTable::Cell{ counter_info->units,
-                                        false } },
                                         { InfoTable::Cell{ "Value Type", false },
                                         InfoTable::Cell{ counter_info->value_type,
                                         false } } }
-                                };
+                                    };
                             }
                         }
                     }


### PR DESCRIPTION
## Motivation

The Track Details panel listed counter statistics (min / max / mean /
standard deviation) and queue utilization as bare numbers with no units,
making the values ambiguous. This adds units so each statistic is
self-describing.

## Technical Details

- `rocprofvis_track_details.cpp`: the statistics value column now renders
  the analysis model's preformatted `compact` string (value + units)
  instead of printing the raw value with `%.1f`. Queue utilization shows
  `%`; counter min/max/mean/std-dev show the counter's own units. A `--`
  placeholder is shown while stats are still being computed, and copying a
  stat now includes the unit.
- `rocprofvis_track_topology.cpp`: dropped the now-redundant standalone
  "Units" row from the counter info table, since the unit is shown
  alongside every statistic.

Units are sourced as-is: counter units come from the database
(`counter->units`), and queue utilization is hardcoded to `%` because it
comes from the analysis path rather than a counter. When a trace provides
no units (e.g. classic rocpd), the value is shown without a unit.