### PR TITLE
Annotation UX enhancements: lock, go-to-anchor, cross-highlight, wrapping, and placement fixes

### DIFF
--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -8,6 +8,8 @@ namespace View
 constexpr ImWchar icon_ranges[] = {
     0xF123, 0xF125,
     0xF128, 0xF128,
+    0xF200, 0xF200,
+    0xF254, 0xF254,
     0xF133, 0xF133,
     0xF13D, 0xF13D,
     0xF1FE, 0xF1FE,
@@ -39,6 +41,8 @@ inline constexpr const char* ICON_CHEVRON_DOWN  = u8"\uF123";
 inline constexpr const char* ICON_CHEVRON_LEFT  = u8"\uF124";
 inline constexpr const char* ICON_CHEVRON_RIGHT = u8"\uF125";
 inline constexpr const char* ICON_X_CIRCLED     = u8"\uF128";
+inline constexpr const char* ICON_LOCKED        = u8"\uF200";
+inline constexpr const char* ICON_UNLOCKED      = u8"\uF254";
 inline constexpr const char* ICON_EYE           = u8"\uF133";
 inline constexpr const char* ICON_GEAR          = u8"\uF13D";
 inline constexpr const char* ICON_CHAIN         = u8"\uF1FE";

--- a/src/view/src/rocprofvis_annotations.cpp
+++ b/src/view/src/rocprofvis_annotations.cpp
@@ -47,6 +47,13 @@ AnnotationsManagerProjectSettings::FromJson()
             is_minimized = note_json[JSON_KEY_ANNOTATION_IS_MINIMIZED].getBool();
         }
 
+        bool is_locked = false;
+        if(note_json.contains(JSON_KEY_ANNOTATION_IS_LOCKED) &&
+           note_json[JSON_KEY_ANNOTATION_IS_LOCKED].isBool())
+        {
+            is_locked = note_json[JSON_KEY_ANNOTATION_IS_LOCKED].getBool();
+        }
+
         // Legacy projects have no track binding; load as unbound and re-anchor
         // on first render.
         uint64_t track_id = INVALID_TRACK_ID;
@@ -65,7 +72,7 @@ AnnotationsManagerProjectSettings::FromJson()
 
         ImVec2 size(size_x, size_y);
         m_annotations_manager.AddSticky(time_ns, y_offset, size, text, title, v_min,
-                                        v_max, track_id, is_minimized);
+                                        v_max, track_id, is_minimized, is_locked);
     }
 }
 
@@ -90,6 +97,7 @@ AnnotationsManagerProjectSettings::ToJson()
         sticky_json[JSON_KEY_TIMELINE_ANNOTATION_V_MIN_X] = notes[i].GetVMinX();
         sticky_json[JSON_KEY_TIMELINE_ANNOTATION_V_MAX_X] = notes[i].GetVMaxX();
         sticky_json[JSON_KEY_ANNOTATION_IS_MINIMIZED]     = notes[i].IsMinimized();
+        sticky_json[JSON_KEY_ANNOTATION_IS_LOCKED]        = notes[i].IsLocked();
 
         m_settings_json[JSON_KEY_ANNOTATIONS][i] = sticky_json;
     }
@@ -155,10 +163,10 @@ void
 AnnotationsManager::AddSticky(double time_ns, float y_offset, const ImVec2& size,
                               const std::string& text, const std::string& title,
                               double v_min, double v_max, uint64_t track_id,
-                              bool is_minimized)
+                              bool is_minimized, bool is_locked)
 {
     m_sticky_notes.emplace_back(time_ns, y_offset, size, text, title, v_min, v_max,
-                                track_id, is_minimized);
+                                track_id, is_minimized, is_locked);
 }
 
 bool

--- a/src/view/src/rocprofvis_annotations.h
+++ b/src/view/src/rocprofvis_annotations.h
@@ -45,7 +45,7 @@ public:
     void AddSticky(double time_ns, float y_offset, const ImVec2& size,
                    const std::string& text, const std::string& title, double v_min,
                    double v_max, uint64_t track_id = INVALID_TRACK_ID,
-                   bool is_minimized = true);
+                   bool is_minimized = true, bool is_locked = false);
 
     void                     RemoveNotesPendingDelete();
     std::vector<StickyNote>& GetStickyNotes();

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -181,6 +181,7 @@ constexpr const char* JSON_KEY_ANNOTATION_TRACK_ID         = "track_id";
 constexpr const char* JSON_KEY_TIMELINE_ANNOTATION_V_MIN_X = "view_start_ns";
 constexpr const char* JSON_KEY_TIMELINE_ANNOTATION_V_MAX_X = "view_end_ns";
 constexpr const char* JSON_KEY_ANNOTATION_IS_MINIMIZED     = "is_minimized";
+constexpr const char* JSON_KEY_ANNOTATION_IS_LOCKED        = "is_locked";
 
 class ProjectSetting
 {

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -510,17 +510,19 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         ImVec2 trash_icon_size = ImGui::CalcTextSize(ICON_TRASH_CAN);
         ImVec2 lock_icon_size  = ImGui::CalcTextSize(ICON_LOCKED);
         ImVec2 unlock_icon_size = ImGui::CalcTextSize(ICON_UNLOCKED);
+        ImVec2 goto_icon_size   = ImGui::CalcTextSize(ICON_ARROW_FORWARD);
         ImGui::PopFont();
         const float action_btn_size = std::max(
             {kHeaderButtonMinSize, close_icon_size.x + kHeaderButtonPadding,
              trash_icon_size.x + kHeaderButtonPadding,
              lock_icon_size.x + kHeaderButtonPadding,
-             unlock_icon_size.x + kHeaderButtonPadding});
+             unlock_icon_size.x + kHeaderButtonPadding,
+             goto_icon_size.x + kHeaderButtonPadding});
         const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
 
         // Title is plain text so the header stays draggable; click to edit.
         const float buttons_width =
-            action_btn_size * 3.0f + kHeaderButtonGap * 2.0f;
+            action_btn_size * 4.0f + kHeaderButtonGap * 3.0f;
         const float title_width   = std::max(
             0.0f, win_size.x - buttons_width - kHeaderButtonGap - kNoteMargin * 2.0f);
         ImGui::PushStyleColor(ImGuiCol_Text, text_color);
@@ -579,6 +581,17 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
         const ImU32 transparent = settings.GetColor(Colors::kTransparent);
         const ImVec2 action_btn(action_btn_size, action_btn_size);
+
+        ImGui::SetCursorPos(ImVec2(
+            win_size.x - action_btn_size * 4.0f - kHeaderButtonGap * 3.0f - kNoteMargin,
+            action_btn_y));
+        if(IconButton(ICON_ARROW_FORWARD, action_icon_font, action_btn, "Go to Anchor",
+                      false,
+                      ImVec2(0.0f, 0.0f), transparent, icon_hover_color,
+                      icon_active_color, ("goto_" + std::to_string(m_id)).c_str()))
+        {
+            m_pending_navigate = true;
+        }
 
         ImGui::SetCursorPos(ImVec2(
             win_size.x - action_btn_size * 3.0f - kHeaderButtonGap * 2.0f - kNoteMargin,

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -670,15 +670,18 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered)
         m_note_engaged =
             hovered || ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
 
-        // Ring hugs the outside edge so it never overlaps the note interior.
+        // Drawn on the note's draw list (not the foreground) so tooltips stay on
+        // top; clip is expanded so the outset ring isn't clipped to the window.
         if(marker_hovered || m_note_engaged)
         {
-            ImGui::GetForegroundDrawList()->AddRect(
-                ImVec2(win_pos.x - kHighlightPad, win_pos.y - kHighlightPad),
-                ImVec2(win_pos.x + win_size.x + kHighlightPad,
-                       win_pos.y + win_size.y + kHighlightPad),
-                settings.GetColor(Colors::kStickyNoteAccent), rounding + kHighlightPad, 0,
-                kHighlightThickness);
+            const ImVec2 ring_min(win_pos.x - kHighlightPad, win_pos.y - kHighlightPad);
+            const ImVec2 ring_max(win_pos.x + win_size.x + kHighlightPad,
+                                  win_pos.y + win_size.y + kHighlightPad);
+            note_draw_list->PushClipRect(ring_min, ring_max, false);
+            note_draw_list->AddRect(ring_min, ring_max,
+                                    settings.GetColor(Colors::kStickyNoteAccent),
+                                    rounding + kHighlightPad, 0, kHighlightThickness);
+            note_draw_list->PopClipRect();
         }
 
         // Provisional note commits on first input, discarded if abandoned empty.

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -94,7 +94,8 @@ PopPlainTextInputStyle()
 static int s_unique_id_counter = 0;
 StickyNote::StickyNote(double time_ns, float y_offset, const ImVec2& size,
                        const std::string& text, const std::string& title, double v_min,
-                       double v_max, uint64_t track_id, bool is_minimized)
+                       double v_max, uint64_t track_id, bool is_minimized,
+                       bool is_locked)
 : m_time_ns(time_ns)
 , m_y_offset(y_offset)
 , m_track_id(track_id)
@@ -106,6 +107,7 @@ StickyNote::StickyNote(double time_ns, float y_offset, const ImVec2& size,
 , m_v_min_x(v_min)
 , m_v_max_x(v_max)
 , m_is_minimized(is_minimized)
+, m_locked(is_locked)
 {
     ++s_unique_id_counter;
 }
@@ -454,14 +456,19 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         ImGui::PushFont(action_icon_font);
         ImVec2 close_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
         ImVec2 trash_icon_size = ImGui::CalcTextSize(ICON_TRASH_CAN);
+        ImVec2 lock_icon_size  = ImGui::CalcTextSize(ICON_LOCKED);
+        ImVec2 unlock_icon_size = ImGui::CalcTextSize(ICON_UNLOCKED);
         ImGui::PopFont();
         const float action_btn_size = std::max(
             {kHeaderButtonMinSize, close_icon_size.x + kHeaderButtonPadding,
-             trash_icon_size.x + kHeaderButtonPadding});
+             trash_icon_size.x + kHeaderButtonPadding,
+             lock_icon_size.x + kHeaderButtonPadding,
+             unlock_icon_size.x + kHeaderButtonPadding});
         const float action_btn_y = (kExpandedHeaderHeight - action_btn_size) * 0.5f;
 
         // Title is plain text so the header stays draggable; click to edit.
-        const float buttons_width = action_btn_size * 2.0f + kHeaderButtonGap;
+        const float buttons_width =
+            action_btn_size * 3.0f + kHeaderButtonGap * 2.0f;
         const float title_width   = std::max(
             0.0f, win_size.x - buttons_width - kHeaderButtonGap - kNoteMargin * 2.0f);
         ImGui::PushStyleColor(ImGuiCol_Text, text_color);
@@ -518,6 +525,17 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         ImGui::PushStyleColor(ImGuiCol_Text, muted_text_color);
         const ImU32 transparent = settings.GetColor(Colors::kTransparent);
         const ImVec2 action_btn(action_btn_size, action_btn_size);
+
+        ImGui::SetCursorPos(ImVec2(
+            win_size.x - action_btn_size * 3.0f - kHeaderButtonGap * 2.0f - kNoteMargin,
+            action_btn_y));
+        if(IconButton(m_locked ? ICON_LOCKED : ICON_UNLOCKED, action_icon_font,
+                      action_btn, m_locked ? "Unlock Position" : "Lock Position", false,
+                      ImVec2(0.0f, 0.0f), transparent, icon_hover_color,
+                      icon_active_color, ("lock_" + std::to_string(m_id)).c_str()))
+        {
+            m_locked = !m_locked;
+        }
 
         ImGui::SetCursorPos(ImVec2(
             win_size.x - action_btn_size * 2.0f - kHeaderButtonGap - kNoteMargin,
@@ -659,9 +677,11 @@ StickyNote::HandleDrag(const ImVec2&                       window_position,
     bool        mouse_released = ImGui::IsMouseReleased(ImGuiMouseButton_Left);
 
     // Drag-start uses the marker's own hover (last frame), which respects z-order
-    // and popups; an anchor overhanging onto a neighbour track still grabs.
-    if((dragged_id == INVALID_STICKY_ID || dragged_id == m_id) && !m_dragging &&
-       m_marker_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
+    // and popups; an anchor overhanging onto a neighbour track still grabs. A
+    // locked note ignores drags so it can't be nudged out of position.
+    if(!m_locked && (dragged_id == INVALID_STICKY_ID || dragged_id == m_id) &&
+       !m_dragging && m_marker_hovered &&
+       ImGui::IsMouseClicked(ImGuiMouseButton_Left) &&
        !HotkeyManager::GetInstance().IsActionHeld(HotkeyActionId::kRegionSelect))
     {
         m_dragging    = true;

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -92,6 +92,25 @@ PopPlainTextInputStyle()
     ImGui::PopStyleVar(1);
     ImGui::PopStyleColor(3);
 }
+
+// Trims text to a single line fitting max_width (and max_chars), appending "..."
+// when shortened. Uses the current font for measurement.
+std::string
+ElideWithEllipsis(const std::string& text, float max_width, size_t max_chars)
+{
+    std::string out       = text.substr(0, max_chars);
+    bool        truncated = text.size() > max_chars;
+    while(!out.empty() && ImGui::CalcTextSize((out + "...").c_str()).x > max_width)
+    {
+        out.pop_back();
+        truncated = true;
+    }
+    if(truncated)
+    {
+        out += "...";
+    }
+    return out;
+}
 }  // namespace
 
 static int s_unique_id_counter = 0;
@@ -369,21 +388,9 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
         ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kDefault));
         if(!m_title.empty())
         {
-            // Keep the title to a single line: cap length, then trim by width.
-            std::string title_preview = m_title.substr(0, kPreviewTitleMaxChars);
-            bool        truncated     = m_title.size() > kPreviewTitleMaxChars;
-            while(!title_preview.empty() &&
-                  ImGui::CalcTextSize((title_preview + "...").c_str()).x >
-                      kPreviewTooltipWidth)
-            {
-                title_preview.pop_back();
-                truncated = true;
-            }
-            if(truncated)
-            {
-                title_preview += "...";
-            }
-            ImGui::TextUnformatted(title_preview.c_str());
+            ImGui::TextUnformatted(
+                ElideWithEllipsis(m_title, kPreviewTooltipWidth, kPreviewTitleMaxChars)
+                    .c_str());
             ImGui::Spacing();
             ImGui::Separator();
             ImGui::Spacing();
@@ -549,7 +556,9 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
             }
             else
             {
-                ElidedText(m_title.c_str(), title_width);
+                ImGui::TextUnformatted(
+                    ElideWithEllipsis(m_title, title_width, kPreviewTitleMaxChars)
+                        .c_str());
             }
 
             const ImVec2 title_min(win_pos.x + kNoteMargin, win_pos.y);
@@ -618,7 +627,7 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         InlineInputTextMultiline(
             ("##body_" + std::to_string(m_id)).c_str(), m_text,
             ImVec2(win_size.x - kNoteMargin * 2.0f, body_height),
-            ImGuiInputTextFlags_AllowTabInput);
+            ImGuiInputTextFlags_AllowTabInput | ImGuiInputTextFlags_WordWrap);
         bool body_active = ImGui::IsItemActive();
         PopPlainTextInputStyle();
         ImGui::PopStyleColor();

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -95,25 +95,6 @@ PopPlainTextInputStyle()
     ImGui::PopStyleColor(3);
 }
 
-// Trims text to a single line fitting max_width (and max_chars), appending "..."
-// when shortened. Uses the current font for measurement.
-std::string
-ElideWithEllipsis(const std::string& text, float max_width, size_t max_chars)
-{
-    std::string out       = text.substr(0, max_chars);
-    bool        truncated = text.size() > max_chars;
-    while(!out.empty() && ImGui::CalcTextSize((out + "...").c_str()).x > max_width)
-    {
-        out.pop_back();
-        truncated = true;
-    }
-    if(truncated)
-    {
-        out += "...";
-    }
-    return out;
-}
-
 // Dark mode uses the brighter header tint.
 ImU32
 HighlightRingColor(SettingsManager& settings)

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -28,8 +28,6 @@ constexpr float kNoteMargin           = 14.0f;
 constexpr float kHeaderButtonGap      = 2.0f;
 constexpr float kHeaderButtonMinSize  = 24.0f;
 constexpr float kHeaderButtonPadding  = 6.0f;
-constexpr float kAccentStripeWidth    = 3.0f;
-constexpr float kAccentStripeAlpha    = 0.78f;
 constexpr float kHeaderSeparatorAlpha = 0.42f;
 constexpr float kIconHoverAlpha       = 0.12f;
 constexpr float kIconActiveAlpha      = 0.22f;
@@ -43,6 +41,8 @@ constexpr float kTimeIndicatorAlpha   = 0.85f;
 constexpr float  kPreviewTooltipWidth = 320.0f;
 constexpr size_t kPreviewMaxChars     = 200;
 constexpr size_t kPreviewTitleMaxChars = 60;
+constexpr float  kHighlightThickness  = 2.0f;
+constexpr float  kHighlightPad        = 2.0f;
 
 // Grows the backing std::string so ImGui can edit it in place.
 int
@@ -318,10 +318,11 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     // Cached for next frame's HandleDrag (which runs before this render pass).
     m_marker_hovered = marker_hovered;
 
+    m_note_engaged      = false;
     bool window_hovered = false;
     if(!m_is_minimized)
     {
-        window_hovered = RenderExpandedWindow(anchor_pos);
+        window_hovered = RenderExpandedWindow(anchor_pos, marker_hovered);
     }
 
     bool pair_hovered = marker_hovered || window_hovered;
@@ -329,6 +330,22 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     if((pair_hovered || m_dragging) && draw_list)
     {
         RenderTimeIndicator(draw_list, window_position, tpt);
+    }
+
+    // Outline the anchor when it (or its note) is engaged. Drawn on the timeline
+    // layer so an overlapping note occludes it instead of the outline bleeding
+    // over the covering window.
+    if((marker_hovered || m_note_engaged) && !marker_hidden && draw_list)
+    {
+        SettingsManager& settings = SettingsManager::GetInstance();
+        const float      rounding =
+            settings.GetDefaultStyle().ChildRounding * kMarkerRoundingScale;
+        const float sz = MarkerSize();
+        draw_list->AddRect(
+            ImVec2(anchor_pos.x - kHighlightPad, anchor_pos.y - kHighlightPad),
+            ImVec2(anchor_pos.x + sz + kHighlightPad, anchor_pos.y + sz + kHighlightPad),
+            settings.GetColor(Colors::kStickyNoteAccent), rounding + kHighlightPad, 0,
+            kHighlightThickness);
     }
 
     TimelineFocusManager::GetInstance().RequestLayerFocus(
@@ -430,7 +447,7 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
 }
 
 bool
-StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
+StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered)
 {
     SettingsManager& settings     = SettingsManager::GetInstance();
     ImU32            bg_color     = settings.GetColor(Colors::kStickyNoteBg);
@@ -442,7 +459,6 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         ApplyAlpha(settings.GetColor(Colors::kStickyNoteText), kIconActiveAlpha);
     ImU32 text_color       = settings.GetColor(Colors::kStickyNoteText);
     ImU32 muted_text_color = settings.GetColor(Colors::kStickyNoteTextMuted);
-    ImU32 accent_color     = settings.GetColor(Colors::kStickyNoteAccent);
 
     const float  rounding    = settings.GetDefaultStyle().ChildRounding;
     const ImVec2 sticky_size = m_size;
@@ -496,10 +512,6 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
             ImVec2(win_pos.x + win_size.x, win_pos.y + kExpandedHeaderHeight);
         note_draw_list->AddRectFilled(win_pos, header_max, header_color, rounding,
                                       ImDrawFlags_RoundCornersTop);
-        note_draw_list->AddRectFilled(
-            win_pos, ImVec2(win_pos.x + kAccentStripeWidth, win_pos.y + win_size.y),
-            ApplyAlpha(accent_color, kAccentStripeAlpha), rounding,
-            ImDrawFlags_RoundCornersLeft);
         note_draw_list->AddLine(ImVec2(win_pos.x, header_max.y),
                                 ImVec2(win_pos.x + win_size.x, header_max.y),
                                 ApplyAlpha(border_color, kHeaderSeparatorAlpha));
@@ -654,6 +666,20 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos)
         }
 
         hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
+
+        m_note_engaged =
+            hovered || ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
+
+        // Ring hugs the outside edge so it never overlaps the note interior.
+        if(marker_hovered || m_note_engaged)
+        {
+            ImGui::GetForegroundDrawList()->AddRect(
+                ImVec2(win_pos.x - kHighlightPad, win_pos.y - kHighlightPad),
+                ImVec2(win_pos.x + win_size.x + kHighlightPad,
+                       win_pos.y + win_size.y + kHighlightPad),
+                settings.GetColor(Colors::kStickyNoteAccent), rounding + kHighlightPad, 0,
+                kHighlightThickness);
+        }
 
         // Provisional note commits on first input, discarded if abandoned empty.
         if(m_provisional)

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -40,6 +40,9 @@ constexpr float kUnplacedCoord        = -1.0f;
 constexpr float kTitleInputPadX       = 4.0f;
 constexpr float kTimeIndicatorWidth   = 1.5f;
 constexpr float kTimeIndicatorAlpha   = 0.85f;
+constexpr float  kPreviewTooltipWidth = 320.0f;
+constexpr size_t kPreviewMaxChars     = 200;
+constexpr size_t kPreviewTitleMaxChars = 60;
 
 // Grows the backing std::string so ImGui can edit it in place.
 int
@@ -359,6 +362,48 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
                   ImVec2(btn_size, btn_size));
     // IsItemHovered respects z-order, so a covered marker won't show the time line.
     bool hovered = ImGui::IsItemHovered();
+    // Hovering a minimized marker previews the note's title/text without expanding.
+    if(m_is_minimized && (!m_title.empty() || !m_text.empty()) &&
+       BeginItemTooltipStyled())
+    {
+        ImGui::PushFont(settings.GetFontManager().GetFont(FontType::kDefault));
+        if(!m_title.empty())
+        {
+            // Keep the title to a single line: cap length, then trim by width.
+            std::string title_preview = m_title.substr(0, kPreviewTitleMaxChars);
+            bool        truncated     = m_title.size() > kPreviewTitleMaxChars;
+            while(!title_preview.empty() &&
+                  ImGui::CalcTextSize((title_preview + "...").c_str()).x >
+                      kPreviewTooltipWidth)
+            {
+                title_preview.pop_back();
+                truncated = true;
+            }
+            if(truncated)
+            {
+                title_preview += "...";
+            }
+            ImGui::TextUnformatted(title_preview.c_str());
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+        }
+        if(!m_text.empty())
+        {
+            std::string preview = m_text.substr(0, kPreviewMaxChars);
+            if(m_text.size() > kPreviewMaxChars)
+            {
+                preview += "...";
+            }
+            ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
+            ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + kPreviewTooltipWidth);
+            ImGui::TextUnformatted(preview.c_str());
+            ImGui::PopTextWrapPos();
+            ImGui::PopStyleColor();
+        }
+        ImGui::PopFont();
+        EndTooltipStyled();
+    }
     // Clicking a minimized marker expands the note; re-seed its window position.
     if(m_is_minimized && hovered && IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
     {

--- a/src/view/src/rocprofvis_stickynote.cpp
+++ b/src/view/src/rocprofvis_stickynote.cpp
@@ -43,6 +43,8 @@ constexpr size_t kPreviewMaxChars     = 200;
 constexpr size_t kPreviewTitleMaxChars = 60;
 constexpr float  kHighlightThickness  = 2.0f;
 constexpr float  kHighlightPad        = 2.0f;
+constexpr float  kLockGlyphScale      = 0.30f;  // Lock badge size vs marker size.
+constexpr float  kLockGlyphPad        = 2.0f;   // Inset from the marker's corner.
 
 // Grows the backing std::string so ImGui can edit it in place.
 int
@@ -110,6 +112,15 @@ ElideWithEllipsis(const std::string& text, float max_width, size_t max_chars)
         out += "...";
     }
     return out;
+}
+
+// Dark mode uses the brighter header tint.
+ImU32
+HighlightRingColor(SettingsManager& settings)
+{
+    return settings.GetUserSettings().display_settings.use_dark_mode
+               ? settings.GetColor(Colors::kStickyNoteHeader)
+               : settings.GetColor(Colors::kStickyNoteAccent);
 }
 }  // namespace
 
@@ -318,7 +329,6 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
     // Cached for next frame's HandleDrag (which runs before this render pass).
     m_marker_hovered = marker_hovered;
 
-    m_note_engaged      = false;
     bool window_hovered = false;
     if(!m_is_minimized)
     {
@@ -332,10 +342,9 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         RenderTimeIndicator(draw_list, window_position, tpt);
     }
 
-    // Outline the anchor when it (or its note) is engaged. Drawn on the timeline
-    // layer so an overlapping note occludes it instead of the outline bleeding
-    // over the covering window.
-    if((marker_hovered || m_note_engaged) && !marker_hidden && draw_list)
+    // Hovering the note glows the anchor. Drawn on the timeline layer so an
+    // overlapping note occludes it.
+    if(window_hovered && !marker_hidden && draw_list)
     {
         SettingsManager& settings = SettingsManager::GetInstance();
         const float      rounding =
@@ -344,7 +353,7 @@ StickyNote::Render(ImDrawList* draw_list, const ImVec2& window_position,
         draw_list->AddRect(
             ImVec2(anchor_pos.x - kHighlightPad, anchor_pos.y - kHighlightPad),
             ImVec2(anchor_pos.x + sz + kHighlightPad, anchor_pos.y + sz + kHighlightPad),
-            settings.GetColor(Colors::kStickyNoteAccent), rounding + kHighlightPad, 0,
+            HighlightRingColor(settings), rounding + kHighlightPad, 0,
             kHighlightThickness);
     }
 
@@ -439,8 +448,22 @@ StickyNote::RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos)
     {
         m_request_focus = true;
     }
+
     ImGui::PopStyleColor(4);
     ImGui::PopFont();
+
+    // Tiny lock badge in the marker's top-right corner when locked.
+    if(m_locked && draw_list)
+    {
+        ImFont* icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
+        float   glyph_sz  = btn_size * kLockGlyphScale;
+        ImVec2  text_dim =
+            icon_font->CalcTextSizeA(glyph_sz, FLT_MAX, 0.0f, ICON_LOCKED);
+        ImVec2 lock_pos(btn_max.x - text_dim.x - kLockGlyphPad,
+                        marker_pos.y + kLockGlyphPad);
+        draw_list->AddText(icon_font, glyph_sz, lock_pos, text_color, ICON_LOCKED);
+    }
+
     ImGui::EndChild();
 
     return hovered;
@@ -667,19 +690,15 @@ StickyNote::RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered)
 
         hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_RootAndChildWindows);
 
-        m_note_engaged =
-            hovered || ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
-
-        // Drawn on the note's draw list (not the foreground) so tooltips stay on
-        // top; clip is expanded so the outset ring isn't clipped to the window.
-        if(marker_hovered || m_note_engaged)
+        // Hovering the anchor glows the note. Drawn on the note's draw list so
+        // tooltips stay on top; clip is expanded so the outset ring isn't clipped.
+        if(marker_hovered)
         {
             const ImVec2 ring_min(win_pos.x - kHighlightPad, win_pos.y - kHighlightPad);
             const ImVec2 ring_max(win_pos.x + win_size.x + kHighlightPad,
                                   win_pos.y + win_size.y + kHighlightPad);
             note_draw_list->PushClipRect(ring_min, ring_max, false);
-            note_draw_list->AddRect(ring_min, ring_max,
-                                    settings.GetColor(Colors::kStickyNoteAccent),
+            note_draw_list->AddRect(ring_min, ring_max, HighlightRingColor(settings),
                                     rounding + kHighlightPad, 0, kHighlightThickness);
             note_draw_list->PopClipRect();
         }

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -46,7 +46,7 @@ public:
     StickyNote(double time_ns, float y_offset, const ImVec2& size,
                const std::string& text, const std::string& title, double v_min,
                double v_max, uint64_t track_id = INVALID_TRACK_ID,
-               bool is_minimized = true);
+               bool is_minimized = true, bool is_locked = false);
 
     bool Render(ImDrawList* draw_list, const ImVec2& window_position,
                 std::shared_ptr<TimePixelTransform> conversion_manager,
@@ -80,6 +80,7 @@ public:
     double             GetVMinX() const;
     double             GetVMaxX() const;
     bool               IsMinimized() const { return m_is_minimized; }
+    bool               IsLocked() const { return m_locked; }
     uint64_t           GetTrackId() const { return m_track_id; }
     void               SetTrackHidden(bool hidden) { m_track_hidden = hidden; }
     bool               IsTrackHidden() const { return m_track_hidden; }
@@ -136,6 +137,7 @@ private:
     double      m_v_min_x;
     double      m_v_max_x;
     bool        m_is_minimized;
+    bool        m_locked         = false;  // Freezes the anchor against mouse drags.
     bool        m_pending_delete = false;
     bool        m_request_focus  = false;
     bool        m_focus_input    = false;  // Focus the title field next frame.

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -89,6 +89,11 @@ public:
     // True after the user hit the delete button; the owner sweeps these notes.
     bool               WantsDelete() const { return m_pending_delete; }
 
+    // True after the user hit the "go to anchor" button; the owner navigates the
+    // timeline to the anchor and clears the flag.
+    bool               WantsNavigate() const { return m_pending_navigate; }
+    void               ClearNavigate() { m_pending_navigate = false; }
+
 private:
     // Binds an unbound note to a track, making its offset track-relative.
     void EnsureBound(const TrackLayout& layout);
@@ -139,6 +144,7 @@ private:
     bool        m_is_minimized;
     bool        m_locked         = false;  // Freezes the anchor against mouse drags.
     bool        m_pending_delete = false;
+    bool        m_pending_navigate = false;
     bool        m_request_focus  = false;
     bool        m_focus_input    = false;  // Focus the title field next frame.
     bool        m_editing_title  = false;

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -117,8 +117,9 @@ private:
     // Always-visible timeline anchor. Returns true if hovered.
     bool RenderAnchorMarker(ImDrawList* draw_list, const ImVec2& marker_pos);
 
-    // Floating expanded window. Returns true if hovered.
-    bool RenderExpandedWindow(const ImVec2& anchor_pos);
+    // Floating expanded window. Returns true if hovered. marker_hovered highlights
+    // the note when the anchor is hovered (cross-highlight).
+    bool RenderExpandedWindow(const ImVec2& anchor_pos, bool marker_hovered);
 
     // True once the floating window has a real stored position.
     bool IsExpandedPlaced() const
@@ -136,6 +137,7 @@ private:
     bool        m_dragging       = false;
     bool        m_track_hidden   = false;
     bool        m_marker_hovered = false;  // Hovered last frame; drives drag-start.
+    bool        m_note_engaged   = false;  // Note hovered/focused; highlights anchor.
     float       m_drag_abs_y     = 0.0f;   // Anchor Y during a drag; bound on drop.
     ImVec2      m_drag_offset    = ImVec2(0, 0);
     bool        m_is_visible;

--- a/src/view/src/rocprofvis_stickynote.h
+++ b/src/view/src/rocprofvis_stickynote.h
@@ -137,7 +137,6 @@ private:
     bool        m_dragging       = false;
     bool        m_track_hidden   = false;
     bool        m_marker_hovered = false;  // Hovered last frame; drives drag-start.
-    bool        m_note_engaged   = false;  // Note hovered/focused; highlights anchor.
     float       m_drag_abs_y     = 0.0f;   // Anchor Y during a drag; bound on drop.
     ImVec2      m_drag_offset    = ImVec2(0, 0);
     bool        m_is_visible;

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -663,6 +663,10 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
             m_measure_copy_target = MeasurementCopyTarget::kEnd;
         }
 
+        // Remember where the right-click landed; menu actions anchor here, not at
+        // the cursor's later position on the menu item.
+        m_context_menu_pos = rel_mouse_pos;
+
         ImGui::OpenPopup("TimelineContextMenu");
     }
 
@@ -716,18 +720,18 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
 
         if(IconMenuItem(ICON_ADD_NOTE, "Add Annotation"))
         {
-            float  x_in_chart = rel_mouse_pos.x;
+            float  x_in_chart = m_context_menu_pos.x;
             double time_ns    = m_tpt->PixelToTime(x_in_chart);
-            // Anchor the new note to the track under the cursor, storing a
+            // Anchor the new note to the track under the right-click, storing a
             // track-relative click offset.
             TrackLayout layout      = BuildTrackLayout();
             uint64_t    track_id    = INVALID_TRACK_ID;
             float       track_top_y = 0.0f;
-            float       y_offset    = rel_mouse_pos.y;
+            float       y_offset    = m_context_menu_pos.y;
             if(layout.track_at &&
-               layout.track_at(rel_mouse_pos.y, track_id, track_top_y))
+               layout.track_at(m_context_menu_pos.y, track_id, track_top_y))
             {
-                y_offset = rel_mouse_pos.y - track_top_y;
+                y_offset = m_context_menu_pos.y - track_top_y;
             }
             m_annotations->CreateStickyNote(time_ns, y_offset, m_tpt->GetVMinX(),
                                             m_tpt->GetVMaxX(), m_tpt->GetGraphSize(),

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -414,6 +414,15 @@ TimelineView::RenderAnnotations(ImDrawList* draw_list, ImVec2 window_position)
 
             annotation_blocks_timeline_input |=
                 note.Render(draw_list, window_position, m_tpt, layout);
+
+            if(note.WantsNavigate())
+            {
+                auto nav = std::make_shared<NavigationEvent>(
+                    note.GetVMinX(), note.GetVMaxX(), note.GetYOffset(), true,
+                    note.GetTrackId());
+                EventManager::GetInstance()->AddEvent(nav);
+                note.ClearNavigate();
+            }
         }
         m_stop_user_interaction |= annotation_blocks_timeline_input;
     }

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -254,6 +254,8 @@ private:
     MeasurementLabelRect       m_measure_label_duration;
     MeasurementCopyTarget      m_measure_copy_target;
 
+    ImVec2                     m_context_menu_pos = ImVec2(0.0f, 0.0f);
+
     TimelineViewProjectSettings m_project_settings;
     LoadingTimer                m_loading_timer;
     TrackTypeCounts             m_track_counts;

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -405,6 +405,23 @@ ElidedText(const char* text, float available_width, float tooltip_width,
     }
 }
 
+std::string
+ElideWithEllipsis(const std::string& text, float max_width, size_t max_chars)
+{
+    std::string out       = text.substr(0, max_chars);
+    bool        truncated = text.size() > max_chars;
+    while(!out.empty() && ImGui::CalcTextSize((out + "...").c_str()).x > max_width)
+    {
+        out.pop_back();
+        truncated = true;
+    }
+    if(truncated)
+    {
+        out += "...";
+    }
+    return out;
+}
+
 void
 CenterNextTextItem(const char* text)
 {

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -109,6 +109,11 @@ ElidedText(const char* text, float available_width, float tooltip_width = 0.0f,
            Alignment alignment                     = Alignment_Left,
            bool      imgui_AlignTextToFramePadding = false);
 
+// Trims text to a single line fitting max_width (and max_chars), appending "..."
+// when shortened. Uses the current font for measurement.
+std::string
+ElideWithEllipsis(const std::string& text, float max_width, size_t max_chars);
+
 void
 CenterNextTextItem(const char* text);
 


### PR DESCRIPTION
## Motivation

The redesigned timeline annotations are floating, detached notes anchored to
tracks. While powerful, a few rough edges made them awkward to use:

- New annotations created from the right-click menu spawned wherever the
  cursor landed on the menu item, not where the user actually right-clicked.
- Once a note was positioned, it was easy to accidentally drag its anchor.
- Because notes float independently, scrolling could move an anchor out of
  sight with no quick way back to it from the note itself.
- Long note text ran off the edge instead of wrapping, and there was no way
  to preview a minimized note's contents without opening it.
- The note's left accent stripe rendered an unclean nub past the rounded
  corners.

This PR polishes the annotation experience to make notes easier to place,
protect, read, and navigate.

## Technical Details

- Right-click "Add Annotation" now anchors at the captured right-click
  position (m_context_menu_pos) instead of the live cursor.
- Added a per-note lock toggle (padlock icon, persisted via is_locked) that
  freezes the anchor against accidental drags.
- Added a "Go to Anchor" header button (ICON_ARROW_FORWARD, matching the
  app's existing navigate convention). The note signals intent via
  WantsNavigate() and TimelineView dispatches the same NavigationEvent used
  by the Annotations tab.
- Hovering an anchor previews the note's title/body in a styled tooltip
  (title elided to one line, body capped at 200 chars).
- Enabled ImGuiInputTextFlags_WordWrap on the note body so text wraps while
  editing and reflows on resize; unified title elision into a single
  ElideWithEllipsis helper using a plain "..." instead of "[...]".
- Cross-highlight: hovering/interacting with a note or its anchor outlines
  the other with a ring. The anchor ring is drawn on the timeline layer so
  an overlapping window occludes it; the note ring hugs the outside edge.
- Removed the left accent stripe (and its now-unused constants) that caused
  an unclean corner artifact.