### PR TITLE
Revamp the in-app profiler launcher UI/UX (rocprof-sys)

### DIFF
--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -22,30 +22,22 @@ namespace
 
 static char s_save_preset_name[128] = {};
 
-// Design tokens for the custom launcher widgets below.
-constexpr float kCardRounding      = 10.0f;
-constexpr float kCardPadX          = 16.0f;
-constexpr float kCardPadY          = 13.0f;
-constexpr float kCardGap           = 7.0f;   // vertical gap between stacked cards
-constexpr float kAccentBarWidth    = 4.0f;   // card-header leading bar
-constexpr float kAccentBarGap      = 8.0f;
-constexpr float kChipPadX          = 9.0f;
-constexpr float kChipPadY          = 3.0f;
-constexpr float kChipBgAlpha       = 0.16f;
-constexpr float kChipEdgeAlpha     = 0.55f;
-constexpr float kPillPadX          = 11.0f;
-constexpr float kPillPadY          = 4.0f;
-constexpr float kPillGap           = 7.0f;
-constexpr float kPillCloseScale    = 0.75f;  // close glyph size, fraction of font
-constexpr float kPillBgAlpha       = 0.16f;
-constexpr float kPillBgHoverAlpha  = 0.30f;
+// Color tints and intrinsic widget geometry only. Padding/spacing come from the
+// shared app style (GetDefaultStyle / frame padding) so the launcher matches the
+// rest of the application rather than inventing its own spacing rules.
+constexpr float kAccentBarWidth     = 4.0f;   // card-header leading accent bar
+constexpr float kAccentBarGap       = 8.0f;
+constexpr float kChipBgAlpha        = 0.16f;
+constexpr float kChipEdgeAlpha      = 0.55f;
+constexpr float kPillGap            = 7.0f;   // gap between pill label and close "x"
+constexpr float kPillCloseScale     = 0.75f;  // close glyph size, fraction of font
+constexpr float kPillBgAlpha        = 0.16f;
+constexpr float kPillBgHoverAlpha   = 0.30f;
 constexpr float kPillCloseIdleAlpha = 0.6f;
-constexpr float kStatusPillPadX    = 12.0f;
-constexpr float kStatusPillPadY    = 5.0f;
-constexpr float kToggleHeightScale = 0.82f;  // of frame height
-constexpr float kToggleWidthScale  = 1.75f;  // of toggle height
-constexpr float kToggleAnimSpeed   = 10.0f;
-constexpr float kToggleKnobInset   = 2.0f;   // knob padding inside the track
+constexpr float kToggleHeightScale  = 0.82f;  // of frame height
+constexpr float kToggleWidthScale   = 1.75f;  // of toggle height
+constexpr float kToggleAnimSpeed    = 10.0f;
+constexpr float kToggleKnobInset    = 2.0f;   // knob padding inside the track
 
 // Linear blend between two packed colors (t in [0,1]).
 ImU32 LerpColor(ImU32 a, ImU32 b, float t)
@@ -61,11 +53,12 @@ ImU32 LerpColor(ImU32 a, ImU32 b, float t)
 
 void BeginLaunchCard(const char* id)
 {
-    SettingsManager& settings = SettingsManager::Get();
+    SettingsManager&  settings = SettingsManager::Get();
+    const ImGuiStyle& def      = settings.GetDefaultStyle();
 
-    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, kCardRounding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, def.ChildRounding);
     ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(kCardPadX, kCardPadY));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, def.WindowPadding);
     ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
     ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
 
@@ -78,7 +71,7 @@ void EndLaunchCard()
     ImGui::EndChild();
     ImGui::PopStyleColor(2);
     ImGui::PopStyleVar(3);
-    ImGui::Dummy(ImVec2(0.0f, kCardGap));
+    ImGui::Dummy(ImVec2(0.0f, ImGui::GetStyle().ItemSpacing.y));
 }
 
 void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
@@ -128,34 +121,36 @@ void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
 
 void Chip(const char* label, ImU32 accent_color)
 {
-    ImVec2      text_size = ImGui::CalcTextSize(label);
-    ImVec2      p         = ImGui::GetCursorScreenPos();
-    ImVec2      size(text_size.x + kChipPadX * 2.0f, text_size.y + kChipPadY * 2.0f);
-    ImDrawList* dl  = ImGui::GetWindowDrawList();
-    float       rnd = size.y * 0.5f;
+    const ImVec2 pad       = ImGui::GetStyle().FramePadding;
+    ImVec2       text_size = ImGui::CalcTextSize(label);
+    ImVec2       p         = ImGui::GetCursorScreenPos();
+    ImVec2       size(text_size.x + pad.x * 2.0f, text_size.y + pad.y * 2.0f);
+    ImDrawList*  dl  = ImGui::GetWindowDrawList();
+    float        rnd = size.y * 0.5f;
 
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y),
                       ApplyAlpha(accent_color, kChipBgAlpha), rnd);
     dl->AddRect(p, ImVec2(p.x + size.x, p.y + size.y),
                 ApplyAlpha(accent_color, kChipEdgeAlpha), rnd);
-    dl->AddText(ImVec2(p.x + kChipPadX, p.y + kChipPadY), accent_color, label);
+    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), accent_color, label);
 
     ImGui::Dummy(size);
 }
 
 PillAction EditablePill(const char* label, ImU32 accent_color)
 {
+    const ImVec2 pad       = ImGui::GetStyle().FramePadding;
     const ImVec2 text_size = ImGui::CalcTextSize(label);
     const float  x_size    = ImGui::GetFontSize() * kPillCloseScale;
 
-    ImVec2 size(kPillPadX * 2.0f + text_size.x + kPillGap + x_size,
-                text_size.y + kPillPadY * 2.0f);
+    ImVec2 size(pad.x * 2.0f + text_size.x + kPillGap + x_size,
+                text_size.y + pad.y * 2.0f);
     ImVec2 p = ImGui::GetCursorScreenPos();
 
     ImGui::InvisibleButton(label, size);
     bool  hovered = ImGui::IsItemHovered();
     bool  clicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
-    float x_left  = p.x + size.x - kPillPadX - x_size;
+    float x_left  = p.x + size.x - pad.x - x_size;
     bool  over_x  = hovered && ImGui::GetIO().MousePos.x >= x_left;
 
     ImDrawList* dl  = ImGui::GetWindowDrawList();
@@ -163,7 +158,7 @@ PillAction EditablePill(const char* label, ImU32 accent_color)
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y),
                       ApplyAlpha(accent_color, hovered ? kPillBgHoverAlpha : kPillBgAlpha),
                       rnd);
-    dl->AddText(ImVec2(p.x + kPillPadX, p.y + kPillPadY), accent_color, label);
+    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), accent_color, label);
 
     // Trailing "x" - brightens when hovered so removal is obvious.
     ImVec2 xc(x_left + x_size * 0.5f, p.y + size.y * 0.5f);
@@ -197,9 +192,10 @@ void RenderConfigChips(const char* lead_label, std::vector<std::string> const& t
     ImGuiStyle&  style     = ImGui::GetStyle();
     const float  window_x2 = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
 
-    // Chip width matches Chip(): text width plus its horizontal padding.
-    auto chip_width = [](std::string const& s)
-    { return ImGui::CalcTextSize(s.c_str()).x + kChipPadX * 2.0f; };
+    // Chip width matches Chip(): text width plus its horizontal frame padding.
+    const float chip_pad_x = ImGui::GetStyle().FramePadding.x;
+    auto chip_width = [chip_pad_x](std::string const& s)
+    { return ImGui::CalcTextSize(s.c_str()).x + chip_pad_x * 2.0f; };
 
     ImGui::SameLine();
     for (size_t i = 0; i < tags.size(); i++)
@@ -219,16 +215,15 @@ void RenderConfigChips(const char* lead_label, std::vector<std::string> const& t
 
 void StatusPill(const char* label, ImU32 bg_color)
 {
-    ImVec2      text_size = ImGui::CalcTextSize(label);
-    ImVec2      p         = ImGui::GetCursorScreenPos();
-    ImVec2      size(text_size.x + kStatusPillPadX * 2.0f,
-                     text_size.y + kStatusPillPadY * 2.0f);
-    ImDrawList* dl  = ImGui::GetWindowDrawList();
-    float       rnd = size.y * 0.5f;
+    const ImVec2 pad       = ImGui::GetStyle().FramePadding;
+    ImVec2       text_size = ImGui::CalcTextSize(label);
+    ImVec2       p         = ImGui::GetCursorScreenPos();
+    ImVec2       size(text_size.x + pad.x * 2.0f, text_size.y + pad.y * 2.0f);
+    ImDrawList*  dl  = ImGui::GetWindowDrawList();
+    float        rnd = size.y * 0.5f;
 
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y), bg_color, rnd);
-    dl->AddText(ImVec2(p.x + kStatusPillPadX, p.y + kStatusPillPadY),
-                IM_COL32(255, 255, 255, 255), label);
+    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), IM_COL32(255, 255, 255, 255), label);
 
     ImGui::Dummy(size);
 }

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -39,6 +39,25 @@ constexpr float kToggleWidthScale   = 1.75f;  // of toggle height
 constexpr float kToggleAnimSpeed    = 10.0f;
 constexpr float kToggleKnobInset    = 2.0f;   // knob padding inside the track
 
+// Card interior vertical padding (horizontal padding still follows the app
+// style). Tighter than the app default so the stacked cards read as one compact
+// form instead of a column of tall panels.
+constexpr float kCardPadY = 5.0f;
+
+// A dimmed "(?)" that shows a wrapped tooltip on hover.
+void HelpTip(const char* tooltip)
+{
+    ImGui::SameLine();
+    ImGui::TextDisabled("(?)");
+    if (ImGui::BeginItemTooltip())
+    {
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 25.0f);
+        ImGui::TextUnformatted(tooltip);
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
+}
+
 // Linear blend between two packed colors (t in [0,1]).
 ImU32 LerpColor(ImU32 a, ImU32 b, float t)
 {
@@ -58,7 +77,7 @@ void BeginLaunchCard(const char* id)
 
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, def.ChildRounding);
     ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, def.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(def.WindowPadding.x, kCardPadY));
     ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
     ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
 
@@ -71,10 +90,10 @@ void EndLaunchCard()
     ImGui::EndChild();
     ImGui::PopStyleColor(2);
     ImGui::PopStyleVar(3);
-    ImGui::Dummy(ImVec2(0.0f, ImGui::GetStyle().ItemSpacing.y));
+    // Cards are separated by the surrounding item spacing only.
 }
 
-void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
+void LaunchCardHeader(const char* icon, const char* title, const char* help)
 {
     SettingsManager& settings = SettingsManager::Get();
     FontManager&     fonts    = settings.GetFontManager();
@@ -108,15 +127,11 @@ void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
     ImGui::PopStyleColor();
     ImGui::PopFont();
 
-    if (subtitle && subtitle[0])
+    if (help && help[0])
     {
-        ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
-        ImGui::TextUnformatted(subtitle);
-        ImGui::PopStyleColor();
+        HelpTip(help);
     }
     ImGui::Unindent(kAccentBarWidth + kAccentBarGap);
-
-    ImGui::Spacing();
 }
 
 void Chip(const char* label, ImU32 accent_color)
@@ -228,13 +243,17 @@ void StatusPill(const char* label, ImU32 bg_color)
     ImGui::Dummy(size);
 }
 
-void LaunchSubHeader(const char* text)
+void LaunchSubHeader(const char* text, const char* help)
 {
     SettingsManager& settings = SettingsManager::Get();
     ImGui::Spacing();
     ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kAccent));
     ImGui::TextUnformatted(text);
     ImGui::PopStyleColor();
+    if (help && help[0])
+    {
+        HelpTip(help);
+    }
 }
 
 bool ToggleSwitch(const char* label, bool* value)
@@ -474,10 +493,12 @@ void RenderCommandPreview(std::string const& preview_text)
     }
 
     // Monospaced, softly-rounded panel so the command reads like a terminal.
-    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.0f);
+    // Fills the remaining height of its container (the launcher's preview panel).
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding,
+                        settings.GetDefaultStyle().ChildRounding);
     ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
     ImGuiWindowFlags flags = ImGuiWindowFlags_HorizontalScrollbar;
-    ImGui::BeginChild("CmdPreview", ImVec2(0, 78), ImGuiChildFlags_Borders, flags);
+    ImGui::BeginChild("CmdPreview", ImVec2(0.0f, 0.0f), ImGuiChildFlags_Borders, flags);
     ImGui::PushFont(fonts.GetFont(FontType::kCode), 0.0f);
     ImGui::TextUnformatted(preview_text.c_str());
     ImGui::PopFont();

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -6,8 +6,10 @@
 #include "rocprofvis_gui_helpers.h"
 #include "rocprofvis_controller_enums.h"
 #include "rocprofvis_settings_manager.h"
+#include "rocprofvis_font_manager.h"
 #include "imgui.h"
 #include <algorithm>
+#include <cfloat>
 #include <sstream>
 #include <cstring>
 
@@ -18,75 +20,310 @@ namespace View
 namespace
 {
 
-static char s_target_exe_buf[512] = {};
-static char s_target_args_buf[512] = {};
-static char s_working_dir_buf[512] = {};
-static char s_output_dir_buf[512] = {};
-
-static char s_new_env_name[128] = {};
-static char s_new_env_value[256] = {};
-
 static char s_save_preset_name[128] = {};
 
-void SyncBufFromString(char* buf, size_t buf_size, std::string const& str)
+// Linear blend between two packed colors (t in [0,1]).
+ImU32 LerpColor(ImU32 a, ImU32 b, float t)
 {
-    std::snprintf(buf, buf_size, "%s", str.c_str());
+    ImVec4 av = ImGui::ColorConvertU32ToFloat4(a);
+    ImVec4 bv = ImGui::ColorConvertU32ToFloat4(b);
+    ImVec4 cv(av.x + (bv.x - av.x) * t, av.y + (bv.y - av.y) * t,
+              av.z + (bv.z - av.z) * t, av.w + (bv.w - av.w) * t);
+    return ImGui::ColorConvertFloat4ToU32(cv);
 }
 
 } // namespace
+
+void BeginLaunchCard(const char* id)
+{
+    SettingsManager& settings = SettingsManager::Get();
+
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(15.0f, 11.0f));
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
+    ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
+
+    ImGui::BeginChild(id, ImVec2(0.0f, 0.0f),
+                      ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders);
+}
+
+void EndLaunchCard()
+{
+    ImGui::EndChild();
+    ImGui::PopStyleColor(2);
+    ImGui::PopStyleVar(3);
+    ImGui::Spacing();
+    ImGui::Spacing();
+}
+
+void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
+{
+    SettingsManager& settings = SettingsManager::Get();
+    FontManager&     fonts    = settings.GetFontManager();
+
+    ImGui::PushFont(fonts.GetFont(FontType::kMainText),
+                    fonts.GetFontSize(FontSize::kMedLarge));
+
+    // Leading accent bar sized to the (larger) header text.
+    const float  bar_h = ImGui::GetFontSize();
+    const float  bar_w = 4.0f;
+    ImVec2       p     = ImGui::GetCursorScreenPos();
+    ImDrawList*  dl    = ImGui::GetWindowDrawList();
+    dl->AddRectFilled(ImVec2(p.x, p.y), ImVec2(p.x + bar_w, p.y + bar_h),
+                      settings.GetColor(Colors::kAccent), 2.0f);
+
+    ImGui::Indent(bar_w + 8.0f);
+
+    // Optional leading icon (drawn from the icon font, in the accent color).
+    if (icon && icon[0])
+    {
+        ImGui::PushFont(fonts.GetFont(FontType::kIcon),
+                        fonts.GetFontSize(FontSize::kMedLarge));
+        ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kAccent));
+        ImGui::TextUnformatted(icon);
+        ImGui::PopStyleColor();
+        ImGui::PopFont();
+        ImGui::SameLine(0.0f, 8.0f);
+    }
+
+    ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextMain));
+    ImGui::TextUnformatted(title);
+    ImGui::PopStyleColor();
+    ImGui::PopFont();
+
+    if (subtitle && subtitle[0])
+    {
+        ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
+        ImGui::TextUnformatted(subtitle);
+        ImGui::PopStyleColor();
+    }
+    ImGui::Unindent(bar_w + 8.0f);
+
+    ImGui::Spacing();
+}
+
+void Chip(const char* label, ImU32 accent_color)
+{
+    ImVec2      text_size = ImGui::CalcTextSize(label);
+    const ImVec2 pad(9.0f, 3.0f);
+    ImVec2      p    = ImGui::GetCursorScreenPos();
+    ImVec2      size(text_size.x + pad.x * 2.0f, text_size.y + pad.y * 2.0f);
+    ImDrawList* dl   = ImGui::GetWindowDrawList();
+    float       rnd  = size.y * 0.5f;
+
+    dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y),
+                      ApplyAlpha(accent_color, 0.16f), rnd);
+    dl->AddRect(p, ImVec2(p.x + size.x, p.y + size.y),
+                ApplyAlpha(accent_color, 0.55f), rnd);
+    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), accent_color, label);
+
+    ImGui::Dummy(size);
+}
+
+PillAction EditablePill(const char* label, ImU32 accent_color)
+{
+    const ImVec2 text_size = ImGui::CalcTextSize(label);
+    const float  pad_x     = 11.0f;
+    const float  pad_y     = 4.0f;
+    const float  gap       = 7.0f;
+    const float  x_size    = ImGui::GetFontSize() * 0.75f;
+
+    ImVec2 size(pad_x + text_size.x + gap + x_size + pad_x - 2.0f,
+                text_size.y + pad_y * 2.0f);
+    ImVec2 p = ImGui::GetCursorScreenPos();
+
+    ImGui::InvisibleButton(label, size);
+    bool  hovered   = ImGui::IsItemHovered();
+    bool  clicked   = ImGui::IsItemClicked(ImGuiMouseButton_Left);
+    float x_left    = p.x + size.x - pad_x - x_size;
+    bool  over_x    = hovered && ImGui::GetIO().MousePos.x >= x_left;
+
+    ImDrawList* dl  = ImGui::GetWindowDrawList();
+    float       rnd = size.y * 0.5f;
+    dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y),
+                      ApplyAlpha(accent_color, hovered ? 0.30f : 0.16f), rnd);
+    dl->AddText(ImVec2(p.x + pad_x, p.y + pad_y), accent_color, label);
+
+    // Trailing "x" - brightens when hovered so removal is obvious.
+    ImVec2 xc(x_left + x_size * 0.5f, p.y + size.y * 0.5f);
+    float  r    = x_size * 0.30f;
+    ImU32  xcol = ApplyAlpha(accent_color, over_x ? 1.0f : 0.6f);
+    dl->AddLine(ImVec2(xc.x - r, xc.y - r), ImVec2(xc.x + r, xc.y + r), xcol, 1.6f);
+    dl->AddLine(ImVec2(xc.x - r, xc.y + r), ImVec2(xc.x + r, xc.y - r), xcol, 1.6f);
+
+    if (clicked)
+    {
+        return over_x ? PillAction::kRemove : PillAction::kEdit;
+    }
+    return PillAction::kNone;
+}
+
+void RenderConfigChips(const char* lead_label, std::vector<std::string> const& tags)
+{
+    SettingsManager& settings = SettingsManager::Get();
+
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextDisabled("%s", lead_label);
+
+    if (tags.empty())
+    {
+        ImGui::SameLine();
+        ImGui::TextDisabled("nothing selected yet");
+        return;
+    }
+
+    const ImU32  accent    = settings.GetColor(Colors::kAccent);
+    ImGuiStyle&  style     = ImGui::GetStyle();
+    const float  window_x2 = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
+
+    // Chip padding matches Chip(): text width + 2*9px horizontal padding.
+    auto chip_width = [](std::string const& s)
+    { return ImGui::CalcTextSize(s.c_str()).x + 18.0f; };
+
+    ImGui::SameLine();
+    for (size_t i = 0; i < tags.size(); i++)
+    {
+        Chip(tags[i].c_str(), accent);
+        if (i + 1 < tags.size())
+        {
+            float last_x2 = ImGui::GetItemRectMax().x;
+            float next_x2 = last_x2 + style.ItemSpacing.x + chip_width(tags[i + 1]);
+            if (next_x2 < window_x2)
+            {
+                ImGui::SameLine();
+            }
+        }
+    }
+}
+
+void StatusPill(const char* label, ImU32 bg_color)
+{
+    ImVec2       text_size = ImGui::CalcTextSize(label);
+    const ImVec2 pad(12.0f, 5.0f);
+    ImVec2       p    = ImGui::GetCursorScreenPos();
+    ImVec2       size(text_size.x + pad.x * 2.0f, text_size.y + pad.y * 2.0f);
+    ImDrawList*  dl   = ImGui::GetWindowDrawList();
+    float        rnd  = size.y * 0.5f;
+
+    dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y), bg_color, rnd);
+    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), IM_COL32(255, 255, 255, 255), label);
+
+    ImGui::Dummy(size);
+}
+
+void LaunchSubHeader(const char* text)
+{
+    SettingsManager& settings = SettingsManager::Get();
+    ImGui::Spacing();
+    ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kAccent));
+    ImGui::TextUnformatted(text);
+    ImGui::PopStyleColor();
+}
+
+bool ToggleSwitch(const char* label, bool* value)
+{
+    SettingsManager& settings = SettingsManager::Get();
+
+    const float frame_h = ImGui::GetFrameHeight();
+    const float height  = frame_h * 0.82f;
+    const float width   = height * 1.75f;
+    const float radius  = height * 0.5f;
+
+    ImGui::PushID(label);
+    ImVec2 p = ImGui::GetCursorScreenPos();
+    ImGui::InvisibleButton("##switch", ImVec2(width, frame_h));
+
+    bool hovered = ImGui::IsItemHovered();
+    bool changed = false;
+    if (ImGui::IsItemClicked())
+    {
+        *value  = !*value;
+        changed = true;
+    }
+
+    // Smoothly animate the knob/fill between states.
+    ImGuiID       id      = ImGui::GetItemID();
+    ImGuiStorage* storage = ImGui::GetStateStorage();
+    float         target  = *value ? 1.0f : 0.0f;
+    float         t       = storage->GetFloat(id, target);
+    float         step    = ImGui::GetIO().DeltaTime * 10.0f;
+    if (t < target) { t = std::min(t + step, target); }
+    else if (t > target) { t = std::max(t - step, target); }
+    storage->SetFloat(id, t);
+
+    const float y_off = (frame_h - height) * 0.5f;
+    ImVec2      bar_min(p.x, p.y + y_off);
+    ImVec2      bar_max(p.x + width, p.y + y_off + height);
+
+    ImU32 off_col = settings.GetColor(Colors::kBorderGray);
+    ImU32 on_col  = settings.GetColor(hovered ? Colors::kAccentHover : Colors::kAccent);
+    ImU32 bar_col = LerpColor(off_col, on_col, t);
+
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+    dl->AddRectFilled(bar_min, bar_max, bar_col, radius);
+
+    float  knob_x = bar_min.x + radius + t * (width - 2.0f * radius);
+    ImVec2 knob_c(knob_x, bar_min.y + radius);
+    dl->AddCircleFilled(knob_c, radius - 2.0f, IM_COL32(255, 255, 255, 255));
+
+    ImGui::PopID();
+
+    if (label && label[0] && label[0] != '#')
+    {
+        ImGui::SameLine();
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted(label);
+    }
+
+    return changed;
+}
 
 bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindow* app_window)
 {
     bool modified = false;
 
-    // In remote (SSH) mode the executable / directories refer to paths on the
-    // remote host, so the local file/path Browse pickers don't apply (a remote
-    // file browser may re-enable them later).
+    // In remote (SSH) mode the executable / output refer to paths on the remote
+    // host, so the local file/path Browse pickers don't apply (a remote file
+    // browser may re-enable them later).
     const bool is_remote = (connection == ConnectionType::kSsh);
 
-    // Always sync buffers from target when target changed externally (e.g. preset load)
-    if (target.executable != s_target_exe_buf)
-    {
-        SyncBufFromString(s_target_exe_buf, sizeof(s_target_exe_buf), target.executable);
-    }
-    if (target.arguments != s_target_args_buf)
-    {
-        SyncBufFromString(s_target_args_buf, sizeof(s_target_args_buf), target.arguments);
-    }
-    if (target.working_directory != s_working_dir_buf)
-    {
-        SyncBufFromString(s_working_dir_buf, sizeof(s_working_dir_buf), target.working_directory);
-    }
-    if (target.output_directory != s_output_dir_buf)
-    {
-        SyncBufFromString(s_output_dir_buf, sizeof(s_output_dir_buf), target.output_directory);
-    }
+    SettingsManager&  settings      = SettingsManager::Get();
+    ProfilerSettings& prof_settings = settings.GetProfilerSettings();
 
-    ImGui::Text(is_remote ? "Remote Target Executable:" : "Target Executable:");
-    if (ImGui::InputText("##TargetExe", s_target_exe_buf, sizeof(s_target_exe_buf)))
+    const float label_w  = 90.0f;
+    const float browse_w = 84.0f;
+    const float spacing  = ImGui::GetStyle().ItemSpacing.x;
+    const float arrow_w  = ImGui::GetFrameHeight();
+
+    // --- Executable (the headline field) --------------------------------------
+    const bool has_recent = (!is_remote && !prof_settings.recent_targets.empty());
+
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Program");
+    ImGui::SameLine(label_w);
+
+    float exe_trailing = browse_w + spacing + (has_recent ? (arrow_w + spacing) : 0.0f);
+    ImGui::SetNextItemWidth(-exe_trailing);
+    if (InputTextStringWithHint(
+            "##TargetExe",
+            is_remote ? "/remote/path/to/app" : "/path/to/app  (or a name on $PATH)",
+            target.executable))
     {
-        target.executable = s_target_exe_buf;
         modified = true;
     }
 
-    // Local file picker - disabled for remote targets until remote browsing exists.
     ImGui::SameLine();
     if (is_remote) ImGui::BeginDisabled();
-    if (ImGui::Button("Browse##TargetExe") && app_window)
+    if (ImGui::Button("Browse##TargetExe", ImVec2(browse_w, 0)) && app_window)
     {
         app_window->ShowOpenFileDialog(
-            "Choose Target Executable", {}, "",
-            [&target](std::string const& path)
-            {
-                target.executable = path;
-                SyncBufFromString(s_target_exe_buf, sizeof(s_target_exe_buf), path);
-            });
+            "Choose Program", {}, "",
+            [&target](std::string const& path) { target.executable = path; });
     }
     if (is_remote) ImGui::EndDisabled();
 
-    SettingsManager& settings = SettingsManager::Get();
-    ProfilerSettings& prof_settings = settings.GetProfilerSettings();
-    if (!is_remote && !prof_settings.recent_targets.empty())
+    if (has_recent)
     {
         ImGui::SameLine();
         if (ImGui::ArrowButton("##RecentTargetExe", ImGuiDir_Down))
@@ -95,22 +332,21 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
         }
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("Choose a recent target executable");
+            ImGui::SetTooltip("Recent programs");
         }
         if (ImGui::BeginPopup("RecentTargetsPopup"))
         {
             for (auto const& t : prof_settings.recent_targets)
             {
                 std::string short_name = t;
-                if (short_name.size() > 25)
+                if (short_name.size() > 48)
                 {
-                    short_name = "..." + short_name.substr(short_name.size() - 22);
+                    short_name = "..." + short_name.substr(short_name.size() - 45);
                 }
                 if (ImGui::Selectable(short_name.c_str(), false))
                 {
                     target.executable = t;
-                    SyncBufFromString(s_target_exe_buf, sizeof(s_target_exe_buf), t);
-                    modified = true;
+                    modified          = true;
                 }
                 if (ImGui::IsItemHovered())
                 {
@@ -121,142 +357,47 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
         }
     }
 
-    ImGui::Text("Target Arguments:");
-    if (ImGui::InputText("##TargetArgs", s_target_args_buf, sizeof(s_target_args_buf)))
+    // --- Arguments (free-form, passed verbatim to the program) ----------------
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Arguments");
+    ImGui::SameLine(label_w);
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    if (InputTextStringWithHint(
+            "##TargetArgs", "e.g.  --iterations 100 --input data.bin", target.arguments))
     {
-        target.arguments = s_target_args_buf;
         modified = true;
     }
 
-    ImGui::Text("Working Directory:");
-    if (ImGui::InputText("##WorkDir", s_working_dir_buf, sizeof(s_working_dir_buf)))
+    // --- Output folder (where the profiler writes the trace) ------------------
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Output");
+    ImGui::SameLine(label_w);
+    ImGui::SetNextItemWidth(-(browse_w + spacing));
+    if (InputTextStringWithHint(
+            "##OutputDir",
+            is_remote ? "remote folder for results" : "folder for results",
+            target.output_directory))
     {
-        target.working_directory = s_working_dir_buf;
         modified = true;
     }
-
-    ImGui::Text(is_remote ? "Remote Output Directory:" : "Output Directory:");
-    if (ImGui::InputText("##OutputDir", s_output_dir_buf, sizeof(s_output_dir_buf)))
-    {
-        target.output_directory = s_output_dir_buf;
-        modified = true;
-    }
-    // Local path picker - disabled for remote targets until remote browsing exists.
     ImGui::SameLine();
     if (is_remote) ImGui::BeginDisabled();
-    if (ImGui::Button("Browse##OutputDir") && app_window)
+    if (ImGui::Button("Browse##OutputDir", ImVec2(browse_w, 0)) && app_window)
     {
         app_window->ShowPathPickerDialog(
             "Choose Output Directory", "",
-            [&target](std::string const& path)
-            {
-                target.output_directory = path;
-                SyncBufFromString(s_output_dir_buf, sizeof(s_output_dir_buf), path);
-            });
+            [&target](std::string const& path) { target.output_directory = path; });
     }
     if (is_remote) ImGui::EndDisabled();
 
-    ImGui::Checkbox("Open trace when profiling completes", &target.auto_load_trace);
+    ImGui::Spacing();
+    if (ImGui::Checkbox("Open the trace automatically when profiling finishes",
+                        &target.auto_load_trace))
+    {
+        modified = true;
+    }
 
     return modified;
-}
-
-void RenderRawEnvVarsTab(std::map<std::string, std::string>& extra_env,
-                         std::vector<std::pair<std::string, std::string>> const& curated_env)
-{
-    ImGui::Text("Additional environment variables passed to the profiler process.");
-    ImGui::Separator();
-
-    // Table of existing entries
-    std::string key_to_remove;
-
-    if (ImGui::BeginTable("EnvVars", 3, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
-                          ImGuiTableFlags_Resizable))
-    {
-        ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthFixed, 200.0f);
-        ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
-        ImGui::TableSetupColumn("##Actions", ImGuiTableColumnFlags_WidthFixed, 60.0f);
-        ImGui::TableHeadersRow();
-
-        for (auto& kv : extra_env)
-        {
-            ImGui::TableNextRow();
-            ImGui::TableSetColumnIndex(0);
-
-            // Check if this shadows a curated env var
-            bool shadows_curated = false;
-            for (auto const& ce : curated_env)
-            {
-                if (ce.first == kv.first)
-                {
-                    shadows_curated = true;
-                    break;
-                }
-            }
-
-            if (shadows_curated)
-            {
-                ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "%s", kv.first.c_str());
-                if (ImGui::IsItemHovered())
-                {
-                    ImGui::SetTooltip("Overrides a curated setting above");
-                }
-            }
-            else
-            {
-                ImGui::TextUnformatted(kv.first.c_str());
-            }
-
-            ImGui::TableSetColumnIndex(1);
-            char val_buf[512];
-            std::snprintf(val_buf, sizeof(val_buf), "%s", kv.second.c_str());
-            std::string input_id = "##env_val_" + kv.first;
-            ImGui::PushItemWidth(-1);
-            if (ImGui::InputText(input_id.c_str(), val_buf, sizeof(val_buf)))
-            {
-                kv.second = val_buf;
-            }
-            ImGui::PopItemWidth();
-
-            ImGui::TableSetColumnIndex(2);
-            std::string rm_id = "X##rm_" + kv.first;
-            if (ImGui::SmallButton(rm_id.c_str()))
-            {
-                key_to_remove = kv.first;
-            }
-        }
-
-        ImGui::EndTable();
-    }
-
-    if (!key_to_remove.empty())
-    {
-        extra_env.erase(key_to_remove);
-    }
-
-    // Add new entry
-    ImGui::Separator();
-    ImGui::Text("Add:");
-    ImGui::SameLine();
-    ImGui::PushItemWidth(180);
-    ImGui::InputText("##NewEnvName", s_new_env_name, sizeof(s_new_env_name));
-    ImGui::PopItemWidth();
-    ImGui::SameLine();
-    ImGui::Text("=");
-    ImGui::SameLine();
-    ImGui::PushItemWidth(200);
-    ImGui::InputText("##NewEnvValue", s_new_env_value, sizeof(s_new_env_value));
-    ImGui::PopItemWidth();
-    ImGui::SameLine();
-    if (ImGui::Button("+##AddEnv"))
-    {
-        if (std::strlen(s_new_env_name) > 0)
-        {
-            extra_env[s_new_env_name] = s_new_env_value;
-            s_new_env_name[0] = '\0';
-            s_new_env_value[0] = '\0';
-        }
-    }
 }
 
 std::string BuildCommandPreviewString(
@@ -305,20 +446,28 @@ std::string BuildCommandPreviewString(
 
 void RenderCommandPreview(std::string const& preview_text)
 {
-    ImGui::AlignTextToFramePadding();
-    ImGui::Text("Command Preview");
-    VerticalSeparator();
+    SettingsManager& settings = SettingsManager::Get();
+    FontManager&     fonts    = settings.GetFontManager();
 
-    if (ImGui::Button("Copy Command##CmdPreview"))
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Command Preview");
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Copy##CmdPreview"))
     {
         ImGui::SetClipboardText(preview_text.c_str());
     }
-    ImGui::Separator();
 
+    // Monospaced, softly-rounded panel so the command reads like a terminal.
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.0f);
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
     ImGuiWindowFlags flags = ImGuiWindowFlags_HorizontalScrollbar;
-    ImGui::BeginChild("CmdPreview", ImVec2(0, 80), ImGuiChildFlags_Borders, flags);
+    ImGui::BeginChild("CmdPreview", ImVec2(0, 78), ImGuiChildFlags_Borders, flags);
+    ImGui::PushFont(fonts.GetFont(FontType::kCode), 0.0f);
     ImGui::TextUnformatted(preview_text.c_str());
+    ImGui::PopFont();
     ImGui::EndChild();
+    ImGui::PopStyleColor();
+    ImGui::PopStyleVar();
 }
 
 bool RenderOutputConsole(
@@ -380,13 +529,21 @@ bool RenderOutputConsole(
     VerticalSeparator();
     ImGui::Checkbox("Auto-scroll##Output", &auto_scroll);
 
+    FontManager&     fonts       = settings.GetFontManager();
     ImGuiWindowFlags output_flags = ImGuiWindowFlags_HorizontalScrollbar;
     float output_height = std::max(ImGui::GetContentRegionAvail().y - 30.0f, 60.0f);
-    ImGui::BeginChild("OutputText", ImVec2(0, output_height), true, output_flags);
+
+    // Terminal-style panel: darker background, soft corners, monospaced text.
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.0f);
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
+    ImGui::BeginChild("OutputText", ImVec2(0, output_height), ImGuiChildFlags_Borders,
+                      output_flags);
+    ImGui::PushFont(fonts.GetFont(FontType::kCode), 0.0f);
 
     if (!error_message.empty())
     {
-        ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "%s", error_message.c_str());
+        ImVec4 err = ImGui::ColorConvertU32ToFloat4(settings.GetColor(Colors::kTextError));
+        ImGui::TextColored(err, "%s", error_message.c_str());
         ImGui::Separator();
     }
 
@@ -397,7 +554,10 @@ bool RenderOutputConsole(
         ImGui::SetScrollHereY(1.0f);
     }
 
+    ImGui::PopFont();
     ImGui::EndChild();
+    ImGui::PopStyleColor();
+    ImGui::PopStyleVar();
 
     return clear_requested;
 }
@@ -414,14 +574,16 @@ std::string RenderSavedProfileBar(
 
     std::vector<PresetInfo> presets = preset_mgr.ListPresets(profiler_id);
 
-    ImGui::Text("Saved Profile:");
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Profile");
     ImGui::SameLine();
 
-    // Combo for selecting preset
-    ImGui::PushItemWidth(150);
-    if (ImGui::BeginCombo("##PresetCombo", current_preset_name.empty() ? "(none)" : current_preset_name.c_str()))
+    // Combo for selecting a saved profile.
+    ImGui::PushItemWidth(170);
+    if (ImGui::BeginCombo("##PresetCombo",
+                          current_preset_name.empty() ? "Unsaved" : current_preset_name.c_str()))
     {
-        if (ImGui::Selectable("(none)", current_preset_name.empty()))
+        if (ImGui::Selectable("Unsaved", current_preset_name.empty()))
         {
             current_preset_name.clear();
         }
@@ -430,7 +592,7 @@ std::string RenderSavedProfileBar(
             bool selected = (p.name == current_preset_name);
             if (ImGui::Selectable(p.name.c_str(), selected))
             {
-                load_name = p.name;
+                load_name           = p.name;
                 current_preset_name = p.name;
             }
         }
@@ -450,48 +612,66 @@ std::string RenderSavedProfileBar(
             ImGui::OpenPopup("SavePresetPopup");
         }
     }
-
-    ImGui::SameLine();
-    if (ImGui::Button("Save As...##Preset"))
+    if (ImGui::IsItemHovered())
     {
-        ImGui::OpenPopup("SavePresetPopup");
+        ImGui::SetTooltip(current_preset_name.empty()
+                              ? "Save these settings as a named profile"
+                              : "Update the selected profile");
     }
 
+    // Overflow menu keeps the less-common actions out of the toolbar.
     ImGui::SameLine();
-    if (ImGui::Button("Delete##Preset"))
+    if (ImGui::Button("More...##Preset"))
     {
-        if (!current_preset_name.empty())
+        ImGui::OpenPopup("ProfileMenu");
+    }
+
+    bool open_save_as = false;
+    bool do_reset     = false;
+    if (ImGui::BeginPopup("ProfileMenu"))
+    {
+        if (ImGui::MenuItem("Save As New Profile..."))
+        {
+            open_save_as = true;
+        }
+        if (ImGui::MenuItem("Delete Profile", nullptr, false,
+                            !current_preset_name.empty()))
         {
             preset_mgr.DeletePreset(current_preset_name, profiler_id);
             current_preset_name.clear();
         }
+        ImGui::Separator();
+        if (ImGui::MenuItem("Reset Options to Defaults"))
+        {
+            do_reset = true;
+        }
+        ImGui::EndPopup();
     }
 
-    ImGui::SameLine();
-    if (ImGui::Button("Reset Overrides"))
+    if (open_save_as)
     {
-        if (backend)
-        {
-            // Reset backend settings to defaults while keeping the
-            // selected rocprof-sys preset and target intact.
-            const_cast<IProfilerBackend*>(backend)->LoadSettings(jt::Json());
-            config.backend_payload = backend->SaveSettings();
-            config.extra_env.clear();
-            config.extra_argv.clear();
-        }
+        ImGui::OpenPopup("SavePresetPopup");
     }
-    if (ImGui::IsItemHovered())
+    if (do_reset && backend)
     {
-        ImGui::SetTooltip("Clear all override settings to defaults. "
-                          "Keeps the selected preset and target.");
+        // Reset backend settings to defaults while keeping the selected profile
+        // name and target intact.
+        const_cast<IProfilerBackend*>(backend)->LoadSettings(jt::Json());
+        config.backend_payload = backend->SaveSettings();
+        config.extra_env.clear();
+        config.extra_argv.clear();
     }
 
     // Save-As popup
     if (ImGui::BeginPopup("SavePresetPopup"))
     {
-        ImGui::Text("Preset name:");
-        ImGui::InputText("##SaveName", s_save_preset_name, sizeof(s_save_preset_name));
-        if (ImGui::Button("OK##SavePreset") && std::strlen(s_save_preset_name) > 0)
+        ImGui::TextUnformatted("Profile name:");
+        ImGui::SetNextItemWidth(240.0f);
+        bool commit = ImGui::InputText("##SaveName", s_save_preset_name,
+                                       sizeof(s_save_preset_name),
+                                       ImGuiInputTextFlags_EnterReturnsTrue);
+        if ((ImGui::Button("Save##SavePreset") || commit) &&
+            std::strlen(s_save_preset_name) > 0)
         {
             current_preset_name = s_save_preset_name;
             preset_mgr.SavePreset(current_preset_name, config, backend);

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -22,6 +22,31 @@ namespace
 
 static char s_save_preset_name[128] = {};
 
+// Design tokens for the custom launcher widgets below.
+constexpr float kCardRounding      = 10.0f;
+constexpr float kCardPadX          = 16.0f;
+constexpr float kCardPadY          = 13.0f;
+constexpr float kCardGap           = 7.0f;   // vertical gap between stacked cards
+constexpr float kAccentBarWidth    = 4.0f;   // card-header leading bar
+constexpr float kAccentBarGap      = 8.0f;
+constexpr float kChipPadX          = 9.0f;
+constexpr float kChipPadY          = 3.0f;
+constexpr float kChipBgAlpha       = 0.16f;
+constexpr float kChipEdgeAlpha     = 0.55f;
+constexpr float kPillPadX          = 11.0f;
+constexpr float kPillPadY          = 4.0f;
+constexpr float kPillGap           = 7.0f;
+constexpr float kPillCloseScale    = 0.75f;  // close glyph size, fraction of font
+constexpr float kPillBgAlpha       = 0.16f;
+constexpr float kPillBgHoverAlpha  = 0.30f;
+constexpr float kPillCloseIdleAlpha = 0.6f;
+constexpr float kStatusPillPadX    = 12.0f;
+constexpr float kStatusPillPadY    = 5.0f;
+constexpr float kToggleHeightScale = 0.82f;  // of frame height
+constexpr float kToggleWidthScale  = 1.75f;  // of toggle height
+constexpr float kToggleAnimSpeed   = 10.0f;
+constexpr float kToggleKnobInset   = 2.0f;   // knob padding inside the track
+
 // Linear blend between two packed colors (t in [0,1]).
 ImU32 LerpColor(ImU32 a, ImU32 b, float t)
 {
@@ -38,9 +63,9 @@ void BeginLaunchCard(const char* id)
 {
     SettingsManager& settings = SettingsManager::Get();
 
-    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, kCardRounding);
     ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, 1.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(15.0f, 11.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(kCardPadX, kCardPadY));
     ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
     ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
 
@@ -53,8 +78,7 @@ void EndLaunchCard()
     ImGui::EndChild();
     ImGui::PopStyleColor(2);
     ImGui::PopStyleVar(3);
-    ImGui::Spacing();
-    ImGui::Spacing();
+    ImGui::Dummy(ImVec2(0.0f, kCardGap));
 }
 
 void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
@@ -67,13 +91,12 @@ void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
 
     // Leading accent bar sized to the (larger) header text.
     const float  bar_h = ImGui::GetFontSize();
-    const float  bar_w = 4.0f;
     ImVec2       p     = ImGui::GetCursorScreenPos();
     ImDrawList*  dl    = ImGui::GetWindowDrawList();
-    dl->AddRectFilled(ImVec2(p.x, p.y), ImVec2(p.x + bar_w, p.y + bar_h),
+    dl->AddRectFilled(ImVec2(p.x, p.y), ImVec2(p.x + kAccentBarWidth, p.y + bar_h),
                       settings.GetColor(Colors::kAccent), 2.0f);
 
-    ImGui::Indent(bar_w + 8.0f);
+    ImGui::Indent(kAccentBarWidth + kAccentBarGap);
 
     // Optional leading icon (drawn from the icon font, in the accent color).
     if (icon && icon[0])
@@ -84,7 +107,7 @@ void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
         ImGui::TextUnformatted(icon);
         ImGui::PopStyleColor();
         ImGui::PopFont();
-        ImGui::SameLine(0.0f, 8.0f);
+        ImGui::SameLine(0.0f, kAccentBarGap);
     }
 
     ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextMain));
@@ -98,7 +121,7 @@ void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
         ImGui::TextUnformatted(subtitle);
         ImGui::PopStyleColor();
     }
-    ImGui::Unindent(bar_w + 8.0f);
+    ImGui::Unindent(kAccentBarWidth + kAccentBarGap);
 
     ImGui::Spacing();
 }
@@ -106,17 +129,16 @@ void LaunchCardHeader(const char* icon, const char* title, const char* subtitle)
 void Chip(const char* label, ImU32 accent_color)
 {
     ImVec2      text_size = ImGui::CalcTextSize(label);
-    const ImVec2 pad(9.0f, 3.0f);
-    ImVec2      p    = ImGui::GetCursorScreenPos();
-    ImVec2      size(text_size.x + pad.x * 2.0f, text_size.y + pad.y * 2.0f);
-    ImDrawList* dl   = ImGui::GetWindowDrawList();
-    float       rnd  = size.y * 0.5f;
+    ImVec2      p         = ImGui::GetCursorScreenPos();
+    ImVec2      size(text_size.x + kChipPadX * 2.0f, text_size.y + kChipPadY * 2.0f);
+    ImDrawList* dl  = ImGui::GetWindowDrawList();
+    float       rnd = size.y * 0.5f;
 
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y),
-                      ApplyAlpha(accent_color, 0.16f), rnd);
+                      ApplyAlpha(accent_color, kChipBgAlpha), rnd);
     dl->AddRect(p, ImVec2(p.x + size.x, p.y + size.y),
-                ApplyAlpha(accent_color, 0.55f), rnd);
-    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), accent_color, label);
+                ApplyAlpha(accent_color, kChipEdgeAlpha), rnd);
+    dl->AddText(ImVec2(p.x + kChipPadX, p.y + kChipPadY), accent_color, label);
 
     ImGui::Dummy(size);
 }
@@ -124,33 +146,31 @@ void Chip(const char* label, ImU32 accent_color)
 PillAction EditablePill(const char* label, ImU32 accent_color)
 {
     const ImVec2 text_size = ImGui::CalcTextSize(label);
-    const float  pad_x     = 11.0f;
-    const float  pad_y     = 4.0f;
-    const float  gap       = 7.0f;
-    const float  x_size    = ImGui::GetFontSize() * 0.75f;
+    const float  x_size    = ImGui::GetFontSize() * kPillCloseScale;
 
-    ImVec2 size(pad_x + text_size.x + gap + x_size + pad_x - 2.0f,
-                text_size.y + pad_y * 2.0f);
+    ImVec2 size(kPillPadX * 2.0f + text_size.x + kPillGap + x_size,
+                text_size.y + kPillPadY * 2.0f);
     ImVec2 p = ImGui::GetCursorScreenPos();
 
     ImGui::InvisibleButton(label, size);
-    bool  hovered   = ImGui::IsItemHovered();
-    bool  clicked   = ImGui::IsItemClicked(ImGuiMouseButton_Left);
-    float x_left    = p.x + size.x - pad_x - x_size;
-    bool  over_x    = hovered && ImGui::GetIO().MousePos.x >= x_left;
+    bool  hovered = ImGui::IsItemHovered();
+    bool  clicked = ImGui::IsItemClicked(ImGuiMouseButton_Left);
+    float x_left  = p.x + size.x - kPillPadX - x_size;
+    bool  over_x  = hovered && ImGui::GetIO().MousePos.x >= x_left;
 
     ImDrawList* dl  = ImGui::GetWindowDrawList();
     float       rnd = size.y * 0.5f;
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y),
-                      ApplyAlpha(accent_color, hovered ? 0.30f : 0.16f), rnd);
-    dl->AddText(ImVec2(p.x + pad_x, p.y + pad_y), accent_color, label);
+                      ApplyAlpha(accent_color, hovered ? kPillBgHoverAlpha : kPillBgAlpha),
+                      rnd);
+    dl->AddText(ImVec2(p.x + kPillPadX, p.y + kPillPadY), accent_color, label);
 
     // Trailing "x" - brightens when hovered so removal is obvious.
     ImVec2 xc(x_left + x_size * 0.5f, p.y + size.y * 0.5f);
-    float  r    = x_size * 0.30f;
-    ImU32  xcol = ApplyAlpha(accent_color, over_x ? 1.0f : 0.6f);
-    dl->AddLine(ImVec2(xc.x - r, xc.y - r), ImVec2(xc.x + r, xc.y + r), xcol, 1.6f);
-    dl->AddLine(ImVec2(xc.x - r, xc.y + r), ImVec2(xc.x + r, xc.y - r), xcol, 1.6f);
+    float  arm  = x_size * 0.3f;
+    ImU32  xcol = ApplyAlpha(accent_color, over_x ? 1.0f : kPillCloseIdleAlpha);
+    dl->AddLine(ImVec2(xc.x - arm, xc.y - arm), ImVec2(xc.x + arm, xc.y + arm), xcol, 1.6f);
+    dl->AddLine(ImVec2(xc.x - arm, xc.y + arm), ImVec2(xc.x + arm, xc.y - arm), xcol, 1.6f);
 
     if (clicked)
     {
@@ -177,9 +197,9 @@ void RenderConfigChips(const char* lead_label, std::vector<std::string> const& t
     ImGuiStyle&  style     = ImGui::GetStyle();
     const float  window_x2 = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
 
-    // Chip padding matches Chip(): text width + 2*9px horizontal padding.
+    // Chip width matches Chip(): text width plus its horizontal padding.
     auto chip_width = [](std::string const& s)
-    { return ImGui::CalcTextSize(s.c_str()).x + 18.0f; };
+    { return ImGui::CalcTextSize(s.c_str()).x + kChipPadX * 2.0f; };
 
     ImGui::SameLine();
     for (size_t i = 0; i < tags.size(); i++)
@@ -199,15 +219,16 @@ void RenderConfigChips(const char* lead_label, std::vector<std::string> const& t
 
 void StatusPill(const char* label, ImU32 bg_color)
 {
-    ImVec2       text_size = ImGui::CalcTextSize(label);
-    const ImVec2 pad(12.0f, 5.0f);
-    ImVec2       p    = ImGui::GetCursorScreenPos();
-    ImVec2       size(text_size.x + pad.x * 2.0f, text_size.y + pad.y * 2.0f);
-    ImDrawList*  dl   = ImGui::GetWindowDrawList();
-    float        rnd  = size.y * 0.5f;
+    ImVec2      text_size = ImGui::CalcTextSize(label);
+    ImVec2      p         = ImGui::GetCursorScreenPos();
+    ImVec2      size(text_size.x + kStatusPillPadX * 2.0f,
+                     text_size.y + kStatusPillPadY * 2.0f);
+    ImDrawList* dl  = ImGui::GetWindowDrawList();
+    float       rnd = size.y * 0.5f;
 
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y), bg_color, rnd);
-    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), IM_COL32(255, 255, 255, 255), label);
+    dl->AddText(ImVec2(p.x + kStatusPillPadX, p.y + kStatusPillPadY),
+                IM_COL32(255, 255, 255, 255), label);
 
     ImGui::Dummy(size);
 }
@@ -226,8 +247,8 @@ bool ToggleSwitch(const char* label, bool* value)
     SettingsManager& settings = SettingsManager::Get();
 
     const float frame_h = ImGui::GetFrameHeight();
-    const float height  = frame_h * 0.82f;
-    const float width   = height * 1.75f;
+    const float height  = frame_h * kToggleHeightScale;
+    const float width   = height * kToggleWidthScale;
     const float radius  = height * 0.5f;
 
     ImGui::PushID(label);
@@ -242,12 +263,12 @@ bool ToggleSwitch(const char* label, bool* value)
         changed = true;
     }
 
-    // Smoothly animate the knob/fill between states.
+    // Animate the knob/fill between states.
     ImGuiID       id      = ImGui::GetItemID();
     ImGuiStorage* storage = ImGui::GetStateStorage();
     float         target  = *value ? 1.0f : 0.0f;
     float         t       = storage->GetFloat(id, target);
-    float         step    = ImGui::GetIO().DeltaTime * 10.0f;
+    float         step    = ImGui::GetIO().DeltaTime * kToggleAnimSpeed;
     if (t < target) { t = std::min(t + step, target); }
     else if (t > target) { t = std::max(t - step, target); }
     storage->SetFloat(id, t);
@@ -265,7 +286,7 @@ bool ToggleSwitch(const char* label, bool* value)
 
     float  knob_x = bar_min.x + radius + t * (width - 2.0f * radius);
     ImVec2 knob_c(knob_x, bar_min.y + radius);
-    dl->AddCircleFilled(knob_c, radius - 2.0f, IM_COL32(255, 255, 255, 255));
+    dl->AddCircleFilled(knob_c, radius - kToggleKnobInset, IM_COL32(255, 255, 255, 255));
 
     ImGui::PopID();
 
@@ -291,7 +312,7 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
     SettingsManager&  settings      = SettingsManager::Get();
     ProfilerSettings& prof_settings = settings.GetProfilerSettings();
 
-    const float label_w  = 90.0f;
+    const float label_w  = 105.0f;
     const float browse_w = 84.0f;
     const float spacing  = ImGui::GetStyle().ItemSpacing.x;
     const float arrow_w  = ImGui::GetFrameHeight();
@@ -370,7 +391,7 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
 
     // --- Output folder (where the profiler writes the trace) ------------------
     ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Output");
+    ImGui::TextUnformatted("Output folder");
     ImGui::SameLine(label_w);
     ImGui::SetNextItemWidth(-(browse_w + spacing));
     if (InputTextStringWithHint(
@@ -575,10 +596,10 @@ std::string RenderSavedProfileBar(
     std::vector<PresetInfo> presets = preset_mgr.ListPresets(profiler_id);
 
     ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Profile");
+    ImGui::TextUnformatted("Saved Config");
     ImGui::SameLine();
 
-    // Combo for selecting a saved profile.
+    // Combo for selecting a saved configuration.
     ImGui::PushItemWidth(170);
     if (ImGui::BeginCombo("##PresetCombo",
                           current_preset_name.empty() ? "Unsaved" : current_preset_name.c_str()))
@@ -615,8 +636,8 @@ std::string RenderSavedProfileBar(
     if (ImGui::IsItemHovered())
     {
         ImGui::SetTooltip(current_preset_name.empty()
-                              ? "Save these settings as a named profile"
-                              : "Update the selected profile");
+                              ? "Save these settings as a named config"
+                              : "Update the selected config");
     }
 
     // Overflow menu keeps the less-common actions out of the toolbar.
@@ -630,11 +651,11 @@ std::string RenderSavedProfileBar(
     bool do_reset     = false;
     if (ImGui::BeginPopup("ProfileMenu"))
     {
-        if (ImGui::MenuItem("Save As New Profile..."))
+        if (ImGui::MenuItem("Save As New Config..."))
         {
             open_save_as = true;
         }
-        if (ImGui::MenuItem("Delete Profile", nullptr, false,
+        if (ImGui::MenuItem("Delete Config", nullptr, false,
                             !current_preset_name.empty()))
         {
             preset_mgr.DeletePreset(current_preset_name, profiler_id);
@@ -665,7 +686,7 @@ std::string RenderSavedProfileBar(
     // Save-As popup
     if (ImGui::BeginPopup("SavePresetPopup"))
     {
-        ImGui::TextUnformatted("Profile name:");
+        ImGui::TextUnformatted("Config name:");
         ImGui::SetNextItemWidth(240.0f);
         bool commit = ImGui::InputText("##SaveName", s_save_preset_name,
                                        sizeof(s_save_preset_name),

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
@@ -32,12 +32,13 @@ void BeginLaunchCard(const char* id);
 void EndLaunchCard();
 
 // Card title with a leading icon (from the icon font; pass nullptr for none),
-// an accent bar, and an optional dimmed subtitle. Call immediately after
-// BeginLaunchCard.
-void LaunchCardHeader(const char* icon, const char* title, const char* subtitle = nullptr);
+// an accent bar, and an optional trailing "(?)" help tooltip. Call immediately
+// after BeginLaunchCard.
+void LaunchCardHeader(const char* icon, const char* title, const char* help = nullptr);
 
-// Lightweight accent-colored group label used to separate blocks inside a card.
-void LaunchSubHeader(const char* text);
+// Lightweight accent-colored group label (with an optional trailing "(?)" help
+// tooltip) used to separate blocks inside a card.
+void LaunchSubHeader(const char* text, const char* help = nullptr);
 
 // iOS-style animated on/off switch. Returns true on the frame it is toggled.
 // Draws the label (and keeps it clickable) to the right of the switch.

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
@@ -6,6 +6,7 @@
 #include "rocprofvis_launch_config.h"
 #include "rocprofvis_profiler_backend.h"
 #include "rocprofvis_launch_preset_manager.h"
+#include "imgui.h"
 #include <string>
 #include <vector>
 #include <utility>
@@ -17,6 +18,56 @@ namespace View
 
 class AppWindow;
 
+// =============================================================================
+// Modern launcher UI primitives
+//
+// Small, self-contained widgets that give the launcher a contemporary,
+// card-based look instead of the default flat ImGui form. They read all colors
+// and fonts from SettingsManager so they track the active theme.
+// =============================================================================
+
+// A rounded, padded, subtly-bordered panel used to group related controls.
+// Auto-sizes to its content height. Always pair Begin/End.
+void BeginLaunchCard(const char* id);
+void EndLaunchCard();
+
+// Card title with a leading icon (from the icon font; pass nullptr for none),
+// an accent bar, and an optional dimmed subtitle. Call immediately after
+// BeginLaunchCard.
+void LaunchCardHeader(const char* icon, const char* title, const char* subtitle = nullptr);
+
+// Lightweight accent-colored group label used to separate blocks inside a card.
+void LaunchSubHeader(const char* text);
+
+// iOS-style animated on/off switch. Returns true on the frame it is toggled.
+// Draws the label (and keeps it clickable) to the right of the switch.
+bool ToggleSwitch(const char* label, bool* value);
+
+// A small rounded "tag": tinted background + accent border + accent text.
+// Advances the cursor by the chip size (use SameLine to place several).
+void Chip(const char* label, ImU32 accent_color);
+
+// Result of interacting with an EditablePill.
+enum class PillAction
+{
+    kNone,
+    kEdit,    // the pill body was clicked (pick it up to edit)
+    kRemove,  // the trailing "x" was clicked
+};
+
+// A removable/editable pill: a rounded tag with the label and a trailing "x".
+// Clicking the x returns kRemove; clicking the body returns kEdit. Used for the
+// command-line argument and environment-variable lists.
+PillAction EditablePill(const char* label, ImU32 accent_color);
+
+// Lays out a set of tags as wrapping accent chips, prefixed by a dim label.
+// Used for the live "this run will..." configuration summary.
+void RenderConfigChips(const char* lead_label, std::vector<std::string> const& tags);
+
+// A filled, rounded status badge with contrasting text - used for the run
+// status (Running / Completed / Failed).
+void StatusPill(const char* label, ImU32 bg_color);
+
 /**
  * Renders the Target section: executable, arguments, working dir, output dir.
  * The connection-mode selector lives in the launcher dialog (ProfilerLauncher
@@ -26,13 +77,6 @@ class AppWindow;
  * Returns true if any field was modified.
  */
 bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindow* app_window);
-
-/**
- * Renders the Raw Env Vars tab: editable name/value table with add/remove rows.
- * Highlights entries that shadow curated env var names.
- */
-void RenderRawEnvVarsTab(std::map<std::string, std::string>& extra_env,
-                         std::vector<std::pair<std::string, std::string>> const& curated_env);
 
 /**
  * Builds the displayed command line from cached execution inputs.

--- a/src/view/src/profiler/rocprofvis_profiler_backend.h
+++ b/src/view/src/profiler/rocprofvis_profiler_backend.h
@@ -26,6 +26,9 @@ struct TabDescriptor
     std::string id;
     std::string display_name;
     std::function<void()> render_fn;
+    // false => shown in the always-visible "General Options" area of the
+    // launcher; true => tucked under the collapsible "Advanced Options" section.
+    bool advanced = false;
 };
 
 struct WarningMessage
@@ -89,6 +92,17 @@ public:
      * tool routing suggestions, deprecated aliases in extra_env, etc.).
      */
     virtual std::vector<WarningMessage> GetWarnings(LaunchConfig const& config) const
+    {
+        (void)config;
+        return {};
+    }
+
+    /**
+     * Short, human-readable tags describing what this run will collect (e.g.
+     * "Perfetto trace", "Sampling 300Hz", "AMD SMI"). Rendered as a live chip
+     * summary in the launcher. Empty by default.
+     */
+    virtual std::vector<std::string> GetSummaryTags(LaunchConfig const& config) const
     {
         (void)config;
         return {};

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -29,6 +29,14 @@ namespace View
 
 namespace
 {
+// Configure-view split: the form and the command-preview panel are divided by a
+// draggable splitter, seeded to a 3:2 (form:preview) ratio on first open and
+// clamped so neither side collapses.
+constexpr float kSplitterWidth       = 6.0f;
+constexpr float kMinPreviewWidth     = 300.0f;
+constexpr float kMinFormWidth        = 320.0f;
+constexpr float kInitialPreviewRatio = 2.0f / 5.0f;
+
 // A filled, accent-colored primary button used for the main call-to-action
 // (Launch / Cancel) so it stands out from the neutral secondary buttons.
 bool AccentButton(const char* label, const ImVec2& size)
@@ -57,6 +65,8 @@ ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
     , m_show_window(false)
     , m_show_run_view(false)
     , m_show_advanced_window(false)
+    , m_preview_width(420.0f)
+    , m_preview_width_initialized(false)
     , m_arg_input()
     , m_env_name_input()
     , m_env_value_input()
@@ -219,15 +229,28 @@ void ProfilerLauncherDialog::RenderConfigureView()
     }
     ImGui::Spacing();
 
-    // Reserve bottom area for warnings + command preview + launch buttons. The
-    // live output console is no longer here - it moved to the run view.
-    float bottom_reserve = 200.0f;
-    ImGui::BeginChild("MainPane", ImVec2(0, -bottom_reserve), true);
+    // Reserve exactly the height the bottom block (warnings + error + separator
+    // + buttons) needs, so it stays pinned to the bottom with no dead space.
+    auto warnings = backend->GetWarnings(m_config);
+
+    const ImGuiStyle& style  = ImGui::GetStyle();
+    const float       line_h = ImGui::GetTextLineHeightWithSpacing();
+    float bottom_reserve = style.ItemSpacing.y            // gap after the form
+                         + style.ItemSpacing.y + 1.0f     // separator line + gap to buttons
+                         + ImGui::GetFrameHeight();        // button row (no trailing spacing)
+    bottom_reserve += warnings.size() * line_h;
+    if (!m_error_message.empty())
+    {
+        float wrap_w = ImGui::GetContentRegionAvail().x;
+        bottom_reserve += ImGui::CalcTextSize(m_error_message.c_str(), nullptr, false,
+                                              wrap_w).y + style.ItemSpacing.y;
+    }
+
+    ImGui::BeginChild("MainPane", ImVec2(0, -bottom_reserve), ImGuiChildFlags_None);
     RenderMainContent();
     ImGui::EndChild();
 
     // Warnings from backend
-    auto warnings = backend->GetWarnings(m_config);
     if (!warnings.empty())
     {
         for (auto const& w : warnings)
@@ -252,9 +275,6 @@ void ProfilerLauncherDialog::RenderConfigureView()
             ImGui::TextColored(color, "%s%s", prefix, w.text.c_str());
         }
     }
-
-    // Command preview
-    RenderCommandPreview(m_execution_cache.command_preview);
 
     // Pre-launch validation / immediate launch errors surface here since the
     // output console (which normally shows them) lives in the run view.
@@ -475,26 +495,8 @@ void ProfilerLauncherDialog::RenderMainContent()
 {
     IProfilerBackend const* backend = m_backends[m_backend_index].get();
 
-#ifdef ROCPROFVIS_ENABLE_REMOTE
-    // --- Where to run card (local vs. SSH) --- first: pick the machine before
-    // the paths, since a path only makes sense once the target host is known.
-    BeginLaunchCard("card_connection");
-    LaunchCardHeader(ICON_CHAIN, "Where to run");
-    RenderRemoteSection();
-    EndLaunchCard();
-#endif
-
-    // --- Target card (what to profile) ---
-    BeginLaunchCard("card_target");
-    LaunchCardHeader(ICON_OPEN, "Target",
-                     "The program to profile and where its results go");
-    RenderTargetSection(m_config.target, m_config.connection, m_app_window);
-    EndLaunchCard();
-
-    // Backend tabs are split by the backend into "general" (everyday controls)
-    // and "advanced" (power-user detail). General options and the raw env vars
-    // stay always-visible; everything else lives under a collapsible "Advanced
-    // Options" so the common path stays clean.
+    // Backend tabs are split into "general" (shown here) and "advanced" (opened
+    // in a separate window), so the common path stays clean.
     auto tabs = backend->GetTabs(m_config.tool_id);
     std::vector<TabDescriptor const*> general_tabs;
     std::vector<TabDescriptor const*> advanced_tabs;
@@ -503,7 +505,42 @@ void ProfilerLauncherDialog::RenderMainContent()
         (tab.advanced ? advanced_tabs : general_tabs).push_back(&tab);
     }
 
-    // --- Profiling Options card (the everyday controls) ---
+    // The configuration form goes on the left; the live command preview fills a
+    // dedicated full-height panel on the right, with a draggable splitter to
+    // adjust the preview width.
+    const float avail = ImGui::GetContentRegionAvail().x;
+
+    // Seed the split on first layout; afterwards the width follows the splitter.
+    if (!m_preview_width_initialized && avail > 0.0f)
+    {
+        m_preview_width             = (avail - kSplitterWidth) * kInitialPreviewRatio;
+        m_preview_width_initialized = true;
+    }
+
+    float max_preview = avail - kSplitterWidth - kMinFormWidth;
+    if (max_preview < kMinPreviewWidth)
+    {
+        max_preview = kMinPreviewWidth;
+    }
+    m_preview_width  = std::clamp(m_preview_width, kMinPreviewWidth, max_preview);
+    float left_w     = avail - kSplitterWidth - m_preview_width;
+
+    // --- Left: the configuration form (scrolls if it overflows) ---
+    ImGui::BeginChild("cfg_form", ImVec2(left_w, 0.0f), ImGuiChildFlags_None);
+#ifdef ROCPROFVIS_ENABLE_REMOTE
+    // Where to run first: pick the machine before the paths.
+    BeginLaunchCard("card_connection");
+    LaunchCardHeader(ICON_CHAIN, "Where to run");
+    RenderRemoteSection();
+    EndLaunchCard();
+#endif
+
+    BeginLaunchCard("card_target");
+    LaunchCardHeader(ICON_OPEN, "Target",
+                     "The program to profile and where its results go");
+    RenderTargetSection(m_config.target, m_config.connection, m_app_window);
+    EndLaunchCard();
+
     BeginLaunchCard("card_general");
     LaunchCardHeader(ICON_CHART_BAR, "Profiling Options");
     if (general_tabs.size() == 1)
@@ -527,23 +564,54 @@ void ProfilerLauncherDialog::RenderMainContent()
     }
     EndLaunchCard();
 
-    // --- Arguments & Environment (single panel) ---
     BeginLaunchCard("card_inputs");
     LaunchCardHeader(ICON_LIST, "Arguments & Environment");
     RenderArgsEnvPanel();
     EndLaunchCard();
 
-    // --- Advanced Options, at the very bottom of all the options. Deeper,
-    // less-common settings open in their own window to keep this view focused.
     if (!advanced_tabs.empty())
     {
         if (ImGui::Button("Advanced Options...", ImVec2(180, 0)))
         {
             m_show_advanced_window = true;
         }
-        ImGui::SameLine();
-        ImGui::TextDisabled("Sampling, ROCm domains, Perfetto, parallelism, logging");
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("Sampling, ROCm domains, Perfetto, parallelism, logging");
+        }
     }
+    ImGui::EndChild();
+
+    // --- Draggable splitter to resize the preview panel ---
+    SettingsManager& settings = SettingsManager::Get();
+    ImGui::SameLine(0.0f, 0.0f);
+    ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kSplitterColor));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kAccent));
+    ImGui::Button("##cfg_splitter", ImVec2(kSplitterWidth, ImGui::GetContentRegionAvail().y));
+    if (ImGui::IsItemHovered() || ImGui::IsItemActive())
+    {
+        ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+    }
+    if (ImGui::IsItemActive())
+    {
+        // Dragging right widens the form (narrows the preview) and vice versa.
+        m_preview_width -= ImGui::GetIO().MouseDelta.x;
+    }
+    ImGui::PopStyleColor(3);
+    ImGui::SameLine(0.0f, 0.0f);
+
+    // --- Right: full-height command preview panel ---
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, settings.GetDefaultStyle().ChildRounding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, settings.GetDefaultStyle().WindowPadding);
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
+    ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
+    ImGui::BeginChild("cfg_preview", ImVec2(0.0f, 0.0f),
+                      ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysUseWindowPadding);
+    RenderCommandPreview(m_execution_cache.command_preview);
+    ImGui::EndChild();
+    ImGui::PopStyleColor(2);
+    ImGui::PopStyleVar(2);
 }
 
 void ProfilerLauncherDialog::RenderAdvancedWindow()
@@ -628,8 +696,8 @@ void ProfilerLauncherDialog::RenderArgsEnvPanel()
     };
 
     // ===== Command line arguments (lead - they read as a one-liner) =====
-    LaunchSubHeader("COMMAND LINE ARGUMENTS");
-    ImGui::TextDisabled("Passed to the profiler, one entry at a time (flag or flag + value).");
+    LaunchSubHeader("COMMAND LINE ARGUMENTS",
+                    "Passed to the profiler, one entry at a time (a flag, or a flag + value).");
 
     bool add_arg = false;
     ImGui::SetNextItemWidth(-90.0f);
@@ -695,8 +763,8 @@ void ProfilerLauncherDialog::RenderArgsEnvPanel()
     ImGui::Spacing();
 
     // ===== Environment variables (name = value, grow vertically) =====
-    LaunchSubHeader("ENVIRONMENT VARIABLES");
-    ImGui::TextDisabled("Extra variables set for the profiler process.");
+    LaunchSubHeader("ENVIRONMENT VARIABLES",
+                    "Extra environment variables set for the profiler process.");
 
     bool add_env = false;
     ImGui::SetNextItemWidth(200.0f);

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -13,6 +13,7 @@
 #endif
 #include "widgets/rocprofvis_widget.h"
 #include "widgets/rocprofvis_gui_helpers.h"
+#include "icons/rocprovfis_icon_defines.h"
 #include "imgui.h"
 #include <cfloat>
 #include <algorithm>
@@ -26,6 +27,37 @@ namespace RocProfVis
 namespace View
 {
 
+namespace
+{
+// A filled, accent-colored primary button used for the main call-to-action
+// (Launch / Cancel) so it stands out from the neutral secondary buttons.
+bool AccentButton(const char* label, const ImVec2& size)
+{
+    SettingsManager& settings = SettingsManager::Get();
+    ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kAccent));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kAccentHover));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kAccentActive));
+    ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextOnAccent));
+    bool clicked = ImGui::Button(label, size);
+    ImGui::PopStyleColor(4);
+    return clicked;
+}
+
+// A collapsing section header flattened to read as a card title (no heavy
+// filled bar) - used for the collapsible cards.
+bool FlatCollapsingHeader(const char* label, bool default_open)
+{
+    SettingsManager& settings = SettingsManager::Get();
+    ImGui::PushStyleColor(ImGuiCol_Header, settings.GetColor(Colors::kTransparent));
+    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, settings.GetColor(Colors::kBgFrame));
+    ImGui::PushStyleColor(ImGuiCol_HeaderActive, settings.GetColor(Colors::kBgFrame));
+    bool open = ImGui::CollapsingHeader(
+        label, default_open ? ImGuiTreeNodeFlags_DefaultOpen : 0);
+    ImGui::PopStyleColor(3);
+    return open;
+}
+}  // namespace
+
 ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
     : m_app_window(app_window)
     , m_orchestrator(app_window)
@@ -37,6 +69,13 @@ ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
 #endif
     , m_should_open(false)
     , m_show_window(false)
+    , m_show_run_view(false)
+    , m_show_advanced_window(false)
+    , m_arg_input()
+    , m_env_name_input()
+    , m_env_value_input()
+    , m_run_start_time(0.0)
+    , m_run_end_time(0.0)
     , m_last_seen_state(kRPVProfilerStateIdle)
     , m_backend_index(0)
     , m_tool_index(0)
@@ -78,6 +117,12 @@ void ProfilerLauncherDialog::Show()
 {
     m_should_open = true;
     m_execution_cache_dirty = true;
+    // Always reopen on the configuration screen; a prior run (if any) was torn
+    // down on close.
+    if (!m_orchestrator.IsRunning())
+    {
+        m_show_run_view = false;
+    }
 }
 
 void ProfilerLauncherDialog::Render()
@@ -101,81 +146,37 @@ void ProfilerLauncherDialog::Render()
     bool window_open = true;
     if (ImGui::Begin("Launch Profiler", &window_open, ImGuiWindowFlags_NoScrollbar))
     {
-        // Sync typed settings to backend_payload so preset save sees current values
-        IProfilerBackend* backend = m_backends[m_backend_index].get();
-        m_config.backend_payload = backend->SaveSettings();
+        // Modern, roomier styling applied to the whole dialog: softer corners on
+        // frames/tabs/grips and a bit more breathing room between items.
+        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_GrabRounding, 6.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_TabRounding, 6.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_PopupRounding, 6.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.0f, 4.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 4.0f));
 
-#ifdef ROCPROFVIS_ENABLE_REMOTE
-        // Keep the launch profile's SSH connection reference in sync with the
-        // currently selected connection so saved profiles reference it.
-        m_config.ssh_connection_ref = m_selected_connection_id;
-#endif
-
-        RenderToolbar();
-        backend = m_backends[m_backend_index].get();
-        ImGui::Separator();
-
-        // Reserve bottom area for preview + output + buttons.
-        float bottom_reserve = 280.0f;
-        ImGui::BeginChild("MainPane", ImVec2(0, -bottom_reserve), true);
-        RenderMainContent();
-        ImGui::EndChild();
-
-        // Warnings from backend
-        auto warnings = backend->GetWarnings(m_config);
-        if (!warnings.empty())
+        // The dialog is a small two-step wizard: author the run (configure), then
+        // watch it (run). Splitting them keeps the configuration uncluttered and
+        // gives the live output the whole window while a run is in flight.
+        if (m_show_run_view)
         {
-            for (auto const& w : warnings)
-            {
-                ImVec4 color;
-                const char* prefix;
-                switch (w.level)
-                {
-                    case WarningMessage::kError:
-                        color = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
-                        prefix = "Error: ";
-                        break;
-                    case WarningMessage::kWarning:
-                        color = ImVec4(1.0f, 0.8f, 0.0f, 1.0f);
-                        prefix = "Warning: ";
-                        break;
-                    default:
-                        color = ImVec4(0.4f, 0.7f, 1.0f, 1.0f);
-                        prefix = "Hint: ";
-                        break;
-                }
-                ImGui::TextColored(color, "%s%s", prefix, w.text.c_str());
-            }
+            RenderRunView();
+        }
+        else
+        {
+            RenderConfigureView();
         }
 
-        // Command preview
-        RenderCommandPreview(m_execution_cache.command_preview);
-
-        // Launch Button row
-        RenderButtonRow();
-
-        // Output console. Collapse the local profiler state / remote workflow
-        // phase into a single badge so remote runs show "Connecting",
-        // "Downloading", etc. (and only show "Completed" once the trace is
-        // local), with the phase detail rendered next to the badge.
-        std::string        status_label  = "Idle";
-        ConsoleStatusLevel status_level  = ConsoleStatusLevel::kIdle;
-        std::string        status_detail;
-        ComputeConsoleStatus(status_label, status_level, status_detail);
-        if (RenderOutputConsole(m_output_text, m_error_message,
-                                status_label, status_level, status_detail,
-                                m_auto_scroll_output))
-        {
-            m_output_text.clear();
-            m_output_preamble.clear();
-            m_output_epilogue.clear();
-            m_process_output_raw.clear();
-            m_process_output_stripped.clear();
-            m_error_message.clear();
-        }
-
+        ImGui::PopStyleVar(6);
     }
     ImGui::End();
+
+    // The Advanced Options window is a separate floating window (only relevant
+    // while configuring).
+    if (!m_show_run_view)
+    {
+        RenderAdvancedWindow();
+    }
 
 #ifdef ROCPROFVIS_ENABLE_REMOTE
     // SSH settings dialog, auth prompts and download progress (rendered outside
@@ -186,8 +187,206 @@ void ProfilerLauncherDialog::Render()
     if (!window_open)
     {
         OnCloseClicked();
-        m_show_window = false;
+        m_show_window          = false;
+        m_show_run_view        = false;
+        m_show_advanced_window = false;
     }
+}
+
+void ProfilerLauncherDialog::RenderConfigureView()
+{
+    // Sync typed settings to backend_payload so preset save sees current values
+    IProfilerBackend* backend = m_backends[m_backend_index].get();
+    m_config.backend_payload = backend->SaveSettings();
+
+#ifdef ROCPROFVIS_ENABLE_REMOTE
+    // Keep the launch profile's SSH connection reference in sync with the
+    // currently selected connection so saved profiles reference it.
+    m_config.ssh_connection_ref = m_selected_connection_id;
+#endif
+
+    RenderToolbar();
+    backend = m_backends[m_backend_index].get();
+    ImGui::Separator();
+
+    // Live "this run" summary: chips that update as options are toggled. Great
+    // for a quick read of exactly what will be collected.
+    {
+        std::vector<std::string> tags;
+#ifdef ROCPROFVIS_ENABLE_REMOTE
+        tags.push_back(IsSshMode() ? "Remote (SSH)" : "Local");
+#else
+        tags.push_back("Local");
+#endif
+        auto tools = backend->GetTools();
+        if (m_tool_index >= 0 && m_tool_index < static_cast<int>(tools.size()))
+        {
+            tags.push_back(tools[m_tool_index].display_name);
+        }
+        std::vector<std::string> backend_tags = backend->GetSummaryTags(m_config);
+        tags.insert(tags.end(), backend_tags.begin(), backend_tags.end());
+        RenderConfigChips("This run:", tags);
+    }
+    ImGui::Spacing();
+
+    // Reserve bottom area for warnings + command preview + launch buttons. The
+    // live output console is no longer here - it moved to the run view.
+    float bottom_reserve = 200.0f;
+    ImGui::BeginChild("MainPane", ImVec2(0, -bottom_reserve), true);
+    RenderMainContent();
+    ImGui::EndChild();
+
+    // Warnings from backend
+    auto warnings = backend->GetWarnings(m_config);
+    if (!warnings.empty())
+    {
+        for (auto const& w : warnings)
+        {
+            ImVec4 color;
+            const char* prefix;
+            switch (w.level)
+            {
+                case WarningMessage::kError:
+                    color = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
+                    prefix = "Error: ";
+                    break;
+                case WarningMessage::kWarning:
+                    color = ImVec4(1.0f, 0.8f, 0.0f, 1.0f);
+                    prefix = "Warning: ";
+                    break;
+                default:
+                    color = ImVec4(0.4f, 0.7f, 1.0f, 1.0f);
+                    prefix = "Hint: ";
+                    break;
+            }
+            ImGui::TextColored(color, "%s%s", prefix, w.text.c_str());
+        }
+    }
+
+    // Command preview
+    RenderCommandPreview(m_execution_cache.command_preview);
+
+    // Pre-launch validation / immediate launch errors surface here since the
+    // output console (which normally shows them) lives in the run view.
+    if (!m_error_message.empty())
+    {
+        SettingsManager& settings = SettingsManager::Get();
+        ImVec4 err_color =
+            ImGui::ColorConvertU32ToFloat4(settings.GetColor(Colors::kTextError));
+        ImGui::PushTextWrapPos(0.0f);
+        ImGui::TextColored(err_color, "%s", m_error_message.c_str());
+        ImGui::PopTextWrapPos();
+    }
+
+    // Launch button row
+    RenderButtonRow();
+}
+
+void ProfilerLauncherDialog::RenderRunView()
+{
+    // Collapse the local profiler state / remote workflow phase into a single
+    // badge so remote runs show "Connecting", "Downloading", etc. (and only show
+    // "Completed" once the trace is local), with the phase detail beside it.
+    std::string        status_label = "Idle";
+    ConsoleStatusLevel status_level = ConsoleStatusLevel::kIdle;
+    std::string        status_detail;
+    ComputeConsoleStatus(status_label, status_level, status_detail);
+
+    // Status header: a colored pill + a live elapsed timer.
+    SettingsManager& settings = SettingsManager::Get();
+    Colors           pill_color_id;
+    switch (status_level)
+    {
+        case ConsoleStatusLevel::kSuccess: pill_color_id = Colors::kTextSuccess; break;
+        case ConsoleStatusLevel::kError:   pill_color_id = Colors::kTextError;   break;
+        case ConsoleStatusLevel::kRunning: pill_color_id = Colors::kAccent;      break;
+        default:                           pill_color_id = Colors::kBorderGray;  break;
+    }
+    StatusPill(status_label.c_str(), settings.GetColor(pill_color_id));
+
+    if (m_run_start_time > 0.0)
+    {
+        double end     = (m_run_end_time > 0.0) ? m_run_end_time : ImGui::GetTime();
+        double elapsed = end - m_run_start_time;
+        ImGui::SameLine(0.0f, 12.0f);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextDisabled("Elapsed  %.1fs", elapsed);
+    }
+    if (!status_detail.empty())
+    {
+        ImGui::SameLine(0.0f, 12.0f);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextDisabled("%s", status_detail.c_str());
+    }
+
+    std::string summary = BuildRunSummary();
+    if (!summary.empty())
+    {
+        ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
+        ImGui::TextWrapped("%s", summary.c_str());
+        ImGui::PopStyleColor();
+    }
+    ImGui::Spacing();
+
+    // The console fills everything above the button row.
+    float button_h = ImGui::GetFrameHeightWithSpacing() + 16.0f;
+    ImGui::BeginChild("RunConsoleArea", ImVec2(0, -button_h), false);
+    if (RenderOutputConsole(m_output_text, m_error_message,
+                            status_label, status_level, status_detail,
+                            m_auto_scroll_output))
+    {
+        m_output_text.clear();
+        m_output_preamble.clear();
+        m_output_epilogue.clear();
+        m_process_output_raw.clear();
+        m_process_output_stripped.clear();
+        m_error_message.clear();
+    }
+    ImGui::EndChild();
+
+    RenderRunButtonRow();
+}
+
+std::string ProfilerLauncherDialog::BuildRunSummary() const
+{
+    std::ostringstream ss;
+
+    if (m_backend_index >= 0 && m_backend_index < static_cast<int>(m_backends.size()))
+    {
+        ss << m_backends[m_backend_index]->DisplayName();
+        auto tools = m_backends[m_backend_index]->GetTools();
+        if (m_tool_index >= 0 && m_tool_index < static_cast<int>(tools.size()))
+        {
+            ss << " (" << tools[m_tool_index].display_name << ")";
+        }
+    }
+
+    if (!m_config.target.executable.empty())
+    {
+        ss << "  ->  " << m_config.target.executable;
+        if (!m_config.target.arguments.empty())
+        {
+            ss << " " << m_config.target.arguments;
+        }
+    }
+
+#ifdef ROCPROFVIS_ENABLE_REMOTE
+    if (IsSshMode())
+    {
+        std::string host = m_remote_uri->GetRemoteHostString();
+        std::string user = m_remote_uri->GetRemoteUserString();
+        ss << "   [Remote: " << (user.empty() ? "?" : user.c_str()) << "@"
+           << (host.empty() ? "?" : host.c_str()) << "]";
+    }
+    else
+    {
+        ss << "   [Local]";
+    }
+#else
+    ss << "   [Local]";
+#endif
+
+    return ss.str();
 }
 
 void ProfilerLauncherDialog::RenderToolbar()
@@ -208,6 +407,13 @@ void ProfilerLauncherDialog::RenderToolbar()
                 SwitchBackend(static_cast<int>(i));
             }
         }
+        // Placeholders for the profilers this launcher is designed to grow into.
+        // Disabled until their backends land; listed so the intended scope
+        // (rocprof-sys, rocprof-compute, rocprofv3) is visible.
+        ImGui::BeginDisabled();
+        ImGui::Selectable("ROCm Compute Profiler (coming soon)", false);
+        ImGui::Selectable("rocprofv3 (coming soon)", false);
+        ImGui::EndDisabled();
         ImGui::EndCombo();
     }
     ImGui::PopItemWidth();
@@ -237,27 +443,6 @@ void ProfilerLauncherDialog::RenderToolbar()
     ImGui::PopItemWidth();
 
     VerticalSeparator();
-
-    // TODO: keep this option?
-    bool show_profiler_path = false;
-    if(show_profiler_path) {
-        ImGui::Text("Profiler Path:");
-        ImGui::SameLine();
-        char path_buf[512];
-        std::snprintf(path_buf, sizeof(path_buf), "%s", m_profiler_path_override.c_str());
-        ImGui::PushItemWidth(220);
-        if (ImGui::InputText("##ProfPath", path_buf, sizeof(path_buf)))
-        {
-            m_profiler_path_override = path_buf;
-        }
-        ImGui::PopItemWidth();
-        if (ImGui::IsItemHovered())
-        {
-            ImGui::SetTooltip("Leave empty to use PATH");
-        }
-
-        VerticalSeparator();
-    }
 
     // Saved launch profiles (Optiq JSON presets)
     std::string load_name = RenderSavedProfileBar(
@@ -301,36 +486,300 @@ void ProfilerLauncherDialog::RenderMainContent()
     IProfilerBackend const* backend = m_backends[m_backend_index].get();
 
 #ifdef ROCPROFVIS_ENABLE_REMOTE
-    // Connection mode selector + SSH connection options (when in SSH mode).
+    // --- Where to run card (local vs. SSH) --- first: pick the machine before
+    // the paths, since a path only makes sense once the target host is known.
+    BeginLaunchCard("card_connection");
+    LaunchCardHeader(ICON_CHAIN, "Where to run");
     RenderRemoteSection();
-    ImGui::Separator();
+    EndLaunchCard();
 #endif
 
-    // Target is always visible at the top, not buried in a tab.
+    // --- Target card (what to profile) ---
+    BeginLaunchCard("card_target");
+    LaunchCardHeader(ICON_OPEN, "Target",
+                     "The program to profile and where its results go");
     RenderTargetSection(m_config.target, m_config.connection, m_app_window);
-    ImGui::Separator();
+    EndLaunchCard();
 
-    if (ImGui::BeginTabBar("LaunchTabs"))
+    // Backend tabs are split by the backend into "general" (everyday controls)
+    // and "advanced" (power-user detail). General options and the raw env vars
+    // stay always-visible; everything else lives under a collapsible "Advanced
+    // Options" so the common path stays clean.
+    auto tabs = backend->GetTabs(m_config.tool_id);
+    std::vector<TabDescriptor const*> general_tabs;
+    std::vector<TabDescriptor const*> advanced_tabs;
+    for (auto const& tab : tabs)
     {
-        // Backend-provided tabs (Quick, Sampling, ROCm, ...)
-        auto tabs = backend->GetTabs(m_config.tool_id);
-        for (auto const& tab : tabs)
+        (tab.advanced ? advanced_tabs : general_tabs).push_back(&tab);
+    }
+
+    // --- Profiling Options card (the everyday controls) ---
+    BeginLaunchCard("card_general");
+    LaunchCardHeader(ICON_CHART_BAR, "Profiling Options");
+    if (general_tabs.size() == 1)
+    {
+        general_tabs[0]->render_fn();
+    }
+    else if (!general_tabs.empty())
+    {
+        if (ImGui::BeginTabBar("GeneralTabs"))
         {
-            if (ImGui::BeginTabItem(tab.display_name.c_str()))
+            for (auto const* tab : general_tabs)
             {
-                tab.render_fn();
-                ImGui::EndTabItem();
+                if (ImGui::BeginTabItem(tab->display_name.c_str()))
+                {
+                    tab->render_fn();
+                    ImGui::EndTabItem();
+                }
+            }
+            ImGui::EndTabBar();
+        }
+    }
+    EndLaunchCard();
+
+    // --- Arguments & Environment (single panel) ---
+    BeginLaunchCard("card_inputs");
+    LaunchCardHeader(ICON_LIST, "Arguments & Environment");
+    RenderArgsEnvPanel();
+    EndLaunchCard();
+
+    // --- Advanced Options, at the very bottom of all the options. Deeper,
+    // less-common settings open in their own window to keep this view focused.
+    if (!advanced_tabs.empty())
+    {
+        if (ImGui::Button("Advanced Options...", ImVec2(180, 0)))
+        {
+            m_show_advanced_window = true;
+        }
+        ImGui::SameLine();
+        ImGui::TextDisabled("Sampling, ROCm domains, Perfetto, parallelism, logging");
+    }
+}
+
+void ProfilerLauncherDialog::RenderAdvancedWindow()
+{
+    if (!m_show_advanced_window)
+    {
+        return;
+    }
+
+    IProfilerBackend const* backend = m_backends[m_backend_index].get();
+
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(700, 560), ImGuiCond_FirstUseEver);
+
+    bool open = true;
+    if (ImGui::Begin("Advanced Profiling Options", &open))
+    {
+        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_GrabRounding, 6.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_TabRounding, 6.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.0f, 4.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 4.0f));
+
+        ImGui::TextDisabled("Fine-grained settings, applied on top of the selected preset.");
+        ImGui::Spacing();
+
+        auto tabs = backend->GetTabs(m_config.tool_id);
+        if (ImGui::BeginTabBar("AdvancedWindowTabs"))
+        {
+            for (auto const& tab : tabs)
+            {
+                if (!tab.advanced)
+                {
+                    continue;
+                }
+                if (ImGui::BeginTabItem(tab.display_name.c_str()))
+                {
+                    ImGui::Spacing();
+                    ImGui::BeginChild("adv_scroll", ImVec2(0.0f, 0.0f), ImGuiChildFlags_None);
+                    tab.render_fn();
+                    ImGui::EndChild();
+                    ImGui::EndTabItem();
+                }
+            }
+            ImGui::EndTabBar();
+        }
+
+        ImGui::PopStyleVar(5);
+    }
+    ImGui::End();
+
+    if (!open)
+    {
+        m_show_advanced_window = false;
+    }
+}
+
+void ProfilerLauncherDialog::RenderArgsEnvPanel()
+{
+    SettingsManager& settings   = SettingsManager::Get();
+    const ImU32      accent     = settings.GetColor(Colors::kAccent);
+    ImGuiStyle&      style      = ImGui::GetStyle();
+
+    auto trim = [](std::string s) -> std::string
+    {
+        size_t a = s.find_first_not_of(" \t");
+        size_t b = s.find_last_not_of(" \t");
+        return (a == std::string::npos) ? std::string() : s.substr(a, b - a + 1);
+    };
+
+    // Wrap-aware pill row: SameLine only while the next pill still fits.
+    auto keep_on_row = [&](float next_label_w)
+    {
+        float window_x2 = ImGui::GetWindowPos().x + ImGui::GetWindowContentRegionMax().x;
+        float last_x2   = ImGui::GetItemRectMax().x;
+        return (last_x2 + style.ItemSpacing.x + next_label_w + 24.0f) < window_x2;
+    };
+
+    // ===== Command line arguments (lead - they read as a one-liner) =====
+    LaunchSubHeader("COMMAND LINE ARGUMENTS");
+    ImGui::TextDisabled("Passed to the profiler, one entry at a time (flag or flag + value).");
+
+    bool add_arg = false;
+    ImGui::SetNextItemWidth(-90.0f);
+    if (InputTextStringWithHint("##ArgInput", "e.g.  --sampling-freq 500",
+                                m_arg_input, ImGuiInputTextFlags_EnterReturnsTrue))
+    {
+        add_arg = true;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Add##Arg", ImVec2(80.0f, 0.0f)))
+    {
+        add_arg = true;
+    }
+    if (add_arg)
+    {
+        std::string value = trim(m_arg_input);
+        if (!value.empty())
+        {
+            m_config.extra_argv.push_back(value);
+            m_arg_input.clear();
+            m_execution_cache_dirty = true;
+        }
+    }
+
+    if (!m_config.extra_argv.empty())
+    {
+        ImGui::Spacing();
+        int edit_idx   = -1;
+        int remove_idx = -1;
+        for (size_t i = 0; i < m_config.extra_argv.size(); i++)
+        {
+            ImGui::PushID(static_cast<int>(i));
+            PillAction act = EditablePill(m_config.extra_argv[i].c_str(), accent);
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Click to edit  -  x to remove");
+            }
+            ImGui::PopID();
+
+            if (act == PillAction::kEdit)   { edit_idx = static_cast<int>(i); }
+            if (act == PillAction::kRemove) { remove_idx = static_cast<int>(i); }
+
+            if (i + 1 < m_config.extra_argv.size() &&
+                keep_on_row(ImGui::CalcTextSize(m_config.extra_argv[i + 1].c_str()).x))
+            {
+                ImGui::SameLine();
             }
         }
-
-        // Raw Env Vars tab (shared)
-        if (ImGui::BeginTabItem("Raw Env Vars"))
+        if (edit_idx >= 0)
         {
-            RenderRawEnvVarsTab(m_config.extra_env, m_execution_cache.curated_env_vars);
-            ImGui::EndTabItem();
+            // Pick it up into the edit box; modify + Add to re-add.
+            m_arg_input = m_config.extra_argv[static_cast<size_t>(edit_idx)];
+            m_config.extra_argv.erase(m_config.extra_argv.begin() + edit_idx);
+            m_execution_cache_dirty = true;
         }
+        else if (remove_idx >= 0)
+        {
+            m_config.extra_argv.erase(m_config.extra_argv.begin() + remove_idx);
+            m_execution_cache_dirty = true;
+        }
+    }
 
-        ImGui::EndTabBar();
+    ImGui::Spacing();
+
+    // ===== Environment variables (name = value, grow vertically) =====
+    LaunchSubHeader("ENVIRONMENT VARIABLES");
+    ImGui::TextDisabled("Extra variables set for the profiler process.");
+
+    bool add_env = false;
+    ImGui::SetNextItemWidth(200.0f);
+    InputTextStringWithHint("##EnvName", "NAME", m_env_name_input);
+    ImGui::SameLine();
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("=");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(-90.0f);
+    if (InputTextStringWithHint("##EnvValue", "value", m_env_value_input,
+                                ImGuiInputTextFlags_EnterReturnsTrue))
+    {
+        add_env = true;
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Add##Env", ImVec2(80.0f, 0.0f)))
+    {
+        add_env = true;
+    }
+    if (add_env)
+    {
+        std::string name = trim(m_env_name_input);
+        if (!name.empty())
+        {
+            m_config.extra_env[name] = m_env_value_input;
+            m_env_name_input.clear();
+            m_env_value_input.clear();
+            m_execution_cache_dirty = true;
+        }
+    }
+
+    if (!m_config.extra_env.empty())
+    {
+        ImGui::Spacing();
+        std::vector<std::pair<std::string, std::string>> envs(
+            m_config.extra_env.begin(), m_config.extra_env.end());
+        std::string edit_key;
+        std::string remove_key;
+        for (size_t i = 0; i < envs.size(); i++)
+        {
+            std::string pill = envs[i].first + " = " + envs[i].second;
+            ImGui::PushID(envs[i].first.c_str());
+            PillAction act = EditablePill(pill.c_str(), accent);
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Click to edit  -  x to remove");
+            }
+            ImGui::PopID();
+
+            if (act == PillAction::kEdit)   { edit_key = envs[i].first; }
+            if (act == PillAction::kRemove) { remove_key = envs[i].first; }
+
+            if (i + 1 < envs.size())
+            {
+                std::string next = envs[i + 1].first + " = " + envs[i + 1].second;
+                if (keep_on_row(ImGui::CalcTextSize(next.c_str()).x))
+                {
+                    ImGui::SameLine();
+                }
+            }
+        }
+        if (!edit_key.empty())
+        {
+            auto it = m_config.extra_env.find(edit_key);
+            if (it != m_config.extra_env.end())
+            {
+                m_env_name_input        = it->first;
+                m_env_value_input       = it->second;
+                m_config.extra_env.erase(it);
+                m_execution_cache_dirty = true;
+            }
+        }
+        else if (!remove_key.empty())
+        {
+            m_config.extra_env.erase(remove_key);
+            m_execution_cache_dirty = true;
+        }
     }
 }
 
@@ -343,45 +792,47 @@ void ProfilerLauncherDialog::RenderRemoteSection()
     // shared RenderTargetSection) so it sits alongside the SSH connection
     // options, which need dialog-owned state (RemoteUri / SshSettingsDialog /
     // RemoteProfilerSession) to render.
-    ImGui::AlignTextToFramePadding();
-    ImGui::Text("Connection:");
-    ImGui::SameLine();
+    const float label_w = 90.0f;
 
-    const char* conn_types[] = {"Local", "Remote (SSH)"};
-    int conn_idx = (m_config.connection == ConnectionType::kLocal) ? 0 : 1;
-    ImGui::PushItemWidth(150);
-    if (ImGui::Combo("##Connection", &conn_idx, conn_types, 2))
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Run on");
+    ImGui::SameLine(label_w);
+
+    // A two-button segmented control reads more clearly than a dropdown for a
+    // binary choice.
+    bool is_local = (m_config.connection == ConnectionType::kLocal);
+    if (ImGui::RadioButton("This machine", is_local))
     {
-        m_config.connection = (conn_idx == 0) ? ConnectionType::kLocal : ConnectionType::kSsh;
+        m_config.connection = ConnectionType::kLocal;
     }
-    ImGui::PopItemWidth();
+    ImGui::SameLine();
+    if (ImGui::RadioButton("Remote (SSH)", !is_local))
+    {
+        m_config.connection = ConnectionType::kSsh;
+    }
 
     if (!IsSshMode())
     {
         return;
     }
 
-    ImGui::Spacing();
-    ImGui::TextUnformatted("Remote (SSH) execution");
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Host");
+    ImGui::SameLine(label_w);
 
-    const float label_w = 170.0f;
-
-    ImGui::AlignTextToFramePadding(); ImGui::Text("Connection"); ImGui::SameLine(label_w);
     std::string host = m_remote_uri->GetRemoteHostString();
     std::string user = m_remote_uri->GetRemoteUserString();
     if (host.empty())
     {
-        ImGui::TextDisabled("Not configured");
+        ImGui::TextDisabled("no connection configured");
     }
     else
     {
-        ImGui::Text("%s@%s:%s",
-                    user.empty() ? "?" : user.c_str(),
-                    host.c_str(),
+        ImGui::Text("%s@%s:%s", user.empty() ? "?" : user.c_str(), host.c_str(),
                     m_remote_uri->GetRemotePortString().c_str());
     }
-
-    if (ImGui::Button("Configure SSH Connection..."))
+    ImGui::SameLine();
+    if (ImGui::SmallButton(host.empty() ? "Configure..." : "Change..."))
     {
         m_ssh_settings_dialog = std::make_unique<SshSettingsDialog>(
             m_connection_store, m_selected_connection_id,
@@ -489,49 +940,123 @@ void ProfilerLauncherDialog::RenderButtonRow()
 
     bool is_running = m_orchestrator.IsRunning();
     rocprofvis_profiler_state_t state = m_orchestrator.GetState();
-    bool can_launch = !is_running &&
+    bool state_ready = !is_running &&
         (state == kRPVProfilerStateIdle ||
          state == kRPVProfilerStateCompleted ||
          state == kRPVProfilerStateFailed ||
          state == kRPVProfilerStateCancelled);
-    bool can_cancel = is_running && state == kRPVProfilerStateRunning;
 
-    if (can_launch)
+    // Live readiness: backend validation plus (for remote) a configured host.
+    IProfilerBackend* backend = m_backends[m_backend_index].get();
+    std::string       readiness = backend->Validate(m_config);
+#ifdef ROCPROFVIS_ENABLE_REMOTE
+    if (readiness.empty() && IsSshMode() &&
+        (m_remote_uri->GetRemoteHostString().empty() ||
+         m_remote_uri->GetRemoteUserString().empty()))
     {
-        if (ImGui::Button("Launch", ImVec2(120, 0)))
-        {
-            OnLaunchClicked();
-        }
+        readiness = "Configure the SSH connection (host/user) to launch";
     }
-    else
+#endif
+    bool valid      = readiness.empty();
+    bool can_launch = state_ready && valid;
+
+    if (!can_launch) ImGui::BeginDisabled();
+    if (AccentButton("Launch Profiler", ImVec2(160, 0)))
     {
-        ImGui::BeginDisabled();
-        ImGui::Button("Launch", ImVec2(120, 0));
-        ImGui::EndDisabled();
+        OnLaunchClicked();
+    }
+    if (!can_launch) ImGui::EndDisabled();
+
+    // If a run is in flight or a previous run's output is available, let the
+    // user jump straight to the focused run view.
+    bool has_run_view = is_running ||
+        state == kRPVProfilerStateRunning ||
+        state == kRPVProfilerStateCompleted ||
+        state == kRPVProfilerStateFailed ||
+        state == kRPVProfilerStateCancelled;
+    if (has_run_view && !m_output_text.empty())
+    {
+        ImGui::SameLine();
+        if (ImGui::Button(is_running ? "View Run" : "View Last Run", ImVec2(130, 0)))
+        {
+            m_show_run_view = true;
+        }
     }
 
     ImGui::SameLine();
-
-    if (can_cancel)
+    if (ImGui::Button("Close", ImVec2(120, 0)))
     {
-        if (ImGui::Button("Cancel", ImVec2(120, 0)))
+        OnCloseClicked();
+        m_show_window   = false;
+        m_show_run_view = false;
+    }
+
+    // Readiness feedback to the right of the buttons, so it is obvious why
+    // Launch is (or isn't) available.
+    if (!is_running)
+    {
+        SettingsManager& settings = SettingsManager::Get();
+        ImGui::SameLine(0.0f, 16.0f);
+        ImGui::AlignTextToFramePadding();
+        if (valid)
+        {
+            ImVec4 ok = ImGui::ColorConvertU32ToFloat4(settings.GetColor(Colors::kTextSuccess));
+            ImGui::TextColored(ok, "Ready to launch");
+        }
+        else
+        {
+            ImGui::TextColored(ImVec4(1.0f, 0.78f, 0.25f, 1.0f), "%s", readiness.c_str());
+        }
+    }
+}
+
+void ProfilerLauncherDialog::RenderRunButtonRow()
+{
+    ImGui::Separator();
+
+    bool                        is_running = m_orchestrator.IsRunning();
+    rocprofvis_profiler_state_t state      = m_orchestrator.GetState();
+
+    if (is_running)
+    {
+        if (AccentButton("Cancel", ImVec2(140, 0)))
         {
             OnCancelClicked();
         }
     }
     else
     {
-        ImGui::BeginDisabled();
-        ImGui::Button("Cancel", ImVec2(120, 0));
-        ImGui::EndDisabled();
+        if (AccentButton("Run Again", ImVec2(140, 0)))
+        {
+            OnLaunchClicked();
+        }
+
+        ImGui::SameLine();
+        if (ImGui::Button("Back to Configuration", ImVec2(190, 0)))
+        {
+            m_show_run_view = false;
+        }
+
+        // Offer a manual open for a completed local run (remote runs auto-load
+        // the downloaded trace through the orchestrator).
+        std::string trace_path = m_orchestrator.GetTracePath();
+        if (state == kRPVProfilerStateCompleted && !trace_path.empty() &&
+            !m_orchestrator.IsRemote())
+        {
+            ImGui::SameLine();
+            if (ImGui::Button("Open Trace", ImVec2(140, 0)) && m_app_window)
+            {
+                m_app_window->OpenFile(trace_path);
+            }
+        }
     }
 
     ImGui::SameLine();
-
     if (ImGui::Button("Close", ImVec2(120, 0)))
     {
         OnCloseClicked();
-        m_show_window = false;
+        m_show_window   = false;
+        m_show_run_view = false;
     }
 }
 
@@ -676,6 +1201,12 @@ void ProfilerLauncherDialog::OnLaunchClicked()
         m_last_seen_state = kRPVProfilerStateRunning;
         RebuildComposedOutput();
 
+        // Swap to the focused run view so the live output owns the window.
+        m_show_run_view        = true;
+        m_show_advanced_window = false;
+        m_run_start_time       = ImGui::GetTime();
+        m_run_end_time         = 0.0;
+
         SaveToSettings();
         AddRecentTarget(m_config.target.executable);
     }
@@ -701,6 +1232,14 @@ void ProfilerLauncherDialog::OnCloseClicked()
 void ProfilerLauncherDialog::HandleStateTransition(rocprofvis_profiler_state_t new_state)
 {
     const bool is_remote = m_orchestrator.IsRemote();
+
+    // Freeze the elapsed-time readout when the run reaches a terminal state.
+    if (new_state == kRPVProfilerStateCompleted ||
+        new_state == kRPVProfilerStateFailed ||
+        new_state == kRPVProfilerStateCancelled)
+    {
+        m_run_end_time = ImGui::GetTime();
+    }
 
     if (new_state == kRPVProfilerStateCompleted)
     {

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -129,27 +129,20 @@ void ProfilerLauncherDialog::Render()
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(1000, 700), ImGuiCond_FirstUseEver);
 
-    // AppWindow renders us inside its main-window scope, which pushes
-    // WindowPadding/WindowRounding to 0 (so the main layout is flush). Restore
-    // the app's standard window padding/rounding so this dialog isn't edge-to-
-    // edge. WindowPadding must be set before Begin() to take effect.
-    SettingsManager& settings = SettingsManager::Get();
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, settings.GetDefaultStyle().WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, settings.GetDefaultStyle().WindowRounding);
+    // AppWindow renders us inside its main-window scope, which zeroes
+    // WindowPadding / ItemSpacing / WindowRounding for the flush main layout.
+    // Restore the app's standard style so this dialog matches the rest of the
+    // app (WindowPadding must be set before Begin() to take effect).
+    const ImGuiStyle& def = SettingsManager::Get().GetDefaultStyle();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, def.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, def.WindowRounding);
 
     bool window_open = true;
     bool visible     = ImGui::Begin("Launch Profiler", &window_open,
                                     ImGuiWindowFlags_NoScrollbar);
     if (visible)
     {
-        // Modern, roomier styling applied to the whole dialog: softer corners on
-        // frames/tabs/grips and a bit more breathing room between items.
-        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_GrabRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_TabRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_PopupRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.0f, 5.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 5.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, def.ItemSpacing);
 
         // The dialog is a small two-step wizard: author the run (configure), then
         // watch it (run). Splitting them keeps the configuration uncluttered and
@@ -163,7 +156,7 @@ void ProfilerLauncherDialog::Render()
             RenderConfigureView();
         }
 
-        ImGui::PopStyleVar(6);
+        ImGui::PopStyleVar(1);
     }
     ImGui::End();
     ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
@@ -566,21 +559,17 @@ void ProfilerLauncherDialog::RenderAdvancedWindow()
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(700, 560), ImGuiCond_FirstUseEver);
 
-    // Restore the app's standard window padding/rounding (AppWindow's scope
-    // zeroes them). WindowPadding must be set before Begin().
-    SettingsManager& settings = SettingsManager::Get();
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, settings.GetDefaultStyle().WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, settings.GetDefaultStyle().WindowRounding);
+    // Restore the app's standard style (AppWindow's scope zeroes window padding /
+    // item spacing / rounding). WindowPadding must be set before Begin().
+    const ImGuiStyle& def = SettingsManager::Get().GetDefaultStyle();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, def.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, def.WindowRounding);
 
     bool open    = true;
     bool visible = ImGui::Begin("Advanced Profiling Options", &open);
     if (visible)
     {
-        ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_GrabRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_TabRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.0f, 5.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 5.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, def.ItemSpacing);
 
         ImGui::TextDisabled("Fine-grained settings, applied on top of the selected preset.");
         ImGui::Spacing();
@@ -606,7 +595,7 @@ void ProfilerLauncherDialog::RenderAdvancedWindow()
             ImGui::EndTabBar();
         }
 
-        ImGui::PopStyleVar(5);
+        ImGui::PopStyleVar(1);
     }
     ImGui::End();
     ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -42,20 +42,6 @@ bool AccentButton(const char* label, const ImVec2& size)
     ImGui::PopStyleColor(4);
     return clicked;
 }
-
-// A collapsing section header flattened to read as a card title (no heavy
-// filled bar) - used for the collapsible cards.
-bool FlatCollapsingHeader(const char* label, bool default_open)
-{
-    SettingsManager& settings = SettingsManager::Get();
-    ImGui::PushStyleColor(ImGuiCol_Header, settings.GetColor(Colors::kTransparent));
-    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, settings.GetColor(Colors::kBgFrame));
-    ImGui::PushStyleColor(ImGuiCol_HeaderActive, settings.GetColor(Colors::kBgFrame));
-    bool open = ImGui::CollapsingHeader(
-        label, default_open ? ImGuiTreeNodeFlags_DefaultOpen : 0);
-    ImGui::PopStyleColor(3);
-    return open;
-}
 }  // namespace
 
 ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
@@ -143,8 +129,18 @@ void ProfilerLauncherDialog::Render()
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(1000, 700), ImGuiCond_FirstUseEver);
 
+    // AppWindow renders us inside its main-window scope, which pushes
+    // WindowPadding/WindowRounding to 0 (so the main layout is flush). Restore
+    // the app's standard window padding/rounding so this dialog isn't edge-to-
+    // edge. WindowPadding must be set before Begin() to take effect.
+    SettingsManager& settings = SettingsManager::Get();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, settings.GetDefaultStyle().WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, settings.GetDefaultStyle().WindowRounding);
+
     bool window_open = true;
-    if (ImGui::Begin("Launch Profiler", &window_open, ImGuiWindowFlags_NoScrollbar))
+    bool visible     = ImGui::Begin("Launch Profiler", &window_open,
+                                    ImGuiWindowFlags_NoScrollbar);
+    if (visible)
     {
         // Modern, roomier styling applied to the whole dialog: softer corners on
         // frames/tabs/grips and a bit more breathing room between items.
@@ -152,8 +148,8 @@ void ProfilerLauncherDialog::Render()
         ImGui::PushStyleVar(ImGuiStyleVar_GrabRounding, 6.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_TabRounding, 6.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_PopupRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.0f, 4.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 4.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.0f, 5.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 5.0f));
 
         // The dialog is a small two-step wizard: author the run (configure), then
         // watch it (run). Splitting them keeps the configuration uncluttered and
@@ -170,6 +166,7 @@ void ProfilerLauncherDialog::Render()
         ImGui::PopStyleVar(6);
     }
     ImGui::End();
+    ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
 
     // The Advanced Options window is a separate floating window (only relevant
     // while configuring).
@@ -569,14 +566,21 @@ void ProfilerLauncherDialog::RenderAdvancedWindow()
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
     ImGui::SetNextWindowSize(ImVec2(700, 560), ImGuiCond_FirstUseEver);
 
-    bool open = true;
-    if (ImGui::Begin("Advanced Profiling Options", &open))
+    // Restore the app's standard window padding/rounding (AppWindow's scope
+    // zeroes them). WindowPadding must be set before Begin().
+    SettingsManager& settings = SettingsManager::Get();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, settings.GetDefaultStyle().WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, settings.GetDefaultStyle().WindowRounding);
+
+    bool open    = true;
+    bool visible = ImGui::Begin("Advanced Profiling Options", &open);
+    if (visible)
     {
         ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 6.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_GrabRounding, 6.0f);
         ImGui::PushStyleVar(ImGuiStyleVar_TabRounding, 6.0f);
-        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.0f, 4.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 4.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(8.0f, 5.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8.0f, 5.0f));
 
         ImGui::TextDisabled("Fine-grained settings, applied on top of the selected preset.");
         ImGui::Spacing();
@@ -605,6 +609,7 @@ void ProfilerLauncherDialog::RenderAdvancedWindow()
         ImGui::PopStyleVar(5);
     }
     ImGui::End();
+    ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
 
     if (!open)
     {

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
@@ -75,9 +75,27 @@ private:
     }
     rocprofvis_profiler_type_t ResolveProfilerType() const;
 
+    // Top-level view routing: the dialog is either in "configure" mode (author
+    // the launch) or "run" mode (a focused output console shown once a run has
+    // been launched). m_show_run_view selects which is rendered.
+    void RenderConfigureView();
+    void RenderRunView();
+
     void RenderToolbar();
     void RenderMainContent();
+    // Deeper, less-common backend settings, shown in a separate floating window
+    // opened from the "Advanced Options..." button.
+    void RenderAdvancedWindow();
+    // Combined "Arguments & Environment" panel: command-line args (one edit box,
+    // added as pills) lead, environment variables (name/value, added as pills)
+    // grow below. Clicking a pill pulls it back into the editor to edit/remove.
+    void RenderArgsEnvPanel();
     void RenderButtonRow();
+    // Buttons for the run view: Cancel while running; Run Again / Back to
+    // Configuration / Open Trace / Close once the run has finished.
+    void RenderRunButtonRow();
+    // One-line "what is being run" summary shown atop the run view.
+    std::string BuildRunSummary() const;
 #ifdef ROCPROFVIS_ENABLE_REMOTE
     // TEMPORARY (remote/SSH): SSH connection selector + popups.
     void RenderRemoteSection();
@@ -121,6 +139,19 @@ private:
 
     bool m_should_open;
     bool m_show_window;
+    // Once a run is launched the dialog swaps to a focused output view; the
+    // user returns to configuration via "Back to Configuration". Reset on open.
+    bool m_show_run_view;
+    // Whether the separate "Advanced Options" window is open.
+    bool m_show_advanced_window;
+    // "Add" edit-box buffers for the Arguments & Environment panel.
+    std::string m_arg_input;
+    std::string m_env_name_input;
+    std::string m_env_value_input;
+    // Wall-clock timing for the run view's elapsed readout. Start is set on
+    // launch; end is frozen when the run finishes (0 while still running).
+    double m_run_start_time;
+    double m_run_end_time;
     // Last run state the dialog has reacted to, so Update() can detect edges and
     // append epilogue text once per transition.
     rocprofvis_profiler_state_t m_last_seen_state;

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
@@ -144,6 +144,10 @@ private:
     bool m_show_run_view;
     // Whether the separate "Advanced Options" window is open.
     bool m_show_advanced_window;
+    // Width (px) of the command-preview panel; user-adjustable via the splitter.
+    // Seeded to ~1/3 of the form width the first time the content is laid out.
+    float m_preview_width;
+    bool  m_preview_width_initialized;
     // "Add" edit-box buffers for the Arguments & Environment panel.
     std::string m_arg_input;
     std::string m_env_name_input;

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
@@ -155,6 +155,16 @@ constexpr float kListW       = 340.0f;  // comma-separated list text
 constexpr float kCheckboxColWidth = 190.0f;
 constexpr int   kCheckboxMaxCols  = 4;
 
+// General tab: the preset row and the side-by-side OUTPUT FORMAT / TRACE WINDOW
+// split (output takes a narrow fixed column so the trace window keeps Delay and
+// Duration on one line).
+constexpr float kPresetLabelW    = 110.0f;
+constexpr float kPresetComboW    = 240.0f;
+constexpr float kOutputColW      = 160.0f;
+constexpr float kTraceInlineNumW = 85.0f;   // Delay / Duration inputs (share a row)
+constexpr float kTraceFieldGapX  = 16.0f;   // gap between Delay and Duration
+constexpr float kTraceRegionTrail = 26.0f;  // width reserved for the Region (?)
+
 // Renders a label in a fixed-width column and sizes the next item so a whole
 // column of controls lines up regardless of label length.
 void FieldLabel(const char* label, float item_w, float label_w = kFieldLabelW)
@@ -211,6 +221,24 @@ bool AnyEnabled(std::map<std::string, bool> const& m)
             return true;
     }
     return false;
+}
+
+const ImVec4 kPresetLockColor(1.0f, 0.8f, 0.0f, 1.0f);  // amber "locked by preset"
+
+// Advanced tabs are read-only while a built-in preset is active. Draws the
+// "controlled by preset" banner (when one is set) and opens a BeginDisabled()
+// scope that the caller closes with ImGui::EndDisabled().
+void BeginPresetLockedSection(std::string const& preset)
+{
+    const bool has_preset = !preset.empty();
+    if (has_preset)
+    {
+        ImGui::TextColored(kPresetLockColor,
+                           "Preset \"%s\" controls these settings.", preset.c_str());
+        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
+        ImGui::Spacing();
+    }
+    ImGui::BeginDisabled(has_preset);
 }
 
 // ==================================================================================
@@ -506,8 +534,8 @@ std::vector<TabDescriptor> RocprofSysBackend::GetTabs(std::string const& tool_id
 {
     std::vector<TabDescriptor> tabs;
 
-    // General: the everyday controls (preset, trace/profile format, collection
-    // toggles, trace delay/duration/region). Always visible in the launcher.
+    // General: the everyday controls (preset, output format, trace window).
+    // Always visible in the launcher.
     tabs.push_back({"general", "General", [this]() {
         const_cast<RocprofSysBackend*>(this)->RenderBackendsTab();
     }, false});
@@ -725,9 +753,8 @@ void RocprofSysBackend::FlattenToExecution(
         env_out.emplace_back("ROCPROFSYS_OUTPUT_PATH", config.target.output_directory);
     }
 
-    // General (skip ROCPROFSYS_MODE — use individual backend toggles instead)
-    // Legacy mode field is no longer emitted; behavior is driven by
-    // ROCPROFSYS_TRACE + ROCPROFSYS_USE_SAMPLING toggles.
+    // Legacy ROCPROFSYS_MODE is intentionally not emitted; the individual
+    // backend toggles drive behavior instead.
     emit_double("ROCPROFSYS_TRACE_DELAY", m_settings.trace_delay, defaults.trace_delay);
     emit_double("ROCPROFSYS_TRACE_DURATION",
                 m_settings.trace_duration, defaults.trace_duration);
@@ -1056,35 +1083,25 @@ std::string RocprofSysBackend::ExportCfg() const
 
 void RocprofSysBackend::RenderGeneralTraceOptions()
 {
-    // Delay + Duration side by side to use the horizontal space.
-    if (ImGui::BeginTable("timing_grid", 2, ImGuiTableFlags_None))
-    {
-        ImGui::TableNextColumn();
-        ImGui::AlignTextToFramePadding();
-        ImGui::TextUnformatted("Delay (s)");
-        ImGui::SameLine();
-        ImGui::SetNextItemWidth(kNumW);
-        ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
-        HelpMarker("ROCPROFSYS_TRACE_DELAY",
-                   "Seconds before collection starts (0 = immediate)");
+    // Delay + Duration share a row; Region takes the next.
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Delay (s)");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(kTraceInlineNumW);
+    ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
 
-        ImGui::TableNextColumn();
-        ImGui::AlignTextToFramePadding();
-        ImGui::TextUnformatted("Duration (s)");
-        ImGui::SameLine();
-        ImGui::SetNextItemWidth(kNumW);
-        ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0, 0.0, "%.2f");
-        HelpMarker("ROCPROFSYS_TRACE_DURATION",
-                   "Duration of collection in seconds (0 = unlimited)");
-
-        ImGui::EndTable();
-    }
+    ImGui::SameLine(0.0f, kTraceFieldGapX);
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Duration (s)");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(kTraceInlineNumW);
+    ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0, 0.0, "%.2f");
 
     ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Trace region");
+    ImGui::TextUnformatted("Region");
     ImGui::SameLine();
-    ImGui::SetNextItemWidth(kListW);
-    InputTextStringWithHint("##TraceRegion", "ROCTX region names (comma-separated)",
+    ImGui::SetNextItemWidth(-kTraceRegionTrail);
+    InputTextStringWithHint("##TraceRegion", "ROCTX regions (comma-separated)",
                             m_settings.trace_region);
     HelpMarker("ROCPROFSYS_TRACE_REGION",
                "Comma-separated ROCTX region names for selective tracing");
@@ -1095,12 +1112,12 @@ void RocprofSysBackend::RenderBackendsTab()
     // Headline choice: the built-in rocprof-sys preset.
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Preset");
-    ImGui::SameLine(110.0f);
+    ImGui::SameLine(kPresetLabelW);
 
     const char* preset_label =
         m_settings.rocprof_preset.empty() ? "Custom" : m_settings.rocprof_preset.c_str();
 
-    ImGui::SetNextItemWidth(240.0f);
+    ImGui::SetNextItemWidth(kPresetComboW);
     if (ImGui::BeginCombo("##RocprofPresetCombo", preset_label))
     {
         if (ImGui::Selectable("Custom", m_settings.rocprof_preset.empty()))
@@ -1128,58 +1145,45 @@ void RocprofSysBackend::RenderBackendsTab()
 
     bool has_preset = !m_settings.rocprof_preset.empty();
 
-    // Show the selected preset's description inline so its intent is visible
-    // (not hidden behind the combo tooltip).
-    const char* preset_desc = nullptr;
-    for (size_t i = 0; i < kRocprofSysPresetsCount; i++)
+    // Show the active preset's description inline so its intent is visible.
+    if (has_preset)
     {
-        if (m_settings.rocprof_preset == kRocprofSysPresets[i].name)
+        for (size_t i = 0; i < kRocprofSysPresetsCount; i++)
         {
-            preset_desc = kRocprofSysPresets[i].description;
-            break;
+            if (m_settings.rocprof_preset == kRocprofSysPresets[i].name)
+            {
+                ImGui::PushStyleColor(ImGuiCol_Text,
+                                      ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+                ImGui::PushTextWrapPos(0.0f);
+                ImGui::TextWrapped("%s", kRocprofSysPresets[i].description);
+                ImGui::PopTextWrapPos();
+                ImGui::PopStyleColor();
+                break;
+            }
         }
     }
-    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-    ImGui::PushTextWrapPos(0.0f);
-    if (preset_desc != nullptr)
-    {
-        ImGui::TextWrapped("%s", preset_desc);
-    }
-    else
-    {
-        ImGui::TextWrapped("Custom - configure the options below manually.");
-    }
-    ImGui::PopTextWrapPos();
-    ImGui::PopStyleColor();
 
-    // Toggle laid out in the next free column of a 2-wide grid, with a help (?).
-    auto toggle_cell = [](const char* label, bool* value, const char* env,
-                          const char* help)
+    // Output format and the trace window sit side by side.
+    if (ImGui::BeginTable("general_split", 2, ImGuiTableFlags_None))
     {
+        ImGui::TableSetupColumn("##out", ImGuiTableColumnFlags_WidthFixed, kOutputColW);
+        ImGui::TableSetupColumn("##trace", ImGuiTableColumnFlags_WidthStretch);
+
         ImGui::TableNextColumn();
-        ToggleSwitch(label, value);
-        HelpMarker(env, help);
-    };
+        LaunchSubHeader("OUTPUT FORMAT");
+        ToggleSwitch("Perfetto trace", &m_settings.trace_backend);
+        HelpMarker("ROCPROFSYS_TRACE", "Enable the Perfetto trace backend");
+        ToggleSwitch("ROCpd database", &m_settings.use_rocpd);
+        HelpMarker("ROCPROFSYS_USE_ROCPD", "Enable ROCpd SQLite output");
 
-    // --- Output format (always editable) ---
-    LaunchSubHeader("OUTPUT FORMAT");
-    if (ImGui::BeginTable("out_fmt_grid", 2, ImGuiTableFlags_None))
-    {
-        toggle_cell("Perfetto trace", &m_settings.trace_backend,
-                    "ROCPROFSYS_TRACE", "Enable the Perfetto trace backend");
-        toggle_cell("ROCpd database", &m_settings.use_rocpd,
-                    "ROCPROFSYS_USE_ROCPD", "Enable ROCpd SQLite output");
+        ImGui::TableNextColumn();
+        ImGui::BeginDisabled(has_preset);
+        LaunchSubHeader("TRACE WINDOW");
+        RenderGeneralTraceOptions();
+        ImGui::EndDisabled();
+
         ImGui::EndTable();
     }
-
-    // Summary profile and the collection toggles now live under Advanced
-    // (Sampling / Process Sampling / Config & Logging) to keep General lean.
-
-    // --- Trace window ---
-    ImGui::BeginDisabled(has_preset);
-    LaunchSubHeader("TRACE WINDOW");
-    RenderGeneralTraceOptions();
-    ImGui::EndDisabled();
 
     if (has_preset)
     {
@@ -1192,16 +1196,7 @@ void RocprofSysBackend::RenderBackendsTab()
 
 void RocprofSysBackend::RenderSamplingTab()
 {
-    bool has_preset = !m_settings.rocprof_preset.empty();
-    if (has_preset)
-    {
-        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
-            "Preset \"%s\" controls these settings.",
-            m_settings.rocprof_preset.c_str());
-        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
-        ImGui::Spacing();
-    }
-    ImGui::BeginDisabled(has_preset);
+    BeginPresetLockedSection(m_settings.rocprof_preset);
 
     LaunchSubHeader("ENABLE");
     ToggleSwitch("Call-stack sampling", &m_settings.use_sampling);
@@ -1268,16 +1263,7 @@ void RocprofSysBackend::RenderSamplingTab()
 
 void RocprofSysBackend::RenderRocmTab()
 {
-    bool has_preset = !m_settings.rocprof_preset.empty();
-    if (has_preset)
-    {
-        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
-            "Preset \"%s\" controls these settings.",
-            m_settings.rocprof_preset.c_str());
-        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
-        ImGui::Spacing();
-    }
-    ImGui::BeginDisabled(has_preset);
+    BeginPresetLockedSection(m_settings.rocprof_preset);
 
     ImGui::Text("ROCm Domains:");
     HelpMarker("ROCPROFSYS_ROCM_DOMAINS",
@@ -1308,20 +1294,11 @@ void RocprofSysBackend::RenderRocmTab()
 
 void RocprofSysBackend::RenderPerfettoTab()
 {
-    bool has_preset = !m_settings.rocprof_preset.empty();
-    if (has_preset)
-    {
-        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
-            "Preset \"%s\" controls these settings.",
-            m_settings.rocprof_preset.c_str());
-        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
-        ImGui::Spacing();
-    }
-    ImGui::BeginDisabled(has_preset);
+    BeginPresetLockedSection(m_settings.rocprof_preset);
 
     const char* backends[] = {"inprocess", "system", "all"};
     int backend_idx = 0;
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < IM_ARRAYSIZE(backends); i++)
     {
         if (m_settings.perfetto_backend == backends[i])
         {
@@ -1330,7 +1307,7 @@ void RocprofSysBackend::RenderPerfettoTab()
         }
     }
     FieldLabel("Backend", kComboW);
-    if (ImGui::Combo("##PerfBackend", &backend_idx, backends, 3))
+    if (ImGui::Combo("##PerfBackend", &backend_idx, backends, IM_ARRAYSIZE(backends)))
     {
         m_settings.perfetto_backend = backends[backend_idx];
     }
@@ -1357,7 +1334,7 @@ void RocprofSysBackend::RenderPerfettoTab()
     const char* policies[] = {"discard", "fill"};
     int policy_idx = (m_settings.perfetto_fill_policy == "fill") ? 1 : 0;
     FieldLabel("Fill Policy", kComboW);
-    if (ImGui::Combo("##FillPolicy", &policy_idx, policies, 2))
+    if (ImGui::Combo("##FillPolicy", &policy_idx, policies, IM_ARRAYSIZE(policies)))
     {
         m_settings.perfetto_fill_policy = policies[policy_idx];
     }
@@ -1417,16 +1394,7 @@ void RocprofSysBackend::RenderPerfettoTab()
 
 void RocprofSysBackend::RenderProcessSamplingTab()
 {
-    bool has_preset = !m_settings.rocprof_preset.empty();
-    if (has_preset)
-    {
-        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
-            "Preset \"%s\" controls these settings.",
-            m_settings.rocprof_preset.c_str());
-        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
-        ImGui::Spacing();
-    }
-    ImGui::BeginDisabled(has_preset);
+    BeginPresetLockedSection(m_settings.rocprof_preset);
 
     LaunchSubHeader("ENABLE");
     ToggleSwitch("AMD SMI GPU metrics", &m_settings.use_amd_smi);
@@ -1475,16 +1443,7 @@ void RocprofSysBackend::RenderProcessSamplingTab()
 
 void RocprofSysBackend::RenderParallelismTab()
 {
-    bool has_preset = !m_settings.rocprof_preset.empty();
-    if (has_preset)
-    {
-        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
-            "Preset \"%s\" controls these settings.",
-            m_settings.rocprof_preset.c_str());
-        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
-        ImGui::Spacing();
-    }
-    ImGui::BeginDisabled(has_preset);
+    BeginPresetLockedSection(m_settings.rocprof_preset);
 
     auto toggle = [](char const* label, bool& val, char const* env,
                      char const* help)
@@ -1516,16 +1475,7 @@ void RocprofSysBackend::RenderParallelismTab()
 
 void RocprofSysBackend::RenderInstrumentTab()
 {
-    bool has_preset = !m_settings.rocprof_preset.empty();
-    if (has_preset)
-    {
-        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
-            "Preset \"%s\" controls these settings.",
-            m_settings.rocprof_preset.c_str());
-        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
-        ImGui::Spacing();
-    }
-    ImGui::BeginDisabled(has_preset);
+    BeginPresetLockedSection(m_settings.rocprof_preset);
 
     ImGui::Text("Binary Instrumentation Options");
     ImGui::Separator();
@@ -1555,16 +1505,7 @@ void RocprofSysBackend::RenderInstrumentTab()
 
 void RocprofSysBackend::RenderAdvancedTab()
 {
-    bool has_preset = !m_settings.rocprof_preset.empty();
-    if (has_preset)
-    {
-        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
-            "Preset \"%s\" controls these settings.",
-            m_settings.rocprof_preset.c_str());
-        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
-        ImGui::Spacing();
-    }
-    ImGui::BeginDisabled(has_preset);
+    BeginPresetLockedSection(m_settings.rocprof_preset);
 
     LaunchSubHeader("SUMMARY PROFILE");
     int profile_mode = 0;
@@ -1604,8 +1545,8 @@ void RocprofSysBackend::RenderAdvancedTab()
     ImGui::Separator();
 
     const char* levels[] = {"trace", "debug", "info", "warning", "error", "critical"};
-    int level_idx = 2;
-    for (int i = 0; i < 6; i++)
+    int level_idx = 2;  // default: "info"
+    for (int i = 0; i < IM_ARRAYSIZE(levels); i++)
     {
         if (m_settings.log_level == levels[i])
         {
@@ -1614,7 +1555,7 @@ void RocprofSysBackend::RenderAdvancedTab()
         }
     }
     FieldLabel("Log Level", kComboW);
-    if (ImGui::Combo("##LogLevel", &level_idx, levels, 6))
+    if (ImGui::Combo("##LogLevel", &level_idx, levels, IM_ARRAYSIZE(levels)))
     {
         m_settings.log_level = levels[level_idx];
     }

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
@@ -6,7 +6,6 @@
 #include "rocprofvis_gui_helpers.h"
 #include "rocprofvis_json_utils.h"
 #include "imgui.h"
-#include <cfloat>
 #include <sstream>
 #include <algorithm>
 #include <cctype>
@@ -102,18 +101,22 @@ CheckboxEntry const kPerfettoCategories[] = {
 size_t const kPerfettoCategoriesCount =
     sizeof(kPerfettoCategories) / sizeof(kPerfettoCategories[0]);
 
+// Descriptions mirror the rocprof-sys preset JSONs shipped in
+// share/rocprofiler-systems/presets/*.json (metadata.description / use_case).
+// The authoritative text lives with the installed tool; these are bundled
+// copies so users see guidance without a rocprof-sys install.
 RocprofPresetEntry const kRocprofSysPresets[] = {
-    {"balanced",          "Balanced profiling with moderate overhead"},
-    {"profile-only",      "Flat profile only, minimal overhead"},
-    {"detailed",          "Comprehensive profiling with full system metrics"},
-    {"trace-gpu",         "GPU workload analysis with host and device activity"},
-    {"workload-trace",    "Optimized for AI/ML/GPU workloads with RCCL"},
-    {"trace-hw-counters", "Hardware counter collection"},
-    {"trace-hpc",         "HPC/MPI/OpenMP with OMPT and MPIP"},
-    {"trace-openmp",      "OpenMP offload workloads with HSA domains"},
-    {"profile-mpi",       "MPI communication latency profiling"},
-    {"sys-trace",         "System-level tracing"},
-    {"runtime-trace",     "Runtime API tracing"},
+    {"balanced",          "Tracing + call-stack sampling for a solid overview at moderate overhead. Good default."},
+    {"profile-only",      "Flat call-stack profile only. Lowest overhead, no timeline."},
+    {"detailed",          "Comprehensive: tracing, sampling, and full system + GPU metrics. Highest overhead."},
+    {"trace-gpu",         "GPU workload timeline: host + device activity and kernel dispatch."},
+    {"workload-trace",    "AI/ML/GPU workloads, including RCCL collective communication."},
+    {"trace-hw-counters", "Collect ROCm hardware counters (PMC) alongside tracing."},
+    {"trace-hpc",         "HPC apps: MPI, OpenMP, Kokkos and RCCL with hardware counters."},
+    {"trace-openmp",      "OpenMP offload workloads with HSA domains."},
+    {"profile-mpi",       "MPI communication latency profiling."},
+    {"sys-trace",         "System-level tracing of the whole application."},
+    {"runtime-trace",     "ROCm/HIP runtime API tracing."},
 };
 size_t const kRocprofSysPresetsCount =
     sizeof(kRocprofSysPresets) / sizeof(kRocprofSysPresets[0]);
@@ -140,9 +143,26 @@ void HelpMarker(char const* env_var, char const* desc)
     }
 }
 
-void WarningText(char const* text)
+// Shared control widths so combos/inputs across the advanced tabs are neither
+// full-window-wide nor ragged.
+constexpr float kFieldLabelW = 150.0f;  // label column width (aligns all inputs)
+constexpr float kNumW        = 130.0f;  // numeric inputs
+constexpr float kComboW      = 200.0f;  // dropdowns
+constexpr float kTextW       = 260.0f;  // single-value text
+constexpr float kListW       = 340.0f;  // comma-separated list text
+
+// Checkbox lists lay out as a responsive grid clamped to this many columns.
+constexpr float kCheckboxColWidth = 190.0f;
+constexpr int   kCheckboxMaxCols  = 4;
+
+// Renders a label in a fixed-width column and sizes the next item so a whole
+// column of controls lines up regardless of label length.
+void FieldLabel(const char* label, float item_w, float label_w = kFieldLabelW)
 {
-    ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "(!) %s", text);
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(label);
+    ImGui::SameLine(label_w);
+    ImGui::SetNextItemWidth(item_w);
 }
 
 void RenderCheckboxMap(
@@ -151,20 +171,35 @@ void RenderCheckboxMap(
     size_t count,
     char const* id_prefix)
 {
-    for (size_t i = 0; i < count; i++)
+    // Long checkbox lists read better as a responsive grid than one tall column.
+    int cols = static_cast<int>(ImGui::GetContentRegionAvail().x / kCheckboxColWidth);
+    cols     = std::clamp(cols, 1, kCheckboxMaxCols);
+    if (count > 0 && static_cast<size_t>(cols) > count)
     {
-        bool val = false;
-        auto it = map.find(entries[i].id);
-        if (it != map.end())
+        cols = static_cast<int>(count);
+    }
+
+    std::string table_id = std::string("cbgrid_") + id_prefix;
+    if (ImGui::BeginTable(table_id.c_str(), cols, ImGuiTableFlags_None))
+    {
+        for (size_t i = 0; i < count; i++)
         {
-            val = it->second;
+            ImGui::TableNextColumn();
+
+            bool val = false;
+            auto it  = map.find(entries[i].id);
+            if (it != map.end())
+            {
+                val = it->second;
+            }
+            std::string label =
+                std::string(entries[i].display_name) + "##" + id_prefix + entries[i].id;
+            if (ImGui::Checkbox(label.c_str(), &val))
+            {
+                map[entries[i].id] = val;
+            }
         }
-        std::string label =
-            std::string(entries[i].display_name) + "##" + id_prefix + entries[i].id;
-        if (ImGui::Checkbox(label.c_str(), &val))
-        {
-            map[entries[i].id] = val;
-        }
+        ImGui::EndTable();
     }
 }
 
@@ -337,7 +372,6 @@ RocprofSysSettings RocprofSysSettings::FromJson(jt::Json const& json)
     s.log_file            = safe_string(j, "log_file", "rocprof-sys-log.txt");
     s.tmpdir              = safe_string(j, "tmpdir", "");
     s.use_pid             = safe_bool(j, "use_pid", true);
-    s.timemory_components = safe_string(j, "timemory_components", "wall_clock");
 
     // Instrument
     s.instr_include    = safe_string(j, "instr_include", "");
@@ -419,7 +453,6 @@ jt::Json RocprofSysSettings::ToJson() const
     p["log_file"]            = log_file;
     p["tmpdir"]              = tmpdir;
     p["use_pid"]             = use_pid;
-    p["timemory_components"] = timemory_components;
 
     // Instrument
     p["instr_include"]    = instr_include;
@@ -817,9 +850,10 @@ void RocprofSysBackend::FlattenToExecution(
     emit_string("ROCPROFSYS_LOG_LEVEL", m_settings.log_level, defaults.log_level);
     emit_string("ROCPROFSYS_LOG_FILE", m_settings.log_file, defaults.log_file);
     emit_string("ROCPROFSYS_TMPDIR", m_settings.tmpdir, defaults.tmpdir);
-    emit_bool("ROCPROFSYS_USE_PID", m_settings.use_pid, defaults.use_pid);
-    emit_string("ROCPROFSYS_TIMEMORY_COMPONENTS",
-                m_settings.timemory_components, defaults.timemory_components);
+    // MPI profiling (MPIP) is incompatible with per-process PID-suffixed output,
+    // so PID suffixing is forced off whenever MPI is enabled.
+    bool effective_use_pid = m_settings.use_pid && !m_settings.use_mpip;
+    emit_bool("ROCPROFSYS_USE_PID", effective_use_pid, defaults.use_pid);
 
     // Instrument args
     if (config.tool_id == "instrument")
@@ -1011,8 +1045,7 @@ std::string RocprofSysBackend::ExportCfg() const
     emit_string("ROCPROFSYS_LOG_LEVEL", m_settings.log_level);
     emit_string("ROCPROFSYS_LOG_FILE", m_settings.log_file);
     emit_string("ROCPROFSYS_TMPDIR", m_settings.tmpdir);
-    emit_bool("ROCPROFSYS_USE_PID", m_settings.use_pid);
-    emit_string("ROCPROFSYS_TIMEMORY_COMPONENTS", m_settings.timemory_components);
+    emit_bool("ROCPROFSYS_USE_PID", m_settings.use_pid && !m_settings.use_mpip);
 
     return cfg.str();
 }
@@ -1030,7 +1063,7 @@ void RocprofSysBackend::RenderGeneralTraceOptions()
         ImGui::AlignTextToFramePadding();
         ImGui::TextUnformatted("Delay (s)");
         ImGui::SameLine();
-        ImGui::SetNextItemWidth(90.0f);
+        ImGui::SetNextItemWidth(kNumW);
         ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
         HelpMarker("ROCPROFSYS_TRACE_DELAY",
                    "Seconds before collection starts (0 = immediate)");
@@ -1039,7 +1072,7 @@ void RocprofSysBackend::RenderGeneralTraceOptions()
         ImGui::AlignTextToFramePadding();
         ImGui::TextUnformatted("Duration (s)");
         ImGui::SameLine();
-        ImGui::SetNextItemWidth(90.0f);
+        ImGui::SetNextItemWidth(kNumW);
         ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0, 0.0, "%.2f");
         HelpMarker("ROCPROFSYS_TRACE_DURATION",
                    "Duration of collection in seconds (0 = unlimited)");
@@ -1048,9 +1081,9 @@ void RocprofSysBackend::RenderGeneralTraceOptions()
     }
 
     ImGui::AlignTextToFramePadding();
-    ImGui::TextUnformatted("Region");
-    ImGui::SameLine(90.0f);
-    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::TextUnformatted("Trace region");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(kListW);
     InputTextStringWithHint("##TraceRegion", "ROCTX region names (comma-separated)",
                             m_settings.trace_region);
     HelpMarker("ROCPROFSYS_TRACE_REGION",
@@ -1095,6 +1128,30 @@ void RocprofSysBackend::RenderBackendsTab()
 
     bool has_preset = !m_settings.rocprof_preset.empty();
 
+    // Show the selected preset's description inline so its intent is visible
+    // (not hidden behind the combo tooltip).
+    const char* preset_desc = nullptr;
+    for (size_t i = 0; i < kRocprofSysPresetsCount; i++)
+    {
+        if (m_settings.rocprof_preset == kRocprofSysPresets[i].name)
+        {
+            preset_desc = kRocprofSysPresets[i].description;
+            break;
+        }
+    }
+    ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    ImGui::PushTextWrapPos(0.0f);
+    if (preset_desc != nullptr)
+    {
+        ImGui::TextWrapped("%s", preset_desc);
+    }
+    else
+    {
+        ImGui::TextWrapped("Custom - configure the options below manually.");
+    }
+    ImGui::PopTextWrapPos();
+    ImGui::PopStyleColor();
+
     // Toggle laid out in the next free column of a 2-wide grid, with a help (?).
     auto toggle_cell = [](const char* label, bool* value, const char* env,
                           const char* help)
@@ -1115,54 +1172,12 @@ void RocprofSysBackend::RenderBackendsTab()
         ImGui::EndTable();
     }
 
-    // --- Summary profile ---
+    // Summary profile and the collection toggles now live under Advanced
+    // (Sampling / Process Sampling / Config & Logging) to keep General lean.
+
+    // --- Trace window ---
     ImGui::BeginDisabled(has_preset);
-    LaunchSubHeader("SUMMARY PROFILE");
-
-    int profile_mode = 0;
-    if (m_settings.profile)      profile_mode = 1;
-    if (m_settings.flat_profile) profile_mode = 2;
-
-    if (ImGui::RadioButton("None##Profile", profile_mode == 0))
-    {
-        m_settings.profile      = false;
-        m_settings.flat_profile = false;
-    }
-    ImGui::SameLine();
-    if (ImGui::RadioButton("Hierarchical", profile_mode == 1))
-    {
-        m_settings.profile      = true;
-        m_settings.flat_profile = false;
-    }
-    ImGui::SameLine();
-    if (ImGui::RadioButton("Flat", profile_mode == 2))
-    {
-        m_settings.profile      = false;
-        m_settings.flat_profile = true;
-    }
-    ImGui::SameLine();
-    HelpMarker("ROCPROFSYS_PROFILE / ROCPROFSYS_FLAT_PROFILE",
-               "Timemory summary profile mode (hierarchical or flat call stacks)");
-    ImGui::EndDisabled();
-
-    // --- Collection ---
-    ImGui::BeginDisabled(has_preset);
-    LaunchSubHeader("COLLECTION");
-    if (ImGui::BeginTable("collection_grid", 3, ImGuiTableFlags_None))
-    {
-        toggle_cell("Statistical sampling", &m_settings.use_sampling,
-                    "ROCPROFSYS_USE_SAMPLING", "Enable call-stack sampling");
-        toggle_cell("Process / system sampling", &m_settings.use_process_sampling,
-                    "ROCPROFSYS_USE_PROCESS_SAMPLING", "Background process/system metrics");
-        toggle_cell("AMD SMI GPU metrics", &m_settings.use_amd_smi,
-                    "ROCPROFSYS_USE_AMD_SMI", "GPU metrics via AMD SMI");
-        ImGui::EndTable();
-    }
-    ImGui::EndDisabled();
-
-    // --- Timing window ---
-    ImGui::BeginDisabled(has_preset);
-    LaunchSubHeader("TIMING");
+    LaunchSubHeader("TRACE WINDOW");
     RenderGeneralTraceOptions();
     ImGui::EndDisabled();
 
@@ -1188,8 +1203,17 @@ void RocprofSysBackend::RenderSamplingTab()
     }
     ImGui::BeginDisabled(has_preset);
 
-    ImGui::Text("Sampling Frequency (Hz):");
-    ImGui::SameLine();
+    LaunchSubHeader("ENABLE");
+    ToggleSwitch("Call-stack sampling", &m_settings.use_sampling);
+    HelpMarker("ROCPROFSYS_USE_SAMPLING", "Enable call-stack sampling");
+    ToggleSwitch("Process / system sampling", &m_settings.use_process_sampling);
+    HelpMarker("ROCPROFSYS_USE_PROCESS_SAMPLING",
+               "Background process/system metrics (CPU freq, memory, GPU via SMI)");
+
+    ImGui::Spacing();
+    ImGui::Separator();
+
+    FieldLabel("Frequency (Hz)", kNumW);
     ImGui::InputDouble("##SampFreq", &m_settings.sampling_freq, 10.0, 100.0, "%.0f");
     HelpMarker("ROCPROFSYS_SAMPLING_FREQ", "Software interrupts per second");
 
@@ -1210,15 +1234,13 @@ void RocprofSysBackend::RenderSamplingTab()
 
     ImGui::Separator();
 
-    ImGui::Text("Duration (s):");
-    ImGui::SameLine();
+    FieldLabel("Duration (s)", kNumW);
     ImGui::InputDouble("##SampDur", &m_settings.sampling_duration, 0.0, 0.0, "%.2f");
     HelpMarker("ROCPROFSYS_SAMPLING_DURATION",
                "Stop sampling after N seconds (0 = unlimited)");
 
     int alloc_sz = m_settings.sampling_allocator_size;
-    ImGui::Text("Allocator Size:");
-    ImGui::SameLine();
+    FieldLabel("Allocator Size", kNumW);
     if (ImGui::InputInt("##AllocSz", &alloc_sz))
     {
         m_settings.sampling_allocator_size = alloc_sz;
@@ -1226,8 +1248,7 @@ void RocprofSysBackend::RenderSamplingTab()
     HelpMarker("ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE",
                "Threads per background allocator");
 
-    ImGui::Text("Overflow Event:");
-    ImGui::SameLine();
+    FieldLabel("Overflow Event", kTextW);
     InputTextString("##OverflowEvt", m_settings.sampling_overflow_event);
     HelpMarker("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
                "Linux perf metric name for overflow sampling");
@@ -1266,15 +1287,14 @@ void RocprofSysBackend::RenderRocmTab()
                       kRocmDomains, kRocmDomainsCount, "rd_");
 
     ImGui::Spacing();
-    ImGui::Text("Custom Domains:");
-    ImGui::SameLine();
+    FieldLabel("Custom Domains", kListW);
     InputTextString("##RocmDomainsCustom", m_settings.rocm_domains_custom);
     HelpMarker("ROCPROFSYS_ROCM_DOMAINS",
                "Additional comma-separated domain names not in the list above");
 
     ImGui::Separator();
 
-    ImGui::Text("Hardware Counters:");
+    FieldLabel("Hardware Counters", kListW);
     InputTextString("##RocmEvents", m_settings.rocm_events);
     HelpMarker("ROCPROFSYS_ROCM_EVENTS",
                "HW counters (use :device=N syntax for specific GPU)");
@@ -1309,8 +1329,7 @@ void RocprofSysBackend::RenderPerfettoTab()
             break;
         }
     }
-    ImGui::Text("Backend:");
-    ImGui::SameLine();
+    FieldLabel("Backend", kComboW);
     if (ImGui::Combo("##PerfBackend", &backend_idx, backends, 3))
     {
         m_settings.perfetto_backend = backends[backend_idx];
@@ -1318,8 +1337,7 @@ void RocprofSysBackend::RenderPerfettoTab()
     HelpMarker("ROCPROFSYS_PERFETTO_BACKEND", "Perfetto tracing backend mode");
 
     int buf_kb = m_settings.perfetto_buffer_size_kb;
-    ImGui::Text("Buffer Size (KB):");
-    ImGui::SameLine();
+    FieldLabel("Buffer Size (KB)", kNumW);
     if (ImGui::InputInt("##BufKB", &buf_kb, 1024, 10240))
     {
         m_settings.perfetto_buffer_size_kb = buf_kb;
@@ -1328,8 +1346,7 @@ void RocprofSysBackend::RenderPerfettoTab()
                "Perfetto shared memory buffer size");
 
     int flush_ms = m_settings.perfetto_flush_period_ms;
-    ImGui::Text("Flush Period (ms):");
-    ImGui::SameLine();
+    FieldLabel("Flush Period (ms)", kNumW);
     if (ImGui::InputInt("##FlushMs", &flush_ms, 1000, 5000))
     {
         m_settings.perfetto_flush_period_ms = flush_ms;
@@ -1339,8 +1356,7 @@ void RocprofSysBackend::RenderPerfettoTab()
 
     const char* policies[] = {"discard", "fill"};
     int policy_idx = (m_settings.perfetto_fill_policy == "fill") ? 1 : 0;
-    ImGui::Text("Fill Policy:");
-    ImGui::SameLine();
+    FieldLabel("Fill Policy", kComboW);
     if (ImGui::Combo("##FillPolicy", &policy_idx, policies, 2))
     {
         m_settings.perfetto_fill_policy = policies[policy_idx];
@@ -1392,8 +1408,7 @@ void RocprofSysBackend::RenderPerfettoTab()
 
     ImGui::Separator();
 
-    ImGui::Text("Output File:");
-    ImGui::SameLine();
+    FieldLabel("Output File", kTextW);
     InputTextString("##PerfFile", m_settings.perfetto_file);
     HelpMarker("ROCPROFSYS_PERFETTO_FILE", "Output filename for perfetto trace");
 
@@ -1413,6 +1428,13 @@ void RocprofSysBackend::RenderProcessSamplingTab()
     }
     ImGui::BeginDisabled(has_preset);
 
+    LaunchSubHeader("ENABLE");
+    ToggleSwitch("AMD SMI GPU metrics", &m_settings.use_amd_smi);
+    HelpMarker("ROCPROFSYS_USE_AMD_SMI", "GPU metrics via AMD SMI");
+
+    ImGui::Spacing();
+    ImGui::Separator();
+
     ImGui::Checkbox("CPU Frequency / Mem / Context Switches",
                     &m_settings.cpu_freq_enabled);
     HelpMarker("ROCPROFSYS_CPU_FREQ_ENABLED",
@@ -1428,22 +1450,19 @@ void RocprofSysBackend::RenderProcessSamplingTab()
                       kAmdSmiMetrics, kAmdSmiMetricsCount, "smi_");
 
     ImGui::Spacing();
-    ImGui::Text("Custom Metrics:");
-    ImGui::SameLine();
+    FieldLabel("Custom Metrics", kListW);
     InputTextString("##SmiMetricsCustom", m_settings.amd_smi_metrics_custom);
     HelpMarker("ROCPROFSYS_AMD_SMI_METRICS",
                "Additional comma-separated metric names not in the list above");
 
     ImGui::Separator();
 
-    ImGui::Text("CPUs:");
-    ImGui::SameLine();
+    FieldLabel("CPUs", kTextW);
     InputTextString("##SampCPUs", m_settings.sampling_cpus);
     HelpMarker("ROCPROFSYS_SAMPLING_CPUS",
                "CPU list for frequency sampling ('none', 'all', or index list)");
 
-    ImGui::Text("GPUs:");
-    ImGui::SameLine();
+    FieldLabel("GPUs", kTextW);
     InputTextString("##SampGPUs", m_settings.sampling_gpus);
     HelpMarker("ROCPROFSYS_SAMPLING_GPUS",
                "AMD SMI device indices for GPU sampling");
@@ -1470,22 +1489,27 @@ void RocprofSysBackend::RenderParallelismTab()
     auto toggle = [](char const* label, bool& val, char const* env,
                      char const* help)
     {
+        ImGui::TableNextColumn();
         ToggleSwitch(label, &val);
         HelpMarker(env, help);
     };
 
-    toggle("MPI (MPIP)", m_settings.use_mpip,
-           "ROCPROFSYS_USE_MPIP", "Profile MPI functions");
-    toggle("UCX", m_settings.use_ucx,
-           "ROCPROFSYS_USE_UCX", "UCX communication wrappers");
-    toggle("OpenSHMEM", m_settings.use_shmem,
-           "ROCPROFSYS_USE_SHMEM", "OpenSHMEM profiling");
-    toggle("RCCL", m_settings.use_rcclp,
-           "ROCPROFSYS_USE_RCCLP", "RCCL collective communication profiling");
-    toggle("OpenMP (OMPT)", m_settings.use_ompt,
-           "ROCPROFSYS_USE_OMPT", "OpenMP Tools interface");
-    toggle("Kokkos", m_settings.use_kokkosp,
-           "ROCPROFSYS_USE_KOKKOSP", "Kokkos Tools callback interface");
+    if (ImGui::BeginTable("parallelism_grid", 2, ImGuiTableFlags_None))
+    {
+        toggle("MPI (MPIP)", m_settings.use_mpip,
+               "ROCPROFSYS_USE_MPIP", "Profile MPI functions");
+        toggle("UCX", m_settings.use_ucx,
+               "ROCPROFSYS_USE_UCX", "UCX communication wrappers");
+        toggle("OpenSHMEM", m_settings.use_shmem,
+               "ROCPROFSYS_USE_SHMEM", "OpenSHMEM profiling");
+        toggle("RCCL", m_settings.use_rcclp,
+               "ROCPROFSYS_USE_RCCLP", "RCCL collective communication profiling");
+        toggle("OpenMP (OMPT)", m_settings.use_ompt,
+               "ROCPROFSYS_USE_OMPT", "OpenMP Tools interface");
+        toggle("Kokkos", m_settings.use_kokkosp,
+               "ROCPROFSYS_USE_KOKKOSP", "Kokkos Tools callback interface");
+        ImGui::EndTable();
+    }
 
     ImGui::EndDisabled();
 }
@@ -1506,19 +1530,18 @@ void RocprofSysBackend::RenderInstrumentTab()
     ImGui::Text("Binary Instrumentation Options");
     ImGui::Separator();
 
-    ImGui::Text("Include Regex:");
+    FieldLabel("Include Regex", kListW);
     InputTextString("##InstrInclude", m_settings.instr_include);
     HelpMarker("-I / --function-include",
                "Regex for functions to include in instrumentation");
 
-    ImGui::Text("Exclude Regex:");
+    FieldLabel("Exclude Regex", kListW);
     InputTextString("##InstrExclude", m_settings.instr_exclude);
     HelpMarker("-E / --function-exclude",
                "Regex for functions to exclude from instrumentation");
 
     int min_instr = m_settings.min_instructions;
-    ImGui::Text("Min Instructions:");
-    ImGui::SameLine();
+    FieldLabel("Min Instructions", kNumW);
     if (ImGui::InputInt("##MinInstr", &min_instr))
     {
         if (min_instr < 0) min_instr = 0;
@@ -1543,8 +1566,36 @@ void RocprofSysBackend::RenderAdvancedTab()
     }
     ImGui::BeginDisabled(has_preset);
 
-    ImGui::Text("Config File:");
+    LaunchSubHeader("SUMMARY PROFILE");
+    int profile_mode = 0;
+    if (m_settings.profile)      profile_mode = 1;
+    if (m_settings.flat_profile) profile_mode = 2;
+
+    if (ImGui::RadioButton("None##Profile", profile_mode == 0))
+    {
+        m_settings.profile      = false;
+        m_settings.flat_profile = false;
+    }
     ImGui::SameLine();
+    if (ImGui::RadioButton("Hierarchical", profile_mode == 1))
+    {
+        m_settings.profile      = true;
+        m_settings.flat_profile = false;
+    }
+    ImGui::SameLine();
+    if (ImGui::RadioButton("Flat", profile_mode == 2))
+    {
+        m_settings.profile      = false;
+        m_settings.flat_profile = true;
+    }
+    ImGui::SameLine();
+    HelpMarker("ROCPROFSYS_PROFILE / ROCPROFSYS_FLAT_PROFILE",
+               "Timemory summary profile mode (hierarchical or flat call stacks)");
+
+    ImGui::Spacing();
+    ImGui::Separator();
+
+    FieldLabel("Config File", kListW);
     InputTextString("##CfgFile", m_settings.config_file);
     HelpMarker("ROCPROFSYS_CONFIG_FILE",
                "Path to rocprof-sys configuration file (overrides individual settings)");
@@ -1562,34 +1613,41 @@ void RocprofSysBackend::RenderAdvancedTab()
             break;
         }
     }
-    ImGui::Text("Log Level:");
-    ImGui::SameLine();
+    FieldLabel("Log Level", kComboW);
     if (ImGui::Combo("##LogLevel", &level_idx, levels, 6))
     {
         m_settings.log_level = levels[level_idx];
     }
     HelpMarker("ROCPROFSYS_LOG_LEVEL", "Logging verbosity level");
 
-    ImGui::Text("Log File:");
-    ImGui::SameLine();
+    FieldLabel("Log File", kTextW);
     InputTextString("##LogFile", m_settings.log_file);
     HelpMarker("ROCPROFSYS_LOG_FILE",
                "Log file name (empty disables file logging)");
 
-    ImGui::Text("Temp Directory:");
-    ImGui::SameLine();
+    FieldLabel("Temp Directory", kTextW);
     InputTextString("##TmpDir", m_settings.tmpdir);
     HelpMarker("ROCPROFSYS_TMPDIR",
                "Base directory for temporary/spill files");
 
-    ImGui::Checkbox("Use PID in Output", &m_settings.use_pid);
-    HelpMarker("ROCPROFSYS_USE_PID",
-               "Suffix output filenames with process ID");
-
-    ImGui::Text("Timemory Components:");
-    InputTextString("##TimComponents", m_settings.timemory_components);
-    HelpMarker("ROCPROFSYS_TIMEMORY_COMPONENTS",
-               "Comma-separated timemory component list");
+    // MPI profiling (MPIP) forces PID suffixing off. Show the toggle off and
+    // disabled while MPI is enabled, but keep the user's underlying preference
+    // so it returns when MPI is turned back off. FlattenToExecution enforces the
+    // effective value regardless of this view.
+    const bool pid_locked_by_mpi = m_settings.use_mpip;
+    bool       pid_display       = m_settings.use_pid && !pid_locked_by_mpi;
+    ImGui::BeginDisabled(pid_locked_by_mpi);
+    if (ImGui::Checkbox("Append process ID to output files", &pid_display))
+    {
+        m_settings.use_pid = pid_display;
+    }
+    ImGui::EndDisabled();
+    HelpMarker("ROCPROFSYS_USE_PID", "Suffix output filenames with the process ID");
+    if (pid_locked_by_mpi)
+    {
+        ImGui::SameLine();
+        ImGui::TextDisabled("(off: forced by MPI profiling)");
+    }
 
     ImGui::EndDisabled();
 }

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_rocprof_sys_backend.h"
+#include "rocprofvis_launch_shared_tabs.h"
 #include "rocprofvis_gui_helpers.h"
 #include "rocprofvis_json_utils.h"
 #include "imgui.h"
+#include <cfloat>
 #include <sstream>
 #include <algorithm>
 #include <cctype>
@@ -471,26 +473,33 @@ std::vector<TabDescriptor> RocprofSysBackend::GetTabs(std::string const& tool_id
 {
     std::vector<TabDescriptor> tabs;
 
-    tabs.push_back({"quick", "Quick", [this]() {
+    // General: the everyday controls (preset, trace/profile format, collection
+    // toggles, trace delay/duration/region). Always visible in the launcher.
+    tabs.push_back({"general", "General", [this]() {
         const_cast<RocprofSysBackend*>(this)->RenderBackendsTab();
-    }});
+    }, false});
+
+    // Advanced: power-user detail, grouped by domain and tucked under the
+    // collapsible "Advanced Options" section so the common case stays simple.
     tabs.push_back({"sampling", "Sampling", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderSamplingTab(); }});
+        const_cast<RocprofSysBackend*>(this)->RenderSamplingTab(); }, true});
     tabs.push_back({"rocm", "ROCm", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderRocmTab(); }});
+        const_cast<RocprofSysBackend*>(this)->RenderRocmTab(); }, true});
+    tabs.push_back({"perfetto", "Perfetto", [this]() {
+        const_cast<RocprofSysBackend*>(this)->RenderPerfettoTab(); }, true});
     tabs.push_back({"process_sampling", "Process Sampling", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderProcessSamplingTab(); }});
+        const_cast<RocprofSysBackend*>(this)->RenderProcessSamplingTab(); }, true});
     tabs.push_back({"parallelism", "Parallelism", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderParallelismTab(); }});
+        const_cast<RocprofSysBackend*>(this)->RenderParallelismTab(); }, true});
 
     if (tool_id == "instrument")
     {
         tabs.push_back({"instrument", "Instrument", [this]() {
-            const_cast<RocprofSysBackend*>(this)->RenderInstrumentTab(); }});
+            const_cast<RocprofSysBackend*>(this)->RenderInstrumentTab(); }, true});
     }
 
-    tabs.push_back({"advanced", "Advanced", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderAdvancedTab(); }});
+    tabs.push_back({"advanced", "Config & Logging", [this]() {
+        const_cast<RocprofSysBackend*>(this)->RenderAdvancedTab(); }, true});
 
     return tabs;
 }
@@ -594,6 +603,40 @@ std::vector<WarningMessage> RocprofSysBackend::GetWarnings(
     }
 
     return warnings;
+}
+
+std::vector<std::string> RocprofSysBackend::GetSummaryTags(
+    LaunchConfig const& config) const
+{
+    (void)config;
+    std::vector<std::string> tags;
+
+    // Output format (what the run will produce).
+    std::string output;
+    if (m_settings.trace_backend && m_settings.use_rocpd)
+    {
+        output = "Perfetto + ROCpd";
+    }
+    else if (m_settings.trace_backend)
+    {
+        output = "Perfetto trace";
+    }
+    else if (m_settings.use_rocpd)
+    {
+        output = "ROCpd database";
+    }
+    else
+    {
+        output = "No trace output";
+    }
+    tags.push_back(output);
+
+    // Active preset (or Custom when none is selected).
+    tags.push_back(m_settings.rocprof_preset.empty()
+                       ? std::string("Custom")
+                       : m_settings.rocprof_preset);
+
+    return tags;
 }
 
 // ==================================================================================
@@ -980,41 +1023,54 @@ std::string RocprofSysBackend::ExportCfg() const
 
 void RocprofSysBackend::RenderGeneralTraceOptions()
 {
-    SectionTitle("General Options");
+    // Delay + Duration side by side to use the horizontal space.
+    if (ImGui::BeginTable("timing_grid", 2, ImGuiTableFlags_None))
+    {
+        ImGui::TableNextColumn();
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Delay (s)");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(90.0f);
+        ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
+        HelpMarker("ROCPROFSYS_TRACE_DELAY",
+                   "Seconds before collection starts (0 = immediate)");
 
-    ImGui::Text("Trace Delay (s):");
-    ImGui::SameLine();
-    ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
-    HelpMarker("ROCPROFSYS_TRACE_DELAY",
-               "Seconds before collection starts (0 = immediate)");
+        ImGui::TableNextColumn();
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Duration (s)");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(90.0f);
+        ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0, 0.0, "%.2f");
+        HelpMarker("ROCPROFSYS_TRACE_DURATION",
+                   "Duration of collection in seconds (0 = unlimited)");
 
-    ImGui::Text("Trace Duration (s):");
-    ImGui::SameLine();
-    ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0, 0.0, "%.2f");
-    HelpMarker("ROCPROFSYS_TRACE_DURATION",
-               "Duration of collection in seconds (0 = unlimited)");
+        ImGui::EndTable();
+    }
 
-    ImGui::Text("Trace Region:");
-    ImGui::SameLine();
-    InputTextString("##TraceRegion", m_settings.trace_region);
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Region");
+    ImGui::SameLine(90.0f);
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    InputTextStringWithHint("##TraceRegion", "ROCTX region names (comma-separated)",
+                            m_settings.trace_region);
     HelpMarker("ROCPROFSYS_TRACE_REGION",
                "Comma-separated ROCTX region names for selective tracing");
 }
 
 void RocprofSysBackend::RenderBackendsTab()
 {
-    // Primary: rocprof-sys built-in preset selector
-    ImGui::Text("Profiling Preset:");
-    ImGui::SameLine();
+    // Headline choice: the built-in rocprof-sys preset.
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Preset");
+    ImGui::SameLine(110.0f);
 
     const char* preset_label =
-        m_settings.rocprof_preset.empty()
-            ? "(none)" : m_settings.rocprof_preset.c_str();
+        m_settings.rocprof_preset.empty() ? "Custom" : m_settings.rocprof_preset.c_str();
 
-    ImGui::PushItemWidth(180);
+    ImGui::SetNextItemWidth(240.0f);
     if (ImGui::BeginCombo("##RocprofPresetCombo", preset_label))
     {
-        if (ImGui::Selectable("(none)", m_settings.rocprof_preset.empty()))
+        if (ImGui::Selectable("Custom", m_settings.rocprof_preset.empty()))
         {
             m_settings.rocprof_preset.clear();
         }
@@ -1032,52 +1088,42 @@ void RocprofSysBackend::RenderBackendsTab()
         }
         ImGui::EndCombo();
     }
-    ImGui::PopItemWidth();
-
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
-    if (ImGui::BeginItemTooltip())
-    {
-        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 25.0f);
-        ImGui::TextUnformatted(
-            "Pick a built-in rocprof-sys preset to configure collection defaults. "
-            "When a preset is active, detailed settings are locked to preset values. "
-            "Use Raw Env Vars for manual overrides, or select (none) to unlock all controls.");
-        ImGui::PopTextWrapPos();
-        ImGui::EndTooltip();
-    }
-
-    ImGui::Separator();
-
-    auto toggle = [](char const* label, bool& val, char const* env,
-                     char const* help)
-    {
-        ImGui::Checkbox(label, &val);
-        HelpMarker(env, help);
-    };
-
-    SectionTitle("Trace Output Format");
-
-    toggle("Perfetto Tracing", m_settings.trace_backend,
-           "ROCPROFSYS_TRACE", "Enable Perfetto trace backend");
-    toggle("ROCpd Database", m_settings.use_rocpd,
-           "ROCPROFSYS_USE_ROCPD", "Enable ROCpd SQLite output");
+    HelpMarker("Profiling preset",
+               "Pick a built-in rocprof-sys preset to configure collection defaults. "
+               "When a preset is active, detailed settings are locked to preset values. "
+               "Choose Custom to unlock every control.");
 
     bool has_preset = !m_settings.rocprof_preset.empty();
 
+    // Toggle laid out in the next free column of a 2-wide grid, with a help (?).
+    auto toggle_cell = [](const char* label, bool* value, const char* env,
+                          const char* help)
+    {
+        ImGui::TableNextColumn();
+        ToggleSwitch(label, value);
+        HelpMarker(env, help);
+    };
+
+    // --- Output format (always editable) ---
+    LaunchSubHeader("OUTPUT FORMAT");
+    if (ImGui::BeginTable("out_fmt_grid", 2, ImGuiTableFlags_None))
+    {
+        toggle_cell("Perfetto trace", &m_settings.trace_backend,
+                    "ROCPROFSYS_TRACE", "Enable the Perfetto trace backend");
+        toggle_cell("ROCpd database", &m_settings.use_rocpd,
+                    "ROCPROFSYS_USE_ROCPD", "Enable ROCpd SQLite output");
+        ImGui::EndTable();
+    }
+
+    // --- Summary profile ---
     ImGui::BeginDisabled(has_preset);
-
-    SectionTitle("Summary Output Format");
-
-    ImGui::Text("Timemory Profile:");
-    HelpMarker("ROCPROFSYS_PROFILE / ROCPROFSYS_FLAT_PROFILE",
-               "Profiling backend mode (hierarchical or flat)");
+    LaunchSubHeader("SUMMARY PROFILE");
 
     int profile_mode = 0;
-    if (m_settings.profile)       profile_mode = 1;
-    if (m_settings.flat_profile)  profile_mode = 2;
+    if (m_settings.profile)      profile_mode = 1;
+    if (m_settings.flat_profile) profile_mode = 2;
 
-    if (ImGui::RadioButton("Off##Profile", profile_mode == 0))
+    if (ImGui::RadioButton("None##Profile", profile_mode == 0))
     {
         m_settings.profile      = false;
         m_settings.flat_profile = false;
@@ -1094,33 +1140,39 @@ void RocprofSysBackend::RenderBackendsTab()
         m_settings.profile      = false;
         m_settings.flat_profile = true;
     }
-
+    ImGui::SameLine();
+    HelpMarker("ROCPROFSYS_PROFILE / ROCPROFSYS_FLAT_PROFILE",
+               "Timemory summary profile mode (hierarchical or flat call stacks)");
     ImGui::EndDisabled();
 
-    RenderGeneralTraceOptions();
-
+    // --- Collection ---
     ImGui::BeginDisabled(has_preset);
-    
-    SectionTitle("Collection Options");
+    LaunchSubHeader("COLLECTION");
+    if (ImGui::BeginTable("collection_grid", 3, ImGuiTableFlags_None))
+    {
+        toggle_cell("Statistical sampling", &m_settings.use_sampling,
+                    "ROCPROFSYS_USE_SAMPLING", "Enable call-stack sampling");
+        toggle_cell("Process / system sampling", &m_settings.use_process_sampling,
+                    "ROCPROFSYS_USE_PROCESS_SAMPLING", "Background process/system metrics");
+        toggle_cell("AMD SMI GPU metrics", &m_settings.use_amd_smi,
+                    "ROCPROFSYS_USE_AMD_SMI", "GPU metrics via AMD SMI");
+        ImGui::EndTable();
+    }
+    ImGui::EndDisabled();
 
-    ImGui::Separator();
+    // --- Timing window ---
+    ImGui::BeginDisabled(has_preset);
+    LaunchSubHeader("TIMING");
+    RenderGeneralTraceOptions();
+    ImGui::EndDisabled();
 
-    toggle("Statistical Sampling", m_settings.use_sampling,
-           "ROCPROFSYS_USE_SAMPLING", "Enable call-stack sampling");
-    toggle("Process Sampling", m_settings.use_process_sampling,
-           "ROCPROFSYS_USE_PROCESS_SAMPLING", "Background process/system metrics");
-    toggle("AMD SMI", m_settings.use_amd_smi,
-           "ROCPROFSYS_USE_AMD_SMI", "GPU metrics via AMD SMI");
-
-    if (m_settings.trace_backend &&
-        (m_settings.profile || m_settings.flat_profile))
+    if (has_preset)
     {
         ImGui::Spacing();
-        WarningText("Both trace and profile backends are enabled -- "
-                    "this increases overhead");
+        ImGui::TextDisabled("Preset \"%s\" controls the locked options above. "
+                            "Choose Custom to edit them.",
+                            m_settings.rocprof_preset.c_str());
     }
-
-    ImGui::EndDisabled();
 }
 
 void RocprofSysBackend::RenderSamplingTab()
@@ -1236,6 +1288,17 @@ void RocprofSysBackend::RenderRocmTab()
 
 void RocprofSysBackend::RenderPerfettoTab()
 {
+    bool has_preset = !m_settings.rocprof_preset.empty();
+    if (has_preset)
+    {
+        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f),
+            "Preset \"%s\" controls these settings.",
+            m_settings.rocprof_preset.c_str());
+        ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
+        ImGui::Spacing();
+    }
+    ImGui::BeginDisabled(has_preset);
+
     const char* backends[] = {"inprocess", "system", "all"};
     int backend_idx = 0;
     for (int i = 0; i < 3; i++)
@@ -1333,6 +1396,8 @@ void RocprofSysBackend::RenderPerfettoTab()
     ImGui::SameLine();
     InputTextString("##PerfFile", m_settings.perfetto_file);
     HelpMarker("ROCPROFSYS_PERFETTO_FILE", "Output filename for perfetto trace");
+
+    ImGui::EndDisabled();
 }
 
 void RocprofSysBackend::RenderProcessSamplingTab()
@@ -1405,7 +1470,7 @@ void RocprofSysBackend::RenderParallelismTab()
     auto toggle = [](char const* label, bool& val, char const* env,
                      char const* help)
     {
-        ImGui::Checkbox(label, &val);
+        ToggleSwitch(label, &val);
         HelpMarker(env, help);
     };
 
@@ -1525,13 +1590,6 @@ void RocprofSysBackend::RenderAdvancedTab()
     InputTextString("##TimComponents", m_settings.timemory_components);
     HelpMarker("ROCPROFSYS_TIMEMORY_COMPONENTS",
                "Comma-separated timemory component list");
-
-    ImGui::Separator();
-
-    if (ImGui::CollapsingHeader("Perfetto (advanced)"))
-    {
-        RenderPerfettoTab();
-    }
 
     ImGui::EndDisabled();
 }

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.h
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.h
@@ -106,7 +106,6 @@ struct RocprofSysSettings
     std::string log_file            = "rocprof-sys-log.txt";
     std::string tmpdir;
     bool        use_pid             = true;
-    std::string timemory_components = "wall_clock";
 
     // Instrument
     std::string instr_include;

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.h
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.h
@@ -147,6 +147,9 @@ public:
     std::vector<WarningMessage> GetWarnings(
         LaunchConfig const& config) const override;
 
+    std::vector<std::string> GetSummaryTags(
+        LaunchConfig const& config) const override;
+
     std::string ParseTraceOutputPath(std::string const& profiler_stdout) const override;
 
 private:


### PR DESCRIPTION
## Motivation

The profiler launcher crammed every option, the command preview, and the live
output into one dense, flat dialog that was hard to scan and use. This PR
reworks it into a clean, card-based UI, reorganizes the rocprof-sys options so
the common path is simple, and splits configuration from execution. Scope is
the ROCm Systems Profiler (rocprof-sys) UI; the backend stays ready for
rocprof-compute and rocprofv3.

## Technical Details

- Two-step flow: a Configure view and a focused Run view (live output, elapsed
  timer, status, Cancel / Run Again / Back).
- Reorganized options: General keeps the essentials (preset, output format,
  trace window); everything else moves to a separate Advanced window
  (Sampling, ROCm, Perfetto, Process Sampling, Parallelism, Config & Logging).
- Modern, theme-aware widgets: card panels, toggle switches, a live config
  summary, and an Arguments & Environment panel using add-and-remove pills.
- Long lists render as responsive column grids; inputs are aligned and sized.
- Behavior: show the selected preset's description inline, remove the
  deprecated Timemory setting, and force PID-suffixed output off under MPI.
- Fixes/cleanup: restore standard window padding, clearer naming, and
  replace magic numbers / remove dead code.