### PR TITLE
[AIPROFVIS-334] - [Optiq-Compute] summary view, inconsistent color when highlighting kernels

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_summary.cpp
+++ b/src/view/src/compute/rocprofvis_compute_summary.cpp
@@ -571,7 +571,7 @@ ComputeTopKernels::RenderPieChart(const ImPlotStyle& plot_style, TimeFormat time
         if(m_hovered_idx)
         {
             ImPlot::PushColormap(m_settings.GetContrastColormapName());
-            ImGui::PushID(1);
+            ImGui::PushID(m_settings.GetContrastColormapName());
             ImPlot::PlotPieChart(
                 &m_kernel_pie.labels[m_hovered_idx.value()],
                 &m_kernel_pie.metric_sets[m_kernel_pie.selected_metric]

--- a/src/view/src/rocprofvis_summary_view.cpp
+++ b/src/view/src/rocprofvis_summary_view.cpp
@@ -708,7 +708,7 @@ TopKernels::RenderPieChart(const ImVec2 region, const ImPlotStyle& plot_style,
         if(m_hovered_idx)
         {
             ImPlot::PushColormap(m_settings.GetContrastColormapName());
-            ImGui::PushID(1);
+            ImGui::PushID(m_settings.GetContrastColormapName());
             ImPlot::PlotPieChart(
                 &m_kernel_pie.labels[m_hovered_idx.value()],
                 &m_kernel_pie.exec_time_pct[m_hovered_idx.value()], 1, 0.0, 0.0,


### PR DESCRIPTION
## Summary

Fixes the Top Kernels pie-chart hover highlight showing an inconsistent color (some slices white, some near-black) after switching between dark and light themes.

## Root cause

The pie renderer fills each slice with `GetCurrentItem()->Color`, which ImPlot assigns **only once** — the frame an item is first created (`just_created` in `BeginItem`) — and then caches on the persistent `ImPlotItem`, keyed by the item's ImGui ID. The highlight item was keyed on a fixed `PushID(1)`, so a dark↔light theme switch never produced a new item: previously-hovered slices kept the old theme's contrast color while newly-hovered ones picked up the current one.

The bar chart is unaffected because it re-applies the fill every frame via `SetNextFillStyle(GetColormapColor(...))` instead of relying on the cached item color.

## Fix

Key the highlight item's ID on the contrast colormap name (`GetContrastColormapName()`, which returns `contrast_dark` / `contrast_light`) instead of a constant. A theme change now resolves the highlight to a fresh item that reads the current contrast colormap. The name-seeded ID still differs from the main slices' plot-only seed, so highlight items stay separate from the main pie (no flame-color collision).

Applied identically to both pie renderers:
- `src/view/src/rocprofvis_summary_view.cpp`
- `src/view/src/compute/rocprofvis_compute_summary.cpp`

## Testing

Manual: hover pie slices, toggle theme, re-hover — highlight color now matches the active theme consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)