### PR TITLE
Add --verbose flag to CTest commands in ci-*.yml files

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           cd ${{ env.BUILD_DIR }}
           ctest \
+            --verbose \
             --output-on-failure \
             --no-tests=error \
             --output-junit ctest-results.xml

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -226,6 +226,7 @@ jobs:
         run: |
           cd ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}
           ctest \
+            --verbose \
             --output-on-failure \
             --no-tests=error \
             --output-junit ctest-results.xml

--- a/.github/workflows/ci-redhat.yml
+++ b/.github/workflows/ci-redhat.yml
@@ -132,6 +132,7 @@ jobs:
         run: |
           cd ${{ env.BUILD_DIR }}
           ctest \
+            --verbose \
             --output-on-failure \
             --no-tests=error \
             --output-junit ctest-results.xml

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -126,6 +126,7 @@ jobs:
         run: |
           cd ${{ env.BUILD_DIR }}
           ctest \
+            --verbose \
             --output-on-failure \
             --no-tests=error \
             --output-junit ctest-results.xml

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -140,6 +140,7 @@ jobs:
           cd ${{ env.BUILD_DIR }}/${{ inputs.cmake_config_preset }}
           ctest `
             -C ${{ env.BINARY_DIR }} `
+            --verbose `
             --output-on-failure `
             --no-tests=error `
             --output-junit ctest-results.xml


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Add `--verbose` flag to CTest test runs in workflows to provide more logs.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Added `--verbose` flag to every `ctest` command in the various `ci-*.yml` workflows

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure extra logs generated from test runs
- No regression issues

## Test Result

<!-- Briefly summarize test outcomes. -->
- Workflows all pass, extra logs present in test runs

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
