### PR TITLE
Revamp remote SSH panels

### DIFF
--- a/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_ssh_settings_dialog.h"
+#include "rocprofvis_font_manager.h"
+#include "rocprofvis_settings_manager.h"
+#include "icons/rocprovfis_icon_defines.h"
 #include "widgets/rocprofvis_widget.h"
 #include "widgets/rocprofvis_gui_helpers.h"
 
@@ -9,6 +12,7 @@
 
 #include <cfloat>
 #include <utility>
+#include <vector>
 
 namespace RocProfVis
 {
@@ -85,128 +89,370 @@ SshSettingsDialog::Render()
     popup_style.PushTitlebarColors();
     popup_style.CenterPopup();
 
-    ImGui::SetNextWindowSize(ImVec2(560, 0));
+    SettingsManager&  settings = SettingsManager::GetInstance();
+    const ImGuiStyle& style    = ImGui::GetStyle();
+
+    // Lock the width but let the modal grow to fit its content vertically, so no
+    // section is ever clipped and no scrollbar is needed.
+    const float dialog_width =
+        GetResponsiveWindowSize(ImVec2(720.0f, 0.0f), ImVec2(620.0f, 0.0f)).x;
+    ImGui::SetNextWindowSizeConstraints(ImVec2(dialog_width, 0.0f),
+                                        ImVec2(dialog_width, FLT_MAX));
 
     if(ImGui::BeginPopupModal(kSshSettingsPopupName, nullptr,
-                              ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove))
+                              ImGuiWindowFlags_AlwaysAutoResize |
+                                  ImGuiWindowFlags_NoSavedSettings |
+                                  ImGuiWindowFlags_NoScrollbar))
     {
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
+        constexpr float CONTENT_PADDING_X = 18.0f;
+        constexpr float CONTENT_PADDING_Y = 12.0f;
+        constexpr float LABEL_WIDTH       = 118.0f;
+        constexpr float BUTTON_WIDTH      = 112.0f;
+        constexpr float PROFILE_BUTTON_W  = 88.0f;
+        constexpr float SHOW_TOGGLE_W     = 76.0f;
 
-        const float label_w = 110.0f;
+        const ImU32 text_dim       = settings.GetColor(Colors::kTextDim);
+        const ImU32 accent         = settings.GetColor(Colors::kAccent);
+        const ImU32 accent_hover   = settings.GetColor(Colors::kAccentHover);
+        const ImU32 accent_active  = settings.GetColor(Colors::kAccentActive);
+        const ImU32 text_on_accent = settings.GetColor(Colors::kTextOnAccent);
+        ImFont*       icon_font     = settings.GetFontManager().GetFont(FontType::kIcon);
 
-        // --- Profile selector row ---
-        ImGui::AlignTextToFramePadding(); ImGui::Text("Profile"); ImGui::SameLine(label_w);
-        ImGui::SetNextItemWidth(-FLT_MIN - 170.0f);
-        const auto& connections = m_store.List();
-        std::string combo_label =
-            m_working.display_name.empty() ? "(unnamed)" : m_working.display_name;
-        if(ImGui::BeginCombo("##sshprofile", combo_label.c_str()))
+        // Default row spacing, restored inside each card so the tight spacing used
+        // between panels does not also cramp the fields within a panel.
+        const ImVec2 default_item_spacing = style.ItemSpacing;
+
+        auto label = [&](const char* text) {
+            ImGui::AlignTextToFramePadding();
+            ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
+            ImGui::TextUnformatted(text);
+            ImGui::PopStyleColor();
+        };
+
+        auto section_title = [&](const char* title, const char* subtitle) {
+            ImGui::PushFont(nullptr,
+                            settings.GetFontManager().GetFontSize(FontSize::kMedium));
+            ImGui::TextUnformatted(title);
+            ImGui::PopFont();
+            ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
+            ImGui::TextWrapped("%s", subtitle);
+            ImGui::PopStyleColor();
+        };
+
+        auto begin_card = [&](const char* id) {
+            ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
+            ImGui::PushStyleColor(ImGuiCol_Border,
+                                  settings.GetColor(Colors::kPanelBorderSubtle));
+            ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                                ImVec2(CONTENT_PADDING_X, CONTENT_PADDING_Y));
+            ImGui::BeginChild(id, ImVec2(0.0f, 0.0f),
+                              ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
+                              ImGuiWindowFlags_NoScrollbar |
+                                  ImGuiWindowFlags_NoScrollWithMouse);
+            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, default_item_spacing);
+        };
+
+        auto end_card = []() {
+            ImGui::PopStyleVar();
+            ImGui::EndChild();
+            ImGui::PopStyleVar(2);
+            ImGui::PopStyleColor(2);
+        };
+
+        bool close_popup = false;
+        bool accept      = false;
+
+        // Tighten the vertical gaps between the stacked panels (header/cards/footer).
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                            ImVec2(default_item_spacing.x, 4.0f));
+
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
+        ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(20.0f, 14.0f));
+        ImGui::BeginChild("##ssh_settings_header", ImVec2(0.0f, 0.0f),
+                          ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
+                          ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
         {
-            for(const auto& cfg : connections)
+            ImGui::PushFont(icon_font, ImGui::GetFontSize());
+            ImGui::PushStyleColor(ImGuiCol_Text, accent);
+            ImGui::TextUnformatted(ICON_COMPASS);
+            ImGui::PopStyleColor();
+            ImGui::PopFont();
+            ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+            ImGui::BeginGroup();
+            ImGui::PushFont(nullptr,
+                            settings.GetFontManager().GetFontSize(FontSize::kMedLarge));
+            ImGui::TextUnformatted("Remote SSH Profile");
+            ImGui::PopFont();
+
+            ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
+            ImGui::TextWrapped(
+                "Save the connection details used when opening profiler traces over SSH.");
+            ImGui::PopStyleColor();
+            ImGui::EndGroup();
+        }
+        ImGui::EndChild();
+        ImGui::PopStyleVar();
+        ImGui::PopStyleColor(2);
+
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 6.0f));
+        ImGui::BeginChild("##ssh_settings_body", ImVec2(0.0f, 0.0f),
+                          ImGuiChildFlags_AutoResizeY,
+                          ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+        {
+            begin_card("##ssh_profile_card");
             {
-                bool selected = (cfg.id == m_working.id);
-                std::string item =
-                    cfg.display_name.empty() ? "(unnamed)" : cfg.display_name;
-                if(ImGui::Selectable(item.c_str(), selected))
+                section_title("Profile", "Choose an existing profile or create a new one.");
+                ImGui::Spacing();
+
+                if(ImGui::BeginTable("##ssh_profile_table", 3,
+                                      ImGuiTableFlags_SizingStretchProp))
                 {
-                    SelectConnection(cfg.id);
+                    ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
+                                            LABEL_WIDTH);
+                    ImGui::TableSetupColumn("Profile", ImGuiTableColumnFlags_WidthStretch);
+                    ImGui::TableSetupColumn("Actions", ImGuiTableColumnFlags_WidthFixed,
+                                            PROFILE_BUTTON_W * 2.0f + style.ItemSpacing.x);
+                    ImGui::TableNextRow();
+
+                    ImGui::TableSetColumnIndex(0);
+                    label("Profile");
+
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    const std::vector<SshConnectionConfig>& connections = m_store.List();
+                    std::string combo_label =
+                        m_working.display_name.empty() ? "(unnamed)" : m_working.display_name;
+                    PushComboStyles();
+                    if(ImGui::BeginCombo("##sshprofile", combo_label.c_str()))
+                    {
+                        for(const SshConnectionConfig& cfg : connections)
+                        {
+                            bool        selected = (cfg.id == m_working.id);
+                            std::string item =
+                                cfg.display_name.empty() ? "(unnamed)" : cfg.display_name;
+                            if(ImGui::Selectable(item.c_str(), selected))
+                            {
+                                SelectConnection(cfg.id);
+                            }
+                            if(selected)
+                            {
+                                ImGui::SetItemDefaultFocus();
+                            }
+                        }
+                        ImGui::EndCombo();
+                    }
+                    PopComboStyles();
+
+                    ImGui::TableSetColumnIndex(2);
+                    if(ImGui::Button("New", ImVec2(PROFILE_BUTTON_W, 0.0f)))
+                    {
+                        BeginNewConnection();
+                    }
+                    ImGui::SameLine();
+                    bool exists_in_store = m_store.Get(m_working.id) != nullptr;
+                    if(!exists_in_store)
+                    {
+                        ImGui::BeginDisabled();
+                    }
+                    if(ImGui::Button("Delete", ImVec2(PROFILE_BUTTON_W, 0.0f)))
+                    {
+                        std::string removed_id = m_working.id;
+                        m_store.Remove(removed_id);
+                        if(!m_store.Empty())
+                        {
+                            SelectConnection(m_store.List().front().id);
+                        }
+                        else
+                        {
+                            BeginNewConnection();
+                        }
+                    }
+                    if(!exists_in_store)
+                    {
+                        ImGui::EndDisabled();
+                    }
+
+                    ImGui::EndTable();
                 }
-                if(selected)
+            }
+            end_card();
+
+            begin_card("##ssh_connection_card");
+            {
+                section_title("Connection", "Name the profile and set the remote host.");
+                ImGui::Spacing();
+
+                if(ImGui::BeginTable("##ssh_connection_table", 2,
+                                      ImGuiTableFlags_SizingStretchProp))
                 {
-                    ImGui::SetItemDefaultFocus();
+                    ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
+                                            LABEL_WIDTH);
+                    ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthStretch);
+
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    label("Name");
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    InputTextString("##rname", m_working.display_name);
+
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    label("Host");
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    InputTextString("##rhost", m_working.host);
+
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    label("Port");
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    InputTextString("##rport", m_working.port);
+
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    label("User");
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    InputTextString("##ruser", m_working.user);
+
+                    ImGui::EndTable();
                 }
             }
-            ImGui::EndCombo();
-        }
+            end_card();
 
-        ImGui::SameLine();
-        if(ImGui::Button("New", ImVec2(80, 0)))
-        {
-            BeginNewConnection();
-        }
-
-        ImGui::SameLine();
-        bool exists_in_store = m_store.Get(m_working.id) != nullptr;
-        if(!exists_in_store) ImGui::BeginDisabled();
-        if(ImGui::Button("Delete", ImVec2(80, 0)))
-        {
-            std::string removed_id = m_working.id;
-            m_store.Remove(removed_id);
-            if(!m_store.Empty())
+            begin_card("##ssh_auth_card");
             {
-                SelectConnection(m_store.List().front().id);
+                section_title("Authentication",
+                              "Use a password, SSH key, or agent-backed key for login.");
+                ImGui::Spacing();
+
+                if(ImGui::BeginTable("##ssh_auth_table", 3,
+                                      ImGuiTableFlags_SizingStretchProp))
+                {
+                    ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
+                                            LABEL_WIDTH);
+                    ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthStretch);
+                    ImGui::TableSetupColumn("Toggle", ImGuiTableColumnFlags_WidthFixed,
+                                            SHOW_TOGGLE_W);
+
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    label("Password");
+                    ImGui::TableSetColumnIndex(1);
+                    ImGuiInputTextFlags pwd_flags =
+                        m_show_password ? 0 : ImGuiInputTextFlags_Password;
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    InputTextString("##rpass", m_working.password, pwd_flags);
+                    ImGui::TableSetColumnIndex(2);
+                    ImGui::Checkbox("Show##password", &m_show_password);
+
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    label("SSH Key");
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    InputTextStringWithHint(
+                        "##rkey", "Optional private key path, e.g. ~/.ssh/id_ed25519",
+                        m_working.identity_file);
+                    ImGui::TableSetColumnIndex(2);
+                    ImGui::TextUnformatted("");
+
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    label("Passphrase");
+                    ImGui::TableSetColumnIndex(1);
+                    ImGuiInputTextFlags pass_flags =
+                        m_show_passphrase ? 0 : ImGuiInputTextFlags_Password;
+                    ImGui::SetNextItemWidth(-FLT_MIN);
+                    InputTextStringWithHint(
+                        "##rkeypass", "Leave blank for unencrypted keys or ssh-agent",
+                        m_working.passphrase, pass_flags);
+                    ImGui::TableSetColumnIndex(2);
+                    ImGui::Checkbox("Show##passphrase", &m_show_passphrase);
+
+                    ImGui::EndTable();
+                }
+
+                ImGui::Spacing();
+                ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
+                ImGui::TextWrapped(
+                    "Open Remote Trace requires a host, user, result database path, and either "
+                    "a password or SSH key.");
+                ImGui::PopStyleColor();
             }
-            else
+            end_card();
+        }
+        ImGui::EndChild();
+        ImGui::PopStyleVar();
+        ImGui::PopStyleColor();
+
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
+        ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 12.0f));
+        ImGui::BeginChild("##ssh_settings_footer", ImVec2(0.0f, 0.0f),
+                          ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
+                          ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+        {
+            const float action_width = BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
+            if(ImGui::BeginTable("##ssh_settings_footer_table", 2,
+                                  ImGuiTableFlags_SizingStretchProp))
             {
-                BeginNewConnection();
+                ImGui::TableSetupColumn("Note", ImGuiTableColumnFlags_WidthStretch);
+                ImGui::TableSetupColumn("Actions", ImGuiTableColumnFlags_WidthFixed,
+                                        action_width);
+                ImGui::TableNextRow();
+
+                ImGui::TableSetColumnIndex(0);
+                ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
+                ElidedText("Profiles are saved locally and reused by remote trace open.",
+                           ImGui::GetContentRegionAvail().x, 360.0f, Alignment_Left, true);
+                ImGui::PopStyleColor();
+
+                ImGui::TableSetColumnIndex(1);
+                if(ImGui::Button("Cancel", ImVec2(BUTTON_WIDTH, 0.0f)))
+                {
+                    close_popup = true;
+                }
+                ImGui::SameLine();
+
+                ImGui::PushStyleColor(ImGuiCol_Button, accent);
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, accent_hover);
+                ImGui::PushStyleColor(ImGuiCol_ButtonActive, accent_active);
+                ImGui::PushStyleColor(ImGuiCol_Text, text_on_accent);
+                if(ImGui::Button("Save", ImVec2(BUTTON_WIDTH, 0.0f)))
+                {
+                    accept      = true;
+                    close_popup = true;
+                }
+                ImGui::PopStyleColor(4);
+                ImGui::EndTable();
             }
         }
-        if(!exists_in_store) ImGui::EndDisabled();
+        ImGui::EndChild();
+        ImGui::PopStyleVar();
+        ImGui::PopStyleColor(2);
 
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
-
-        ImGui::AlignTextToFramePadding(); ImGui::Text("Name"); ImGui::SameLine(label_w);
-        ImGui::SetNextItemWidth(-FLT_MIN);
-        InputTextString("##rname", m_working.display_name);
-
-        ImGui::AlignTextToFramePadding(); ImGui::Text("Host"); ImGui::SameLine(label_w);
-        ImGui::SetNextItemWidth(-FLT_MIN);
-        InputTextString("##rhost", m_working.host);
-
-        ImGui::AlignTextToFramePadding(); ImGui::Text("Port"); ImGui::SameLine(label_w);
-        ImGui::SetNextItemWidth(-FLT_MIN);
-        InputTextString("##rport", m_working.port);
-
-        ImGui::AlignTextToFramePadding(); ImGui::Text("User"); ImGui::SameLine(label_w);
-        ImGui::SetNextItemWidth(-FLT_MIN);
-        InputTextString("##ruser", m_working.user);
-
-        ImGui::AlignTextToFramePadding(); ImGui::Text("Password"); ImGui::SameLine(label_w);
-        ImGuiInputTextFlags pwd_flags = m_show_password ? 0 : ImGuiInputTextFlags_Password;
-        ImGui::SetNextItemWidth(-FLT_MIN - 90.0f);
-        InputTextString("##rpass", m_working.password, pwd_flags);
-        ImGui::SameLine();
-        ImGui::Checkbox("Show", &m_show_password);
-
-        ImGui::AlignTextToFramePadding(); ImGui::Text("SSH Key"); ImGui::SameLine(label_w);
-        ImGui::SetNextItemWidth(-FLT_MIN);
-        InputTextStringWithHint(
-            "##rkey",
-            "Optional - path to private key (e.g. ~/.ssh/id_ed25519). Leave blank for default keys or password.",
-            m_working.identity_file);
-
-        ImGui::AlignTextToFramePadding(); ImGui::Text("Key Passphrase"); ImGui::SameLine(label_w);
-        ImGuiInputTextFlags pass_flags = m_show_passphrase ? 0 : ImGuiInputTextFlags_Password;
-        ImGui::SetNextItemWidth(-FLT_MIN - 90.0f);
-        InputTextStringWithHint(
-            "##rkeypass", "Leave blank if key is unencrypted or loaded in ssh-agent",
-            m_working.passphrase, pass_flags);
-
-        ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
-
-        if(ImGui::Button("OK", ImVec2(110, 0)))
+        if(accept)
         {
             m_store.Save(m_working);
             if(m_on_commit)
             {
                 m_on_commit(m_working.id);
             }
-            m_open = false;
-            ImGui::CloseCurrentPopup();
         }
 
-        ImGui::SameLine();
-        if(ImGui::Button("Cancel", ImVec2(110, 0)))
+        if(close_popup)
         {
             m_open = false;
             ImGui::CloseCurrentPopup();
         }
+
+        ImGui::PopStyleVar();
 
         ImGui::EndPopup();
     }

--- a/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
@@ -94,7 +94,7 @@ SshSettingsDialog::Render()
 
     // Fixed width, auto height, so no section clips and no scrollbar is needed.
     const float dialog_width =
-        GetResponsiveWindowSize(ImVec2(720.0f, 0.0f), ImVec2(620.0f, 0.0f)).x;
+        GetResponsiveWindowSize(ImVec2(560.0f, 0.0f), ImVec2(480.0f, 0.0f)).x;
     ImGui::SetNextWindowSizeConstraints(ImVec2(dialog_width, 0.0f),
                                         ImVec2(dialog_width, FLT_MAX));
 
@@ -103,12 +103,11 @@ SshSettingsDialog::Render()
                                   ImGuiWindowFlags_NoSavedSettings |
                                   ImGuiWindowFlags_NoScrollbar))
     {
-        constexpr float CONTENT_PADDING_X = 18.0f;
-        constexpr float CONTENT_PADDING_Y = 12.0f;
-        constexpr float LABEL_WIDTH       = 118.0f;
-        constexpr float BUTTON_WIDTH      = 112.0f;
-        constexpr float PROFILE_BUTTON_W  = 88.0f;
-        constexpr float SHOW_TOGGLE_W     = 76.0f;
+        constexpr float CONTENT_PADDING_X = 14.0f;
+        constexpr float CONTENT_PADDING_Y = 8.0f;
+        constexpr float LABEL_WIDTH       = 104.0f;
+        constexpr float BUTTON_WIDTH      = 104.0f;
+        constexpr float PROFILE_BUTTON_W  = 78.0f;
 
         const ImU32 text_dim       = settings.GetColor(Colors::kTextDim);
         const ImU32 accent         = settings.GetColor(Colors::kAccent);
@@ -127,14 +126,34 @@ SshSettingsDialog::Render()
             ImGui::PopStyleColor();
         };
 
-        auto section_title = [&](const char* title, const char* subtitle) {
+        auto section_title = [&](const char* title) {
             ImGui::PushFont(nullptr,
                             settings.GetFontManager().GetFontSize(FontSize::kMedium));
             ImGui::TextUnformatted(title);
             ImGui::PopFont();
-            ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
-            ImGui::TextWrapped("%s", subtitle);
-            ImGui::PopStyleColor();
+        };
+
+        // Compact reveal toggle that lives inside the field cell, so it can never
+        // overflow past the card like a trailing "Show" checkbox column would.
+        auto reveal_toggle = [&](const char* id, std::string& value, const char* hint,
+                                 bool& show) {
+            const float eye_w = ImGui::GetFrameHeight();
+            ImGui::SetNextItemWidth(-(eye_w + style.ItemInnerSpacing.x));
+            ImGuiInputTextFlags flags = show ? 0 : ImGuiInputTextFlags_Password;
+            if(hint)
+            {
+                InputTextStringWithHint(id, hint, value, flags);
+            }
+            else
+            {
+                InputTextString(id, value, flags);
+            }
+            ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+            if(IconButton(show ? ICON_EYE_SLASH : ICON_EYE, icon_font,
+                          ImVec2(eye_w, eye_w), show ? "Hide" : "Show"))
+            {
+                show = !show;
+            }
         };
 
         auto begin_card = [&](const char* id) {
@@ -167,7 +186,7 @@ SshSettingsDialog::Render()
 
         ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
         ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(20.0f, 14.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16.0f, 10.0f));
         ImGui::BeginChild("##ssh_settings_header", ImVec2(0.0f, 0.0f),
                           ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                           ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
@@ -195,14 +214,14 @@ SshSettingsDialog::Render()
         ImGui::PopStyleColor(2);
 
         ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 6.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(12.0f, 4.0f));
         ImGui::BeginChild("##ssh_settings_body", ImVec2(0.0f, 0.0f),
                           ImGuiChildFlags_AutoResizeY,
                           ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
         {
             begin_card("##ssh_profile_card");
             {
-                section_title("Profile", "Choose an existing profile or create a new one.");
+                section_title("Profile");
                 ImGui::Spacing();
 
                 if(ImGui::BeginTable("##ssh_profile_table", 3,
@@ -280,7 +299,7 @@ SshSettingsDialog::Render()
 
             begin_card("##ssh_connection_card");
             {
-                section_title("Connection", "Name the profile and set the remote host.");
+                section_title("Connection");
                 ImGui::Spacing();
 
                 if(ImGui::BeginTable("##ssh_connection_table", 2,
@@ -325,29 +344,21 @@ SshSettingsDialog::Render()
 
             begin_card("##ssh_auth_card");
             {
-                section_title("Authentication",
-                              "Use a password, SSH key, or agent-backed key for login.");
+                section_title("Authentication");
                 ImGui::Spacing();
 
-                if(ImGui::BeginTable("##ssh_auth_table", 3,
+                if(ImGui::BeginTable("##ssh_auth_table", 2,
                                       ImGuiTableFlags_SizingStretchProp))
                 {
                     ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
                                             LABEL_WIDTH);
                     ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthStretch);
-                    ImGui::TableSetupColumn("Toggle", ImGuiTableColumnFlags_WidthFixed,
-                                            SHOW_TOGGLE_W);
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
                     label("Password");
                     ImGui::TableSetColumnIndex(1);
-                    ImGuiInputTextFlags pwd_flags =
-                        m_show_password ? 0 : ImGuiInputTextFlags_Password;
-                    ImGui::SetNextItemWidth(-FLT_MIN);
-                    InputTextString("##rpass", m_working.password, pwd_flags);
-                    ImGui::TableSetColumnIndex(2);
-                    ImGui::Checkbox("Show##password", &m_show_password);
+                    reveal_toggle("##rpass", m_working.password, nullptr, m_show_password);
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
@@ -362,24 +373,12 @@ SshSettingsDialog::Render()
                     ImGui::TableSetColumnIndex(0);
                     label("Passphrase");
                     ImGui::TableSetColumnIndex(1);
-                    ImGuiInputTextFlags pass_flags =
-                        m_show_passphrase ? 0 : ImGuiInputTextFlags_Password;
-                    ImGui::SetNextItemWidth(-FLT_MIN);
-                    InputTextStringWithHint(
-                        "##rkeypass", "Leave blank for unencrypted keys or ssh-agent",
-                        m_working.passphrase, pass_flags);
-                    ImGui::TableSetColumnIndex(2);
-                    ImGui::Checkbox("Show##passphrase", &m_show_passphrase);
+                    reveal_toggle("##rkeypass", m_working.passphrase,
+                                  "Leave blank for unencrypted keys or ssh-agent",
+                                  m_show_passphrase);
 
                     ImGui::EndTable();
                 }
-
-                ImGui::Spacing();
-                ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
-                ImGui::TextWrapped(
-                    "Open Remote Trace requires a host, user, result database path, and either "
-                    "a password or SSH key.");
-                ImGui::PopStyleColor();
             }
             end_card();
         }
@@ -389,7 +388,7 @@ SshSettingsDialog::Render()
 
         ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
         ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 12.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 8.0f));
         ImGui::BeginChild("##ssh_settings_footer", ImVec2(0.0f, 0.0f),
                           ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                           ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);

--- a/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
@@ -92,8 +92,7 @@ SshSettingsDialog::Render()
     SettingsManager&  settings = SettingsManager::GetInstance();
     const ImGuiStyle& style    = ImGui::GetStyle();
 
-    // Lock the width but let the modal grow to fit its content vertically, so no
-    // section is ever clipped and no scrollbar is needed.
+    // Fixed width, auto height, so no section clips and no scrollbar is needed.
     const float dialog_width =
         GetResponsiveWindowSize(ImVec2(720.0f, 0.0f), ImVec2(620.0f, 0.0f)).x;
     ImGui::SetNextWindowSizeConstraints(ImVec2(dialog_width, 0.0f),
@@ -116,10 +115,9 @@ SshSettingsDialog::Render()
         const ImU32 accent_hover   = settings.GetColor(Colors::kAccentHover);
         const ImU32 accent_active  = settings.GetColor(Colors::kAccentActive);
         const ImU32 text_on_accent = settings.GetColor(Colors::kTextOnAccent);
-        ImFont*       icon_font     = settings.GetFontManager().GetFont(FontType::kIcon);
+        ImFont*     icon_font      = settings.GetFontManager().GetFont(FontType::kIcon);
 
-        // Default row spacing, restored inside each card so the tight spacing used
-        // between panels does not also cramp the fields within a panel.
+        // Restored inside each card so the tighter panel gaps do not cramp fields.
         const ImVec2 default_item_spacing = style.ItemSpacing;
 
         auto label = [&](const char* text) {
@@ -359,8 +357,6 @@ SshSettingsDialog::Render()
                     InputTextStringWithHint(
                         "##rkey", "Optional private key path, e.g. ~/.ssh/id_ed25519",
                         m_working.identity_file);
-                    ImGui::TableSetColumnIndex(2);
-                    ImGui::TextUnformatted("");
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);

--- a/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
@@ -145,8 +145,7 @@ SshTestDialog::Render()
         const ImU32 text_on_accent = settings.GetColor(Colors::kTextOnAccent);
         const ImU32 text_dim       = settings.GetColor(Colors::kTextDim);
 
-        // Lock the width but let the window hug its content vertically so there is
-        // no empty band below the single result-database field.
+        // Fixed width, auto height, so the window hugs its content with no empty band.
         const float dialog_width =
             GetResponsiveWindowSize(ImVec2(720.0f, 0.0f), ImVec2(620.0f, 0.0f)).x;
         if(const ImGuiViewport* viewport = ImGui::GetMainViewport())

--- a/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
@@ -5,6 +5,8 @@
 #include "rocprofvis_ssh_auth_modal.h"
 #include "rocprofvis_appwindow.h"
 #include "rocprofvis_settings_manager.h"
+#include "rocprofvis_font_manager.h"
+#include "icons/rocprovfis_icon_defines.h"
 #include "widgets/rocprofvis_widget.h"
 #include "widgets/rocprofvis_gui_helpers.h"
 
@@ -133,36 +135,48 @@ SshTestDialog::Render()
 {
     if(m_show_window)
     {
-        ImGui::SetNextWindowSize(ImVec2(560, 0), ImGuiCond_FirstUseEver);
-        if(ImGui::Begin("SSH Test", &m_show_window))
+        SettingsManager&  settings  = SettingsManager::GetInstance();
+        ImFont*           icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
+        const ImGuiStyle& style     = ImGui::GetStyle();
+
+        const ImU32 accent         = settings.GetColor(Colors::kAccent);
+        const ImU32 accent_hover   = settings.GetColor(Colors::kAccentHover);
+        const ImU32 accent_active  = settings.GetColor(Colors::kAccentActive);
+        const ImU32 text_on_accent = settings.GetColor(Colors::kTextOnAccent);
+        const ImU32 text_dim       = settings.GetColor(Colors::kTextDim);
+
+        // Lock the width but let the window hug its content vertically so there is
+        // no empty band below the single result-database field.
+        const float dialog_width =
+            GetResponsiveWindowSize(ImVec2(720.0f, 0.0f), ImVec2(620.0f, 0.0f)).x;
+        if(const ImGuiViewport* viewport = ImGui::GetMainViewport())
         {
-            ImGui::Spacing();
-            ImGui::Separator();
-            ImGui::Spacing();
+            ImGui::SetNextWindowPos(viewport->GetCenter(), ImGuiCond_Appearing,
+                                    ImVec2(0.5f, 0.5f));
+        }
+        ImGui::SetNextWindowSizeConstraints(ImVec2(dialog_width, 0.0f),
+                                            ImVec2(dialog_width, FLT_MAX));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
+        if(ImGui::Begin("Open Remote Trace", &m_show_window,
+               ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize |
+                   ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoTitleBar))
+        {
+            const bool running = m_orchestrator && m_orchestrator->IsRunning();
 
-            const float label_w = 170.0f;
-
-            // Connection target summary (edited via the settings dialog).
-            ImGui::AlignTextToFramePadding(); ImGui::Text("Connection"); ImGui::SameLine(label_w);
-            std::string host = m_uri->GetRemoteHostString();
-            std::string user = m_uri->GetRemoteUserString();
-            if(host.empty())
-            {
-                ImGui::TextDisabled("Not configured");
-            }
-            else
-            {
-                ImGui::Text("%s@%s:%s",
-                            user.empty() ? "?" : user.c_str(),
-                            host.c_str(),
-                            m_uri->GetRemotePortString().c_str());
-            }
-
-            if(ImGui::Button("Configure SSH Connection..."))
-            {
-                // Create the transient profile-managing dialog on demand, seeded
-                // with the currently selected connection; on commit, bind the
-                // chosen connection into m_uri.
+            auto render_icon = [&](const char* glyph, ImU32 color) {
+                ImGui::PushFont(icon_font, ImGui::GetFontSize());
+                ImGui::PushStyleColor(ImGuiCol_Text, color);
+                ImGui::TextUnformatted(glyph);
+                ImGui::PopStyleColor();
+                ImGui::PopFont();
+            };
+            auto field_label = [&](const char* label) {
+                ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
+                ImGui::TextUnformatted(label);
+                ImGui::PopStyleColor();
+            };
+            auto open_connection_settings = [&]() {
                 m_settings_dialog = std::make_unique<SshSettingsDialog>(
                     m_connection_store, m_selected_connection_id,
                     [this](const std::string& id)
@@ -170,96 +184,248 @@ SshTestDialog::Render()
                         m_selected_connection_id = id;
                         ApplySelectedConnection();
                     });
-            }
+            };
 
-            ImGui::Spacing();
+            const bool can_authenticate = !m_uri->GetRemotePasswordString().empty() ||
+                                          !m_uri->GetRemoteIdentityFileString().empty();
+            const bool has_remote_path = !m_uri->GetRemoteResultPathString().empty();
+            const bool can_open = !m_uri->GetRemoteHostString().empty() &&
+                                  !m_uri->GetRemoteUserString().empty() &&
+                                  has_remote_path && can_authenticate;
 
-            // Per-profiler fields that stay on this dialog.
-            ImGui::AlignTextToFramePadding(); ImGui::Text("Profiler command line"); ImGui::SameLine(label_w);
-            ImGui::SetNextItemWidth(-FLT_MIN);
-            InputTextStringWithHint("##rcommand", "/path/to/executable [parameters]",
-                m_uri->GetRemoteCommandLine());
+            const std::string host = m_uri->GetRemoteHostString();
+            const std::string user = m_uri->GetRemoteUserString();
+            const std::string host_chip =
+                host.empty()
+                    ? std::string("Configure")
+                    : (user.empty() ? std::string("?") : user) + "@" + host + ":" +
+                          m_uri->GetRemotePortString();
 
-            ImGui::AlignTextToFramePadding(); ImGui::Text("Profiler output database"); ImGui::SameLine(label_w);
-            ImGui::SetNextItemWidth(-FLT_MIN-90);
-            InputTextStringWithHint("##rpath", "/path/to/file.db",
-                m_uri->GetRemoteResultPath());
-            ImGui::SameLine();
-            if (ImGui::Button("Browse", ImVec2(80, 0)))
+            constexpr float LABEL_WIDTH  = 132.0f;
+            constexpr float BUTTON_WIDTH = 118.0f;
+
+            // Tighten the vertical gaps between the stacked panels.
+            const ImVec2 default_item_spacing = style.ItemSpacing;
+            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                                ImVec2(default_item_spacing.x, 4.0f));
+
+            ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
+            ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
+            ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(18.0f, 14.0f));
+            ImGui::BeginChild("##remote_trace_header", ImVec2(0.0f, 0.0f),
+                              ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
+                              ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
             {
-                m_uri->InitRemoteBrowsingPathString(m_uri->GetRemoteResultPathString().c_str());
-                // Start a fresh browsing session from the top-level Browse
-                // button; subsequent folder navigation reuses this session.
-                m_orchestrator.reset();
-                BrowseRemotePath();
-            }
+                if(ImGui::BeginTable("##remote_trace_header_table", 3,
+                                      ImGuiTableFlags_SizingStretchProp))
+                {
+                    ImGui::TableSetupColumn("Title", ImGuiTableColumnFlags_WidthStretch);
+                    ImGui::TableSetupColumn("Connection", ImGuiTableColumnFlags_WidthFixed,
+                                            248.0f);
+                    ImGui::TableSetupColumn("Close", ImGuiTableColumnFlags_WidthFixed, 24.0f);
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    render_icon(ICON_COMPASS, accent);
+                    ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+                    ImGui::BeginGroup();
+                    ImGui::PushFont(nullptr,
+                                    settings.GetFontManager().GetFontSize(FontSize::kMedLarge));
+                    ImGui::TextUnformatted("Remote Trace");
+                    ImGui::PopFont();
+                    ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
+                    ImGui::TextUnformatted("Launch or fetch a profiler trace over SSH.");
+                    ImGui::PopStyleColor();
+                    ImGui::EndGroup();
 
-            ImGui::Spacing();
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::PushID("header_connection");
+                    if(running)
+                    {
+                        ImGui::BeginDisabled();
+                    }
+                    ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kButton));
+                    ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                                          settings.GetColor(Colors::kButtonHovered));
+                    ImGui::PushStyleColor(ImGuiCol_ButtonActive,
+                                          settings.GetColor(Colors::kButtonActive));
+                    ImGui::PushStyleColor(ImGuiCol_Text, host.empty() ? text_dim : accent);
+                    if(ImGui::Button((host_chip + "##button").c_str(),
+                                     ImVec2(-FLT_MIN, 0.0f)))
+                    {
+                        open_connection_settings();
+                    }
+                    ImGui::PopStyleColor(4);
+                    if(running)
+                    {
+                        ImGui::EndDisabled();
+                    }
+                    ImGui::PopID();
+
+                    ImGui::TableSetColumnIndex(2);
+                    if(XButton("##remote_trace_close", "Close", &settings))
+                    {
+                        m_show_window = false;
+                    }
+                    ImGui::EndTable();
+                }
+            }
+            ImGui::EndChild();
+            ImGui::PopStyleVar(2);
+            ImGui::PopStyleColor(2);
+
+            ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16.0f, 10.0f));
+            ImGui::BeginChild("##remote_trace_body", ImVec2(0.0f, 0.0f),
+                              ImGuiChildFlags_AutoResizeY,
+                              ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+            {
+                ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
+                ImGui::PushStyleColor(ImGuiCol_Border,
+                                      settings.GetColor(Colors::kPanelBorderSubtle));
+                ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
+                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 12.0f));
+                ImGui::BeginChild("##remote_trace_target", ImVec2(0.0f, 0.0f),
+                                  ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
+                                  ImGuiWindowFlags_NoScrollbar |
+                                      ImGuiWindowFlags_NoScrollWithMouse);
+                {
+                    if(ImGui::BeginTable("##remote_trace_target_table", 3,
+                                          ImGuiTableFlags_SizingStretchProp))
+                    {
+                        ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
+                                                LABEL_WIDTH);
+                        ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
+                        ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed,
+                                                94.0f);
+                        ImGui::TableNextRow();
+                        ImGui::TableSetColumnIndex(0);
+                        ImGui::AlignTextToFramePadding();
+                        field_label("Result database");
+
+                        ImGui::TableSetColumnIndex(1);
+                        ImGui::SetNextItemWidth(-FLT_MIN);
+                        InputTextStringWithHint("##rpath", "/path/to/file.db",
+                                                m_uri->GetRemoteResultPath());
+
+                        ImGui::TableSetColumnIndex(2);
+                        if(ImGui::Button("Browse", ImVec2(-FLT_MIN, 0.0f)))
+                        {
+                            m_uri->InitRemoteBrowsingPathString(
+                                m_uri->GetRemoteResultPathString().c_str());
+                            // Start a fresh browsing session; subsequent folder
+                            // navigation reuses this session.
+                            m_orchestrator.reset();
+                            BrowseRemotePath();
+                        }
+                        ImGui::EndTable();
+                    }
+                }
+                ImGui::EndChild();
+                ImGui::PopStyleVar(2);
+                ImGui::PopStyleColor(2);
+            }
+            ImGui::EndChild();
+            ImGui::PopStyleVar();
+            ImGui::PopStyleColor();
 
             const std::string& status_msg =
                 m_orchestrator ? m_orchestrator->GetStatusMessage() : m_status_msg;
-            if(!status_msg.empty())
+            bool open_clicked = false;
+            ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
+            ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(18.0f, 14.0f));
+            ImGui::BeginChild("##remote_trace_footer", ImVec2(0.0f, 0.0f),
+                              ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
+                              ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
             {
-                ImVec4 color = ImVec4(1.0f, 0.5f, 0.3f, 1.0f);
-                ImGui::TextColored(color, "%s", status_msg.c_str());
-            }
-
-            ImGui::Spacing();
-            ImGui::Separator();
-            ImGui::Spacing();
-
-            bool can_authenticate = !m_uri->GetRemotePasswordString().empty() ||
-                                    !m_uri->GetRemoteIdentityFileString().empty();
-            bool has_remote_path = !m_uri->GetRemoteCommandLineString().empty() ||
-                                   !m_uri->GetRemoteResultPathString().empty();
-            bool can_open = !m_uri->GetRemoteHostString().empty() &&
-                            !m_uri->GetRemoteUserString().empty() &&
-                            has_remote_path && can_authenticate;
-
-            bool running = m_orchestrator && m_orchestrator->IsRunning();
-
-            if(!can_open) ImGui::BeginDisabled();
-            if(!running)
-            {
-                if(ImGui::Button("Open", ImVec2(110, 0)))
+                if(ImGui::BeginTable("##remote_trace_footer_table", 2,
+                                      ImGuiTableFlags_SizingStretchProp))
                 {
-                    // Connection config is persisted by the settings dialog; bind
-                    // the selected profile in case it changed since last apply.
-                    ApplySelectedConnection();
-                    m_show_stdout_popup   = false;
-                    m_show_progress_popup = false;
+                    const float total_width = BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
+                    ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthStretch);
+                    ImGui::TableSetupColumn("Actions", ImGuiTableColumnFlags_WidthFixed,
+                                            total_width);
+                    ImGui::TableNextRow();
+                    ImGui::TableSetColumnIndex(0);
+                    if(status_msg.empty())
+                    {
+                        ImGui::AlignTextToFramePadding();
+                        ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
+                        ImGui::TextUnformatted("Ready");
+                        ImGui::PopStyleColor();
+                    }
+                    else
+                    {
+                        render_icon(running ? ICON_ARROWS_CYCLE : ICON_CHAIN,
+                                    running ? accent : text_dim);
+                        ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+                        ImGui::PushID("footer_status");
+                        ImGui::PushStyleColor(ImGuiCol_Text, running ? accent : text_dim);
+                        ElidedText(status_msg.c_str(), ImGui::GetContentRegionAvail().x, 420.0f,
+                                   Alignment_Left, true);
+                        ImGui::PopStyleColor();
+                        ImGui::PopID();
+                    }
 
-                    // Drive the connect -> authenticate -> execute -> download
-                    // chain on the main thread via the AppMonitor; OpenFile is
-                    // invoked when the trace has been downloaded.
-                    m_orchestrator = std::make_unique<RemoteTraceOrchestrator>(
-                        m_uri,
-                        [this](const std::string& local_path)
+                    ImGui::TableSetColumnIndex(1);
+                    if(ImGui::Button("Close", ImVec2(BUTTON_WIDTH, 0.0f)))
+                    {
+                        m_show_window = false;
+                    }
+                    ImGui::SameLine();
+
+                    const bool open_disabled = !can_open || running;
+                    if(open_disabled)
+                    {
+                        ImGui::BeginDisabled();
+                    }
+                    ImGui::PushStyleColor(ImGuiCol_Button, accent);
+                    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, accent_hover);
+                    ImGui::PushStyleColor(ImGuiCol_ButtonActive, accent_active);
+                    ImGui::PushStyleColor(ImGuiCol_Text, text_on_accent);
+                    open_clicked =
+                        ImGui::Button(running ? "Working..." : "Open",
+                                      ImVec2(BUTTON_WIDTH, 0.0f));
+                    ImGui::PopStyleColor(4);
+                    if(open_disabled)
+                    {
+                        ImGui::EndDisabled();
+                    }
+                    ImGui::EndTable();
+                }
+            }
+            ImGui::EndChild();
+            ImGui::PopStyleVar();
+            ImGui::PopStyleColor(2);
+
+            if(open_clicked)
+            {
+                // Connection config is persisted by the settings dialog; bind the
+                // selected profile in case it changed since last apply.
+                ApplySelectedConnection();
+                m_show_stdout_popup   = false;
+                m_show_progress_popup = false;
+
+                // Drive the connect -> authenticate -> execute -> download chain
+                // on the main thread via the AppMonitor; OpenFile is invoked when
+                // the trace has been downloaded.
+                m_orchestrator = std::make_unique<RemoteTraceOrchestrator>(
+                    m_uri,
+                    [this](const std::string& local_path)
+                    {
+                        if(m_app_window)
                         {
-                            if(m_app_window)
-                            {
-                                m_app_window->OpenFile(local_path);
-                            }
-                        });
-                    m_orchestrator->Start();
-                }
+                            m_app_window->OpenFile(local_path);
+                        }
+                    });
+                m_orchestrator->Start();
             }
-            else
-            {
-                ImGui::Text("%s", m_orchestrator->GetStatusMessage().c_str());
-            }
-            if(!can_open) ImGui::EndDisabled();
 
-            ImGui::SameLine();
-            if(!running)
-            {
-                if(ImGui::Button("Close", ImVec2(110, 0)))
-                {
-                    m_show_window = false;
-                }
-            }
+            ImGui::PopStyleVar();
         }
         ImGui::End();
+        ImGui::PopStyleVar(2);
     }
 
     // Render the transient settings dialog; destroy it once it reports closed.

--- a/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
@@ -147,7 +147,7 @@ SshTestDialog::Render()
 
         // Fixed width, auto height, so the window hugs its content with no empty band.
         const float dialog_width =
-            GetResponsiveWindowSize(ImVec2(720.0f, 0.0f), ImVec2(620.0f, 0.0f)).x;
+            GetResponsiveWindowSize(ImVec2(560.0f, 0.0f), ImVec2(480.0f, 0.0f)).x;
         if(const ImGuiViewport* viewport = ImGui::GetMainViewport())
         {
             ImGui::SetNextWindowPos(viewport->GetCenter(), ImGuiCond_Appearing,
@@ -200,8 +200,8 @@ SshTestDialog::Render()
                     : (user.empty() ? std::string("?") : user) + "@" + host + ":" +
                           m_uri->GetRemotePortString();
 
-            constexpr float LABEL_WIDTH  = 132.0f;
-            constexpr float BUTTON_WIDTH = 118.0f;
+            constexpr float LABEL_WIDTH  = 104.0f;
+            constexpr float BUTTON_WIDTH = 104.0f;
 
             // Tighten the vertical gaps between the stacked panels.
             const ImVec2 default_item_spacing = style.ItemSpacing;
@@ -211,7 +211,7 @@ SshTestDialog::Render()
             ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
             ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
             ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(18.0f, 14.0f));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16.0f, 10.0f));
             ImGui::BeginChild("##remote_trace_header", ImVec2(0.0f, 0.0f),
                               ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                               ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
@@ -221,7 +221,7 @@ SshTestDialog::Render()
                 {
                     ImGui::TableSetupColumn("Title", ImGuiTableColumnFlags_WidthStretch);
                     ImGui::TableSetupColumn("Connection", ImGuiTableColumnFlags_WidthFixed,
-                                            248.0f);
+                                            210.0f);
                     ImGui::TableSetupColumn("Close", ImGuiTableColumnFlags_WidthFixed, 24.0f);
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
@@ -274,7 +274,7 @@ SshTestDialog::Render()
             ImGui::PopStyleColor(2);
 
             ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16.0f, 10.0f));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(12.0f, 4.0f));
             ImGui::BeginChild("##remote_trace_body", ImVec2(0.0f, 0.0f),
                               ImGuiChildFlags_AutoResizeY,
                               ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
@@ -283,7 +283,7 @@ SshTestDialog::Render()
                 ImGui::PushStyleColor(ImGuiCol_Border,
                                       settings.GetColor(Colors::kPanelBorderSubtle));
                 ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
-                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 12.0f));
+                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 8.0f));
                 ImGui::BeginChild("##remote_trace_target", ImVec2(0.0f, 0.0f),
                                   ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                                   ImGuiWindowFlags_NoScrollbar |
@@ -333,7 +333,7 @@ SshTestDialog::Render()
             bool open_clicked = false;
             ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
             ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(18.0f, 14.0f));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 8.0f));
             ImGui::BeginChild("##remote_trace_footer", ImVec2(0.0f, 0.0f),
                               ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                               ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);


### PR DESCRIPTION
Panels revamped:

- Remote Trace dialog (rocprofvis_ssh_test_dialog.cpp): header/body/footer layout, connection shown as a clickable header button that opens Configure (or 'Configure' when unset), auto-height window so there is no wasted vertical space, tighter panel spacing.

- SSH Connection Settings dialog (rocprofvis_ssh_settings_dialog.cpp): Profile / Connection / Authentication cards with a titled header (compass icon), aligned label+field rows, password and passphrase show toggles, sticky footer with Cancel/Save, auto-height (no scrollbar), draggable window, tighter panel spacing.
<img width="805" height="820" alt="image" src="https://github.com/user-attachments/assets/deb6dd1a-246f-45c1-8f71-00f05efaac69" />

<img width="1072" height="334" alt="image" src="https://github.com/user-attachments/assets/9478a23f-a8a0-468c-aec5-d909e0e90cdc" />



