### PR TITLE
Fixed mutiple topology issues

### DIFF
--- a/src/view/src/model/rocprofvis_topology_model.cpp
+++ b/src/view/src/model/rocprofvis_topology_model.cpp
@@ -126,16 +126,16 @@ TopologyDataModel::ClearSampledThreads()
 
 // Queue access
 const QueueInfo*
-TopologyDataModel::GetQueue(uint64_t queue_id) const
+TopologyDataModel::GetQueue(uint64_t queue_id, uint64_t device_id) const
 {
-    auto it = m_queues.find(queue_id);
+    auto it = m_queues.find({ queue_id,device_id });
     return (it != m_queues.end()) ? &it->second : nullptr;
 }
 
 void
 TopologyDataModel::AddQueue(uint64_t queue_id, QueueInfo&& queue)
 {
-    m_queues[queue_id] = std::move(queue);
+    m_queues[{queue_id, queue.device_id}] = std::move(queue);
 }
 
 void
@@ -198,89 +198,6 @@ TopologyDataModel::Clear()
     ClearCounters();
 }
 
-uint64_t
-TopologyDataModel::GetDeviceIdByInfoId(uint64_t             info_id,
-                                       TrackInfo::TrackType track_type) const
-{
-    uint64_t device_id = INVALID_UINT64_INDEX;
-
-    switch(track_type)
-    {
-        case TrackInfo::TrackType::Counter:
-        {
-            const CounterInfo* counter_info = GetCounter(info_id);
-            if(counter_info)
-            {
-                device_id = counter_info->device_id;
-            }
-        }
-        break;
-        case TrackInfo::TrackType::Queue:
-        {
-            const QueueInfo* queue_info = GetQueue(info_id);
-            if(queue_info)
-            {
-                device_id = queue_info->device_id;
-            }
-        }
-        break;
-        case TrackInfo::TrackType::Stream:
-        {
-            const StreamInfo* stream_info = GetStream(info_id);
-            if(stream_info)
-            {
-                device_id = stream_info->processors[0].id;
-            }
-        }
-        break;
-        default: break;
-    }
-    return device_id;
-}
-
-const DeviceInfo*
-TopologyDataModel::GetDeviceByInfoId(uint64_t             info_id,
-                                     TrackInfo::TrackType track_type) const
-{
-    const DeviceInfo* device_info = nullptr;
-    uint64_t          device_id   = GetDeviceIdByInfoId(info_id, track_type);
-
-    if(device_id != INVALID_UINT64_INDEX)
-    {
-        device_info = GetDevice(device_id);
-    }
-    return device_info;
-}
-
-std::string
-TopologyDataModel::GetDeviceTypeLabelByInfoId(uint64_t             info_id,
-                                              TrackInfo::TrackType track_type,
-                                              std::string_view default_label) const
-{
-    const DeviceInfo* device_info = GetDeviceByInfoId(info_id, track_type);
-    if(device_info)
-    {
-        std::string label;
-        if(GetDeviceTypeLabel(*device_info, label))
-        {
-            return label;
-        }
-    }
-    return std::string(default_label);
-}
-
-std::string
-TopologyDataModel::GetDeviceProductLabelByInfoId(uint64_t             info_id,
-                                                 TrackInfo::TrackType track_type,
-                                                std::string_view default_label) const
-{
-    const DeviceInfo* device_info = GetDeviceByInfoId(info_id, track_type);
-    if(device_info)
-    {
-        return device_info->product_name;
-    }
-    return std::string(default_label);
-}
 
 bool
 TopologyDataModel::GetDeviceTypeLabel(const DeviceInfo& device_info,
@@ -332,7 +249,7 @@ TopologyDataModel::TopologyToString()
             ss << indent(level) << "Queues: " << devInfo->queue_ids.size() << std::endl;
             for(const uint64_t& d : devInfo->queue_ids)
             {
-                const QueueInfo* queueInfo = GetQueue(d);
+                const QueueInfo* queueInfo = GetQueue(d, devInfo->id.value);
                 ss << QueueInfoToString(queueInfo, level+1) << std::endl;                       
             }
 

--- a/src/view/src/model/rocprofvis_topology_model.h
+++ b/src/view/src/model/rocprofvis_topology_model.h
@@ -6,6 +6,7 @@
 #include "rocprofvis_model_types.h"
 
 #include <unordered_map>
+#include <map>
 #include <vector>
 
 namespace RocProfVis
@@ -58,7 +59,7 @@ public:
     size_t SampledThreadCount() const { return m_sampled_threads.size(); }
 
     // Queue access
-    const QueueInfo* GetQueue(uint64_t queue_id) const;
+    const QueueInfo* GetQueue(uint64_t queue_id, uint64_t device_id) const;
     void AddQueue(uint64_t queue_id, QueueInfo&& queue);
     void ClearQueues();
     size_t QueueCount() const { return m_queues.size(); }
@@ -80,29 +81,6 @@ public:
 
     // Helpers
 
-    /* Gets the device ID associated with a given topology info ID and track type
-        @param info_id - id of the topology item ex: TrackInfo::topology.id
-        @param track_type - type of the topology item ex: TrackInfo::topology.type
-        @return device ID if found, INVALID_UINT64_INDEX otherwise
-    */
-    uint64_t GetDeviceIdByInfoId(uint64_t info_id, TrackInfo::TrackType track_type) const;
-
-    /* Gets the device info associated with a given topology info ID and track type
-        @param info_id - id of the topology item ex: TrackInfo::topology.id
-        @param track_type - type of the topology item ex: TrackInfo::topology.type
-        @return a pointer to the device info if found, nullptr otherwise
-    */
-    const DeviceInfo* GetDeviceByInfoId(uint64_t             info_id,
-                                        TrackInfo::TrackType track_type) const;
-
-    std::string GetDeviceTypeLabelByInfoId(
-        uint64_t info_id, TrackInfo::TrackType track_type,
-        std::string_view default_label = "Unknown Device") const;
-
-    std::string GetDeviceProductLabelByInfoId(
-        uint64_t info_id, TrackInfo::TrackType track_type,
-        std::string_view default_label = "Unknown") const;
-
     bool GetDeviceTypeLabel(const DeviceInfo& device_info, std::string& label_out) const;
 
     // Debug
@@ -120,7 +98,7 @@ private:
     std::unordered_map<uint64_t, ProcessInfo> m_processes;
     std::unordered_map<uint64_t, ThreadInfo>  m_instrumented_threads;
     std::unordered_map<uint64_t, ThreadInfo>  m_sampled_threads;
-    std::unordered_map<uint64_t, QueueInfo>   m_queues;
+    std::map<std::pair<uint64_t,uint64_t>, QueueInfo>   m_queues;
     std::unordered_map<uint64_t, StreamInfo>  m_streams;
     std::unordered_map<uint64_t, CounterInfo> m_counters;
 };

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -276,7 +276,7 @@ TrackTopology::UpdateTopology()
                             m_topology.nodes[i].processors[j].queue_lut[queue_ids[k]] =
                                 &m_topology.nodes[i].processors[j].queues[k];
                             const QueueInfo* queue_info =
-                                topology_data.GetQueue(queue_ids[k]);
+                                topology_data.GetQueue(queue_ids[k], processor_info->id.value);
                             if(queue_info)
                             {
                                 const DeviceInfo* device_info =
@@ -388,9 +388,9 @@ TrackTopology::UpdateTopology()
                                     
                                 for (int processor_index = 0; processor_index < stream_processors.size(); processor_index++)
                                 {
-                                    stream->processor_lut[processor_ids[processor_index]] = &stream->processors[processor_index];
+                                    stream->processor_lut[stream_processors[processor_index].id] = &stream->processors[processor_index];
                                     const DeviceInfo* processor_info =
-                                        topology_data.GetDevice(processor_ids[processor_index]);
+                                        topology_data.GetDevice(stream_processors[processor_index].id);
                                     if (processor_info)
                                     {
                                         stream->processors[processor_index].info       = processor_info;
@@ -413,7 +413,7 @@ TrackTopology::UpdateTopology()
                                             stream->processors[processor_index].queue_lut[queue_ids[queue_index]] =
                                                 &stream->processors[processor_index].queues[queue_index];
                                             const QueueInfo* queue_info =
-                                                topology_data.GetQueue(queue_ids[queue_index]);
+                                                topology_data.GetQueue(queue_ids[queue_index],processor_info->id.value);
                                             if(queue_info)
                                             {
                                                 const DeviceInfo* device_info =


### PR DESCRIPTION
## Motivation

Stream topology processor doesn't match track processor.
"Memory allocation" track is duplicated across all the streams.

## Technical Details

First issue is Fixed by Derek - The stream processor loop is using the wrong list [Update rocprofvis_track_topology.cpp · ROCm/roc-optiq@9980801](https://github.com/ROCm/roc-optiq/commit/186bd52f0225ede7489189aa070141f484a0241e)

Second issue happens because queue with the same id can belong to multiple processor. So m_queues map of TopologyDataModel class has to be keyed not just queue_id, but also by device id. 

