### PR TITLE
View: Color-code tracks and sidebar by node

### DIFF
--- a/src/view/src/model/rocprofvis_topology_model.cpp
+++ b/src/view/src/model/rocprofvis_topology_model.cpp
@@ -4,8 +4,10 @@
 #include "rocprofvis_topology_model.h"
 #include "rocprofvis_common_defs.h"
 
+#include <algorithm>
 #include <limits>
 #include <sstream>
+#include <vector>
 
 namespace RocProfVis
 {
@@ -30,6 +32,20 @@ TopologyDataModel::GetNodeList() const
         result.push_back(&pair.second);
     }
     return result;
+}
+
+size_t
+TopologyDataModel::GetNodeDisplayIndex(uint64_t node_id) const
+{
+    std::vector<uint64_t> ids;
+    ids.reserve(m_nodes.size());
+    for(const auto& pair : m_nodes)
+    {
+        ids.push_back(pair.first);
+    }
+    std::sort(ids.begin(), ids.end());
+    auto it = std::find(ids.begin(), ids.end(), node_id);
+    return (it != ids.end()) ? static_cast<size_t>(std::distance(ids.begin(), it)) + 1 : 0;
 }
 
 void

--- a/src/view/src/model/rocprofvis_topology_model.h
+++ b/src/view/src/model/rocprofvis_topology_model.h
@@ -34,6 +34,10 @@ public:
     void ClearNodes();
     size_t NodeCount() const { return m_nodes.size(); }
 
+    // Stable 1-based display index for a node (nodes ordered by ascending id).
+    // Returns 0 if the node id is unknown.
+    size_t GetNodeDisplayIndex(uint64_t node_id) const;
+
     // Device access
     const DeviceInfo* GetDevice(uint64_t device_id) const;
     void AddDevice(uint64_t device_id, DeviceInfo&& device);

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -449,6 +449,8 @@ SettingsManager::SerializeDisplaySettings(jt::Json& json)
         m_usersettings.display_settings.dpi_based_scaling;
     ds[JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE] =
         m_usersettings.display_settings.font_size_index;
+    ds[JSON_KEY_SETTINGS_DISPLAY_NODE_COLORS] =
+        m_usersettings.display_settings.show_node_colors;
 }
 
 void
@@ -471,6 +473,11 @@ SettingsManager::DeserializeDisplaySettings(jt::Json& json)
         {
             m_usersettings.display_settings.font_size_index =
                 static_cast<int>(ds[JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE].getLong());
+        }
+        if(ds[JSON_KEY_SETTINGS_DISPLAY_NODE_COLORS].isBool())
+        {
+            m_usersettings.display_settings.show_node_colors =
+                ds[JSON_KEY_SETTINGS_DISPLAY_NODE_COLORS].getBool();
         }
     }
 }
@@ -612,8 +619,8 @@ SettingsManager::GetContrastColormapName() const
 SettingsManager::SettingsManager()
 : m_color_store(nullptr)
 , m_usersettings_default(
-      { DisplaySettings{ false, true, 6 }, UnitSettings{ TimeFormat::kTimecode }, false,
-        false, LOG_VIEWER_MAX_ENTRIES_DEFAULT,
+      { DisplaySettings{ false, true, 6, true }, UnitSettings{ TimeFormat::kTimecode },
+        false, false, LOG_VIEWER_MAX_ENTRIES_DEFAULT,
         LogViewerSettings{ LOG_VIEWER_DEFAULT_LEVEL_MASK, true, false, false, false } })
 , m_usersettings(m_usersettings_default)
 , m_appwindowsettings({ AppWindowSettings{ true, true, true, true, false } })

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -24,6 +24,7 @@ typedef struct DisplaySettings
     bool use_dark_mode;
     bool dpi_based_scaling;
     int  font_size_index;
+    bool show_node_colors;  // color-code timeline tracks by node
 
 } DisplaySettings;
 
@@ -213,6 +214,7 @@ constexpr const char* JSON_KEY_SETTINGS_CATEGORY_INTERNAL = "internal";
 constexpr const char* JSON_KEY_SETTINGS_DISPLAY_DARK_MODE   = "use_dark_mode";
 constexpr const char* JSON_KEY_SETTINGS_DISPLAY_DPI_SCALING = "dpi_based_scaling";
 constexpr const char* JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE   = "font_size_index";
+constexpr const char* JSON_KEY_SETTINGS_DISPLAY_NODE_COLORS = "show_node_colors";
 
 constexpr const char* JSON_KEY_SETTINGS_UNITS_TIME_FORMAT = "time_format";
 
@@ -257,6 +259,7 @@ public:
     float        GetDPI();
 
     // Styling
+    bool ShowNodeColors() const { return m_usersettings.display_settings.show_node_colors; }
     ImU32                     GetColor(Colors color) const;
     const std::vector<ImU32>& GetColorWheel() const;
     const std::vector<ImU32>& GetHighlightedEventColorWheel() const;

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -228,6 +228,17 @@ SettingsPanel::RenderDisplayOptions()
         SetTooltipStyled("Switch between dark and light UI themes.");
     }
 
+    if(ImGui::Checkbox("Color-code tracks by node",
+                       &m_usersettings.display_settings.show_node_colors))
+    {
+        m_settings_changed = true;
+    }
+    if(ImGui::IsItemHovered())
+    {
+        SetTooltipStyled("Show a colored strip and pill on each timeline track so "
+                         "tracks belonging to the same node are easy to spot.");
+    }
+
     ImGui::Spacing();
     ImGui::TextUnformatted("Fonts");
     ImGui::Separator();

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -228,15 +228,14 @@ SettingsPanel::RenderDisplayOptions()
         SetTooltipStyled("Switch between dark and light UI themes.");
     }
 
-    if(ImGui::Checkbox("Color-code tracks by node",
+    if(ImGui::Checkbox("Multi-node decorators",
                        &m_usersettings.display_settings.show_node_colors))
     {
         m_settings_changed = true;
     }
     if(ImGui::IsItemHovered())
     {
-        SetTooltipStyled("Show a colored strip and pill on each timeline track so "
-                         "tracks belonging to the same node are easy to spot.");
+        SetTooltipStyled("Color-code tracks and sidebar nodes by node on multi-node traces.");
     }
 
     ImGui::Spacing();

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -9,6 +9,8 @@
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_timeline_selection.h"
 
+#include <cmath>
+#include <string>
 #include <unordered_set>
 
 namespace RocProfVis
@@ -369,27 +371,37 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
         ImGui::SameLine();
     }
 
-    // Node color swatch matching the track color-coding.
-    if(node.show_color_swatch && m_settings.ShowNodeColors())
-    {
-        const std::vector<ImU32>& wheel = m_settings.GetColorWheel();
-        if(!wheel.empty())
-        {
-            const float  frame_h = ImGui::GetFrameHeight();
-            const float  radius  = ImGui::GetTextLineHeight() * NODE_SWATCH_RADIUS_SCALE;
-            const ImVec2 pos     = ImGui::GetCursorScreenPos();
-            ImGui::GetWindowDrawList()->AddCircleFilled(
-                ImVec2(pos.x + radius, pos.y + frame_h * 0.5f), radius,
-                wheel[node.color_index % wheel.size()]);
-            ImGui::Dummy(ImVec2(radius * 2.0f, frame_h));
-            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
-        }
-    }
+    const bool draw_swatch = node.show_color_swatch && m_settings.ShowNodeColors() &&
+                             !m_settings.GetColorWheel().empty();
 
     bool open = true;
     if(node.collapsable)
     {
-        open = ImGui::TreeNodeEx(node.label.c_str(), HEADER_FLAGS);
+        if(draw_swatch)
+        {
+            // Reserve room after the collapse arrow with leading spaces, then draw
+            // the swatch into that gap so the row reads: arrow, swatch, label.
+            const float radius  = ImGui::GetTextLineHeight() * NODE_SWATCH_RADIUS_SCALE;
+            const float gap     = ImGui::GetStyle().ItemInnerSpacing.x;
+            const float space_w = ImGui::CalcTextSize(" ").x;
+            const int   pad     = space_w > 0.0f
+                                      ? static_cast<int>(std::ceil((radius * 2.0f + gap) / space_w))
+                                      : 0;
+
+            const ImVec2 node_pos = ImGui::GetCursorScreenPos();
+            open = ImGui::TreeNodeEx((std::string(pad, ' ') + node.label).c_str(),
+                                     HEADER_FLAGS);
+
+            const std::vector<ImU32>& wheel = m_settings.GetColorWheel();
+            ImGui::GetWindowDrawList()->AddCircleFilled(
+                ImVec2(node_pos.x + ImGui::GetTreeNodeToLabelSpacing() + radius,
+                       node_pos.y + ImGui::GetFrameHeight() * 0.5f),
+                radius, wheel[node.color_index % wheel.size()]);
+        }
+        else
+        {
+            open = ImGui::TreeNodeEx(node.label.c_str(), HEADER_FLAGS);
+        }
     }
 
     if(open)

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -20,8 +20,27 @@ constexpr ImGuiTreeNodeFlags HEADER_FLAGS = ImGuiTreeNodeFlags_Framed |
                                             ImGuiTreeNodeFlags_DefaultOpen |
                                             ImGuiTreeNodeFlags_SpanLabelWidth;
 constexpr float TREE_LINE_W = 1.5f;
-// Node swatch radius as a fraction of the text line height.
-constexpr float NODE_SWATCH_RADIUS_SCALE = 0.3f;
+
+// Recolors a framed tree node's collapse arrow, matching ImGui::RenderArrow's
+// geometry so it overlaps the default arrow exactly.
+static void
+DrawTreeArrow(ImDrawList* draw_list, float cx, float cy, float font_size, bool open,
+              ImU32 col)
+{
+    const float r = font_size * 0.40f;
+    if(open)  // pointing down
+    {
+        draw_list->AddTriangleFilled(ImVec2(cx, cy + 0.75f * r),
+                                     ImVec2(cx - 0.866f * r, cy - 0.75f * r),
+                                     ImVec2(cx + 0.866f * r, cy - 0.75f * r), col);
+    }
+    else  // pointing right
+    {
+        draw_list->AddTriangleFilled(ImVec2(cx + 0.75f * r, cy),
+                                     ImVec2(cx - 0.75f * r, cy + 0.866f * r),
+                                     ImVec2(cx - 0.75f * r, cy - 0.866f * r), col);
+    }
+}
 
 class TreeConnector
 {
@@ -369,41 +388,24 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
         ImGui::SameLine();
     }
 
-    const bool draw_swatch = node.show_color_swatch && m_settings.ShowNodeColors() &&
+    const bool color_arrow = node.show_color_swatch && m_settings.ShowNodeColors() &&
                              !m_settings.GetColorWheel().empty();
-
-    // Constant id so collapsed state survives the decorator toggle.
-    const char* const node_id = node.show_color_swatch ? "###node" : "";
 
     bool open = true;
     if(node.collapsable)
     {
-        if(draw_swatch)
-        {
-            const ImGuiTreeNodeFlags flags =
-                (HEADER_FLAGS & ~ImGuiTreeNodeFlags_SpanLabelWidth) |
-                ImGuiTreeNodeFlags_SpanAvailWidth;
+        const ImVec2 node_pos = ImGui::GetCursorScreenPos();
+        open                  = ImGui::TreeNodeEx(node.label.c_str(), HEADER_FLAGS);
 
-            const ImVec2 node_pos = ImGui::GetCursorScreenPos();
-            open                  = ImGui::TreeNodeEx(node_id, flags);
-
-            const float               radius = ImGui::GetTextLineHeight() *
-                                               NODE_SWATCH_RADIUS_SCALE;
-            const float               label_x = node_pos.x + ImGui::GetTreeNodeToLabelSpacing();
-            const std::vector<ImU32>& wheel   = m_settings.GetColorWheel();
-            ImDrawList*               draw    = ImGui::GetWindowDrawList();
-            draw->AddCircleFilled(
-                ImVec2(label_x + radius, node_pos.y + ImGui::GetFrameHeight() * 0.5f),
-                radius, wheel[node.color_index % wheel.size()]);
-            draw->AddText(
-                ImVec2(label_x + radius * 2.0f + ImGui::GetStyle().ItemInnerSpacing.x,
-                       node_pos.y +
-                           (ImGui::GetFrameHeight() - ImGui::GetTextLineHeight()) * 0.5f),
-                ImGui::GetColorU32(ImGuiCol_Text), node.label.c_str());
-        }
-        else
+        if(color_arrow)
         {
-            open = ImGui::TreeNodeEx((node.label + node_id).c_str(), HEADER_FLAGS);
+            const std::vector<ImU32>& wheel     = m_settings.GetColorWheel();
+            const float               font_size = ImGui::GetFontSize();
+            DrawTreeArrow(
+                ImGui::GetWindowDrawList(),
+                node_pos.x + ImGui::GetStyle().FramePadding.x + font_size * 0.5f,
+                (ImGui::GetItemRectMin().y + ImGui::GetItemRectMax().y) * 0.5f, font_size,
+                open, wheel[node.color_index % wheel.size()]);
         }
     }
 

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -20,15 +20,17 @@ constexpr ImGuiTreeNodeFlags HEADER_FLAGS = ImGuiTreeNodeFlags_Framed |
                                             ImGuiTreeNodeFlags_DefaultOpen |
                                             ImGuiTreeNodeFlags_SpanLabelWidth;
 constexpr float TREE_LINE_W = 1.5f;
+// Node swatch radius as a fraction of the text line height.
+constexpr float NODE_SWATCH_RADIUS_SCALE = 0.3f;
 
 class TreeConnector
 {
 public:
-    explicit TreeConnector(SettingsManager& s)
+    explicit TreeConnector(SettingsManager& s, ImU32 color = 0)
     {
         float indent = ImGui::GetStyle().IndentSpacing;
         m_draw_list  = ImGui::GetWindowDrawList();
-        m_color      = s.GetColor(Colors::kMetaDataSeparator);
+        m_color      = color ? color : s.GetColor(Colors::kMetaDataSeparator);
         m_line_x     = ImGui::GetCursorScreenPos().x - indent * 0.5f;
         m_branch_len = indent * 0.45f;
         m_prev_y     = ImGui::GetCursorScreenPos().y;
@@ -367,6 +369,23 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
         ImGui::SameLine();
     }
 
+    // Node color swatch matching the track color-coding.
+    if(node.show_color_swatch && m_settings.ShowNodeColors())
+    {
+        const std::vector<ImU32>& wheel = m_settings.GetColorWheel();
+        if(!wheel.empty())
+        {
+            const float  frame_h = ImGui::GetFrameHeight();
+            const float  radius  = ImGui::GetTextLineHeight() * NODE_SWATCH_RADIUS_SCALE;
+            const ImVec2 pos     = ImGui::GetCursorScreenPos();
+            ImGui::GetWindowDrawList()->AddCircleFilled(
+                ImVec2(pos.x + radius, pos.y + frame_h * 0.5f), radius,
+                wheel[node.color_index % wheel.size()]);
+            ImGui::Dummy(ImVec2(radius * 2.0f, frame_h));
+            ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+        }
+    }
+
     bool open = true;
     if(node.collapsable)
     {
@@ -375,7 +394,19 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
 
     if(open)
     {
+        // While inside a node's subtree, tint all descendant connector lines
+        // with the node color (restored when the subtree finishes).
+        const ImU32 prev_node_color = m_active_node_color;
+        if(node.show_color_swatch && m_settings.ShowNodeColors())
+        {
+            const std::vector<ImU32>& wheel = m_settings.GetColorWheel();
+            if(!wheel.empty())
+            {
+                m_active_node_color = wheel[node.color_index % wheel.size()];
+            }
+        }
         RenderTreeChildren(node);
+        m_active_node_color = prev_node_color;
         if(node.collapsable)
         {
             ImGui::TreePop();
@@ -404,7 +435,9 @@ SideBar::RenderTreeChildren(const TreeNode& node)
         return;
     }
 
-    TreeConnector tc(m_settings);
+    // m_active_node_color carries the enclosing node's color down the whole
+    // subtree so deeper connector lines are tinted too, not just direct children.
+    TreeConnector tc(m_settings, m_active_node_color);
     for(const auto& child : node.children)
     {
         if(!child)

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -9,8 +9,6 @@
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_timeline_selection.h"
 
-#include <cmath>
-#include <string>
 #include <unordered_set>
 
 namespace RocProfVis
@@ -374,33 +372,38 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
     const bool draw_swatch = node.show_color_swatch && m_settings.ShowNodeColors() &&
                              !m_settings.GetColorWheel().empty();
 
+    // Constant id so collapsed state survives the decorator toggle.
+    const char* const node_id = node.show_color_swatch ? "###node" : "";
+
     bool open = true;
     if(node.collapsable)
     {
         if(draw_swatch)
         {
-            // Reserve room after the collapse arrow with leading spaces, then draw
-            // the swatch into that gap so the row reads: arrow, swatch, label.
-            const float radius  = ImGui::GetTextLineHeight() * NODE_SWATCH_RADIUS_SCALE;
-            const float gap     = ImGui::GetStyle().ItemInnerSpacing.x;
-            const float space_w = ImGui::CalcTextSize(" ").x;
-            const int   pad     = space_w > 0.0f
-                                      ? static_cast<int>(std::ceil((radius * 2.0f + gap) / space_w))
-                                      : 0;
+            const ImGuiTreeNodeFlags flags =
+                (HEADER_FLAGS & ~ImGuiTreeNodeFlags_SpanLabelWidth) |
+                ImGuiTreeNodeFlags_SpanAvailWidth;
 
             const ImVec2 node_pos = ImGui::GetCursorScreenPos();
-            open = ImGui::TreeNodeEx((std::string(pad, ' ') + node.label).c_str(),
-                                     HEADER_FLAGS);
+            open                  = ImGui::TreeNodeEx(node_id, flags);
 
-            const std::vector<ImU32>& wheel = m_settings.GetColorWheel();
-            ImGui::GetWindowDrawList()->AddCircleFilled(
-                ImVec2(node_pos.x + ImGui::GetTreeNodeToLabelSpacing() + radius,
-                       node_pos.y + ImGui::GetFrameHeight() * 0.5f),
+            const float               radius = ImGui::GetTextLineHeight() *
+                                               NODE_SWATCH_RADIUS_SCALE;
+            const float               label_x = node_pos.x + ImGui::GetTreeNodeToLabelSpacing();
+            const std::vector<ImU32>& wheel   = m_settings.GetColorWheel();
+            ImDrawList*               draw    = ImGui::GetWindowDrawList();
+            draw->AddCircleFilled(
+                ImVec2(label_x + radius, node_pos.y + ImGui::GetFrameHeight() * 0.5f),
                 radius, wheel[node.color_index % wheel.size()]);
+            draw->AddText(
+                ImVec2(label_x + radius * 2.0f + ImGui::GetStyle().ItemInnerSpacing.x,
+                       node_pos.y +
+                           (ImGui::GetFrameHeight() - ImGui::GetTextLineHeight()) * 0.5f),
+                ImGui::GetColorU32(ImGuiCol_Text), node.label.c_str());
         }
         else
         {
-            open = ImGui::TreeNodeEx(node.label.c_str(), HEADER_FLAGS);
+            open = ImGui::TreeNodeEx((node.label + node_id).c_str(), HEADER_FLAGS);
         }
     }
 

--- a/src/view/src/rocprofvis_sidebar.h
+++ b/src/view/src/rocprofvis_sidebar.h
@@ -61,6 +61,7 @@ private:
     std::shared_ptr<std::vector<TrackItem*>> m_tracks;
     DataProvider&                            m_data_provider;
     bool                                     m_eye_state_dirty = false;
+    ImU32                                    m_active_node_color = 0;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -806,10 +806,13 @@ TrackItem::SetNodeColor(const TrackInfo* track_info)
 {
     TopologyDataModel& tdm = m_data_provider.DataModel().GetTopology();
 
+    // Node decorations only make sense on multi-node traces; a single-node
+    // trace looks exactly as it did before this feature.
     const uint64_t            node_id = track_info->topology.node_id;
     const std::vector<ImU32>& wheel   = m_settings.GetColorWheel();
     m_node_display_index              = tdm.GetNodeDisplayIndex(node_id);
-    m_has_node_color                  = m_node_display_index > 0 && !wheel.empty();
+    m_has_node_color =
+        tdm.NodeCount() > 1 && m_node_display_index > 0 && !wheel.empty();
     if(!m_has_node_color)
     {
         return;
@@ -1199,6 +1202,13 @@ Pill::Render(const ImVec2& pos, SettingsManager& settings, Sizing sizing)
 void
 Pill::CalculateSize()
 {
+    // Measure with the same font Render() draws with; otherwise the width is
+    // computed from the larger default font and the gap grows with DPI, letting
+    // adjacent pills overlap on high-resolution displays.
+    FontManager& fonts = SettingsManager::GetInstance().GetFontManager();
+    ImGui::PushFont(fonts.GetFont(FontType::kDefault),
+                    fonts.GetFontSize(FontSize::kSmall));
+
     m_widths[kElided]  = ImGui::CalcTextSize("...").x + 2 * m_padding_x;
     m_widths[kCompact] = ImGui::CalcTextSize(m_compact_label.c_str()).x + 2 * m_padding_x;
     m_widths[kExtended] =
@@ -1206,6 +1216,8 @@ Pill::CalculateSize()
             ? m_widths[kCompact]
             : ImGui::CalcTextSize(m_ext_label.c_str()).x + 2 * m_padding_x;
     m_height = ImGui::GetTextLineHeight() + 2 * m_padding_y;
+
+    ImGui::PopFont();
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -58,6 +58,10 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id, bool display,
 , m_chunk_duration_ns(DEFAULT_CHUNK_DURATION)
 , m_group_id_counter(0)
 , m_meta_area_label("")
+, m_has_node_color(false)
+, m_node_color_index(0)
+, m_node_display_index(0)
+, m_node_pill(nullptr)
 , m_selected(false)
 , m_selected_changed_token(EventManager::InvalidSubscriptionToken)
 , m_track_project_settings(m_data_provider.GetTraceFilePath(), *this)
@@ -78,6 +82,7 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id, bool display,
     m_track_metadata = track_info;
     m_name = m_data_provider.DataModel().BuildTrackName(m_track_id);
     SetMetaAreaLabel(track_info);
+    SetNodeColor(track_info);
     SetDefaultPillLabel(track_info);
 
     EventManager::EventHandler selected_changed_handler =
@@ -350,9 +355,16 @@ TrackItem::RenderMetaArea()
         ImGui::PopStyleColor();
         ImGui::EndGroup();
 
+        // The node pill is toggled from Edit -> Preferences.
+        if(m_node_pill)
+        {
+            m_node_pill->SetVisible(m_has_node_color && m_settings.ShowNodeColors());
+        }
+
         RenderMetaAreaScale();
         RenderMetaAreaExpand();
         RenderPills(ImVec2(available_for_text, content_size.y));
+
         ImGui::GetWindowDrawList()->AddLine(
             ImGui::GetWindowPos() + ImVec2(0.0f, ImGui::GetWindowSize().y),
             ImGui::GetWindowPos() + ImGui::GetWindowSize(),
@@ -660,11 +672,18 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
 {
     TopologyDataModel& tdm = m_data_provider.DataModel().GetTopology();
 
-    std::string node_id_str    = std::to_string(track_info->topology.node_id);
     std::string process_id_str = std::to_string(track_info->topology.process_id);
 
-    bool show_node_id    = tdm.NodeCount() > 1;
     bool show_process_id = tdm.ProcessCount() > 1;
+
+    // Node is conveyed by the colored node pill, so the tooltip carries the
+    // human-readable name + stable index instead of the raw node id.
+    const size_t    node_index = tdm.GetNodeDisplayIndex(track_info->topology.node_id);
+    const NodeInfo* node_info  = tdm.GetNode(track_info->topology.node_id);
+    const std::string node_name =
+        (node_info && !node_info->host_name.empty())
+            ? node_info->host_name
+            : "Node " + std::to_string(node_index);
 
     switch(track_info->topology.type)
     {
@@ -703,10 +722,6 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
         case TrackInfo::TrackType::Counter:
         {
             m_meta_area_label = track_info->sub_name;
-            if(show_node_id)
-            {
-                m_meta_area_label += " (NID: " + node_id_str + ")";
-            }
             if(show_process_id)
             {
                 m_meta_area_label += " (PID: " + process_id_str + ")";
@@ -730,10 +745,6 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
                 m_meta_area_label = track_info->sub_name;
             }
 
-            if(show_node_id)
-            {
-                m_meta_area_label += " (NID: " + node_id_str + ")";
-            }
             if(show_process_id)
             {
                 m_meta_area_label += " (PID: " + process_id_str + ")";
@@ -744,10 +755,6 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
         {
             m_meta_area_label = track_info->main_name;
 
-            if(show_node_id)
-            {
-                m_meta_area_label += " (NID: " + node_id_str + ")";
-            }
             if(show_process_id)
             {
                 m_meta_area_label += " (PID: " + process_id_str + ")";
@@ -767,7 +774,7 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
 
     std::string meta_lines;
     meta_lines += "Track ID: " + std::to_string(track_info->id) + "\n";
-    meta_lines += "Node ID: " + node_id_str + "\n";
+    meta_lines += "Node: " + node_name + " [" + std::to_string(node_index) + "]\n";
     meta_lines += "Process ID: " + process_id_str + "\n";
     meta_lines += std::string(count_label) + ": ";
 #ifdef ROCPROFVIS_DEVELOPER_MODE
@@ -792,6 +799,36 @@ TrackItem::SetMetaAreaLabel(const TrackInfo* track_info)
     {
         m_meta_area_tooltip += "\n\n" + meta_lines;
     }
+}
+
+void
+TrackItem::SetNodeColor(const TrackInfo* track_info)
+{
+    TopologyDataModel& tdm = m_data_provider.DataModel().GetTopology();
+
+    const uint64_t            node_id = track_info->topology.node_id;
+    const std::vector<ImU32>& wheel   = m_settings.GetColorWheel();
+    m_node_display_index              = tdm.GetNodeDisplayIndex(node_id);
+    m_has_node_color                  = m_node_display_index > 0 && !wheel.empty();
+    if(!m_has_node_color)
+    {
+        return;
+    }
+
+    const NodeInfo* node = tdm.GetNode(node_id);
+    m_node_name          = (node && !node->host_name.empty())
+                               ? node->host_name
+                               : "Node " + std::to_string(m_node_display_index);
+
+    // The 1-based display index maps to a stable color-wheel slot shared with
+    // the pill accent and the sidebar so every node cue matches.
+    m_node_color_index = (m_node_display_index - 1) % wheel.size();
+
+    m_node_pill = AddPill(true, true);
+    m_node_pill->SetLabel(std::to_string(m_node_display_index));
+    m_node_pill->SetAccentColor(m_node_color_index);
+    m_node_pill->SetTooltip("Node " + std::to_string(m_node_display_index) + ": " +
+                            m_node_name);
 }
 
 Pill*

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -145,6 +145,7 @@ protected:
     void  FetchHelper();
     void  SetDefaultPillLabel(const TrackInfo* track_info);
     void  SetMetaAreaLabel(const TrackInfo* track_info);
+    void  SetNodeColor(const TrackInfo* track_info);
     Pill* AddPill(bool shown = true, bool active = true);
 
     const TrackInfo*                    m_track_metadata;
@@ -178,6 +179,15 @@ protected:
     static float                                     s_metadata_width;
     std::string                                      m_meta_area_label;
     std::string                                      m_meta_area_tooltip;
+
+    // Node color-coding: a pill showing the node's display index, accented with
+    // a color-wheel slot keyed by that index. Gated at render time by the
+    // "Color-code tracks by node" preference.
+    bool        m_has_node_color;
+    size_t      m_node_color_index;
+    size_t      m_node_display_index;
+    std::string m_node_name;
+    Pill*       m_node_pill;
 
 private:
     void RenderPills(ImVec2 region);

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -772,15 +772,16 @@ TrackTopology::BuildSidebarTree()
                 continue;
             }
 
-            TopologyDataModel& tdm = m_data_provider.DataModel().GetTopology();
+            TopologyDataModel& tdm        = m_data_provider.DataModel().GetTopology();
+            const bool         multi_node = tdm.NodeCount() > 1;
             const size_t       node_index = tdm.GetNodeDisplayIndex(node.info->id);
             const std::string  node_label =
-                (node_index > 0)
+                (multi_node && node_index > 0)
                     ? "[" + std::to_string(node_index) + "] " + node.info->host_name
                     : node.info->host_name;
             TreeNode* node_branch =
                 AddBranchNode(node_list, NodeType::kNode, node_label, true, true, false);
-            if(node_index > 0)
+            if(multi_node && node_index > 0)
             {
                 const size_t wheel_size =
                     SettingsManager::GetInstance().GetColorWheel().size();

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -772,8 +772,21 @@ TrackTopology::BuildSidebarTree()
                 continue;
             }
 
-            TreeNode* node_branch = AddBranchNode(node_list, NodeType::kNode,
-                node.info->host_name, true, true, false);
+            TopologyDataModel& tdm = m_data_provider.DataModel().GetTopology();
+            const size_t       node_index = tdm.GetNodeDisplayIndex(node.info->id);
+            const std::string  node_label =
+                (node_index > 0)
+                    ? "[" + std::to_string(node_index) + "] " + node.info->host_name
+                    : node.info->host_name;
+            TreeNode* node_branch =
+                AddBranchNode(node_list, NodeType::kNode, node_label, true, true, false);
+            if(node_index > 0)
+            {
+                const size_t wheel_size =
+                    SettingsManager::GetInstance().GetColorWheel().size();
+                node_branch->show_color_swatch = true;
+                node_branch->color_index = wheel_size ? (node_index - 1) % wheel_size : 0;
+            }
 
             if(!node.processors.empty())
             {

--- a/src/view/src/rocprofvis_tree_node.h
+++ b/src/view/src/rocprofvis_tree_node.h
@@ -58,6 +58,8 @@ public:
     bool                                    breaks_visibility_chain = false;
     bool                                    render_children_inline  = false;
     mutable uint8_t                         cached_eye_state        = 0;
+    bool                                    show_color_swatch       = false;
+    size_t                                  color_index             = 0;
     std::vector<std::unique_ptr<TreeNode>>  children;
 };
 


### PR DESCRIPTION
## Motivation

On multi-node traces it's hard to tell which node a given track belongs to.
Track meta labels don't surface node identity clearly, and there's no visual
link between the sidebar topology tree and the tracks on the timeline. This
PR adds subtle, consistent node color-coding so users can immediately see how
tracks group by node and correlate them with the sidebar.

## Technical Details

- **Track pill (`rocprofvis_track_item`):** Added `SetNodeColor`, which pulls
  the track's node from the topology model and builds a pill in the track meta
  area showing the node's display index. The pill is accented with a color-wheel
  slot keyed by that index and carries a tooltip of the form `Node <n>: <name>`.
- **Sidebar (`rocprofvis_sidebar` / `rocprofvis_tree_node`):** Node rows now
  draw a matching color swatch, so the topology tree and the timeline agree on
  which node is which. `TreeNode` gained `show_color_swatch` / `color_index`.
- **Topology model (`rocprofvis_topology_model`):** Added `GetNodeDisplayIndex`,
  returning a stable 1-based index per node used as the color-wheel key across
  the pill and swatch.
- **Preferences (`rocprofvis_settings_manager` / `rocprofvis_settings_panel`):**
  Added a "Color-code tracks by node" display setting (defaults on), toggleable
  from Edit → Preferences and persisted to config. The pill and swatch are
  gated on this preference at render time.
- **Colors** come from the shared theme color wheel, so they follow the active
  theme (dark/light) and stay consistent across the pill, swatch, and any
  future node cues.