### PR TITLE
View: Refine inline device nodes in the sidebar topology tree

### DIFF
--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -23,6 +23,9 @@ constexpr ImGuiTreeNodeFlags HEADER_FLAGS = ImGuiTreeNodeFlags_Framed |
 constexpr float TREE_LINE_W = 1.5f;
 constexpr float MENU_PAD_X  = 8.0f;
 constexpr float MENU_PAD_Y  = 6.0f;
+// ImGui offsets a framed tree node's label by FontSize + FramePadding.x * this
+// factor (see TreeNodeBehavior); used to place the inline device lead arrow.
+constexpr float FRAMED_LABEL_PAD_MULT = 3.0f;
 
 // Recolors a framed tree node's collapse arrow, matching ImGui::RenderArrow's
 // geometry so it overlaps the default arrow exactly.
@@ -226,7 +229,8 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     ImGui::PushStyleColor(
         ImGuiCol_Button,
         m_settings.GetColor(track.IsSelected() ? Colors::kSelection : Colors::kTransparent));
-    if(!display)
+    const bool dim_text = !display || m_render_muted;
+    if(dim_text)
     {
         ImGui::PushStyleColor(ImGuiCol_Text,
                               ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
@@ -235,7 +239,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     {
         m_timeline_selection->ToggleSelectTrack(track);
     }
-    if(!display)
+    if(dim_text)
     {
         ImGui::PopStyleColor();
     }
@@ -560,7 +564,52 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
     if(node.collapsable)
     {
         const ImVec2 node_pos = ImGui::GetCursorScreenPos();
-        open                  = ImGui::TreeNodeEx(node.label.c_str(), HEADER_FLAGS);
+
+        // Lead arrow: pad the label to open a slot after the chevron, then draw
+        // the glyph at the label's start (keeps the chevron in place).
+        std::string display_label   = node.label;
+        ImFont*     lead_arrow_font = nullptr;
+        float       lead_arrow_size = 0.0f;
+        float       lead_arrow_x    = 0.0f;
+        if(node.show_lead_arrow)
+        {
+            ImFont* icon_font = m_settings.GetFontManager().GetFont(FontType::kIcon);
+            ImGui::PushFont(icon_font, 0.0f);
+            const float arrow_w = ImGui::CalcTextSize(ICON_ARROW_FORWARD).x;
+            lead_arrow_font     = icon_font;
+            lead_arrow_size     = ImGui::GetFontSize();
+            ImGui::PopFont();
+
+            const float gap     = ImGui::GetStyle().ItemInnerSpacing.x;
+            const float space_w = ImGui::CalcTextSize(" ").x;
+            const int   pad =
+                (space_w > 0.0f) ? static_cast<int>((arrow_w + gap) / space_w) + 1 : 2;
+            display_label.insert(0, static_cast<size_t>(pad), ' ');
+            lead_arrow_x = node_pos.x + ImGui::GetFontSize() +
+                           ImGui::GetStyle().FramePadding.x * FRAMED_LABEL_PAD_MULT;
+        }
+
+        if(m_render_muted)
+        {
+            ImGui::PushStyleColor(ImGuiCol_Text,
+                                  ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+        }
+        open = ImGui::TreeNodeEx(node.label.c_str(), HEADER_FLAGS, "%s",
+                                 display_label.c_str());
+        if(m_render_muted)
+        {
+            ImGui::PopStyleColor();
+        }
+
+        if(lead_arrow_font)
+        {
+            const float cy =
+                (ImGui::GetItemRectMin().y + ImGui::GetItemRectMax().y) * 0.5f;
+            ImGui::GetWindowDrawList()->AddText(
+                lead_arrow_font, lead_arrow_size,
+                ImVec2(lead_arrow_x, cy - lead_arrow_size * 0.5f),
+                ImGui::GetColorU32(ImGuiCol_Text), ICON_ARROW_FORWARD);
+        }
 
         if(color_arrow)
         {
@@ -609,7 +658,15 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
                 m_active_node_color = wheel[node.color_index % wheel.size()];
             }
         }
+        const bool prev_muted = m_render_muted;
+        if(node.show_lead_arrow)
+        {
+            // Dim the tracks nested under an inline device node (but not the
+            // device label itself) so they draw less attention.
+            m_render_muted = true;
+        }
         RenderTreeChildren(node);
+        m_render_muted = prev_muted;
         m_active_node_color = prev_node_color;
         if(node.collapsable)
         {

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -229,8 +229,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     ImGui::PushStyleColor(
         ImGuiCol_Button,
         m_settings.GetColor(track.IsSelected() ? Colors::kSelection : Colors::kTransparent));
-    const bool dim_text = !display || m_render_muted;
-    if(dim_text)
+    if(!display)
     {
         ImGui::PushStyleColor(ImGuiCol_Text,
                               ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
@@ -239,7 +238,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     {
         m_timeline_selection->ToggleSelectTrack(track);
     }
-    if(dim_text)
+    if(!display)
     {
         ImGui::PopStyleColor();
     }
@@ -589,17 +588,8 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
                            ImGui::GetStyle().FramePadding.x * FRAMED_LABEL_PAD_MULT;
         }
 
-        if(m_render_muted)
-        {
-            ImGui::PushStyleColor(ImGuiCol_Text,
-                                  ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-        }
         open = ImGui::TreeNodeEx(node.label.c_str(), HEADER_FLAGS, "%s",
                                  display_label.c_str());
-        if(m_render_muted)
-        {
-            ImGui::PopStyleColor();
-        }
 
         if(lead_arrow_font)
         {
@@ -658,15 +648,7 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
                 m_active_node_color = wheel[node.color_index % wheel.size()];
             }
         }
-        const bool prev_muted = m_render_muted;
-        if(node.show_lead_arrow)
-        {
-            // Dim the tracks nested under an inline device node (but not the
-            // device label itself) so they draw less attention.
-            m_render_muted = true;
-        }
         RenderTreeChildren(node);
-        m_render_muted = prev_muted;
         m_active_node_color = prev_node_color;
         if(node.collapsable)
         {

--- a/src/view/src/rocprofvis_sidebar.h
+++ b/src/view/src/rocprofvis_sidebar.h
@@ -68,7 +68,6 @@ private:
     std::shared_ptr<std::vector<TrackItem*>> m_tracks;
     DataProvider&                            m_data_provider;
     ImU32                                    m_active_node_color;
-    bool                                     m_render_muted = false;
     EventManager::SubscriptionToken          m_track_visibility_token;
 };
 

--- a/src/view/src/rocprofvis_sidebar.h
+++ b/src/view/src/rocprofvis_sidebar.h
@@ -68,6 +68,7 @@ private:
     std::shared_ptr<std::vector<TrackItem*>> m_tracks;
     DataProvider&                            m_data_provider;
     ImU32                                    m_active_node_color;
+    bool                                     m_render_muted = false;
     EventManager::SubscriptionToken          m_track_visibility_token;
 };
 

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -96,6 +96,7 @@ BuildProcessorTree(TreeNode* parent, const ProcessorModel& processor,
     TreeNode* node = AddBranchNode(parent, NodeType::kProcessor,
                                    processor.header, true, show_controls, false);
     node->breaks_visibility_chain = breaks_chain;
+    node->show_lead_arrow         = !show_controls;
     BuildLeafList(node, NodeType::kQueueList, processor.queue_header,
                   processor.queues, track_list, show_controls);
     BuildLeafList(node, NodeType::kCounterList, processor.counter_header,
@@ -398,7 +399,7 @@ TrackTopology::UpdateTopology()
                                             { InfoTable::Cell{ "Product name", false },
                                             InfoTable::Cell{ processor_info->product_name, false } } }
                                         };
-                                        stream->processors[processor_index].header = stream_info->name + " >>> " + 
+                                        stream->processors[processor_index].header =
                                             DeviceTypeString(processor_info->type) +
                                             std::to_string(processor_info->type_index);
 

--- a/src/view/src/rocprofvis_tree_node.h
+++ b/src/view/src/rocprofvis_tree_node.h
@@ -57,6 +57,7 @@ public:
     bool                                    show_eye_button         = true;
     bool                                    breaks_visibility_chain = false;
     bool                                    render_children_inline  = false;
+    bool                                    show_lead_arrow         = false;
     mutable uint8_t                         cached_eye_state        = 0;
     bool                                    show_color_swatch       = false;
     size_t                                  color_index             = 0;


### PR DESCRIPTION
## Motivation

In the timeline sidebar's topology tree, each stream lists the device it maps
to. That device node repeated the stream name (e.g. `stream 0 >>> GPU0`), which
was redundant and noisy, and the tracks nested under it competed visually with
the primary stream/device entries. This tidies up the inline device section so
the tree is easier to scan.

## Technical Details

- **Label dedup** (`rocprofvis_track_topology.cpp`): drop the `"<stream> >>> "`
  prefix from the inline device header so it reads just `GPU0` / `CPU0`.
- **Lead-in arrow** (`rocprofvis_sidebar.cpp`, `rocprofvis_tree_node.h`): a new
  `show_lead_arrow` flag on the inline device node draws a forward-arrow glyph
  (`ICON_ARROW_FORWARD`) between the collapse chevron and the label, so it reads
  `-> GPU0`. The label is padded with leading spaces to open the slot and the
  glyph is drawn at the label start; the chevron keeps its normal position and
  the tree-node ID stays bound to the label so collapse state is unaffected.
- **De-emphasize nested tracks** (`rocprofvis_sidebar.cpp`): dim the tracks
  under the device node (via `m_render_muted` + `ImGuiCol_TextDisabled`), scoped
  to the device node's children only — the device label itself stays normal.
