### PR TITLE
Add usage tooltip to Compute comparison threshold input

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -707,6 +707,7 @@ ComputeComparisonView::RenderToolbar()
         ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + window_width * 0.25f);
         ImGui::TextUnformatted(
             "Highlight absolute percentage differences above this threshold.");
+        ImGui::TextUnformatted("Drag to adjust or double click to edit.");
         ImGui::PopTextWrapPos();
         EndTooltipStyled();
     }

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -597,13 +597,6 @@ AppWindow::WantsContinuousRender()
         return true;
     }
 
-    // Keep rendering while an item is hovered so the tooltip hover-delay timer
-    // can elapse instead of the idle loop sleeping before tooltips appear.
-    if(ImGui::IsAnyItemHovered())
-    {
-        return true;
-    }
-
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     if(m_test_data_provider.GetState() == ProviderState::kLoading ||
        m_test_data_provider.GetPendingRequestCount() > 0)

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -597,6 +597,13 @@ AppWindow::WantsContinuousRender()
         return true;
     }
 
+    // Keep rendering while an item is hovered so the tooltip hover-delay timer
+    // can elapse instead of the idle loop sleeping before tooltips appear.
+    if(ImGui::IsAnyItemHovered())
+    {
+        return true;
+    }
+
 #ifdef ROCPROFVIS_DEVELOPER_MODE
     if(m_test_data_provider.GetState() == ProviderState::kLoading ||
        m_test_data_provider.GetPendingRequestCount() > 0)


### PR DESCRIPTION
## Motivation

The Compute comparison threshold input is a drag-to-edit control, but
nothing on screen tells the user they can drag it or double-click to
type a value, so the interaction isn't discoverable.

## Technical Details

- Added a tooltip to the Compute comparison threshold box reading
  "Drag to adjust or double click to edit." alongside the existing
  threshold description.
- Made hover tooltips render reliably when the app is idle so the new
  hint (and other tooltips) actually show up.