### PR TITLE
View: Refactor track stats into components; show real values in Track Details

### DIFF
--- a/src/view/src/model/rocprofvis_analysis_model.cpp
+++ b/src/view/src/model/rocprofvis_analysis_model.cpp
@@ -5,8 +5,6 @@
 #include "../rocprofvis_utils.h"
 #include "rocprofvis_topology_model.h"
 #include <array>
-#include <iomanip>
-#include <sstream>
 #include <tuple>
 
 namespace RocProfVis
@@ -14,7 +12,6 @@ namespace RocProfVis
 namespace View
 {
 
-constexpr int SIGNIFICANT_DIGITS = 1;
 // Name, compact name, accent color index
 constexpr std::array<std::tuple<const char*, const char*, size_t>,
                      AnalysisTrackStatistics::Queue::kQueueCount>
@@ -208,17 +205,15 @@ void
 AnalysisModel::ToString(const TrackInfo* track, AnalysisTrackStatistics::Stat& stat,
                         const std::string& units)
 {
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(SIGNIFICANT_DIGITS) << stat.value;
     stat.suffix = units;
-    stat.full   = oss.str();
+    stat.full   = full_number_format(stat.value);
     switch(track->topology.type)
     {
         case TrackInfo::Queue:
         {
             // Utilization percentages are already small; the compact form is
-            // the same fixed-precision value as the full form.
-            stat.compact = oss.str();
+            // the same value as the full form.
+            stat.compact = stat.full;
             break;
         }
         case TrackInfo::Counter:

--- a/src/view/src/model/rocprofvis_analysis_model.cpp
+++ b/src/view/src/model/rocprofvis_analysis_model.cpp
@@ -5,7 +5,6 @@
 #include "../rocprofvis_utils.h"
 #include "rocprofvis_topology_model.h"
 #include <array>
-#include <cmath>
 #include <iomanip>
 #include <sstream>
 #include <tuple>
@@ -16,7 +15,6 @@ namespace View
 {
 
 constexpr int SIGNIFICANT_DIGITS = 1;
-const double  ROUND_FACTOR       = std::pow(10.0, SIGNIFICANT_DIGITS);
 // Name, compact name, accent color index
 constexpr std::array<std::tuple<const char*, const char*, size_t>,
                      AnalysisTrackStatistics::Queue::kQueueCount>
@@ -142,7 +140,7 @@ AnalysisModel::SetQueueUtilization(uint64_t track_id, const double& util_pct)
        store.state == AnalysisTrackStatistics::State::kRequested)
     {
         store.stats[AnalysisTrackStatistics::Queue::kQueueUtilization].value =
-            Round(util_pct);
+            util_pct;
         ToString(store.track,
                  store.stats[AnalysisTrackStatistics::Queue::kQueueUtilization], "%");
         store.state = AnalysisTrackStatistics::State::kReady;
@@ -158,13 +156,13 @@ AnalysisModel::SetCounterStatistics(uint64_t track_id,
        store.state == AnalysisTrackStatistics::State::kRequested)
     {
         store.stats[AnalysisTrackStatistics::Counter::kCounterMin].value =
-            Round(stats.min_value);
+            stats.min_value;
         store.stats[AnalysisTrackStatistics::Counter::kCounterMax].value =
-            Round(stats.max_value);
+            stats.max_value;
         store.stats[AnalysisTrackStatistics::Counter::kCounterMean].value =
-            Round(stats.mean_value);
+            stats.mean_value;
         store.stats[AnalysisTrackStatistics::Counter::kCounterStandardDeviation].value =
-            Round(stats.std_dev);
+            stats.std_dev;
         const CounterInfo* counter =
             m_topology.GetCounter(store.track->topology.id.value);
         if(counter)
@@ -212,32 +210,23 @@ AnalysisModel::ToString(const TrackInfo* track, AnalysisTrackStatistics::Stat& s
 {
     std::ostringstream oss;
     oss << std::fixed << std::setprecision(SIGNIFICANT_DIGITS) << stat.value;
+    stat.suffix = units;
+    stat.full   = oss.str();
     switch(track->topology.type)
     {
         case TrackInfo::Queue:
         {
-            stat.compact  = oss.str() + (units.empty() ? "" : " " + units);
-            stat.extended = std::string(stat.compact_name) + ": " + stat.compact;
-            stat.full     = std::string(stat.name) + ": " + oss.str() +
-                            (units.empty() ? "" : " " + units);
+            // Utilization percentages are already small; the compact form is
+            // the same fixed-precision value as the full form.
+            stat.compact = oss.str();
             break;
         }
         case TrackInfo::Counter:
         {
-            stat.compact =
-                compact_number_format(stat.value) + (units.empty() ? "" : " " + units);
-            stat.extended = std::string(stat.compact_name) + ": " + stat.compact;
-            stat.full     = std::string(stat.name) + ": " + oss.str() +
-                            (units.empty() ? "" : " " + units);
+            stat.compact = compact_number_format(stat.value);
             break;
         }
     }
-}
-
-double
-AnalysisModel::Round(double d) const
-{
-    return std::round(d * ROUND_FACTOR) / ROUND_FACTOR;
 }
 
 }  // namespace View

--- a/src/view/src/model/rocprofvis_analysis_model.h
+++ b/src/view/src/model/rocprofvis_analysis_model.h
@@ -35,9 +35,8 @@ public:
     void Clear();
 
 private:
-    void   ToString(const TrackInfo* track, AnalysisTrackStatistics::Stat& stat,
-                    const std::string& units);
-    double Round(double d) const;
+    void ToString(const TrackInfo* track, AnalysisTrackStatistics::Stat& stat,
+                  const std::string& units);
 
     double m_analysis_range_start_ns;
     double m_analysis_range_end_ns;

--- a/src/view/src/model/rocprofvis_model_types.h
+++ b/src/view/src/model/rocprofvis_model_types.h
@@ -287,15 +287,39 @@ struct AnalysisTrackStatistics
         kRequested,  // Pending fetch completion
         kReady,
     };
+    // One statistic (min/max/mean/util/...) broken into its raw building
+    // blocks. Consumers (track pills, track details) compose the exact label
+    // they need from these components instead of a single pre-baked string.
     struct Stat
     {
-        const char* name;
-        const char* compact_name;
-        size_t      accent_color;
-        double      value;
-        std::string compact;
-        std::string extended;
-        std::string full;
+        const char* name         = "";   // Prefix, long form (e.g. "Mean").
+        const char* compact_name = "";   // Prefix, short form (e.g. "Avg").
+        size_t      accent_color = 0;    // Index into the settings color wheel.
+        double      value        = 0.0;  // Real, unrounded value (e.g. 22123.333).
+        std::string suffix;              // Units (e.g. "MB"), may be empty.
+        std::string compact;             // Compact value only (e.g. "22K").
+        std::string full;                // Full value only (e.g. "22123.3").
+
+        // Value with its units suffix appended.
+        std::string CompactValue() const { return WithSuffix(compact); }
+        std::string FullValue() const { return WithSuffix(full); }
+
+        // "<prefix>: <value> <units>". Compact uses the short prefix, full the
+        // long one.
+        std::string CompactLabel() const
+        {
+            return std::string(compact_name) + ": " + CompactValue();
+        }
+        std::string FullLabel() const
+        {
+            return std::string(name) + ": " + FullValue();
+        }
+
+    private:
+        std::string WithSuffix(const std::string& value_str) const
+        {
+            return suffix.empty() ? value_str : value_str + " " + suffix;
+        }
     };
     enum Queue : size_t
     {

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -182,21 +182,13 @@ FlameTrackItem::Update()
         if(m_track_statistics->state == AnalysisTrackStatistics::kReady &&
            m_track_statistics_dirty)
         {
+            const AnalysisTrackStatistics::Stat& stat =
+                m_track_statistics
+                    ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization];
             m_pill_analysis_queue->Activate();
-            m_pill_analysis_queue->SetLabel(
-                m_track_statistics
-                    ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
-                    .compact,
-                Pill::kCompact);
-            m_pill_analysis_queue->SetLabel(
-                m_track_statistics
-                    ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
-                    .extended,
-                Pill::kExtended);
-            m_pill_analysis_queue->SetTooltip(
-                m_track_statistics
-                    ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization]
-                    .full);
+            m_pill_analysis_queue->SetLabel(stat.CompactValue(), Pill::kCompact);
+            m_pill_analysis_queue->SetLabel(stat.CompactLabel(), Pill::kExtended);
+            m_pill_analysis_queue->SetTooltip(stat.FullLabel());
         }
         else if(m_track_statistics->state < AnalysisTrackStatistics::kReady)
         {

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -186,7 +186,7 @@ FlameTrackItem::Update()
                 m_track_statistics
                     ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization];
             m_pill_analysis_queue->Activate();
-            m_pill_analysis_queue->SetCompactLabel(stat.CompactValue());
+            m_pill_analysis_queue->SetLabel(stat.CompactValue());
             m_pill_analysis_queue->SetExtendedLabel(stat.CompactLabel());
             m_pill_analysis_queue->SetTooltip(stat.FullLabel());
         }

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -186,8 +186,8 @@ FlameTrackItem::Update()
                 m_track_statistics
                     ->stats[AnalysisTrackStatistics::Queue::kQueueUtilization];
             m_pill_analysis_queue->Activate();
-            m_pill_analysis_queue->SetLabel(stat.CompactValue(), Pill::kCompact);
-            m_pill_analysis_queue->SetLabel(stat.CompactLabel(), Pill::kExtended);
+            m_pill_analysis_queue->SetCompactLabel(stat.CompactValue());
+            m_pill_analysis_queue->SetExtendedLabel(stat.CompactLabel());
             m_pill_analysis_queue->SetTooltip(stat.FullLabel());
         }
         else if(m_track_statistics->state < AnalysisTrackStatistics::kReady)

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -258,7 +258,7 @@ LineTrackItem::Update()
                     const AnalysisTrackStatistics::Stat& stat =
                         m_track_statistics->stats[i];
                     m_pills_analysis[i]->Activate();
-                    m_pills_analysis[i]->SetCompactLabel(stat.CompactValue());
+                    m_pills_analysis[i]->SetLabel(stat.CompactValue());
                     m_pills_analysis[i]->SetExtendedLabel(stat.CompactLabel());
                     m_pills_analysis[i]->SetTooltip(stat.FullLabel());
                 }

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -256,12 +256,12 @@ LineTrackItem::Update()
                 if(m_track_statistics->state == AnalysisTrackStatistics::kReady &&
                    m_track_statistics_dirty)
                 {
+                    const AnalysisTrackStatistics::Stat& stat =
+                        m_track_statistics->stats[i];
                     m_pills_analysis[i]->Activate();
-                    m_pills_analysis[i]->SetLabel(m_track_statistics->stats[i].compact,
-                                                  Pill::kCompact);
-                    m_pills_analysis[i]->SetLabel(m_track_statistics->stats[i].extended,
-                                                  Pill::kExtended);
-                    m_pills_analysis[i]->SetTooltip(m_track_statistics->stats[i].full);
+                    m_pills_analysis[i]->SetLabel(stat.CompactValue(), Pill::kCompact);
+                    m_pills_analysis[i]->SetLabel(stat.CompactLabel(), Pill::kExtended);
+                    m_pills_analysis[i]->SetTooltip(stat.FullLabel());
                 }
                 else if(m_track_statistics->state < AnalysisTrackStatistics::kReady)
                 {

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -259,8 +259,8 @@ LineTrackItem::Update()
                     const AnalysisTrackStatistics::Stat& stat =
                         m_track_statistics->stats[i];
                     m_pills_analysis[i]->Activate();
-                    m_pills_analysis[i]->SetLabel(stat.CompactValue(), Pill::kCompact);
-                    m_pills_analysis[i]->SetLabel(stat.CompactLabel(), Pill::kExtended);
+                    m_pills_analysis[i]->SetCompactLabel(stat.CompactValue());
+                    m_pills_analysis[i]->SetExtendedLabel(stat.CompactLabel());
                     m_pills_analysis[i]->SetTooltip(stat.FullLabel());
                 }
                 else if(m_track_statistics->state < AnalysisTrackStatistics::kReady)

--- a/src/view/src/rocprofvis_track_details.cpp
+++ b/src/view/src/rocprofvis_track_details.cpp
@@ -455,8 +455,9 @@ TrackDetails::RenderTable(InfoTable& table, const char* table_id,
                     CaptureCellRightClick(0, stat_row, m_cell_menu, open_menu);
                     PositionCell(1);
                     ImGui::BeginDisabled(!stats_ready);
-                    ImGui::TextUnformatted(stats_ready ? stats->stats[i].compact.c_str()
-                                                       : "--");
+                    const std::string stat_value =
+                        stats_ready ? stats->stats[i].FullValue() : "--";
+                    ImGui::TextUnformatted(stat_value.c_str());
                     ImGui::EndDisabled();
                     CaptureCellRightClick(1, stat_row, m_cell_menu, open_menu);
                     ImGui::PopID();
@@ -486,7 +487,8 @@ TrackDetails::RenderTable(InfoTable& table, const char* table_id,
                 {
                     const AnalysisTrackStatistics::Stat& stat =
                         stats->stats[m_cell_menu.row - rows];
-                    std::string stat_cells[2] = { std::string(stat.name), stat.compact };
+                    std::string stat_cells[2] = { std::string(stat.name),
+                                                  stat.FullValue() };
                     AddCopyRowCellMenuItems(stat_cells, 2, m_cell_menu.column);
                 }
                 EndCellContextMenu();

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -671,21 +671,21 @@ TrackItem::SetDefaultPillLabel(const TrackInfo* track_info)
         {
             std::string pill_label =
                 "QUEUE" + (device_type_label.empty() ? "" : " " + device_type_label);
-            pill->SetCompactLabel(pill_label);
+            pill->SetLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::Stream:
         {
             std::string pill_label =
                 "STREAM" + (device_type_label.empty() ? "" : " " + device_type_label);
-            pill->SetCompactLabel(pill_label);
+            pill->SetLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::Counter:
         {
             std::string pill_label =
                 "COUNTER" + (device_type_label.empty() ? "" : " " + device_type_label);
-            pill->SetCompactLabel(pill_label);
+            pill->SetLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::InstrumentedThread:
@@ -695,17 +695,17 @@ TrackItem::SetDefaultPillLabel(const TrackInfo* track_info)
                thread_info && thread_info->tid == track_info->topology.process_id)
             {
                 pill->Activate();
-                pill->SetCompactLabel("MAIN THREAD");
+                pill->SetLabel("MAIN THREAD");
             }
             else
             {
-                pill->SetCompactLabel("THREAD");
+                pill->SetLabel("THREAD");
             }
             break;
         }
         case TrackInfo::TrackType::SampledThread:
         {
-            pill->SetCompactLabel("SAMPLED THREAD");
+            pill->SetLabel("SAMPLED THREAD");
             break;
         }
         default:
@@ -899,7 +899,7 @@ TrackItem::SetNodeColor(const TrackInfo* track_info)
     m_node_color_index = (m_node_display_index - 1) % wheel.size();
 
     m_node_pill = AddPill(true, true);
-    m_node_pill->SetCompactLabel(std::to_string(m_node_display_index));
+    m_node_pill->SetLabel(std::to_string(m_node_display_index));
     m_node_pill->SetAccentColor(m_node_color_index);
     m_node_pill->SetTooltip("Node " + std::to_string(m_node_display_index) + ": " +
                             m_node_name);
@@ -1128,7 +1128,7 @@ Pill::~Pill()
 }
 
 void
-Pill::SetCompactLabel(const std::string& label)
+Pill::SetLabel(const std::string& label)
 {
     m_compact_label = label;
     CalculateSize();

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -671,21 +671,21 @@ TrackItem::SetDefaultPillLabel(const TrackInfo* track_info)
         {
             std::string pill_label =
                 "QUEUE" + (device_type_label.empty() ? "" : " " + device_type_label);
-            pill->SetLabel(pill_label);
+            pill->SetCompactLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::Stream:
         {
             std::string pill_label =
                 "STREAM" + (device_type_label.empty() ? "" : " " + device_type_label);
-            pill->SetLabel(pill_label);
+            pill->SetCompactLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::Counter:
         {
             std::string pill_label =
                 "COUNTER" + (device_type_label.empty() ? "" : " " + device_type_label);
-            pill->SetLabel(pill_label);
+            pill->SetCompactLabel(pill_label);
             break;
         }
         case TrackInfo::TrackType::InstrumentedThread:
@@ -695,17 +695,17 @@ TrackItem::SetDefaultPillLabel(const TrackInfo* track_info)
                thread_info && thread_info->tid == track_info->topology.process_id)
             {
                 pill->Activate();
-                pill->SetLabel("MAIN THREAD");
+                pill->SetCompactLabel("MAIN THREAD");
             }
             else
             {
-                pill->SetLabel("THREAD");
+                pill->SetCompactLabel("THREAD");
             }
             break;
         }
         case TrackInfo::TrackType::SampledThread:
         {
-            pill->SetLabel("SAMPLED THREAD");
+            pill->SetCompactLabel("SAMPLED THREAD");
             break;
         }
         default:
@@ -899,7 +899,7 @@ TrackItem::SetNodeColor(const TrackInfo* track_info)
     m_node_color_index = (m_node_display_index - 1) % wheel.size();
 
     m_node_pill = AddPill(true, true);
-    m_node_pill->SetLabel(std::to_string(m_node_display_index));
+    m_node_pill->SetCompactLabel(std::to_string(m_node_display_index));
     m_node_pill->SetAccentColor(m_node_color_index);
     m_node_pill->SetTooltip("Node " + std::to_string(m_node_display_index) + ": " +
                             m_node_name);
@@ -1128,21 +1128,16 @@ Pill::~Pill()
 }
 
 void
-Pill::SetLabel(const std::string& label, Sizing sizing)
+Pill::SetCompactLabel(const std::string& label)
 {
-    switch(sizing)
-    {
-        case kCompact:
-        {
-            m_compact_label = label;
-            break;
-        }
-        case kExtended:
-        {
-            m_ext_label = label;
-            break;
-        }
-    }
+    m_compact_label = label;
+    CalculateSize();
+}
+
+void
+Pill::SetExtendedLabel(const std::string& label)
+{
+    m_ext_label = label;
     CalculateSize();
 }
 

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -63,7 +63,7 @@ public:
     Pill(bool shown, bool active);
     ~Pill();
 
-    void   SetCompactLabel(const std::string& label);
+    void   SetLabel(const std::string& label);
     void   SetExtendedLabel(const std::string& label);
     void   SetTooltip(std::string label);
     void   SetAccentColor(size_t accent_color);

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -63,7 +63,8 @@ public:
     Pill(bool shown, bool active);
     ~Pill();
 
-    void   SetLabel(const std::string& label, Sizing sizing = kCompact);
+    void   SetCompactLabel(const std::string& label);
+    void   SetExtendedLabel(const std::string& label);
     void   SetTooltip(std::string label);
     void   SetAccentColor(size_t accent_color);
     void   Activate();

--- a/src/view/src/rocprofvis_utils.cpp
+++ b/src/view/src/rocprofvis_utils.cpp
@@ -438,6 +438,15 @@ RocProfVis::View::get_application_log_path(bool create_dirs)
 #endif
 }
 
+// Number of decimal places to show for a value of the given magnitude. Fewer
+// decimals for larger numbers keeps things readable while preserving precision
+// for small values.
+static int
+adaptive_decimal_places(double magnitude)
+{
+    return magnitude >= 100.0 ? 0 : (magnitude >= 10.0 ? 1 : 2);
+}
+
 std::string
 RocProfVis::View::compact_number_format(double number)
 {
@@ -470,9 +479,23 @@ RocProfVis::View::compact_number_format(double number)
         return output.str();
     }
 
-    output << std::fixed << std::setprecision(number >= 100 ? 0 : (number >= 10 ? 1 : 2))
-        << number
-        << suffixes[magnitude];
+    output << std::fixed << std::setprecision(adaptive_decimal_places(number)) << number
+           << suffixes[magnitude];
+    return output.str();
+}
+
+std::string
+RocProfVis::View::full_number_format(double number)
+{
+    if(!std::isfinite(number))
+    {
+        if(std::isnan(number)) return "NaN";
+        return std::signbit(number) ? "-Inf" : "+Inf";
+    }
+
+    std::ostringstream output;
+    output << std::fixed << std::setprecision(adaptive_decimal_places(std::fabs(number)))
+           << number;
     return output.str();
 }
 

--- a/src/view/src/rocprofvis_utils.h
+++ b/src/view/src/rocprofvis_utils.h
@@ -239,6 +239,12 @@ get_application_log_path(bool create_dirs);
 std::string
 compact_number_format(double number);
 
+// Full (non-abbreviated) number with adaptive decimal precision that matches
+// compact_number_format, so small values keep the same precision as their
+// compact form instead of being truncated.
+std::string
+full_number_format(double number);
+
 bool 
 open_url(const std::string& url);
 


### PR DESCRIPTION
## Motivation

Track stats were stored as pre-baked strings that mixed name, value, and units
together, so the Track Details table showed abbreviated values (e.g. `1.83B MB`)
instead of the real ones (e.g. `1830730632.2 MB`), and consumers couldn't
compose their own labels.

## Technical Details

- Refactored `AnalysisTrackStatistics::Stat` into raw components (prefix,
  units suffix, compact value, full value, real double) with label helpers
  (`CompactValue` / `FullValue` / `CompactLabel` / `FullLabel`).
- `AnalysisModel` now stores the real unrounded value and fills the components
  instead of combined strings.
- Consumers build the label they need: timeline pills stay abbreviated, while
  the Track Details table shows the full real values.