### PR TITLE
[PoC]: Add dedicated per-GPU KFD tracks

### DIFF
--- a/src/controller/src/system/rocprofvis_controller_trace_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_trace_system.cpp
@@ -186,6 +186,7 @@ rocprofvis_result_t SystemTrace::LoadRocpd(Future* future) {
                                    dm_track_type == kRocProfVisDmMemoryAllocationTrack ||
                                    dm_track_type == kRocProfVisDmMemoryCopyTrack ||
                                    dm_track_type == kRocProfVisDmStreamTrack ||
+                                   dm_track_type == kRocProfVisDmKfdTrack ||
                                    dm_track_type == kRocProfVisDmPmcTrack)
                                 {
                                     auto   type = (dm_track_type == kRocProfVisDmPmcTrack)
@@ -413,6 +414,12 @@ rocprofvis_result_t SystemTrace::LoadRocpd(Future* future) {
                                             {
                                                 track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
                                                 track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationLaunchSample);
+                                                break;
+                                            }
+                                            case kRocProfVisDmKfdTrack:
+                                            {
+                                                track->SetUInt64(kRPVControllerTrackNumberOfOperationTypes, 0, 1);
+                                                track->SetUInt64(kRPVControllerTrackOperationTypeIndexed, 0, kRocProfVisDmOperationKfd);
                                                 break;
                                             }
                                             default:

--- a/src/controller/src/system/rocprofvis_controller_track.cpp
+++ b/src/controller/src/system/rocprofvis_controller_track.cpp
@@ -310,6 +310,7 @@ rocprofvis_result_t Track::FetchFromDataModel(double start, double end, Future* 
                         case kRocProfVisDmMemoryAllocationTrack:
                         case kRocProfVisDmMemoryCopyTrack:
                         case kRocProfVisDmStreamTrack:
+                        case kRocProfVisDmKfdTrack:
                         {
                             uint64_t index = 0;
 

--- a/src/model/inc/rocprofvis_interface_types.h
+++ b/src/model/inc/rocprofvis_interface_types.h
@@ -105,12 +105,14 @@ typedef enum rocprofvis_dm_track_category_t {
     kRocProfVisDmRegionMainTrack = 0x100,
     // Object is region sample track
     kRocProfVisDmRegionSampleTrack = 0x200,
+    // Object is KFD track (kernel fusion driver events: page fault, page migrate, queue, etc.)
+    kRocProfVisDmKfdTrack = 0x400,
 
     kRocProfVisDmLaunchTrack = kRocProfVisDmRegionTrack | kRocProfVisDmRegionMainTrack | kRocProfVisDmRegionSampleTrack,
     kRocProfVisDmDispatchTrack = kRocProfVisDmKernelDispatchTrack | kRocProfVisDmMemoryAllocationTrack | kRocProfVisDmMemoryCopyTrack,
-    kRocProfVisDmEventTrack = kRocProfVisDmLaunchTrack | kRocProfVisDmDispatchTrack,
+    kRocProfVisDmEventTrack = kRocProfVisDmLaunchTrack | kRocProfVisDmDispatchTrack | kRocProfVisDmKfdTrack,
     kRocProfVisDmCounterTrack = kRocProfVisDmPmcTrack,
-    kRocProfVisDmAgentTrack = kRocProfVisDmDispatchTrack | kRocProfVisDmCounterTrack,
+    kRocProfVisDmAgentTrack = kRocProfVisDmDispatchTrack | kRocProfVisDmCounterTrack | kRocProfVisDmKfdTrack,
     kRocProfVisDmProcessTrack = kRocProfVisDmEventTrack | kRocProfVisDmCounterTrack
 } rocprofvis_dm_track_category_t;
 
@@ -128,8 +130,10 @@ typedef enum rocprofvis_dm_event_operation_t {
     kRocProfVisDmOperationMemoryCopy = 4,
     // Memory copy event
     kRocProfVisDmOperationLaunchSample = 5,
+    // KFD event (page fault, page migrate, queue, event queue, unmap, dropped events)
+    kRocProfVisDmOperationKfd = 6,
     // Number of operations
-    kRocProfVisDmNumOperation = kRocProfVisDmOperationLaunchSample + 1,
+    kRocProfVisDmNumOperation = kRocProfVisDmOperationKfd + 1,
     kRocProfVisDmMultipleOperations,
 } rocprofvis_dm_event_operation_t;
 

--- a/src/model/src/database/rocprofvis_db_query_factory.cpp
+++ b/src/model/src/database/rocprofvis_db_query_factory.cpp
@@ -31,6 +31,9 @@ namespace DataModel
                 
                 { Builder::From("rocpd_region", "R"),
                 Builder::InnerJoin("rocpd_track", "T", "T.id = R.track_id"),
+                // Exclude KFD events; they are rendered on dedicated per-GPU KFD tracks.
+                Builder::InnerJoin("rocpd_event", "KE", "KE.id = R.event_id"),
+                Builder::InnerJoin("rocpd_string", "KCAT", "KCAT.id = KE.category_id AND KCAT.string NOT LIKE 'rocm_kfd_%'"),
                 is_sample_track ? Builder::InnerJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id") : 
                                   Builder::LeftJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id")},
                 { is_sample_track ? Builder::Blank() : Builder::Where("SAMPLE.id", " IS ", "NULL") },
@@ -48,6 +51,9 @@ namespace DataModel
                 Builder::StoreConfigVersion()
                 },
                 { Builder::From("rocpd_region", "R"),
+                // Exclude KFD events; they are rendered on dedicated per-GPU KFD tracks.
+                Builder::InnerJoin("rocpd_event", "KE", "KE.id = R.event_id"),
+                Builder::InnerJoin("rocpd_string", "KCAT", "KCAT.id = KE.category_id AND KCAT.string NOT LIKE 'rocm_kfd_%'"),
                 is_sample_track ? Builder::InnerJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id") : 
                                   Builder::LeftJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id")},
                 { is_sample_track ? Builder::Blank() : Builder::Where("SAMPLE.id", " IS ", "NULL") },
@@ -143,6 +149,125 @@ namespace DataModel
                 },
                 { Builder::From("rocpd_memory_copy") } }));
         }
+    }
+
+/*************************************************************************************************
+*                               KFD (kernel fusion driver) track/level/slice/table queries
+*
+* KFD events are stored as rocpd_region rows. The owning GPU agent and a human
+* readable sub-label are resolved from rocpd_arg (name 'agent' for single-agent
+* events; 'src_agent'/'dst_agent' for page migrations) joined to
+* rocpd_info_agent on logical_index. This targets the rocprofiler-systems rocpd
+* schema (direct rocpd_region start/end columns, arguments in rocpd_arg).
+**************************************************************************************************/
+
+    const char* QueryFactory::GetRocprofKfdOwningAgentExpr()
+    {
+        // Single-agent events use their agent. Migrations bucket under the GPU
+        // endpoint: host->device -> dst agent; otherwise (device->host, device->
+        // device) the src agent (which is a GPU).
+        return "CASE WHEN AG.value IS NOT NULL THEN IA.id "
+               "WHEN IAS.type = 'CPU' THEN IAD.id ELSE IAS.id END";
+    }
+
+    const char* QueryFactory::GetRocprofKfdLabelExpr()
+    {
+        return "CASE CAT.string "
+               "WHEN 'rocm_kfd_page_fault' THEN 'Page Fault' "
+               "WHEN 'rocm_kfd_queue' THEN 'Queue' "
+               "WHEN 'rocm_kfd_event_queue' THEN 'Event Queue' "
+               "WHEN 'rocm_kfd_event_unmap_from_gpu' THEN 'Unmap from GPU' "
+               "WHEN 'rocm_kfd_event_dropped_events' THEN 'Dropped Events' "
+               "WHEN 'rocm_kfd_page_migrate' THEN 'Page Migrate [' || IAS.type || ' ' || "
+               "IAS.type_index || ' -> ' || IAD.type || ' ' || IAD.type_index || ']' "
+               "ELSE CAT.string END";
+    }
+
+    std::vector<std::string> QueryFactory::GetRocprofKfdFromClause()
+    {
+        return {
+            Builder::From("rocpd_region", "R"),
+            Builder::InnerJoin("rocpd_event", "E", "E.id = R.event_id"),
+            Builder::InnerJoin("rocpd_string", "CAT", "CAT.id = E.category_id AND CAT.string LIKE 'rocm_kfd_%'"),
+            Builder::LeftJoin("rocpd_arg", "AG", "AG.event_id = R.event_id AND AG.name = 'agent'"),
+            Builder::LeftJoin("rocpd_arg", "SRC", "SRC.event_id = R.event_id AND SRC.name = 'src_agent'"),
+            Builder::LeftJoin("rocpd_arg", "DST", "DST.event_id = R.event_id AND DST.name = 'dst_agent'"),
+            Builder::LeftJoin("rocpd_info_agent", "IA", "IA.logical_index = CAST(AG.value AS INTEGER)"),
+            Builder::LeftJoin("rocpd_info_agent", "IAS", "IAS.logical_index = CAST(SRC.value AS INTEGER)"),
+            Builder::LeftJoin("rocpd_info_agent", "IAD", "IAD.logical_index = CAST(DST.value AS INTEGER)")
+        };
+    }
+
+    std::string QueryFactory::GetRocprofKfdTrackQuery() {
+        return Builder::Select(rocprofvis_db_sqlite_region_track_query_format(
+            { { Builder::QParam("R.nid", Builder::NODE_ID_SERVICE_NAME),
+            Builder::QParam(GetRocprofKfdOwningAgentExpr(), Builder::AGENT_ID_SERVICE_NAME),
+            Builder::QParam(GetRocprofKfdLabelExpr(), Builder::QUEUE_ID_SERVICE_NAME),
+            Builder::QParam("R.pid", Builder::PROCESS_ID_PUBLIC_NAME),
+            Builder::QParamCategory(kRocProfVisDmKfdTrack),
+            Builder::QParamOperation(kRocProfVisDmOperationKfd),
+            Builder::StoreConfigVersion()
+            },
+            GetRocprofKfdFromClause(),
+            { } }));
+    }
+
+    std::string QueryFactory::GetRocprofKfdLevelQuery() {
+        return Builder::Select(rocprofvis_db_sqlite_level_query_format(
+            { { Builder::QParamOperation(kRocProfVisDmOperationKfd),
+            Builder::QParam("R.start", Builder::START_SERVICE_NAME),
+            Builder::QParam("R.end", Builder::END_SERVICE_NAME),
+            Builder::QParam("R.id"),
+            Builder::QParam("R.nid", Builder::NODE_ID_SERVICE_NAME),
+            Builder::QParam(GetRocprofKfdOwningAgentExpr(), Builder::AGENT_ID_SERVICE_NAME),
+            Builder::QParam(GetRocprofKfdLabelExpr(), Builder::QUEUE_ID_SERVICE_NAME),
+            Builder::SpaceSaver(0),
+            Builder::QParam("R.pid", Builder::PROCESS_ID_SERVICE_NAME)
+            },
+            GetRocprofKfdFromClause() }));
+    }
+
+    std::string QueryFactory::GetRocprofKfdSliceQuery() {
+        std::vector<std::string> from = GetRocprofKfdFromClause();
+        from.push_back(Builder::LeftJoin(Builder::LevelTable("kfd"), "L", "R.id = L.eid"));
+        return Builder::Select(rocprofvis_db_sqlite_slice_query_format(
+            { { Builder::QParamOperation(kRocProfVisDmOperationKfd),
+            Builder::QParam("R.start", Builder::START_SERVICE_NAME),
+            Builder::QParam("R.end", Builder::END_SERVICE_NAME),
+            Builder::QParam("E.category_id"),
+            Builder::QParam("R.name_id"),
+            Builder::QParam("R.id"),
+            Builder::QParam("R.nid", Builder::NODE_ID_SERVICE_NAME),
+            Builder::QParam(GetRocprofKfdOwningAgentExpr(), Builder::AGENT_ID_SERVICE_NAME),
+            Builder::QParam(GetRocprofKfdLabelExpr(), Builder::QUEUE_ID_SERVICE_NAME),
+            Builder::QParam("L.level", Builder::EVENT_LEVEL_SERVICE_NAME),
+            Builder::QParamCategory(kRocProfVisDmKfdTrack)
+            },
+            from }));
+    }
+
+    std::string QueryFactory::GetRocprofKfdTableQuery() {
+        return Builder::Select(rocprofvis_db_sqlite_launch_table_query_format(
+            { m_db,
+            { Builder::QParamOperation(kRocProfVisDmOperationKfd),
+            Builder::QParam("R.id", Builder::ID_PUBLIC_NAME),
+            Builder::QParam("R.id", Builder::DB_ID_PUBLIC_NAME),
+            Builder::QParam("E.category_id", Builder::CATEGORY_REFERENCE),
+            Builder::QParam("R.name_id", Builder::EVENT_NAME_REFERENCE),
+            Builder::QParam("R.nid", Builder::NODE_ID_SERVICE_NAME),
+            Builder::QParam("P.pid", Builder::PROCESS_ID_PUBLIC_NAME),
+            Builder::QParam("T.tid", Builder::THREAD_ID_PUBLIC_NAME),
+            Builder::QParam("R.start", Builder::START_SERVICE_NAME),
+            Builder::QParam("R.end", Builder::END_SERVICE_NAME),
+            Builder::QParam("(R.end-R.start)", Builder::DURATION_PUBLIC_NAME),
+            Builder::QParam("R.pid", Builder::PROCESS_ID_SERVICE_NAME),
+            Builder::QParam("R.tid", Builder::THREAD_ID_SERVICE_NAME),
+            Builder::QParam("-1", Builder::STREAM_ID_SERVICE_NAME) },
+            { Builder::From("rocpd_region", "R"),
+            Builder::InnerJoin("rocpd_event", "E", "E.id = R.event_id"),
+            Builder::InnerJoin("rocpd_string", "CAT", "CAT.id = E.category_id AND CAT.string LIKE 'rocm_kfd_%'"),
+            Builder::InnerJoin("rocpd_info_process", "P", "P.id = R.pid"),
+            Builder::InnerJoin("rocpd_info_thread", "T", "T.id = R.tid") } }));
     }
 
     std::string QueryFactory::GetRocprofPerformanceCountersTrackQuery() {
@@ -368,6 +493,9 @@ namespace DataModel
                 Builder::InnerJoin("rocpd_track", "T", "T.id = R.track_id"),
                 Builder::InnerJoin("rocpd_timestamp", "TS", "TS.id = R.start_id"),
                 Builder::InnerJoin("rocpd_timestamp", "TE", "TE.id = R.end_id"),
+                // Exclude KFD events; their levels are computed on the KFD tracks.
+                Builder::InnerJoin("rocpd_event", "KE", "KE.id = R.event_id"),
+                Builder::InnerJoin("rocpd_string", "KCAT", "KCAT.id = KE.category_id AND KCAT.string NOT LIKE 'rocm_kfd_%'"),
                 is_sample_track ? Builder::InnerJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id") : 
                                   Builder::LeftJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id")
                 } }));
@@ -385,6 +513,9 @@ namespace DataModel
                 Builder::SpaceSaver(0),
                 Builder::SpaceSaver(0) },
                 { Builder::From("rocpd_region", "R"),
+                // Exclude KFD events; their levels are computed on the KFD tracks.
+                Builder::InnerJoin("rocpd_event", "KE", "KE.id = R.event_id"),
+                Builder::InnerJoin("rocpd_string", "KCAT", "KCAT.id = KE.category_id AND KCAT.string NOT LIKE 'rocm_kfd_%'"),
                 is_sample_track ? Builder::InnerJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id") : 
                                   Builder::LeftJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id")
                 } }));
@@ -621,6 +752,8 @@ namespace DataModel
                 },
                 { Builder::From("rocpd_region", "R"),
                 Builder::InnerJoin("rocpd_event", "E", "E.id = R.event_id"),
+                // Exclude KFD events; they are rendered on dedicated per-GPU KFD tracks.
+                Builder::InnerJoin("rocpd_string", "KCAT", "KCAT.id = E.category_id AND KCAT.string NOT LIKE 'rocm_kfd_%'"),
                 Builder::InnerJoin("rocpd_track", "T", "T.id = R.track_id"),
                 Builder::InnerJoin("rocpd_timestamp", "TS", "TS.id = R.start_id"),
                 Builder::InnerJoin("rocpd_timestamp", "TE", "TE.id = R.end_id"),
@@ -646,6 +779,8 @@ namespace DataModel
                 },
                 { Builder::From("rocpd_region", "R"),
                 Builder::InnerJoin("rocpd_event", "E", "E.id = R.event_id"),
+                // Exclude KFD events; they are rendered on dedicated per-GPU KFD tracks.
+                Builder::InnerJoin("rocpd_string", "KCAT", "KCAT.id = E.category_id AND KCAT.string NOT LIKE 'rocm_kfd_%'"),
                 is_sample_track ? Builder::InnerJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id") : 
                                   Builder::LeftJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id"),
                 Builder::LeftJoin(Builder::LevelTable(is_sample_track ? "launch_sample":"launch"), "L", "R.id = L.eid") } }));
@@ -1056,6 +1191,8 @@ namespace DataModel
                 Builder::QParam("-1", Builder::STREAM_ID_SERVICE_NAME) },
                 { Builder::From("rocpd_region", "R"),
                 Builder::InnerJoin("rocpd_event", "E", "E.id = R.event_id"),
+                // Exclude KFD events; they are shown via the dedicated KFD table query.
+                Builder::InnerJoin("rocpd_string", "KCAT", "KCAT.id = E.category_id AND KCAT.string NOT LIKE 'rocm_kfd_%'"),
                 Builder::InnerJoin("rocpd_track", "T", "T.id = R.track_id"),
                 Builder::InnerJoin("rocpd_timestamp", "TS", "TS.id = R.start_id"),
                 Builder::InnerJoin("rocpd_timestamp", "TE", "TE.id = R.end_id"),
@@ -1086,6 +1223,8 @@ namespace DataModel
                 is_sample_track ? Builder::InnerJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id") : 
                 Builder::LeftJoin("rocpd_sample", "SAMPLE", "SAMPLE.event_id = R.event_id"),
                 Builder::InnerJoin("rocpd_event", "E", "E.id = R.event_id"),
+                // Exclude KFD events; they are shown via the dedicated KFD table query.
+                Builder::InnerJoin("rocpd_string", "KCAT", "KCAT.id = E.category_id AND KCAT.string NOT LIKE 'rocm_kfd_%'"),
                 Builder::InnerJoin("rocpd_info_process", "P", "P.id = R.pid"),
                 Builder::InnerJoin("rocpd_info_thread", "T", "T.id = R.tid") } }));
         }

--- a/src/model/src/database/rocprofvis_db_query_factory.h
+++ b/src/model/src/database/rocprofvis_db_query_factory.h
@@ -47,6 +47,14 @@ public:
     std::string GetRocprofMemoryCopySliceQueryForStream();
     std::string GetRocprofMemoryCopyTableQuery();
 
+    // KFD (Kernel Fusion Driver) events. These live in rocpd_region and are
+    // grouped onto per-GPU tracks; the owning GPU agent and the human-readable
+    // sub-label are resolved from rocpd_arg joined to rocpd_info_agent.
+    std::string GetRocprofKfdTrackQuery();
+    std::string GetRocprofKfdLevelQuery();
+    std::string GetRocprofKfdSliceQuery();
+    std::string GetRocprofKfdTableQuery();
+
     std::string GetRocprofPerformanceCountersTrackQuery();
     std::string GetRocprofPerformanceCountersLevelQuery();
     std::string GetRocprofPerformanceCountersSliceQuery();
@@ -83,6 +91,12 @@ public:
     std::string GetRocprofMemoryCopyStreamFlowQuery();
 
 private:
+    // Shared building blocks for the KFD queries so the track / level / slice
+    // queries all compute the owning GPU agent and the sub-label identically
+    // (BuildSliceQueryMap matches events to tracks by these exact expressions).
+    std::vector<std::string> GetRocprofKfdFromClause();
+    static const char* GetRocprofKfdOwningAgentExpr();
+    static const char* GetRocprofKfdLabelExpr();
 
     ProfileDatabase* m_db;
 };

--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -116,7 +116,8 @@ int RocprofDatabase::ProcessTrack(rocprofvis_dm_track_params_t& track_params, ro
         else if(track_params.track_indentifiers.category == kRocProfVisDmKernelDispatchTrack ||
             track_params.track_indentifiers.category == kRocProfVisDmMemoryAllocationTrack ||
             track_params.track_indentifiers.category == kRocProfVisDmMemoryCopyTrack ||
-            track_params.track_indentifiers.category == kRocProfVisDmPmcTrack)
+            track_params.track_indentifiers.category == kRocProfVisDmPmcTrack ||
+            track_params.track_indentifiers.category == kRocProfVisDmKfdTrack)
         {
             track_params.track_indentifiers.name[TRACK_ID_AGENT] = CachedTables(db_instance->GuidIndex())->GetTableCell("Agent", track_params.track_indentifiers.id[TRACK_ID_AGENT], "product_name");
             track_params.track_indentifiers.name[TRACK_ID_AGENT] += "(";
@@ -128,10 +129,11 @@ int RocprofDatabase::ProcessTrack(rocprofvis_dm_track_params_t& track_params, ro
             {
                 track_params.track_indentifiers.name[TRACK_ID_QUEUE] = CachedTables(db_instance->GuidIndex())->GetTableCell("Queue", track_params.track_indentifiers.id[TRACK_ID_QUEUE], "name");
             }
-            else {
+            else if(track_params.track_indentifiers.category == kRocProfVisDmPmcTrack) {
                 track_params.track_indentifiers.name[TRACK_ID_QUEUE] = CachedTables(db_instance->GuidIndex())->GetTableCell("PMC", track_params.track_indentifiers.id[TRACK_ID_QUEUE], "symbol");
             }
-
+            // KFD tracks carry their human-readable label (e.g. "Page Migrate [CPU 0 -> GPU 0]")
+            // as a string already stored in name[TRACK_ID_QUEUE] by CallBackAddTrack.
         }
         else if(track_params.track_indentifiers.category == kRocProfVisDmStreamTrack)
         {
@@ -160,7 +162,8 @@ int RocprofDatabase::ProcessTrack(rocprofvis_dm_track_params_t& track_params, ro
         else if(track_params.track_indentifiers.category == kRocProfVisDmKernelDispatchTrack ||
             track_params.track_indentifiers.category == kRocProfVisDmMemoryAllocationTrack ||
             track_params.track_indentifiers.category == kRocProfVisDmMemoryCopyTrack ||
-            track_params.track_indentifiers.category == kRocProfVisDmPmcTrack)
+            track_params.track_indentifiers.category == kRocProfVisDmPmcTrack ||
+            track_params.track_indentifiers.category == kRocProfVisDmKfdTrack)
         {
             if (CachedTables(db_instance->GuidIndex())->PopulateTrackExtendedDataTemplate(this, db_instance->GuidIndex(), "Agent", track_params.track_indentifiers.id[TRACK_ID_AGENT]) != kRocProfVisDmResultSuccess) return 1; 
             if(track_params.track_indentifiers.category == kRocProfVisDmKernelDispatchTrack ||
@@ -169,7 +172,7 @@ int RocprofDatabase::ProcessTrack(rocprofvis_dm_track_params_t& track_params, ro
             {
                 if (CachedTables(db_instance->GuidIndex())->PopulateTrackExtendedDataTemplate(this, db_instance->GuidIndex(), "Queue", track_params.track_indentifiers.id[TRACK_ID_QUEUE]) != kRocProfVisDmResultSuccess) return 1;
             }
-            else
+            else if(track_params.track_indentifiers.category == kRocProfVisDmPmcTrack)
             {
                 if(track_params.track_indentifiers.id[TRACK_ID_QUEUE] > 0)
                     if (CachedTables(db_instance->GuidIndex())->PopulateTrackExtendedDataTemplate(this, db_instance->GuidIndex(), "PMC", track_params.track_indentifiers.id[TRACK_ID_COUNTER]) != kRocProfVisDmResultSuccess) return 1;
@@ -1179,6 +1182,35 @@ rocprofvis_dm_result_t  RocprofDatabase::ReadTraceMetadata(Future* future)
             load_id++;
         }
 
+        ShowProgress(5, "Adding KFD tracks", kRPVDbBusy, future );
+        {
+            std::vector<std::thread> threads;
+            m_add_track_mutex.init(NumDbInstances());
+            auto task = [&](DbInstance* db_instance)
+                {
+                    Future* sub_future = future->AddSubFuture();
+                    result = ExecuteSQLQuery(sub_future, db_instance, load_id,
+                    { 
+                        m_query_factory.GetRocprofKfdTrackQuery(),
+                        "",
+                        m_query_factory.GetRocprofKfdLevelQuery(),
+                        m_query_factory.GetRocprofKfdSliceQuery(),
+                        "",
+                        m_query_factory.GetRocprofKfdTableQuery(),
+                    },
+                    &CallBackAddTrack, &CallBackLoadTrack);
+                    future->DeleteSubFuture(sub_future);
+                    m_add_track_mutex.unlock(db_instance->GuidIndex());
+                };
+            for (auto& guid_info : DbInstances())
+            {
+                threads.emplace_back(task, &guid_info.first);
+            }
+            for (auto& t : threads)
+                t.join();
+            load_id++;
+        }
+
         ShowProgress(5, "Adding memory allocation activity tracks", kRPVDbBusy, future );
         {
             std::vector<std::thread> threads;
@@ -1275,7 +1307,8 @@ rocprofvis_dm_result_t  RocprofDatabase::ReadTraceMetadata(Future* future)
             {m_metadata_version_control.GetTableName(m_metadata_version_control.kRocOptiqTableRegionSampleLevel),kRocProfVisDmOperationLaunchSample},
             {m_metadata_version_control.GetTableName(m_metadata_version_control.kRocOptiqTableKernelDispatchLevel), kRocProfVisDmOperationDispatch},
             {m_metadata_version_control.GetTableName(m_metadata_version_control.kRocOptiqTableMemoryAllocLevel),kRocProfVisDmOperationMemoryAllocate},
-            {m_metadata_version_control.GetTableName(m_metadata_version_control.kRocOptiqTableMemoryCopyLevel), kRocProfVisDmOperationMemoryCopy} 
+            {m_metadata_version_control.GetTableName(m_metadata_version_control.kRocOptiqTableMemoryCopyLevel), kRocProfVisDmOperationMemoryCopy}, 
+            {m_metadata_version_control.GetTableName(m_metadata_version_control.kRocOptiqTableKfdLevel), kRocProfVisDmOperationKfd} 
         };
 
         ShowProgress(10, "Calculating event levels", kRPVDbBusy, future);
@@ -1865,6 +1898,10 @@ rocprofvis_dm_string_t RocprofDatabase::GetEventOperationQuery(const rocprofvis_
         case kRocProfVisDmOperationLaunchSample:
         {
             return m_query_factory.GetRocprofRegionTableQuery(true);
+        }
+        case kRocProfVisDmOperationKfd:
+        {
+            return m_query_factory.GetRocprofKfdTableQuery();
         }
         default:
         {

--- a/src/model/src/database/rocprofvis_db_version.cpp
+++ b/src/model/src/database/rocprofvis_db_version.cpp
@@ -78,6 +78,14 @@ namespace DataModel
             kRocOptiqTableVersionMemoryCopyLevel, 
             std::hash<std::string>{}(db->m_query_factory.GetRocprofMemoryCopyLevelQuery()+db->GetLevelSchemaHashStr()),
         };
+        m_roc_optiq_table_properties[kRocOptiqTableKfdLevel] = {
+            "roc_optiq_event_levels_kfd_",
+            kRocOptiqTablePerGuid,
+            kRocOptiqTableDisposeWhenTrimmed,
+            kRocOptiqTableDependentOnAllLevelTables,
+            kRocOptiqTableVersionKfdLevel,
+            std::hash<std::string>{}(db->m_query_factory.GetRocprofKfdLevelQuery()+db->GetLevelSchemaHashStr()),
+        };
         m_roc_optiq_table_properties[kRocOptiqTableHistogram] = {
             "roc_optiq_histogram",
             kRocOptiqTablePerFile,

--- a/src/model/src/database/rocprofvis_db_version.h
+++ b/src/model/src/database/rocprofvis_db_version.h
@@ -63,6 +63,7 @@ namespace DataModel
             kRocOptiqTableVersionRegionSampleLevel = kRocOptiqTableVersionForLevelCalculation,
             kRocOptiqTableVersionMemoryAllocLevel = kRocOptiqTableVersionForLevelCalculation,
             kRocOptiqTableVersionMemoryCopyLevel = kRocOptiqTableVersionForLevelCalculation,
+            kRocOptiqTableVersionKfdLevel = kRocOptiqTableVersionForLevelCalculation,
             kRocOptiqTableVersionHistogram = 0x0001,
             kRocOptiqTableVersionTrackInfo = 0x0003,
         };
@@ -119,6 +120,7 @@ namespace DataModel
             kRocOptiqTableRegionSampleLevel,
             kRocOptiqTableMemoryAllocLevel,
             kRocOptiqTableMemoryCopyLevel,
+            kRocOptiqTableKfdLevel,
             kRocOptiqTableHistogram,
 
             kRocOptiqNumTables
@@ -138,12 +140,14 @@ namespace DataModel
             kRocOptiqTableDependentOnRegionSampleLevel = 1 << kRocOptiqTableRegionSampleLevel,
             kRocOptiqTableDependentOnMemoryAllocLevel = 1 << kRocOptiqTableMemoryAllocLevel,
             kRocOptiqTableDependentOnMemoryCopyLevel = 1 << kRocOptiqTableMemoryCopyLevel,
+            kRocOptiqTableDependentOnKfdLevel = 1 << kRocOptiqTableKfdLevel,
             kRocOptiqTableDependentOnAllLevelTables = 
             kRocOptiqTableDependentOnKernelDispatchLevel | 
             kRocOptiqTableDependentOnRegionLevel | 
             kRocOptiqTableDependentOnRegionSampleLevel | 
             kRocOptiqTableDependentOnMemoryAllocLevel | 
             kRocOptiqTableDependentOnMemoryCopyLevel | 
+            kRocOptiqTableDependentOnKfdLevel | 
             kRocOptiqTableDependentOnTrackInfo,
             kRocOptiqTableDependentOnHistogram = 1 << kRocOptiqTableHistogram,
 
@@ -154,7 +158,8 @@ namespace DataModel
                 MustRebuild(file_node_id, kRocOptiqTableRegionLevel) ||
                 MustRebuild(file_node_id, kRocOptiqTableRegionSampleLevel) ||
                 MustRebuild(file_node_id, kRocOptiqTableMemoryAllocLevel) ||
-                MustRebuild(file_node_id, kRocOptiqTableMemoryCopyLevel);
+                MustRebuild(file_node_id, kRocOptiqTableMemoryCopyLevel) ||
+                MustRebuild(file_node_id, kRocOptiqTableKfdLevel);
         }
         const char* GetHistogramTableName() override { return GetTableName(kRocOptiqTableHistogram); };
         const char* GetTrackInfoTableName() override { return GetTableName(kRocOptiqTableTrackInfo); };

--- a/src/model/src/datamodel/rocprofvis_dm_topology.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_topology.cpp
@@ -374,7 +374,8 @@ rocprofvis_dm_result_t TopologyNodeSystemNode::AddNode(rocprofvis_dm_track_ident
 	if (track_identifiers->category == kRocProfVisDmKernelDispatchTrack || 
 	track_identifiers->category == kRocProfVisDmMemoryAllocationTrack || 
 	track_identifiers->category == kRocProfVisDmMemoryCopyTrack ||
-    track_identifiers->category == kRocProfVisDmPmcTrack)
+    track_identifiers->category == kRocProfVisDmPmcTrack ||
+    track_identifiers->category == kRocProfVisDmKfdTrack)
 	{
 			m_children.push_back(std::make_unique<TopologyNodeProcessor>(track_identifiers,this));
 			return m_children.back()->AddNode(track_identifiers);
@@ -467,6 +468,10 @@ rocprofvis_dm_result_t TopologyNodeProcessor::AddNode(rocprofvis_dm_track_identi
 		else if (track_identifiers->category == kRocProfVisDmPmcTrack)
 		{
 		    m_children.push_back(std::make_unique<TopologyNodeCounter>(track_identifiers, this));
+		}
+		else if (track_identifiers->category == kRocProfVisDmKfdTrack)
+		{
+		    m_children.push_back(std::make_unique<TopologyNodeKfd>(track_identifiers, this));
 		}
 		else
 		{
@@ -671,6 +676,27 @@ bool TopologyNodeKernelDispatch::DoesThisNodeMatchIdentifiers(rocprofvis_dm_trac
 	if (result)
 	{
 		result = track_identifiers->category == kRocProfVisDmKernelDispatchTrack;
+	}
+	return result;
+}
+
+bool TopologyNodeKfd::DoesThisNodeMatchIdentifiers(rocprofvis_dm_track_identifiers_t* track_identifiers)
+{
+	// KFD sub-lanes under a GPU are distinguished by their human-readable label
+	// (e.g. "Page Fault", "Page Migrate [CPU 0 -> GPU 0]") carried as a string in
+	// the queue slot, not by a numeric queue id.
+	bool result = track_identifiers->category == kRocProfVisDmKfdTrack;
+	if (result)
+	{
+		result = m_db_instance == track_identifiers->db_instance;
+	}
+	if (result)
+	{
+		result = m_pid == track_identifiers->process_id;
+	}
+	if (result)
+	{
+		result = m_label == track_identifiers->name[TRACK_ID_QUEUE];
 	}
 	return result;
 }

--- a/src/model/src/datamodel/rocprofvis_dm_topology.h
+++ b/src/model/src/datamodel/rocprofvis_dm_topology.h
@@ -320,6 +320,21 @@ public:
     bool DoesThisNodeMatchIdentifiers(rocprofvis_dm_track_identifiers_t* track_identifiers) override;
 };
 
+// KFD sub-lane under a GPU processor node. Keyed by the human-readable KFD label
+// (a string carried in the queue slot), e.g. "Page Fault" or
+// "Page Migrate [CPU 0 -> GPU 0]".
+class TopologyNodeKfd : public TopologyNodeQueue {
+public:
+    TopologyNodeKfd(rocprofvis_dm_track_identifiers_t* track_identifiers, TopologyNode* ctx) :
+        TopologyNodeQueue(track_identifiers, ctx),
+        m_label(track_identifiers->name[TRACK_ID_QUEUE]) {}
+    ~TopologyNodeKfd() {};
+    std::string GetNodeName() override { return m_label; }
+    bool DoesThisNodeMatchIdentifiers(rocprofvis_dm_track_identifiers_t* track_identifiers) override;
+private:
+    std::string m_label;
+};
+
 class TopologyNodeStream : public TopologyNode, public TopologyTrackRefence {
 public:
 

--- a/src/model/src/datamodel/rocprofvis_dm_track.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_track.cpp
@@ -171,6 +171,7 @@ rocprofvis_dm_charptr_t  Track::CategoryString(){
         case kRocProfVisDmSQTTTrack: return "Shader Execution";
         case kRocProfVisDmNICTrack: return "Network Activity";
         case kRocProfVisDmStreamTrack: return "GPU Stream";
+        case kRocProfVisDmKfdTrack: return "KFD";
     }
     return "Invalid track";
 }

--- a/src/view/src/model/rocprofvis_trace_data_model.cpp
+++ b/src/view/src/model/rocprofvis_trace_data_model.cpp
@@ -37,9 +37,10 @@ TraceDataModel::BuildTrackName(uint64_t track_id) const
     {
         case TrackInfo::TrackType::Queue:
         {
-            // If the category is not "GPU Queue", use it as the name
-            // For example, "Memory Copy", "Memory Allocation", etc
-            if(track_info->category != "GPU Queue")
+            // "GPU Queue" and "KFD" lanes carry their distinguishing label in
+            // sub_name (queue name, or KFD label like "Page Migrate [CPU 0 -> GPU 0]").
+            // Other queue-shaped tracks (Memory copy/allocation) use the category.
+            if(track_info->category != "GPU Queue" && track_info->category != "KFD")
             {
                 name = track_info->category;
             }

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -699,6 +699,15 @@ TrackTopology::UpdateGraphs()
                 {
                     case TrackInfo::TrackType::Queue:
                     {
+                        // KFD sub-lanes are queue-shaped but are not backed by a
+                        // rocpd_info_queue row, so they have no queue_lut entry.
+                        // Keep them out of the queue tree to avoid a null deref;
+                        // they still render as timeline lanes from the track list.
+                        if(track->category == "KFD")
+                        {
+                            m_topology.uncategorized_graph_indices.push_back(index);
+                            break;
+                        }
                         m_topology.node_lut[node_id]
                             ->processor_lut[processor_id]
                             ->queue_lut[id]


### PR DESCRIPTION
Render KFD events (page fault, queue, unmap, migrate) as dedicated per-GPU tracks under each GPU node instead of on the CPU main-thread track. Wires the KFD query builders into track discovery, topology routing (TopologyNodeKfd), track naming/category, controller track creation and slice fetch, and view track-name/label handling.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
