### PR TITLE
Store SSH secrets in the OS credential vault instead of plaintext

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -196,7 +196,15 @@ cmake --build build/macos-release --preset "macOS Release Build" --parallel 4
 
 ---
 
-## Crypto backend (SSH / remote features)
+## Remote / SSH support
+
+Remote/SSH connectivity and remote profiling are opt-in and **disabled by
+default** (the feature set is in development). Enable it at configure time with
+`-DROCPROFVIS_ENABLE_REMOTE=ON`. When enabled, the build pulls in the SSH
+transport (`libssh2`), a crypto backend, and the OS credential vault used to
+persist SSH secrets. Each of these has its own dependency notes below.
+
+### Crypto backend
 
 The SSH and remote-profiling features use `libssh2`, which needs a crypto backend selected at configure time via `CRYPTO_BACKEND`.
 
@@ -241,6 +249,52 @@ Example (OpenSSL backend on Linux):
 ```bash
 sudo apt install -y libssl-dev
 cmake -B build/linux-release --preset "linux-release" -DCRYPTO_BACKEND=OpenSSL
+cmake --build build/linux-release --preset "Linux Release Build" --parallel 4 --target package
+```
+
+### Credential storage (SSH secret vault)
+
+When remote/SSH support is enabled, the app can persist SSH passwords and
+key passphrases in the operating system's credential vault rather than
+prompting for them on every connect. This is handled by `SecretStore`
+(`src/view/src/remote/rocprofvis_secret_store.cpp`), which links a different
+backend per platform:
+
+| Platform | Backend | Extra dependency to install |
+|----------|---------|------------------------------|
+| Windows | Windows Credential Manager (`Advapi32` / `wincred.h`) | None — part of the Windows SDK |
+| macOS | Keychain (`Security` + `CoreFoundation` frameworks) | None — part of the system SDK |
+| Linux | libsecret (Secret Service / freedesktop.org, e.g. GNOME Keyring or KWallet) | `libsecret-1` development package (**optional**) |
+
+On Windows and macOS the credential store is always available and needs nothing
+extra installed. On Linux it is **optional**: CMake probes for `libsecret-1`
+via `pkg-config` at configure time.
+
+- If found, it is linked and `ROCPROFVIS_HAVE_LIBSECRET` is defined, enabling
+  secure persistence of SSH secrets.
+- If **not** found, CMake emits a warning and `SecretStore` compiles a stub
+  that reports itself unavailable. The build still succeeds, but SSH secrets
+  are never persisted — the user is prompted at connect time instead (secrets
+  are never written to disk in plaintext).
+
+To enable secure credential storage on Linux, install the development package
+before configuring:
+
+| Platform | Install |
+|----------|---------|
+| Linux (Ubuntu/Debian) | `sudo apt install -y libsecret-1-dev` |
+| Linux (RHEL/Rocky/Oracle) | `sudo dnf install -y libsecret-devel` |
+
+At runtime, a Secret Service provider (e.g. `gnome-keyring` or `kwallet` with
+its Secret Service interface) must be running for storage/retrieval to
+actually work; if none is present, `SecretStore::IsAvailable()` returns false
+and the app falls back to prompting.
+
+Example (remote support with credential storage on Ubuntu):
+
+```bash
+sudo apt install -y libsecret-1-dev
+cmake -B build/linux-release --preset "linux-release" -DROCPROFVIS_ENABLE_REMOTE=ON
 cmake --build build/linux-release --preset "Linux Release Build" --parallel 4 --target package
 ```
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,8 @@ endif(ROCPROFVIS_ENABLE_PROFILER)
 if(ROCPROFVIS_ENABLE_REMOTE)
 list(APPEND VIEW_FILES
     src/view/src/remote/rocprofvis_ssh_uri.cpp
+    src/view/src/remote/rocprofvis_secret_store.cpp
+    src/view/src/remote/rocprofvis_secret_store.h
     src/view/src/remote/rocprofvis_ssh_connection_config.cpp
     src/view/src/remote/rocprofvis_ssh_connection_config.h
     src/view/src/remote/rocprofvis_ssh_connection_store.cpp
@@ -334,6 +336,31 @@ endif()
 
 if (CRYPTO_BACKEND STREQUAL "OpenSSL")
 target_link_libraries(${TARGET_NAME} PRIVATE libssh2_static OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
+# SecretStore backends: link the OS credential-vault APIs. On Linux libsecret
+# is optional; when absent, SecretStore compiles a stub that reports itself
+# unavailable and the app falls back to prompting for SSH secrets at connect
+# time (never persisting them in plaintext).
+if(WIN32)
+    target_link_libraries(${TARGET_NAME} PRIVATE Advapi32)
+elseif(APPLE)
+    target_link_libraries(${TARGET_NAME} PRIVATE "-framework Security" "-framework CoreFoundation")
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(LIBSECRET QUIET libsecret-1)
+    endif()
+    if(LIBSECRET_FOUND)
+        target_include_directories(${TARGET_NAME} PRIVATE ${LIBSECRET_INCLUDE_DIRS})
+        target_link_libraries(${TARGET_NAME} PRIVATE ${LIBSECRET_LIBRARIES})
+        target_compile_definitions(${TARGET_NAME} PRIVATE ROCPROFVIS_HAVE_LIBSECRET)
+    else()
+        message(WARNING
+            "libsecret-1 not found: SSH passwords will not be persisted on this "
+            "Linux build (users are prompted at connect time). Install "
+            "libsecret-1-dev / libsecret-devel to enable secure credential storage.")
+    endif()
 endif()
 endif(ROCPROFVIS_ENABLE_REMOTE)
 

--- a/src/view/src/remote/rocprofvis_secret_store.cpp
+++ b/src/view/src/remote/rocprofvis_secret_store.cpp
@@ -1,0 +1,313 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_secret_store.h"
+
+#include <string>
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <wincred.h>
+#elif defined(__APPLE__)
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+#elif defined(ROCPROFVIS_HAVE_LIBSECRET)
+#include <libsecret/secret.h>
+#endif
+
+namespace RocProfVis
+{
+namespace View
+{
+
+namespace
+{
+    // Prefix so our entries are recognizable in the OS credential UI.
+    const char* const SERVICE_NAME = "ROCm-Optiq";
+}  // namespace
+
+#if defined(_WIN32)
+
+namespace
+{
+    std::wstring Widen(const std::string& utf8)
+    {
+        if(utf8.empty())
+        {
+            return std::wstring();
+        }
+        int size = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(),
+                                       static_cast<int>(utf8.size()), nullptr, 0);
+        std::wstring wide(static_cast<size_t>(size), L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), static_cast<int>(utf8.size()),
+                            wide.data(), size);
+        return wide;
+    }
+
+    std::wstring TargetName(const std::string& key)
+    {
+        return Widen(std::string(SERVICE_NAME) + ":" + key);
+    }
+}  // namespace
+
+bool SecretStore::IsAvailable()
+{
+    return true;
+}
+
+bool SecretStore::Set(const std::string& key, const std::string& secret)
+{
+    std::wstring target = TargetName(key);
+
+    CREDENTIALW cred        = {};
+    cred.Type               = CRED_TYPE_GENERIC;
+    cred.TargetName         = const_cast<LPWSTR>(target.c_str());
+    cred.CredentialBlobSize = static_cast<DWORD>(secret.size());
+    cred.CredentialBlob     = reinterpret_cast<LPBYTE>(const_cast<char*>(secret.data()));
+    cred.Persist            = CRED_PERSIST_LOCAL_MACHINE;
+
+    return CredWriteW(&cred, 0) == TRUE;
+}
+
+bool SecretStore::Get(const std::string& key, std::string& out_secret)
+{
+    out_secret.clear();
+
+    PCREDENTIALW cred = nullptr;
+    if(CredReadW(TargetName(key).c_str(), CRED_TYPE_GENERIC, 0, &cred) != TRUE)
+    {
+        return false;
+    }
+
+    if(cred->CredentialBlob != nullptr && cred->CredentialBlobSize > 0)
+    {
+        out_secret.assign(reinterpret_cast<const char*>(cred->CredentialBlob),
+                          cred->CredentialBlobSize);
+    }
+    CredFree(cred);
+    return true;
+}
+
+bool SecretStore::Erase(const std::string& key)
+{
+    if(CredDeleteW(TargetName(key).c_str(), CRED_TYPE_GENERIC, 0) == TRUE)
+    {
+        return true;
+    }
+    return GetLastError() == ERROR_NOT_FOUND;
+}
+
+#elif defined(__APPLE__)
+
+namespace
+{
+    // Query matching a single generic-password item for the given key.
+    CFDictionaryRef MakeIdentityQuery(const std::string& key)
+    {
+        CFStringRef service =
+            CFStringCreateWithCString(nullptr, SERVICE_NAME, kCFStringEncodingUTF8);
+        CFStringRef account =
+            CFStringCreateWithCString(nullptr, key.c_str(), kCFStringEncodingUTF8);
+
+        const void* keys[] = { kSecClass, kSecAttrService, kSecAttrAccount };
+        const void* vals[] = { kSecClassGenericPassword, service, account };
+        CFDictionaryRef query =
+            CFDictionaryCreate(nullptr, keys, vals, 3, &kCFTypeDictionaryKeyCallBacks,
+                               &kCFTypeDictionaryValueCallBacks);
+
+        CFRelease(service);
+        CFRelease(account);
+        return query;
+    }
+}  // namespace
+
+bool SecretStore::IsAvailable()
+{
+    return true;
+}
+
+bool SecretStore::Set(const std::string& key, const std::string& secret)
+{
+    CFDictionaryRef query = MakeIdentityQuery(key);
+    CFDataRef       data  = CFDataCreate(nullptr,
+                                         reinterpret_cast<const UInt8*>(secret.data()),
+                                         static_cast<CFIndex>(secret.size()));
+
+    const void*     update_keys[] = { kSecValueData };
+    const void*     update_vals[] = { data };
+    CFDictionaryRef update        =
+        CFDictionaryCreate(nullptr, update_keys, update_vals, 1,
+                           &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    OSStatus status = SecItemUpdate(query, update);
+    if(status == errSecItemNotFound)
+    {
+        CFMutableDictionaryRef add = CFDictionaryCreateMutableCopy(nullptr, 0, query);
+        CFDictionarySetValue(add, kSecValueData, data);
+        status = SecItemAdd(add, nullptr);
+        CFRelease(add);
+    }
+
+    CFRelease(update);
+    CFRelease(data);
+    CFRelease(query);
+    return status == errSecSuccess;
+}
+
+bool SecretStore::Get(const std::string& key, std::string& out_secret)
+{
+    out_secret.clear();
+
+    CFStringRef service =
+        CFStringCreateWithCString(nullptr, SERVICE_NAME, kCFStringEncodingUTF8);
+    CFStringRef account =
+        CFStringCreateWithCString(nullptr, key.c_str(), kCFStringEncodingUTF8);
+
+    const void* keys[] = { kSecClass, kSecAttrService, kSecAttrAccount,
+                           kSecReturnData, kSecMatchLimit };
+    const void* vals[] = { kSecClassGenericPassword, service, account,
+                           kCFBooleanTrue, kSecMatchLimitOne };
+    CFDictionaryRef query =
+        CFDictionaryCreate(nullptr, keys, vals, 5, &kCFTypeDictionaryKeyCallBacks,
+                           &kCFTypeDictionaryValueCallBacks);
+
+    CFTypeRef result = nullptr;
+    OSStatus  status = SecItemCopyMatching(query, &result);
+
+    CFRelease(service);
+    CFRelease(account);
+    CFRelease(query);
+
+    if(status != errSecSuccess || result == nullptr)
+    {
+        return false;
+    }
+
+    CFDataRef data = reinterpret_cast<CFDataRef>(result);
+    out_secret.assign(reinterpret_cast<const char*>(CFDataGetBytePtr(data)),
+                      static_cast<size_t>(CFDataGetLength(data)));
+    CFRelease(result);
+    return true;
+}
+
+bool SecretStore::Erase(const std::string& key)
+{
+    CFDictionaryRef query  = MakeIdentityQuery(key);
+    OSStatus        status = SecItemDelete(query);
+    CFRelease(query);
+    return status == errSecSuccess || status == errSecItemNotFound;
+}
+
+#elif defined(ROCPROFVIS_HAVE_LIBSECRET)
+
+namespace
+{
+    const SecretSchema* Schema()
+    {
+        static const SecretSchema schema = {
+            "com.amd.roc-optiq.ssh",
+            SECRET_SCHEMA_NONE,
+            {
+                { "key", SECRET_SCHEMA_ATTRIBUTE_STRING },
+                { nullptr, static_cast<SecretSchemaAttributeType>(0) },
+            },
+            0, 0, 0, 0, 0, 0, 0, 0
+        };
+        return &schema;
+    }
+}  // namespace
+
+bool SecretStore::IsAvailable()
+{
+    GError*        error   = nullptr;
+    SecretService* service = secret_service_get_sync(SECRET_SERVICE_NONE, nullptr, &error);
+    if(error != nullptr)
+    {
+        g_error_free(error);
+        return false;
+    }
+    if(service == nullptr)
+    {
+        return false;
+    }
+    g_object_unref(service);
+    return true;
+}
+
+bool SecretStore::Set(const std::string& key, const std::string& secret)
+{
+    GError*     error = nullptr;
+    std::string label = std::string(SERVICE_NAME) + ": " + key;
+    gboolean    ok    = secret_password_store_sync(Schema(), SECRET_COLLECTION_DEFAULT,
+                                                   label.c_str(), secret.c_str(), nullptr,
+                                                   &error, "key", key.c_str(), nullptr);
+    if(error != nullptr)
+    {
+        g_error_free(error);
+        return false;
+    }
+    return ok == TRUE;
+}
+
+bool SecretStore::Get(const std::string& key, std::string& out_secret)
+{
+    out_secret.clear();
+
+    GError* error = nullptr;
+    gchar*  value = secret_password_lookup_sync(Schema(), nullptr, &error, "key",
+                                                key.c_str(), nullptr);
+    if(error != nullptr)
+    {
+        g_error_free(error);
+        return false;
+    }
+    if(value == nullptr)
+    {
+        return false;
+    }
+    out_secret.assign(value);
+    secret_password_free(value);
+    return true;
+}
+
+bool SecretStore::Erase(const std::string& key)
+{
+    GError* error = nullptr;
+    secret_password_clear_sync(Schema(), nullptr, &error, "key", key.c_str(), nullptr);
+    if(error != nullptr)
+    {
+        g_error_free(error);
+        return false;
+    }
+    return true;
+}
+
+#else
+
+// No credential store on this platform/build: report unavailable so callers
+// fall back to prompting for the secret instead of persisting it.
+bool SecretStore::IsAvailable()
+{
+    return false;
+}
+
+bool SecretStore::Set(const std::string&, const std::string&)
+{
+    return false;
+}
+
+bool SecretStore::Get(const std::string&, std::string& out_secret)
+{
+    out_secret.clear();
+    return false;
+}
+
+bool SecretStore::Erase(const std::string&)
+{
+    return true;
+}
+
+#endif
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/remote/rocprofvis_secret_store.h
+++ b/src/view/src/remote/rocprofvis_secret_store.h
@@ -1,0 +1,33 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <string>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+// Access to the OS credential store, used to keep SSH passwords and key
+// passphrases out of profiles.json. The backend is picked at build time:
+// Windows Credential Manager, macOS Keychain, or libsecret on Linux (when it
+// is available). Secrets are keyed by the SshConnectionConfig id.
+//
+// IsAvailable() is false when there is no usable store (a Linux build without
+// libsecret, or no running Secret Service). Callers should then leave the
+// secret unset and let the SSH layer prompt for it at connect time instead of
+// writing it to disk.
+class SecretStore
+{
+public:
+    static bool IsAvailable();
+    static bool Set(const std::string& key, const std::string& secret);
+    // Returns false and clears out_secret when the key is absent.
+    static bool Get(const std::string& key, std::string& out_secret);
+    static bool Erase(const std::string& key);
+};
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/remote/rocprofvis_ssh_connection_config.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_connection_config.cpp
@@ -83,9 +83,9 @@ jt::Json SshConnectionConfig::ToJson() const
     obj["host"]          = host;
     obj["port"]          = port;
     obj["user"]          = user;
-    obj["password"]      = password;
     obj["identity_file"] = identity_file;
-    obj["passphrase"]    = passphrase;
+    // password and passphrase are deliberately not written; they live in the
+    // OS credential store (see SecretStore).
 
     return json;
 }
@@ -98,9 +98,8 @@ SshConnectionConfig SshConnectionConfig::FromJson(jt::Json const& j)
     cfg.host          = JsonUtils::GetString(j, "host", "");
     cfg.port          = JsonUtils::GetString(j, "port", "22");
     cfg.user          = JsonUtils::GetString(j, "user", "");
-    cfg.password      = JsonUtils::GetString(j, "password", "");
     cfg.identity_file = JsonUtils::GetString(j, "identity_file", "");
-    cfg.passphrase    = JsonUtils::GetString(j, "passphrase", "");
+    // Secrets are not read from disk; they come from the OS credential store.
 
     if(cfg.id.empty())
     {

--- a/src/view/src/remote/rocprofvis_ssh_connection_config.h
+++ b/src/view/src/remote/rocprofvis_ssh_connection_config.h
@@ -17,8 +17,9 @@ namespace View
 // inside RemoteUri. Each profile carries a stable id (used as the on-disk key
 // and the reference target for launch profiles) and a user-facing display name.
 //
-// NOTE: password and passphrase are stored in plaintext for now. Secure storage
-// (e.g. an OS keyring) is intended future work and is explicitly out of scope.
+// NOTE: password and passphrase are held in memory only, never written to
+// profiles.json. They are persisted in the OS credential store (SecretStore)
+// keyed by this profile's id; SshConnectionStore moves them in and out.
 struct SshConnectionConfig
 {
     std::string id;            // stable, auto-generated identifier

--- a/src/view/src/remote/rocprofvis_ssh_connection_store.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_connection_store.cpp
@@ -3,11 +3,79 @@
 
 #include "rocprofvis_ssh_connection_store.h"
 #include "rocprofvis_profiles_document.h"
+#include "rocprofvis_secret_store.h"
 
 namespace RocProfVis
 {
 namespace View
 {
+
+namespace
+{
+
+// Vault keys for a connection's secrets, derived from its stable id.
+std::string password_key(const std::string& id)
+{
+    return "ssh/" + id + "/password";
+}
+
+std::string passphrase_key(const std::string& id)
+{
+    return "ssh/" + id + "/passphrase";
+}
+
+// Writes the config's secrets to the vault, erasing entries whose field is now
+// empty. Returns false when the vault is unavailable so the caller knows the
+// secrets were not persisted.
+bool store_secrets(const SshConnectionConfig& config)
+{
+    if(!SecretStore::IsAvailable())
+    {
+        return false;
+    }
+
+    bool ok = true;
+    if(!config.password.empty())
+    {
+        ok = SecretStore::Set(password_key(config.id), config.password) && ok;
+    }
+    else
+    {
+        SecretStore::Erase(password_key(config.id));
+    }
+
+    if(!config.passphrase.empty())
+    {
+        ok = SecretStore::Set(passphrase_key(config.id), config.passphrase) && ok;
+    }
+    else
+    {
+        SecretStore::Erase(passphrase_key(config.id));
+    }
+    return ok;
+}
+
+// Populates the config's in-memory secrets from the OS vault, if present.
+void load_secrets(SshConnectionConfig& config)
+{
+    std::string value;
+    if(SecretStore::Get(password_key(config.id), value))
+    {
+        config.password = value;
+    }
+    if(SecretStore::Get(passphrase_key(config.id), value))
+    {
+        config.passphrase = value;
+    }
+}
+
+void erase_secrets(const std::string& id)
+{
+    SecretStore::Erase(password_key(id));
+    SecretStore::Erase(passphrase_key(id));
+}
+
+}  // namespace
 
 SshConnectionStore::SshConnectionStore()
 {
@@ -23,12 +91,29 @@ bool SshConnectionStore::Load()
         return false;
     }
 
+    bool had_legacy_plaintext = false;
     for(auto& entry : connections.getObject())
     {
+        // Old builds stored plaintext secrets here. We don't migrate them; the
+        // field stays empty (the user re-enters on connect) and the plaintext is
+        // stripped from disk below.
+        if(entry.second.contains("password") || entry.second.contains("passphrase"))
+        {
+            had_legacy_plaintext = true;
+        }
+
         SshConnectionConfig cfg = SshConnectionConfig::FromJson(entry.second);
         // Trust the on-disk object key as the id of record.
         cfg.id = entry.first;
+        load_secrets(cfg);
         m_connections.push_back(std::move(cfg));
+    }
+
+    // Rewrite the document so any leftover plaintext is dropped (ToJson no
+    // longer emits secrets).
+    if(had_legacy_plaintext)
+    {
+        Persist();
     }
 
     return true;
@@ -65,17 +150,23 @@ void SshConnectionStore::Save(SshConnectionConfig& config)
         config.id = SshConnectionConfig::GenerateId();
     }
 
+    bool replaced = false;
     for(auto& cfg : m_connections)
     {
         if(cfg.id == config.id)
         {
-            cfg = config;
-            Persist();
-            return;
+            cfg      = config;
+            replaced = true;
+            break;
         }
     }
+    if(!replaced)
+    {
+        m_connections.push_back(config);
+    }
 
-    m_connections.push_back(config);
+    // Secrets go to the OS credential vault, never into profiles.json.
+    store_secrets(config);
     Persist();
 }
 
@@ -86,6 +177,7 @@ void SshConnectionStore::Remove(const std::string& id)
         if(it->id == id)
         {
             m_connections.erase(it);
+            erase_secrets(id);
             Persist();
             return;
         }


### PR DESCRIPTION
Add SecretStore, a small wrapper over the OS credential store (Windows Credential Manager, macOS Keychain, libsecret on Linux). SSH passwords and key passphrases now live there, keyed by the connection id, and are no longer written to profiles.json.

SshConnectionStore moves secrets in/out of the vault on load/save/remove. Legacy plaintext left by older builds is ignored (the user re-enters on connect) and stripped from disk on load. When no vault is available, secrets are not persisted and the SSH layer prompts at connect time.

