### PR TITLE
ROCM-28258 - [Optiq-Systems]: Multi-node Systems trace: Summary Window shows data only for the first node in the .yaml; all subsequent nodes are blank

### DIFF
--- a/src/controller/src/system/rocprofvis_controller_summary.cpp
+++ b/src/controller/src/system/rocprofvis_controller_summary.cpp
@@ -2,15 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_controller_summary.h"
-#include "rocprofvis_controller_array.h"
 #include "rocprofvis_controller_future.h"
 #include "rocprofvis_controller_topology.h"
-#include "rocprofvis_controller_reference.h"
 #include "rocprofvis_controller_table_system.h"
 #include "rocprofvis_controller_trace.h"
 #include "rocprofvis_controller_track.h"
 #include "rocprofvis_controller_arguments.h"
-#include "rocprofvis_core_assert.h"
 #include <cstdlib>
 
 namespace RocProfVis
@@ -522,7 +519,7 @@ rocprofvis_result_t Summary::FetchTopKernels(rocprofvis_dm_trace_t dm_handle, No
                         result = processor->GetUInt64(kRPVControllerProcessorId, 0, &agent_id);
                         if(result == kRocProfVisResultSuccess)
                         {
-                            where_str += " AND agentId = " + std::to_string(agent_id);
+                            where_str += " AND agentId = " + std::to_string(agent_id & TOPOLOGY_ID_MASK);
                         }
                     }
                 }

--- a/src/controller/src/system/rocprofvis_controller_trace_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_trace_system.cpp
@@ -39,6 +39,7 @@ SystemTrace::SystemTrace(const std::string& filename)
 , m_search_table(nullptr)
 , m_summary(nullptr)
 , m_mem_mgmt(nullptr)
+, m_topology_root(nullptr)
 {
     
 }
@@ -53,6 +54,7 @@ SystemTrace::SystemTrace(const std::vector<std::string>& filenames)
 , m_search_table(nullptr)
 , m_summary(nullptr)
 , m_mem_mgmt(nullptr)
+, m_topology_root(nullptr)
 {
 
 }
@@ -95,10 +97,6 @@ SystemTrace::~SystemTrace()
     for (Track* track : m_tracks)
     {
         delete track;
-    }
-    for (auto* node : m_nodes)
-    {
-        delete node;
     }
 }
 
@@ -1072,24 +1070,6 @@ rocprofvis_result_t SystemTrace::SetUInt64(rocprofvis_property_t property, uint6
         case kRPVControllerSystemNumAnalysisView:
         {
             ROCPROFVIS_UNIMPLEMENTED;
-            break;
-        }
-        case kRPVControllerSystemNumNodes:
-        {
-            if (m_nodes.size() != value)
-            {
-                for (uint64_t i = value; i < m_nodes.size(); i++)
-                {
-                    delete m_nodes[i];
-                    m_nodes[i] = nullptr;
-                }
-                m_nodes.resize(value);
-                result = m_nodes.size() == value ? kRocProfVisResultSuccess : kRocProfVisResultMemoryAllocError;
-            }
-            else
-            {
-                result = kRocProfVisResultSuccess;
-            }
             break;
         }
         default:

--- a/src/controller/src/system/rocprofvis_controller_trace_system.h
+++ b/src/controller/src/system/rocprofvis_controller_trace_system.h
@@ -27,7 +27,6 @@ class Graph;
 class Timeline;
 class Event;
 class Table;
-class Node;
 class SystemTable;
 class Summary;
 class SummaryMetrics;
@@ -89,7 +88,6 @@ public:
 private:
     std::vector<std::string>                       m_files;  // >1 entry => combined/compare load
     std::vector<Track*>                            m_tracks;
-    std::vector<Node*>                             m_nodes;
     Timeline*                                      m_timeline;
     SystemTable*                                   m_event_table;
     SystemTable*                                   m_sample_table;

--- a/src/model/inc/rocprofvis_shared_types.h
+++ b/src/model/inc/rocprofvis_shared_types.h
@@ -6,6 +6,8 @@
 
 #define INVALID_INDEX    0xFFFFFFFFu
 #define INVALID_INDEX_64 0xFFFFFFFFFFFFFFFFull
+#define TOPOLOGY_INSTANCE_BIT_POS 54
+#define TOPOLOGY_ID_MASK ((1ULL << TOPOLOGY_INSTANCE_BIT_POS) - 1)
 
 typedef enum rocprofvis_controller_node_properties_t : uint32_t
 {

--- a/src/model/src/common/rocprofvis_common_types.h
+++ b/src/model/src/common/rocprofvis_common_types.h
@@ -69,8 +69,6 @@ typedef union{
 #define TRACK_ID_STORE_ID 6
 #define TRACK_ID_RECORD_COUNT 7
 
-#define TOPOLOGY_INSTANCE_BIT_POS 54
-
 typedef struct
 {
     uint64_t id;

--- a/src/view/src/rocprofvis_summary_view.cpp
+++ b/src/view/src/rocprofvis_summary_view.cpp
@@ -1122,7 +1122,7 @@ KernelInstanceTable::ToggleSelectKernel(const std::string& kernel_name,
         m_where = "nodeId = " + std::to_string(*node_id);
         if(device_id)
         {
-            m_where += " AND agentId = " + std::to_string(*device_id);
+            m_where += " AND agentId = " + std::to_string(*device_id & TOPOLOGY_ID_MASK);
         }
     }
     Fetch();


### PR DESCRIPTION
Problem:
-DB guid indexes are bit shifted inside processor ids. Single DB is immune because it has index 0. Second DB and beyond will have inflated processor ids that do not match any agent and return no results when used as query parameter.

Fix:
-Mask out guid index.
-Also remove leftover `Node` list from old controller topology implementation.