### PR TITLE
View: Fix editable counter track value inputs

### DIFF
--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -8,7 +8,6 @@
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
 #include <algorithm>
-#include <charconv>
 #include <iomanip>
 #include <sstream>
 
@@ -593,7 +592,7 @@ LineTrackItem::VerticalLimits::VerticalLimits(std::string field_id)
         {
             UpdateValue(m_default_value);
         }
-        else if(committed_text != m_compact_str)
+        else if(committed_text != m_edit_str)
         {
             double processed = ProcessUserInput(committed_text);
             UpdateValue(processed);
@@ -651,12 +650,15 @@ LineTrackItem::VerticalLimits::UpdateValue(double value)
     m_value         = value;
     m_formatted_str = FormatValue(value);
     m_compact_str   = compact_number_format(value);
+    // Units-free so the edit box shows "25.2M", not "25.2M bytes".
+    m_edit_str = m_compact_str;
     if(!m_units.empty())
     {
         m_formatted_str += " " + m_units;
         m_compact_str += " " + m_units;
     }
     m_text_field.SetText(m_compact_str, m_formatted_str, m_formatted_default);
+    m_text_field.SetEditText(m_edit_str);
 }
 
 std::string
@@ -670,37 +672,13 @@ LineTrackItem::VerticalLimits::FormatValue(double value)
 double
 LineTrackItem::VerticalLimits::ProcessUserInput(std::string_view input)
 {
-    double      result = 0.0;
-    const char* first  = input.data();
-    const char* last   = input.data() + input.size();
-    
-#if defined(__APPLE__)
-    // macOS doesn't support from_chars for floating point yet, use strtod as fallback
-    char* end_ptr = nullptr;
-    std::string null_terminated(input);
-    result = std::strtod(null_terminated.c_str(), &end_ptr);
-    if(end_ptr == null_terminated.c_str() + null_terminated.size() && std::isfinite(result))
+    double value = 0.0;
+    if(parse_compact_number(input, m_units, value))
     {
-        return result;
+        return value;
     }
-    else
-    {
-        m_text_field.RevertToDefault();
-        return m_default_value;
-    }
-#else
-    auto [ptr, error_code] =
-        std::from_chars(first, last, result, std::chars_format::general);
-    if(error_code == std::errc{} && std::isfinite(result) && ptr == last)
-    {
-        return result;
-    }
-    else
-    {
-        m_text_field.RevertToDefault();
-        return m_default_value;
-    }
-#endif
+    m_text_field.RevertToDefault();
+    return m_default_value;
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_line_track_item.h
+++ b/src/view/src/rocprofvis_line_track_item.h
@@ -71,6 +71,7 @@ class LineTrackItem : public TrackItem
 
         std::string m_formatted_str;
         std::string m_compact_str;
+        std::string m_edit_str;
         std::string m_units;
 
         EditableTextField m_text_field;

--- a/src/view/src/rocprofvis_utils.cpp
+++ b/src/view/src/rocprofvis_utils.cpp
@@ -3,6 +3,7 @@
 
 #include "rocprofvis_utils.h"
 #include <cctype>
+#include <charconv>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -474,6 +475,80 @@ RocProfVis::View::compact_number_format(double number)
         << number
         << suffixes[magnitude];
     return output.str();
+}
+
+bool
+RocProfVis::View::parse_compact_number(std::string_view input, std::string_view units,
+                                       double& out_value)
+{
+    auto trim = [](std::string_view s) -> std::string_view {
+        const size_t begin = s.find_first_not_of(" \t\r\n");
+        if(begin == std::string_view::npos) return {};
+        return s.substr(begin, s.find_last_not_of(" \t\r\n") - begin + 1);
+    };
+
+    std::string_view sv = trim(input);
+
+    if(!units.empty() && sv.size() >= units.size())
+    {
+        std::string_view tail  = sv.substr(sv.size() - units.size());
+        bool             match = true;
+        for(size_t i = 0; i < units.size() && match; ++i)
+        {
+            match = std::tolower(static_cast<unsigned char>(tail[i])) ==
+                    std::tolower(static_cast<unsigned char>(units[i]));
+        }
+        if(match)
+        {
+            sv = trim(sv.substr(0, sv.size() - units.size()));
+        }
+    }
+
+    double multiplier = 1.0;
+    if(!sv.empty())
+    {
+        switch(std::toupper(static_cast<unsigned char>(sv.back())))
+        {
+        case 'K': multiplier = 1e3; break;
+        case 'M': multiplier = 1e6; break;
+        case 'B':
+        case 'G': multiplier = 1e9; break;
+        case 'T': multiplier = 1e12; break;
+        case 'P': multiplier = 1e15; break;
+        default: break;
+        }
+        if(multiplier != 1.0)
+        {
+            sv = trim(sv.substr(0, sv.size() - 1));
+        }
+    }
+
+    if(sv.empty())
+    {
+        return false;
+    }
+
+    double result = 0.0;
+    bool   parsed = false;
+#if defined(__APPLE__)
+    // macOS doesn't support from_chars for floating point yet, use strtod.
+    char*       end_ptr = nullptr;
+    std::string null_terminated(sv);
+    result = std::strtod(null_terminated.c_str(), &end_ptr);
+    parsed = (end_ptr == null_terminated.c_str() + null_terminated.size());
+#else
+    const char* last = sv.data() + sv.size();
+    auto [ptr, ec]   = std::from_chars(sv.data(), last, result, std::chars_format::general);
+    parsed           = (ec == std::errc{} && ptr == last);
+#endif
+
+    result *= multiplier;
+    if(parsed && std::isfinite(result))
+    {
+        out_value = result;
+        return true;
+    }
+    return false;
 }
 
 bool RocProfVis::View::open_url(const std::string& url)

--- a/src/view/src/rocprofvis_utils.h
+++ b/src/view/src/rocprofvis_utils.h
@@ -6,6 +6,7 @@
 #include <deque>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 namespace RocProfVis
 {
@@ -238,6 +239,19 @@ get_application_log_path(bool create_dirs);
 
 std::string
 compact_number_format(double number);
+
+/**
+ * @brief Parses a user-entered number that may carry a compact magnitude suffix
+ * (K/M/B/G/T/P, where G is an alias for B) and/or a trailing units string. This
+ * is the inverse of compact_number_format, tolerant of surrounding whitespace.
+ *
+ * @param input     The raw user input, e.g. "25.2M bytes", "35K", "50 %".
+ * @param units     Units to strip from the end if present (case-insensitive).
+ * @param out_value Receives the parsed value on success.
+ * @return true if the input parsed to a finite number, false otherwise.
+ */
+bool
+parse_compact_number(std::string_view input, std::string_view units, double& out_value);
 
 bool 
 open_url(const std::string& url);

--- a/src/view/src/widgets/rocprofvis_editable_textfield.cpp
+++ b/src/view/src/widgets/rocprofvis_editable_textfield.cpp
@@ -5,6 +5,7 @@
 #include "rocprofvis_settings_manager.h"
 #include "icons/rocprovfis_icon_defines.h"
 #include "widgets/rocprofvis_gui_helpers.h"
+#include <algorithm>
 
 namespace RocProfVis
 {
@@ -73,11 +74,12 @@ EditableTextField::DrawPlainText()
                              ImGui::CalcTextSize(m_text.c_str()).x -
                              ImGui::GetStyle().WindowPadding.x);
     }
-    // Draw the text as a button to avoid the background
-    // and prevent clicks from being registered.
+    // Transparent at rest, themed highlight on hover/press.
     ImGui::PushStyleColor(ImGuiCol_Button, 0);
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, 0);
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, 0);
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                          ImGui::GetStyleColorVec4(ImGuiCol_FrameBgHovered));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,
+                          ImGui::GetStyleColorVec4(ImGuiCol_FrameBgActive));
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
     if(ImGui::Button(m_text.c_str()))
     {
@@ -96,9 +98,10 @@ EditableTextField::DrawPlainText()
 void
 EditableTextField::DrawEditingText()
 {
-    if(m_edit_buf != m_text)
+    // Seed only on entering edit mode so keystrokes aren't clobbered each frame.
+    if(m_request_keyboard_focus)
     {
-        m_edit_buf = m_text;
+        m_edit_buf = m_edit_text.empty() ? m_text : m_edit_text;
     }
 
     auto resize_callback = [](ImGuiInputTextCallbackData* data) -> int {
@@ -111,13 +114,17 @@ EditableTextField::DrawEditingText()
         return 0;
     };
 
-    float width = ImGui::CalcTextSize(m_edit_buf.c_str()).x;
+    // Keep a readable minimum width so short values don't collapse to a sliver.
+    const ImGuiStyle& style       = ImGui::GetStyle();
+    const float       min_width   = ImGui::CalcTextSize("00000").x;
+    const float       text_width  = ImGui::CalcTextSize(m_edit_buf.c_str()).x;
+    const float       label_width = ImGui::CalcTextSize(m_text.c_str()).x;
+    const float       width       = std::max({ text_width, label_width, min_width }) +
+                        style.FramePadding.x * 2.0f;
     ImGui::SetNextItemWidth(width);
 
-    // make edit field on the same level as the textfield
-    ImGui::SetCursorPos(ImVec2(ImGui::GetContentRegionMax().x -
-                                   ImGui::CalcTextSize(m_text.c_str()).x -
-                                   ImGui::GetStyle().WindowPadding.x,
+    ImGui::SetCursorPos(ImVec2(ImGui::GetContentRegionMax().x - width -
+                                   style.WindowPadding.x,
                                ImGui::GetCursorPosY() - 2.0f));
 
     if(m_request_keyboard_focus)
@@ -152,6 +159,12 @@ EditableTextField::SetText(std::string text, std::string tooltip, std::string re
     m_text = std::move(text);
     m_tooltip_text = std::move(tooltip);
     m_reset_tooltip = std::move(reset_tooltip);
+}
+
+void
+EditableTextField::SetEditText(std::string edit_text)
+{
+    m_edit_text = std::move(edit_text);
 }
 
 float

--- a/src/view/src/widgets/rocprofvis_editable_textfield.h
+++ b/src/view/src/widgets/rocprofvis_editable_textfield.h
@@ -17,6 +17,7 @@ public:
     ~EditableTextField() = default;
     void        SetText(std::string text, std::string tooltip = "",
                         std::string reset_tooltip = "");
+    void        SetEditText(std::string edit_text);
     void        Render();
     float       ButtonSize() const;
     void        RevertToDefault();
@@ -33,6 +34,7 @@ private:
     bool        m_show_reset_button = false;
     std::string m_id;
     std::string m_text;
+    std::string m_edit_text;
     std::string m_reset_tooltip;
     std::string m_tooltip_text;    
     std::string m_edit_buf;


### PR DESCRIPTION
## Motivation

The min/max value fields on counter tracks were hard to edit: the box included
the units, rejected abbreviated input like `25M`, shrank too small to read while
typing, and gave no hint it was clickable.

## Technical Details

- Edit box now shows a units-free value (e.g. `25.2M`) and only re-seeds on
  entering edit mode so keystrokes aren't lost.
- Added `parse_compact_number()` in `rocprofvis_utils` (inverse of
  `compact_number_format`) that accepts whitespace, a trailing units string, and
  `K/M/B/G/T/P` suffixes, so edits like `30M bytes` or `50 %` work.
- Kept a readable minimum width and added a hover highlight.