### PR TITLE
Rename View agent guide to UI.md and refresh for current features

### DIFF
--- a/.agents/CONTROLLER.md
+++ b/.agents/CONTROLLER.md
@@ -178,11 +178,11 @@ rocprofvis_controller_save_trimmed_trace(handle, start, end, path, future);
 rocprofvis_controller_cleanup_trace_database(handle, rebuild, future);
 ```
 
-Plus the analysis library's free function (declared in
-`rocprofvis_controller_analysis.h`):
+Plus the analysis sub-API (declared in
+`rocprofvis_controller_analysis.h`; see section 2.7), e.g.:
 
 ```c
-rocprofvis_controller_analysis_fetch_queue_utilization(
+rocprofvis_analysis_fetch_queue_utilization(
     controller, track, start_time, end_time, future, &out_double);
 ```
 
@@ -223,6 +223,31 @@ trace -> node -> processor metrics; see section 5.5).
 For compute metric fetches, results land in a
 `rocprofvis_controller_metrics_container_t` (a flat list of
 `{metric_id, source_type, source_id, value_name, value}` rows).
+
+### 2.7 The "analysis" sub-API
+
+Cross-cutting analytics live in
+`src/controller/src/rocprofvis_controller_analysis.{h,cpp}` and are
+exposed as `rocprofvis_analysis_*` functions (note this family drops
+the `_controller` infix). They reuse the same `Job + Future` plumbing
+as the data fetchers and back the View's Track Details and Top Events
+UI:
+
+- `rocprofvis_analysis_fetch_queue_utilization` - per-track queue
+  utilization over a time range (writes a `double`).
+- `rocprofvis_analysis_fetch_counter_statistics` - per-track counter
+  min/max/mean/stddev over a time range
+  (`rocprofvis_analysis_counter_statistics_t`).
+- `rocprofvis_analysis_get_*_events_table` - the five "top events"
+  table-handle getters (instrumented, dispatch, memory allocation,
+  memory copy, sampled).
+- `rocprofvis_analysis_fetch_table` - fetch rows for one of those
+  tables (paged via `rocprofvis_controller_arguments_t`).
+- `rocprofvis_analysis_free_trace_data` - release cached analysis
+  results for the trace.
+
+Add new cross-cutting analyses here rather than in the per-domain
+system / compute modules.
 
 ## 3. Internal Architecture & Threading Model
 
@@ -1279,13 +1304,3 @@ the Reuse Catalog). Keep this file the single source of truth for
 of writing it." If you find a duplicate of something listed here,
 prefer to delete the duplicate and route callers through the canonical
 entry.
-
-### 2.7 The "analysis" Sub-API
-
-The controller currently exposes one analysis function on top of the
-generic surface:
-`rocprofvis_controller_analysis_fetch_queue_utilization`. It is built
-on the same internal `Job + Future` plumbing as the data fetchers but
-runs a SQL query against the trace's database directly instead of
-serving from the segment cache. New cross-cutting analyses go in
-`src/controller/src/rocprofvis_controller_analysis.{h,cpp}`.

--- a/.agents/CONTROLLER.md
+++ b/.agents/CONTROLLER.md
@@ -1,10 +1,10 @@
 # CONTROLLER.md - ROCm Optiq Controller Layer Guide
 
 This document is the controller-layer companion to
-[`.agents/AGENTS.md`](./AGENTS.md). The main guide covers the View layer
-in depth and gives a high-level pass over `controller/`. **This file is
-the deep dive for `src/controller/`** - the C ABI bridge between the
-Model (SQLite, parsing) and the View (ImGui UI).
+[`.agents/UI.md`](./UI.md). The UI guide covers the View layer in depth
+and gives a high-level pass over `controller/`. **This file is the deep
+dive for `src/controller/`** - the C ABI bridge between the Model
+(SQLite, parsing) and the View (ImGui UI).
 
 When humans and `CODING.md` disagree with this file, `CODING.md` wins.
 When this file disagrees with the source under `src/controller/`, the

--- a/.agents/DATABASE.md
+++ b/.agents/DATABASE.md
@@ -1,8 +1,8 @@
 # DATABASE.md - ROCm Optiq Model / Database Layer Guide
 
 This document is the database/model-layer companion to
-[`.agents/AGENTS.md`](./AGENTS.md) and
-[`.agents/CONTROLLER.md`](./CONTROLLER.md). The main guide gives a
+[`.agents/UI.md`](./UI.md) and
+[`.agents/CONTROLLER.md`](./CONTROLLER.md). The UI guide gives a
 high-level pass over `src/model/`. **This file is the deep dive for
 `src/model/`** - the SQLite-backed data model that ingests trace files
 and serves typed records to the controller.
@@ -51,7 +51,7 @@ wins; please update this file in the same change.
 - **Linked by:** `src/controller/`. The controller is the normal
   consumer of `src/model/` headers (the View must never include
   `src/model/` directly; see the architecture rules in
-  `.agents/AGENTS.md`).
+  `.agents/UI.md`).
 - **CFFI / Python:** `src/model/python/rocprofvis_cffi_build.py`
   builds a Python wrapper that calls `rocprofvis_dm_*` and
   `rocprofvis_db_*` directly without going through the controller.

--- a/.agents/DATABASE.md
+++ b/.agents/DATABASE.md
@@ -78,7 +78,7 @@ controller-facing topology property enums, and
 
 ## 2. Public C ABI Surface (`src/model/inc/`)
 
-Three headers form the entire public contract:
+Four headers form the entire public contract:
 
 - `rocprofvis_interface.h` - all functions. Keep this header
   compatible with `src/model/python/rocprofvis_cffi_build.py`: avoid

--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -1,15 +1,17 @@
-# AGENTS.md - ROCm Optiq Codebase Guide
+# UI.md - ROCm Optiq View Layer Guide
 
-This document is the repo-level reference for AI assistants working on
-ROCm Optiq (binary name: `roc-optiq`). It is written as plain,
-tool-agnostic Markdown so any LLM-based coding agent can inspect and
-reuse it as project context.
+This document is the source-of-truth guide for `src/view/` and its
+UI-facing integration with `src/app/` and `src/controller/`. Read the
+root [`AGENTS.md`](../AGENTS.md) first for the guide map.
 
-**Scope:** class-level architecture, where things live, and a reuse
-catalog so contributors do not duplicate existing widgets, events, or
-utilities. For per-method API details, read the headers under
-`src/view/src/`. When this file and the source disagree, the source is
-authoritative; please update this file in the same change.
+**Scope:** View-layer class architecture, ownership and data flow,
+where UI code lives, and a reuse catalog so contributors do not
+duplicate existing widgets, events, or utilities. Sections 1-5 retain
+the project context needed to work safely in the View; the sibling
+guides are authoritative for controller and model internals. For
+per-method API details, read the headers under `src/view/src/`. When
+this file and the source disagree, the source is authoritative; update
+this file in the same change.
 
 It pairs with the human-facing docs:
 
@@ -43,20 +45,21 @@ When humans and `CODING.md` disagree with this file, `CODING.md` wins.
 2. Build & Run
 3. Repository Layout
 4. Architectural Pillars
-5. Module Boundaries: app / core / model / controller / view
-6. The View Layer (UI) - top-down tour
+5. Module Boundaries
+6. The View Layer - Top-Down Tour
 7. Widget Library Reference (`src/view/src/widgets/`)
 8. Track Item Hierarchy (Timeline rendering primitives)
 9. Trace View Internals (System Profiler UI)
 10. Compute View Internals (Compute Profiler UI)
 11. UI Models (`src/view/src/model/`)
-12. Cross-cutting Services (Events, Settings, Hotkeys, Notifications, Fonts, Icons)
-13. Data Flow: How a click becomes a request becomes pixels
-14. Coding Conventions in this Repo
-15. Comment & Documentation Style
-16. Reuse Catalog: "Before you write a new X, check if Y exists"
-17. Common Pitfalls
-18. Quick Reference Index of Every UI Class
+12. Cross-cutting Services (Events, Monitoring, Settings, Logging, Persistence)
+13. Remote / SSH and Profiler Launch UI
+14. Data Flow: Requests, Remote Operations, and Profiler Runs
+15. Coding Conventions in this Repo
+16. Comment & Documentation Style
+17. Reuse Catalog: Before You Write a New X
+18. Common Pitfalls
+19. Quick Reference Index of Every UI Class
 
 ---
 
@@ -102,6 +105,11 @@ CMake options worth knowing:
   `ComputeTester`. Guarded with `#ifdef ROCPROFVIS_DEVELOPER_MODE` in code.
 - `COMPUTE_UI_SUPPORT` - guards the entire Compute analysis surface.
   Code touching compute features is wrapped with `#ifdef COMPUTE_UI_SUPPORT`.
+- `ROCPROFVIS_ENABLE_PROFILER` - enables the in-app profiler launcher
+  (default off).
+- `ROCPROFVIS_ENABLE_REMOTE` - enables SSH connection, browse, transfer,
+  and remote-trace UI (default off). Remote profiling needs both remote
+  and profiler support.
 - `USE_NATIVE_FILE_DIALOG` - off disables `nativefiledialog-extended`.
 
 The CLI flag `--file-dialog={auto|imgui|native}` overrides dialog selection
@@ -125,19 +133,24 @@ at runtime (see `src/app/src/rocprofvis_cli_parser.h`).
 |   |   +-- src/database/ # SQLite, RocPD/RocProf adapters, query factories
 |   |   +-- src/datamodel # In-memory dm_* types (events, tracks, samples)
 |   |   +-- src/test*/    # Unit tests (Catch2)
-|   +-- controller/       # Coordinates model + view, owns request queue
-|   |   +-- inc/          # rocprofvis_controller.h (PUBLIC C API)
+|   +-- controller/       # Coordinates model + view, owns async futures/handles
+|   |   +-- inc/          # rocprofvis_controller.h + rocprofvis_profiler.h
 |   |   +-- src/          # Generic controller plumbing
 |   |   +-- src/system/   # System-profile-specific (events, samples, tracks...)
 |   |   +-- src/compute/  # Compute-profile-specific (kernels, roofline...)
+|   |   +-- src/remote/   # SSH bridge/client/known-host handling
+|   |   +-- src/profiler/ # Local/remote profiler process execution
 |   |   +-- tests/        # System & compute Catch2 tests
-|   \-- view/             # << This is the UI. Read sections 6-12. >>
+|   \-- view/             # << This is the UI. Read sections 6-14. >>
 |       +-- inc/          # rocprofvis_view_module.h (entry: init/render/destroy)
 |       +-- src/          # All UI classes
 |       |   +-- compute/  # Compute-only views (#ifdef COMPUTE_UI_SUPPORT)
 |       |   +-- icons/    # Icon font glyph constants & ranges
 |       |   +-- model/    # UI-side data models (cached projections)
 |       |   |   +-- compute/
+|       |   +-- profiler/ # Profiler launcher/session UI (optional)
+|       |   +-- remote/   # SSH profiles, sessions, dialogs (optional)
+|       |   +-- welcome/  # WelcomePage empty state
 |       |   +-- widgets/  # Reusable widget library (use these first!)
 +-- thirdparty/           # Vendored libs (imgui, glfw, sqlite3, spdlog, ...)
 +-- resources/            # Icons, fonts, AMD logo, embedded assets
@@ -155,7 +168,7 @@ at runtime (see `src/app/src/rocprofvis_cli_parser.h`).
 +-- README.md             # Public README + UI tour
 +-- AGENTS.md             # Root pointer to .agents/ guides
 \-- .agents/              # AI/agent architecture guides
-    +-- AGENTS.md         # This file: whole-repo + View layer guide
+    +-- UI.md             # This file: View-layer guide
     +-- CONTROLLER.md     # Controller-layer deep dive
     \-- DATABASE.md       # Model/database-layer deep dive
 ```
@@ -182,7 +195,7 @@ on top. The same trace can drive multiple parallel projects (one per tab).
                    +-------------------------+
                    |  controller/  (C ABI)   |
                    |  rocprofvis_controller* |
-                   |  request/future queues  |
+                   |  futures / data handles |
                    +------------+------------+
                                 |
                                 v
@@ -196,22 +209,26 @@ Key invariants:
 
 1. **The view never touches SQLite or trace files directly.** It calls
    `controller`'s C API through `DataProvider`.
-2. **The controller exposes a stable C ABI** (`src/controller/inc/`) so it
-   can be called from C/C++/Python (CFFI). All long-running operations are
-   asynchronous via `rocprofvis_controller_future_t`.
+2. **The controller exposes a stable C ABI** (`src/controller/inc/`) to
+   C/C++ callers. All long-running operations are asynchronous via
+   `rocprofvis_controller_future_t`. Python CFFI binds the model ABI
+   directly; it does not call the controller.
 3. **The view is single-threaded immediate mode.** All ImGui calls happen on
    the main thread inside the per-frame `Render()` traversal. Heavy work
-   (SQL queries, file save, cleanup) is offloaded to controller futures or
-   to `std::future<...>` jobs owned by `AppWindow`.
+   (queries, remote I/O, profiler runs, save, cleanup) is offloaded to
+   controller futures, `AppMonitor`, or owned `std::future<...>` jobs.
 4. **Ownership is explicit.** Every `Project` owns one `DataProvider`. Every
    widget that subscribes to events stores its `EventManager::SubscriptionToken`
    and unsubscribes in its destructor.
-5. **Per-project state is keyed by trace path.** `Project::GetID()` is the
-   trace file path; the `EventManager` source ID and `ProjectSetting`
-   serialization use the same key.
+5. **Normal project state is keyed by trace path.** Compare projects are
+   the exception: `AppWindow::MakeCompareId()` creates a synthetic ID
+   and `Project::OpenCompare()` persists both source paths.
 6. **The app supports both system traces (`TraceView`) and compute traces
    (`ComputeView`)**, both deriving from `RootView` and gated by
    `Project::TraceType`. Compute is conditional behind `COMPUTE_UI_SUPPORT`.
+7. **Long-running UI operations are non-blocking.** SSH and profiler
+   sessions register with `AppMonitor`; status changes become typed
+   `RocEvent`s and teardown is deferred until controller futures resolve.
 
 ## 5. Module Boundaries
 
@@ -220,7 +237,9 @@ Key invariants:
 Owns the OS-level shell. Specifically:
 
 - `main.cpp` - GLFW window, fullscreen state, drag-and-drop callback, and
-  the per-frame loop that calls `rocprofvis_view_render()`.
+  the lazy frame loop that calls `rocprofvis_view_render()` and sleeps
+  unless `rocprofvis_view_wants_continuous_render()` or an input/event
+  wake requires more frames.
 - `glfw_util.{h,cpp}` - `FullscreenState`, `toggle_fullscreen`,
   `sync_fullscreen_state`. Use these instead of touching GLFW directly.
 - `rocprofvis_imgui_backend.{h,cpp}` plus `rocprofvis_imgui_opengl.cpp` /
@@ -250,8 +269,9 @@ Tiny library reused by every other module. Its job is to be header-light:
 Owns the on-disk trace and produces typed in-memory records. The view
 should not include anything from this directory directly.
 
-- `inc/rocprofvis_c_interface.h` - the C ABI surface (used by Python CFFI).
-- `inc/rocprofvis_interface.h` - C++ wrappers and helpers.
+- `inc/rocprofvis_interface.h` - model C ABI declarations parsed by
+  Python CFFI.
+- `inc/rocprofvis_c_interface.h` - C++ convenience wrappers/helpers.
 - `src/database/` - SQLite adapters (`rocprofvis_db_sqlite`), source-format
   adapters (`rocprofvis_db_rocpd`, `rocprofvis_db_rocprof`), packed storage,
   query builders/factories, expression filter, schema versioning.
@@ -261,8 +281,9 @@ should not include anything from this directory directly.
   `dm_table_row`, `dm_topology`, `dm_track`, `dm_track_slice`, `dm_trace`,
   `dm_ext_data`. These are the canonical model types.
 - `src/common/rocprofvis_error_handling.{h,cpp}` - error propagation
-  primitives (`rocprofvis_result_t` codes).
-- `src/tests/` - Catch2 unit tests for the model.
+  primitives (`rocprofvis_dm_result_t` codes).
+- `src/model/src/tests/` - Catch2 model tests
+  (`src/model/src/test/` contains exploratory drivers).
 - `python/` - CFFI build script (`rocprofvis_cffi_build.py`) and tests.
 
 ### `src/controller/`
@@ -271,6 +292,8 @@ The bridge between model and view. **Public** API in `inc/`:
 
 - `rocprofvis_controller.h` - the full C function set. Highlights:
   - `rocprofvis_controller_alloc(filename)` / `rocprofvis_controller_load_async`.
+  - `rocprofvis_controller_alloc_compare(filenames, count)` for
+    multi-source compare projects.
   - `rocprofvis_controller_future_alloc/free` for async fences.
   - `rocprofvis_controller_array_alloc` and `_arguments_alloc` for batched
     calls.
@@ -280,6 +303,8 @@ The bridge between model and view. **Public** API in `inc/`:
     roofline, metrics, queue utilization, cleanup, save trim, etc).
 - `rocprofvis_controller_enums.h` / `_types.h` - all opaque handles
   (`rocprofvis_handle_t`, `rocprofvis_controller_t`, ...) and result codes.
+- `rocprofvis_profiler.h` - profiler config/session C API used by the
+  optional launcher, including local and remote async launch.
 
 Internal source layout under `src/controller/src/`:
 
@@ -289,7 +314,9 @@ Internal source layout under `src/controller/src/`:
 - `rocprofvis_controller_arguments.{h,cpp}` - typed argument lists for
   controller calls.
 - `rocprofvis_controller_data.{h,cpp}` - shared "result data" wrapper.
-- `rocprofvis_controller_handle.{h,cpp}` - ref-counted handle base class.
+- `rocprofvis_controller_handle.{h,cpp}` - common opaque handle base;
+  retention is selective for pooled object types, not universal
+  reference counting.
 - `rocprofvis_controller_id.h` - 64-bit ID encoding helpers.
 - `rocprofvis_controller_job_system.{h,cpp}` - small thread pool for
   async work. Prefer scheduling controller async work here; if a
@@ -307,6 +334,10 @@ Internal source layout under `src/controller/src/`:
 - `compute/` - per-domain modules covering kernel, metrics container,
   plots (+compute, +series), roofline, table compute (+pivot), trace
   compute, workload.
+- `remote/` - SSH bridge/client/known-host implementation behind the
+  controller C API; the View never links libssh2 directly.
+- `profiler/` - profiler command construction, process execution, and
+  optional SSH executor.
 - `tests/` - Catch2 system + compute tests.
 
 ### `src/view/`
@@ -326,6 +357,8 @@ void rocprofvis_view_set_fullscreen_state(bool is_fullscreen);
 void rocprofvis_view_set_texture_backend(...);
 std::string rocprofvis_get_application_config_path();
 bool rocprofvis_view_is_remote_display_session();
+std::string rocprofvis_get_application_log_path();
+bool rocprofvis_view_wants_continuous_render();
 ```
 
 These are the only symbols `app/` should call from `view/`. Internally
@@ -346,7 +379,7 @@ AppWindow (singleton, RocWidget)
 +-- VFixedContainer m_main_view  (vertical fixed layout, 3 slots)
 |   +-- [0] toolbar slot (RootView::GetToolbar(), per active project)
 |   +-- [1] main_area_item : RocCustomWidget
-|   |       renders m_tab_container OR RenderEmptyState() if no tabs
+|   |       renders m_tab_container OR WelcomePage if no tabs
 |   |       Per-tab widget = Project::GetView() = RootView
 |   |         |
 |   |         +-- TraceView : RootView                 (system trace)
@@ -360,6 +393,7 @@ AppWindow (singleton, RocWidget)
 |   |         |   +-- m_event_search   : EventSearch (toolbar pop-down)
 |   |         |   +-- m_summary_view   : SummaryView (separate sub-window)
 |   |         |   +-- AnnotationsManager (per-project, drives StickyNote items)
+|   |         |   +-- MeasurementController (two-point timeline measurement)
 |   |         |   +-- TimelineSelection (per-project, owns selection state)
 |   |         |   +-- TrackTopology    (per-project, owns sidebar tree)
 |   |         |
@@ -369,13 +403,19 @@ AppWindow (singleton, RocWidget)
 |   |                 +-- ComputeSummaryView
 |   |                 +-- ComputeKernelDetailsView
 |   |                 +-- ComputeTableView
-|   |                 +-- ComputeComparisonView
 |   |                 +-- ComputeWorkloadView
-|   |                 +-- (ComputeTester, dev mode only)
+|   |                 +-- ComputeComparisonView
+|   |                 +-- (ComputeCodeView / ComputeTester, dev mode only)
 |   +-- [2] status bar (RocCustomWidget calling AppWindow::RenderStatusBar)
++-- WelcomePage              : empty-state landing page
++-- CompareFilesDialog       : two-trace compare modal (File > Compare, dev mode)
 +-- m_settings_panel        : SettingsPanel (modal, opened via menu)
 +-- m_confirmation_dialog   : ConfirmationDialog
 +-- m_message_dialog        : MessageDialog
++-- ProfilerLauncherDialog   : optional profiler UI
++-- SshTestDialog            : optional dev-only remote trace UI
++-- AppMonitor               : singleton; polls background controller operations
++-- LogViewer                : singleton production log overlay
 +-- NotificationManager     : singleton, drawn last (toasts overlay)
 +-- DebugWindow             : singleton, dev mode only
 ```
@@ -391,16 +431,26 @@ File: `src/view/src/rocprofvis_appwindow.{h,cpp}`. Owns global UI state:
 - `void Render()` / `void Update()` - per-frame entry points.
 - `void OpenFile(std::string file_path)` - opens a trace or `.rpv`
   project. Routes via `Project::Open()` and adds a tab.
+- `void OpenCompare(base_path, target_path)` / `MakeCompareId(files)` -
+  creates a synthetic compare project containing two trace sources. The
+  `File > Compare` entry point is currently gated behind
+  `ROCPROFVIS_DEVELOPER_MODE`, though the dialog object is always built.
 - `void ShowConfirmationDialog(title, message, on_confirm)` /
   `ShowMessageDialog` - centralized modal dialogs. Always go through
   these, do not create your own popups for ok/cancel flows.
 - `void ShowSaveFileDialog(...)` / `ShowOpenFileDialog(...)` - file
   pickers. Auto-routes between native and ImGui implementations based on
   `m_file_dialog_preference`.
+- `void ShowPathPickerDialog(...)` - folder picker used by workflows
+  such as profiler output selection.
+- `void ShowProfilerLauncher()` - lazy-opens the optional profiler
+  launcher (`ROCPROFVIS_ENABLE_PROFILER`).
 - `Project* GetCurrentProject() / GetProject(id)` - lookup helpers.
 - `BeginAppShutdown()` - graceful shutdown that drains async
-  `DataProvider` cleanup work via `m_provider_cleanup_jobs`. Use this
+  `DataProvider` cleanup jobs and `AppMonitor` operations. Use this
   rather than terminating the process.
+- `WantsContinuousRender()` - keeps the lazy app loop awake while a
+  view, queued event, log stream, or monitored operation needs frames.
 - `SetTabLabel(label, id)` - pushed to the `TabContainer` via the
   `Project` system; useful when a child view wants to indicate dirty
   state.
@@ -410,18 +460,24 @@ State of note:
   for the main window: `[0]` toolbar slot (filled from
   `RootView::GetToolbar()` of the active tab via the `m_tool_bar_index`
   index), `[1]` `RocCustomWidget` that renders `m_tab_container` or
-  `RenderEmptyState()`, `[2]` status bar. The ImGui menu bar is rendered
+  `WelcomePage`, `[2]` status bar. The ImGui menu bar is rendered
   inline by `AppWindow::Render()` before this view, not slotted in.
 - `m_tab_container` (`shared_ptr<TabContainer>`) - the project tabs;
   source name is `TAB_CONTAINER_SRC_NAME` (`"MainTabContainer"`).
 - `m_projects` (`unordered_map<string, unique_ptr<Project>>`) - one
-  entry per opened trace.
+  entry per normal trace path or synthetic compare ID.
 - `m_provider_cleanup_jobs` - async cleanup of in-flight `DataProvider`
   requests when a tab closes or the app exits.
 - `m_status_message`, `m_status_show_busy_indicator` -
-  `UpdateStatusBar()` populates these from the active project's
-  `DataProvider::GetProgressMessage()`.
+  `UpdateStatusBar()` combines active-project request progress,
+  provider cleanup jobs, monitored SSH/profiler operations, and idle
+  SSH-session counts.
 - Subscribed events: `kTabClosed`, `kTabSelected`, `kFontSizeChanged`.
+
+`AppWindow::Update()` polls `AppMonitor`, dispatches queued events, then
+polls `LogViewer`. Keep controller polling and ImGui rendering on the
+main thread; callbacks may enqueue events from worker threads, but
+widgets consume them during normal frame dispatch.
 
 ### `Project` - per-trace bundle
 
@@ -431,6 +487,10 @@ trace file:
 - `OpenResult Open(std::string& file_path)` - opens a `.rpv`/trace and
   attaches a `RootView` (either `TraceView` or `ComputeView`). Returns
   `Success`, `Duplicate`, or `Failed`.
+- `OpenResult OpenCompare(project_id, file_paths)` - builds a system
+  trace project through
+  `rocprofvis_controller_alloc_compare(file_ptrs.data(), count)`,
+  then attaches compare-source metadata and the supplied synthetic ID.
 - `void Save()` / `void SaveAs(file_path)` - serializes registered
   `ProjectSetting`s into a `.rpv`.
 - `void RegisterSetting(ProjectSetting*)` - any per-project state that
@@ -442,8 +502,8 @@ trace file:
 - `jt::Json& GetSettingsJson()` - the in-memory JSON tree. JSON keys
   used in `.rpv` files are the `JSON_KEY_*` constants in this header.
 - `TraceType GetTraceType()` - `Undefined | System | Compute`.
-- `GetID()` - the trace file path; used as event source ID and as the
-  registration key in `PresetManager`.
+- `GetID()` - the trace path for normal projects or synthetic compare
+  ID; used as event source ID and the `PresetManager` registration key.
 
 ### `RootView` - polymorphic per-trace view
 
@@ -457,6 +517,7 @@ public:
     virtual void                                RenderEditMenuOptions();
     virtual std::optional<DataProviderCleanupWork> DetachProviderCleanup();
     virtual DataProvider* GetDataProvider();
+    virtual bool WantsContinuousRender() const;
 protected:
     void                 RenderLoadingScreen(const char* progress_label);
     SettingsManager&     m_settings_manager;
@@ -467,6 +528,19 @@ Implementations: `TraceView` (system) and `ComputeView` (compute, gated
 by `COMPUTE_UI_SUPPORT`). When you add a new project type, you derive
 from `RootView`, fill `GetToolbar`, `RenderEditMenuOptions`, and
 `DetachProviderCleanup`, then teach `Project::Open` to instantiate it.
+
+### `WelcomePage` and compare projects
+
+- `WelcomePage` (`welcome/rocprofvis_welcome_page.{h,cpp}`) is the
+  no-tabs landing page. It renders Open Trace, recent files, and
+  resource links using `FlexContainer`; do not recreate an empty state
+  in `AppWindow`.
+- `CompareFilesDialog` (`rocprofvis_compare_files_dialog.{h,cpp}`)
+  collects base and target traces. `AppWindow::OpenCompare()` routes
+  them through `Project::OpenCompare()`,
+  `TraceDataModel::SetCompareSources()`, and per-track
+  `CompareSourceInfo` badges/colors. The `File > Compare` menu item is
+  currently behind `ROCPROFVIS_DEVELOPER_MODE`.
 
 ## 7. Widget Library Reference (`src/view/src/widgets/`)
 
@@ -538,8 +612,9 @@ Use these instead of inlining their logic anywhere new.
 
 - `RenderLoadingIndicator(color, window_id, centering, dot_radius,
   num_dots, dot_spacing, anim_speed)` and the lower-level
-  `RenderLoadingIndicatorDots`. Use this any time you need the standard
-  bouncing-dots spinner. `LoadingIndicatorCentering` enum =
+  `RenderLoadingIndicatorDots` / `MeasureLoadingIndicatorDots`. Use
+  these any time you need the standard bouncing-dots spinner.
+  `LoadingIndicatorCentering` enum =
   `kCenterNone | kCenterHorizontal | kCenterVertical | kCenterBoth`.
 - `ApplyAlpha(color, alpha)` - mix alpha into an `ImU32`.
 - `ThemeColor(settings, Colors color, alpha)` - fetch a themed color
@@ -552,8 +627,12 @@ Use these instead of inlining their logic anywhere new.
 - `IconButton(icon, icon_font, size, tooltip, frameless, ...)` - the
   canonical glyph button. Must use the icon font from `FontManager`.
 - `CopyableTextUnformatted(text, unique_id, ...)` - clickable copy-to-
-  clipboard text. Use this for any cell whose value the user may want
-  to copy (events, args, paths).
+  clipboard text with optional one-click copy, context menu, and custom
+  menu callback. Use this for values users may need to copy.
+- `CellMenuTarget`, `PositionCell`, `RenderRowHitbox`,
+  `CaptureCellRightClick`, `BeginCellContextMenu`,
+  `EndCellContextMenu`, `AddCopyRowCellMenuItems` - shared table
+  right-click/copy scaffolding. Reuse it so cell and row hitboxes agree.
 - `IconMenuItem(icon, label, enabled)` / `IconBeginMenu(icon, label)` -
   menu entries with a leading icon-font glyph. Use inside
   `BeginPopup`/`BeginPopupContextItem` blocks instead of plain
@@ -564,12 +643,16 @@ Use these instead of inlining their logic anywhere new.
   vs drag" disambiguator.
 - `InputTextWithClear(id, hint, buf, buf_size, icon_font, bg_color,
   style, width)` - standard text input with an X-button to clear.
+- `InputTextString(...)` / `InputTextStringWithHint(...)` -
+  resize-aware `std::string` inputs used by profiler and SSH forms.
 - `SetTooltipStyled / BeginTooltipStyled / BeginItemTooltipStyled /
   EndTooltipStyled` - themed tooltip helpers; use these instead of
   `ImGui::SetTooltip` so font/color/padding stay consistent.
 - `enum Alignment { Left, Center, Right }` and `ElidedText(text,
   available_width, tooltip_width, alignment, align_to_frame)` -
   ellipsizes text and shows the full text in a tooltip on hover.
+- `ElideWithEllipsis(text, available_width)` - returns an elided
+  string for callers that draw text themselves.
 - `CenterNextTextItem` / `CenterNextItem` - centers the next ImGui
   draw within the current row.
 - `XButton(id, tool_tip, settings)` - the small "x" close button
@@ -663,6 +746,16 @@ subclassing this; don't roll your own.**
   scrollable panel. `AddDebugMessage`, `AddPersitentDebugMessage`
   (sic), max-message limit, transient/persistent split panes.
 
+### 7.14 `rocprofvis_log_viewer.{h,cpp}` - production log viewer
+
+- `class LogViewer` - singleton user-facing spdlog mirror with a
+  bounded ring buffer, level filter, regex search, relative time, and
+  auto-scroll. `AppWindow::Update()` calls `Poll()` and `Render()` draws
+  the overlay.
+- Settings live in `UserSettings::log_viewer`; use this viewer for
+  application logs. `DebugWindow` remains a separate developer-only
+  diagnostic surface.
+
 ## 8. Track Item Hierarchy
 
 Tracks are the horizontal lanes in the timeline. They live in
@@ -676,12 +769,16 @@ Tracks are the horizontal lanes in the timeline. They live in
 
 ### `TrackItem` (base) - what every track has
 
-Constructor: `TrackItem(DataProvider& dp, uint64_t id,
-shared_ptr<TimePixelTransform> tpt)`.
+`TrackItem` is a standalone timeline render object, **not** a
+`RocWidget`. Constructor:
+`TrackItem(DataProvider& dp, uint64_t id, bool display,
+shared_ptr<TimePixelTransform> tpt,
+shared_ptr<TimelineSelection> selection)`.
 
 Public:
 - `Render(width)` / `Update()` - per-frame work.
 - `GetID() / SetID(id)` - the controller's track id.
+- `IsDisplayed() / SetDisplay(bool)` - timeline/sidebar visibility.
 - `GetTrackHeight()` and `bool TrackHeightChanged()` - height
   bookkeeping that the parent timeline reads.
 - `IsInViewVertical() / SetInViewVertical(bool)` - culling hint.
@@ -691,30 +788,35 @@ Public:
 - `IsSelected() / SetSelected(bool)` - selection state (mirrored to
   `TimelineSelection`).
 - `IsMetaAreaClicked()` - did the user click the description column.
-- `GetRequestState()` - `kIdle | kRequesting | kTimeout | kError`.
-- `GetMetaAreaScaleWidth() / UpdateMaxMetaAreaSize(new_size)` -
-  contributes to the global meta-area width sync.
+- `GetRequestState()` - returns `TrackDataRequestState`
+  (`kIdle | kRequesting | kTimeout | kError`).
+- `GetMaxMetaAreaScaleWidth()` / `UpdateMetaScaleAreaSize()` /
+  `UpdateMaxMetaScaleAreaSize()` - global meta-scale width sync.
 - Data-handling overrides: `HasData`, `ReleaseData`, `RequestData`,
   `RequestAnalysis`, `HandleTrackDataChanged`, `HasPendingRequests`,
   `IsCompactMode`. Override `ExtractPointsFromData()` to convert raw
-  data into your renderable cache.
+  data into your renderable cache. `RequestAnalysis()` fetches the
+  shared `AnalysisTrackStatistics` used by pills and Track Details.
 
 Protected hooks every subclass implements:
 - `RenderMetaArea()` - left "description" column (default impl is
   reused).
 - `RenderMetaAreaScale()` - the in-meta numeric scale (per type).
-- `RenderMetaAreaOptions()` - the gear-icon menu (per type).
+- `RenderMetaAreaOptions()` - the per-type options context menu.
 - `RenderMetaAreaExpand()` - expand/collapse affordance.
 - `RenderChart(graph_width)` - the actual graph drawing.
 - `RenderResizeBar(parent_size)` - drag handle for height.
 
 State of note: `m_track_metadata` (`const TrackInfo*` from
-`TrackTopology`), `m_track_height`, `m_pill` (`Pill`, the small label
-pill in the meta area), `m_request_queue`, `m_pending_requests`.
+`TrackTopology`), `m_track_statistics`, `m_track_height`, `m_pills`
+(multiple labels/statistics in the meta area), `m_request_queue`, and
+`m_pending_requests`. `SetNodeColor()` and the node pill implement the
+optional `show_node_colors` display preference.
 
 `class Pill` - the rounded label badge used inside meta areas.
-`Activate/Deactivate`, `Show/Hide`, `SetLabel/SetTooltipLabel`. Renders
-through `RenderPillLabel(container_size, settings, reorder_grip_width)`.
+Use `SetLabel`, `SetExtendedLabel`, `SetTooltip`, `SetAccentColor`,
+`Activate/Deactivate`, `SetVisible`, and `Render`. `Sizing` supports
+`kElided`, `kCompact`, and `kExtended`.
 
 ### `FlameTrackItem` - flame-chart for events
 
@@ -722,7 +824,7 @@ Used for queues, streams, and instrumented threads. It holds:
 
 - `enum class EventColorMode { kNone, kByEventName, kByTimeLevel }`.
 - `class FlameTrackProjectSettings : ProjectSetting` - persists
-  `ColorEvents()` and `CompactMode()`.
+  `ColorEvents()`, `CompactMode()`, and queue-analysis pill visibility.
 - A cache of `ChartItem` (`TraceEvent` + selected/highlight + child
   info), refilled via `ExtractPointsFromData()`.
 - Selection / highlight bookkeeping that listens to
@@ -730,17 +832,24 @@ Used for queues, streams, and instrumented threads. It holds:
   `kTimelineEventHighlightChanged`.
 - A static `s_max_event_label_width` and helper
   `CalculateMaxEventLabelWidth()` invoked when fonts change.
+- Event rows use `SettingsManager::GetEventLevelHeight()` or
+  `GetEventLevelCompactHeight()`. The expand/contract affordance shows
+  all event levels, and `MeasurementController` can anchor measure
+  points to flame events.
 
 ### `LineTrackItem` - line/box-plot for counters
 
 Holds `m_data` (`vector<TraceCounter>`) and:
 
 - `class LineTrackProjectSettings : ProjectSetting` - persists box-plot
-  toggle, stripes, highlight band, and Y limits.
+  toggle, stripes, highlight band, Y limits, and statistic-pill
+  visibility.
 - `class LineTrackItem::VerticalLimits` - inline editable Y-min/Y-max
   fields backed by `EditableTextField`.
 - `BoxPlotRender(width)` and `RenderHighlightBand(...)`.
 - `MapToUI` helper that converts `(x, y)` data to screen.
+- Counter tracks expose min/max/mean/standard-deviation pills from
+  `AnalysisTrackStatistics::Counter`.
 
 When you add a new track type:
 
@@ -768,6 +877,8 @@ Composition (members):
   hierarchical sidebar tree on metadata changes.
 - `m_annotations` (`shared_ptr<AnnotationsManager>`) - sticky-note
   annotations.
+- `m_measurement` (`shared_ptr<MeasurementController>`) - two-point,
+  event-aware timeline measurement state.
 - `m_timeline_view` (`shared_ptr<TimelineView>`) - the grid + tracks +
   scrubber surface (described below).
 - `m_horizontal_split_container` / `m_vertical_split_container` -
@@ -798,9 +909,9 @@ Public surface:
 
 The big one. Owns the timeline rendering surface. Members worth knowing:
 
-- `m_graphs` (`shared_ptr<vector<TrackGraph>>`) - the ordered set of
-  visible tracks. Each `TrackGraph` has `{ graph_type, display, chart
-  (TrackItem*), selected }`.
+- `m_tracks` (`shared_ptr<vector<TrackItem*>>`) - ordered, indexed
+  timeline tracks. Display and selection state live on each
+  `TrackItem`; `TrackGraph` no longer exists.
 - `m_tpt` (`shared_ptr<TimePixelTransform>`) - **the** time<->pixel
   conversion. All time math goes through this.
 - `m_arrow_layer` (`TimelineArrow`) - draws fan/chain arrows for event
@@ -819,7 +930,7 @@ The big one. Owns the timeline rendering surface. Members worth knowing:
   when the timeline (or histogram) "owns" focus.
 
 Public surface:
-- `MakeGraphView()` - rebuilds `m_graphs` from current track metadata.
+- `MakeGraphView()` - rebuilds `m_tracks` from current track metadata.
 - `ResetView()` - restores zoom/pan defaults.
 - `RenderInteractiveUI`, `RenderGraphPoints`, `RenderHistogram`,
   `RenderTraceView`, `RenderGrid`, `RenderScrubber`, `RenderSplitter`,
@@ -831,6 +942,8 @@ Public surface:
   GetVisibleTrackFractions(...)` - everything needed to bookmark,
   navigate, or query the current view.
 - `GetArrowLayer()` returns the `TimelineArrow` for flow visuals.
+- `GetTracks()` exposes the shared track vector to the sidebar and
+  project settings.
 
 Subscribed events: `kNewTrackData`, `kHandleUserGraphNavigationEvent`
 (carries `ScrollToTrackEvent`), `kSetViewRange`, `kFontSizeChanged`,
@@ -878,7 +991,10 @@ Renders the topology tree in the left pane:
 - `EyeButtonState` (`kAllVisible|kAllHidden|kMixed`) is computed
   recursively to drive the show/hide eye icon at each level.
 - `ApplyVisibility(node, visible)` toggles every leaf below `node` and
-  pushes the change through `m_graphs` and `DataProvider`.
+  pushes the change through the shared `TrackItem*` vector and
+  `DataProvider`.
+- The active-node accent mirrors timeline node coloring when
+  `SettingsManager::ShowNodeColors()` is enabled.
 
 ### `Minimap` (`rocprofvis_minimap.{h,cpp}`)
 
@@ -907,13 +1023,14 @@ with:
 
 ### `AnalysisView` (`rocprofvis_analysis_view.{h,cpp}`)
 
-The bottom-right tabbed panel. Hosts:
+The bottom-right tabbed panel. Hosts, in source order:
 - `m_tab_container` (`TabContainer`) with sub-tabs:
+  - `MultiTrackTable` (event table) - cross-track event listing.
+  - `MultiTrackTable` (sample table) - cross-track sample listing.
   - `EventsView` - per-event detail tab (basic info, ext data, flow,
     callstack, args).
   - `TrackDetails` - selected-track summary tab.
-  - `MultiTrackTable` (event table) - cross-track event listing.
-  - `MultiTrackTable` (sample table) - cross-track sample listing.
+  - `TopEventsView` - category-specific top event/sample tables.
   - `AnnotationView` - sticky-note list.
 - Listens to track / range / event selection events to keep tabs in
   sync.
@@ -938,6 +1055,15 @@ Shows aggregated info per selected track, sourced from
 `TrackTopology::GetTopology()`. `DetailItem` collects pointers into
 the topology models (node, process, processor, queue, thread, stream,
 counter) for the track, then renders an `InfoTable`.
+Real queue/counter statistics come from `AnalysisTrackStatistics`, the
+same cache used by track pills.
+
+### `TopEventsView` (`rocprofvis_top_events_view.{h,cpp}`)
+
+Hosts five `TopEventsTable` instances for instrumented events,
+dispatches, memory allocations, memory copies, and sampled launches.
+Each table uses its dedicated analysis request/table type through the
+normal `DataProvider` + `TablesModel` pipeline.
 
 ### `Annotations` and `StickyNote`
 
@@ -947,8 +1073,9 @@ counter) for the track, then renders an `InfoTable`.
   `RemoveNotesPendingDelete`. Persisted via
   `AnnotationsManagerProjectSettings`.
 - `StickyNote` (`rocprofvis_stickynote.{h,cpp}`) - one note. Carries
-  position (time + y_offset), size, text/title, and view-range
-  metadata. `Render(draw_list, window_pos, tpt)` and `HandleDrag(...)`
+  position (time + track-relative y offset), optional track binding,
+  lock state, size, text/title, and view-range metadata.
+  `Render(draw_list, window_pos, tpt)` and `HandleDrag(...)`
   drag the timeline anchor (minimized or expanded), and the timeline
   auto-scrolls when the anchor nears a viewport edge. The expanded note
   is a floating window with an inline-editable title (click to edit) and
@@ -972,7 +1099,16 @@ instead of poking the timeline yourself.
 Renders the flow arrows between events on different tracks. Two
 `RenderStyle`s: `kFan` and `kChain`. Two `FlowDisplayMode`s:
 `kShowAll` and `kHide`. `Render(draw_list, window, track_position_y,
-graphs, tpt)` is called from `TimelineView::RenderTraceView`.
+tracks, tpt)` is called from `TimelineView::RenderTraceView`.
+
+### Measurement mode (`rocprofvis_measurement_controller.{h,cpp}`)
+
+`MeasurementController` owns the
+`kInactive | kWaitingForFirst | kWaitingForSecond | kComplete` state
+machine and two `MeasurementPoint`s. Points may be freehand or anchored
+to events; `TraceView` renders toolbar controls and `TimelineView`
+renders the overlay. Reuse this controller instead of storing a second
+measurement state in a widget.
 
 ### Click / focus arbitration: `TimelineFocusManager`
 
@@ -996,7 +1132,8 @@ historical reasons; the class is `TimelineFocusManager`).
 Defined in `rocprofvis_timeline_view.h`. Tiny timer that delays
 showing the loading indicator until a request takes longer than a
 threshold. Use this pattern (don't show spinners immediately) for any
-new long-running fetch.
+new long-running fetch. Call `Tick()` while active; elapsed state does
+not advance correctly if the lazy render loop is allowed to sleep.
 
 ## 10. Compute View Internals
 
@@ -1019,8 +1156,9 @@ The compute analogue of `TraceView`. Owns:
     workload SOL, workload roofline).
   - `ComputeKernelDetailsView` - per-kernel deep-dive.
   - `ComputeTableView` - hierarchical metric tables.
-  - `ComputeComparisonView` - baseline vs target comparison.
   - `ComputeWorkloadView` - system info + profiling config tables.
+  - `ComputeComparisonView` - baseline vs target comparison.
+  - `ComputeCodeView` - dev-only source/ISA correlation.
   - `ComputeTester` - dev-mode scratchpad
     (`#ifdef ROCPROFVIS_DEVELOPER_MODE`).
 - `m_data_provider` - same `DataProvider` type as `TraceView`, but its
@@ -1133,6 +1271,13 @@ Internal scratchpad UI for exercising the metric / roofline APIs.
 Behind `#ifdef ROCPROFVIS_DEVELOPER_MODE`. Not user-facing - keep
 production code from depending on it.
 
+### `ComputeCodeView` (`rocprofvis_compute_code_view.{h,cpp}`) - dev only
+
+Correlates source code and ISA through `SourceCodeWidget` and
+`IsaCodeWidget`. PC-sampling data is fetched through
+`PcSamplingRequestParams` / `DataProvider::FetchPcSampling`; do not
+query the model directly from this view.
+
 ### Compute data plumbing
 
 - `ComputeDataProvider` (`rocprofvis_compute_data_provider.{h,cpp}`)
@@ -1161,11 +1306,12 @@ controller results.
   constant instead of writing `std::numeric_limits<uint64_t>::max()`.
 - `rocprofvis_model_types.h` - the **shared vocabulary** for the
   view layer. Defines:
-  - `enum class GraphType { TYPE_LINECHART, TYPE_FLAMECHART }`,
-    `struct TrackGraph`.
   - `union TopologyId` - 54-bit `id` + 10-bit `instance` packing.
-  - `struct TrackInfo` (`id`, `track_type`, `min_ts/max_ts`,
-    `num_entries`, names, `Topology` substruct, `graph_handle`).
+  - `struct TrackInfo` (`index`, `id`, `track_type`, time/value ranges,
+    source instance/file IDs, order/topology IDs, names/category,
+    operations, `graph_handle`, and `CompareSourceInfo`).
+  - `struct CompareSourceInfo { id, name, path }` for base/target
+    provenance in compare projects.
   - `union TraceEventId` - 52/8/4-bit packing for `(event_id,
     event_node, event_op)`.
   - `struct EventInfo` and its parts: `BasicEventData`, `EventArg`,
@@ -1176,13 +1322,16 @@ controller results.
   - `struct SummaryInfo` with `KernelMetrics`, `GPUMetrics`,
     `CPUMetrics`, `AggregateMetrics`.
   - `struct TableInfo`, `FormattedColumnInfo`,
-    `AnalysisQueueUtilization` (with state machine `kStale ->
-    kPending -> kRequested -> kReady`).
+    `AnalysisTrackStatistics` with `Stat`, queue utilization,
+    counter min/max/mean/standard deviation, and state machine
+    `kStale -> kPending -> kRequested -> kReady`.
 
 - `rocprofvis_trace_data_model.{h,cpp}` - the **`TraceDataModel`
   facade**: aggregates `TopologyDataModel`, `TimelineModel`,
   `TablesModel`, `SummaryModel`, `EventModel`, `AnalysisModel`. Use
-  `DataProvider::DataModel()` to access it.
+  `DataProvider::DataModel()` to access it. Compare projects call
+  `SetCompareSources()`; use `HasCompareSources()` /
+  `GetCompareSource()` instead of inferring provenance from IDs.
 - `rocprofvis_topology_model.{h,cpp}` - holds the eight
   `unordered_map<uint64_t, *Info>` (nodes, devices, processes,
   instrumented threads, sampled threads, queues, streams, counters)
@@ -1198,10 +1347,11 @@ controller results.
   computed `SummaryInfo::AggregateMetrics`.
 - `rocprofvis_tables_model.{h,cpp}` - `TablesModel`: `enum class
   TableType { kSampleTable, kEventTable, kEventSearchTable,
-  kSummaryKernelTable }` and the table cache addressed by it.
+  kSummaryKernelTable, kAnalysisTop* }` and the table cache addressed
+  by it.
 - `rocprofvis_analysis_model.{h,cpp}` - `AnalysisModel`: per-track
-  queue-utilization cache, with the `AnalysisQueueUtilization` state
-  machine.
+  queue/counter statistic cache plus analysis tables, using the
+  `AnalysisTrackStatistics` state machine.
 - `rocprofvis_compute_data_model.{h,cpp}` and
   `rocprofvis_compute_model_types.h` (compute) - described above.
 
@@ -1230,9 +1380,10 @@ EventManager::GetInstance()->AddEvent(
 - **Always store `SubscriptionToken`s in members** named
   `m_<event>_token`, and unsubscribe in your destructor:
   `EventManager::GetInstance()->Unsubscribe(event_id, m_xxx_token)`.
-- The bus uses **deferred dispatch**: `AddEvent` queues, then
-  `DispatchEvents()` (called once per frame) drains. Don't rely on
-  same-frame ordering with the dispatcher.
+- The bus uses **thread-safe deferred dispatch**: `AddEvent` queues
+  under a mutex, then main-thread `DispatchEvents()` drains once per
+  frame. `HasPendingEvents()` keeps the lazy render loop awake. Do not
+  rely on same-frame ordering.
 - Use the typed `RocEvent` subclasses in `rocprofvis_events.h`:
   `NavigationEvent`, `TrackDataEvent`, `TableDataEvent`,
   `ScrollToTrackEvent`, `TabEvent`,
@@ -1240,10 +1391,14 @@ EventManager::GetInstance()->AddEvent(
   `EventSelectionChangedEvent`, `EventHighlightChangedEvent`,
   `RangeEvent`, `RequestProgressUpdateEvent`,
   `ComputeSelectionChangedEvent`, `ComputeMetricsFetchedEvent`,
-  `ComputeAddMetricToKernelDetailsEvent`. Add new event types here;
-  do not pass payloads through the base `RocEvent`.
+  `ComputeAddMetricToKernelDetailsEvent`, `ProfilerStatusEvent`, and
+  `RemoteStatusEvent`. Selection/highlight events support batch
+  payloads through `IsBatch()`. Add new event types here; do not pass
+  payloads through the base `RocEvent`.
 - Set `SetSourceId()` on every event you emit (typically the project
   ID or widget name) so subscribers can filter by source.
+- `RocEvent::SetAllowPropagate`, `StopPropagation`, and
+  `CanPropagate` coordinate handlers that may consume an event.
 
 ### `enum class RocEvents` - the canonical event IDs
 
@@ -1254,7 +1409,8 @@ The full list is in `rocprofvis_events.h`. Examples used widely:
 `kHandleUserGraphNavigationEvent`, `kTrackMetadataChanged`,
 `kFontSizeChanged`, `kSetViewRange`,
 `kGoToTimelineSpot`, `kTimeFormatChanged`, `kTopologyChanged`,
-`kRequestProgressUpdate`. Compute-only:
+`kRequestProgressUpdate`, `kProfilerStatusChanged`,
+`kRemoteStatusChanged`. Compute-only:
 `kComputeWorkloadSelectionChanged`,
 `kComputeKernelSelectionChanged`, `kComputeMetricsFetched`,
 `kComputeShowMetricInKernelDetails`.
@@ -1265,6 +1421,26 @@ When adding a new event:
    `RocEventType` value.
 3. Document the source ID convention in this file.
 
+### `AppMonitor` (`rocprofvis_appmonitor.{h,cpp}`)
+
+Singleton polling registry for long-running controller operations used
+by SSH and profiler sessions. `AppWindow::Update()` polls it before
+event dispatch.
+
+- `MonitorOperationType` distinguishes SSH connection/authentication,
+  profiler sessions, file transfers, and directory listings.
+- `AddOperation(...)` registers status, event-factory, terminal,
+  cancellation, future, and teardown callbacks.
+- `RemoveOperation()` cancels non-blockingly. `AppendTeardown()` /
+  `AddTeardownOp()` defer resource destruction until futures resolve.
+- `HasPendingOperations()` participates in continuous rendering and
+  shutdown; `GetActiveOperationCount()` feeds the status bar.
+- Event factories emit `RemoteStatusEvent` or
+  `ProfilerStatusEvent`. Subscribers must filter by operation ID.
+
+Teardown callbacks must capture owned handles and `shared_ptr`s by
+value, never a dying session's `this`.
+
 ### `SettingsManager` (`rocprofvis_settings_manager.{h,cpp}`)
 
 Application settings + theme. Singleton. **Read colors and fonts only
@@ -1272,6 +1448,11 @@ through this** - never hardcode `IM_COL32(...)` in feature code.
 
 - `GetUserSettings()` -> `UserSettings` (display, units, "don't ask"
   flags). `ApplyUserSettings(old, save_json)` writes JSON to disk.
+- `DisplaySettings::show_node_colors` /
+  `SettingsManager::ShowNodeColors()` controls matching node accents in
+  tracks and the sidebar.
+- `UserSettings::log_viewer` stores level mask, entry limit, search and
+  presentation preferences for `LogViewer`.
 - `GetInternalSettings()` -> recent files (`MAX_RECENT_FILES = 5`).
   Use `AddRecentFile / RemoveRecentFile / ClearRecentFiles`.
 - `GetAppWindowSettings()` -> show/hide flags (`show_toolbar`,
@@ -1289,6 +1470,9 @@ through this** - never hardcode `IM_COL32(...)` in feature code.
 - `GetEventLevelHeight()` / `GetEventLevelCompactHeight()` - the
   pixel height of one flame-chart row in normal / compact mode.
   **Reuse these instead of magic numbers.**
+- `GetProfilerSettings()` / `SaveProfilerSettings()` persist launcher
+  paths, auto-load behavior, recent targets, and last profiler/preset/
+  SSH-connection IDs.
 
 JSON keys are constants in this header
 (`JSON_KEY_SETTINGS_DISPLAY_DARK_MODE` etc.).
@@ -1339,7 +1523,7 @@ preferences UI.
 
 ### `PresetManager` and `PresetComponent` (`rocprofvis_presets.{h,cpp}`)
 
-Save/load named on-disk presets per project. Used by Compute views
+Save/load named layouts per trace project. Used by Compute views
 (comparison, table view, kernel metric table). To make a widget
 preset-aware:
 
@@ -1352,6 +1536,23 @@ preset-aware:
 
 `PresetBrowser` is the floating popup that lists presets and binds
 into the Compute toolbar.
+
+Do not confuse this with `LaunchPresetManager`: compute presets belong
+to a trace project, while profiler launch profiles are global entries
+in `profiles.json`.
+
+### `JsonUtils` and `ProfilesDocument`
+
+- `JsonUtils` (`rocprofvis_json_utils.{h,cpp}`) provides typed JSON
+  reads, bool-map conversion, and shared file read/write helpers.
+- `ProfilesDocument` (`rocprofvis_profiles_document.{h,cpp}`) is the
+  singleton owner of `{config}/profiles.json` (schema version 1), with
+  `ssh_connections` and `launch_profiles` sections.
+- `SshConnectionStore` and `LaunchPresetManager` both update this
+  document; persist through their APIs so one section does not clobber
+  the other.
+- `profiles.json` currently stores SSH passwords/passphrases in
+  plaintext. Treat it as sensitive and never log credentials.
 
 ### `Project` settings serialization
 
@@ -1403,7 +1604,9 @@ Use these instead of writing your own.
     `ICON_CHART_BAR`, `ICON_CHART_PIE`, `ICON_ARCHIVE`,
     `ICON_DELETE`, `ICON_TREE`, `ICON_GRID`, `ICON_ARROW_UP/DOWN`,
     `ICON_EDIT`, `ICON_TRASH_CAN`, `ICON_OPEN`,
-    `ICON_ARROWS_CYCLE`, `ICON_LIST`, `ICON_STICKY_NOTE`.
+    `ICON_ARROWS_CYCLE`, `ICON_LIST`, `ICON_STICKY_NOTE`,
+    `ICON_LOCKED/UNLOCKED`, `ICON_COPY`, `ICON_CROP`,
+    `ICON_ARROW_FORWARD`, `ICON_EXPAND`.
   - `icon_ranges[]` - the codepoint ranges added to the icon font
     glyph set.
 - `rocprofvis_icon_data.h` - the embedded icon font binary blob.
@@ -1411,7 +1614,120 @@ Use these instead of writing your own.
   glyph. Adding a new icon requires updating both files and the
   ranges array.
 
-## 13. Data Flow: How a click becomes pixels
+## 13. Remote / SSH and Profiler Launch UI
+
+These optional UI slices are separate from trace-project tabs until a
+downloaded/generated trace is passed to `AppWindow::OpenFile()`:
+
+- `ROCPROFVIS_ENABLE_REMOTE` gates `src/view/src/remote/`.
+- `ROCPROFVIS_ENABLE_PROFILER` gates `src/view/src/profiler/`.
+- Remote profiling requires both flags.
+- The View never calls libssh2 or launches child processes directly;
+  it uses controller C APIs and `AppMonitor`. Read `CONTROLLER.md` when
+  changing those APIs or worker lifetimes.
+
+### 13.1 Remote / SSH stack (`src/view/src/remote/`)
+
+- `SshConnectionConfig` - named host/port/user/auth profile with JSON
+  serialization.
+- `SshConnectionStore` - profile registry backed by
+  the `"ssh_connections"` section of `profiles.json`.
+- `RemoteUri` - per-operation state: selected connection, command,
+  remote result, browse state, cache key, and local download path.
+  Keep persisted connection identity separate from ephemeral operation
+  fields.
+- `SshSession` - owns one controller SSH connection and permits one
+  `SshOperation` (`Connect`, `Authenticate`, `Execute`, `Download`, or
+  `Browse`) at a time. Each phase registers with `AppMonitor`.
+- `RemoteTraceOrchestrator` - connect -> authenticate -> optional
+  execute -> optional download state machine. It filters
+  `kRemoteStatusChanged` by active operation ID and reuses an
+  authenticated session for browsing.
+- `RenderSshAuthModal(session)` - renders keyboard-interactive and
+  host-key requests. The owning dialog must call it every frame while
+  the session exists; it is not rendered globally by `AppWindow`.
+- `SshSettingsDialog` - connection-profile CRUD modal.
+- `SshTestDialog` - remote trace opener/browser owned lazily by
+  `AppWindow`; its entry point requires both
+  `ROCPROFVIS_ENABLE_REMOTE` and `ROCPROFVIS_DEVELOPER_MODE`.
+- `PromptRequest`, `HostKeyRequest`, `ExecutionOutput`, `FileStat`, and
+  `RemoteDir` in `rocprofvis_ssh_fetch.*` are mutex-protected snapshots;
+  consume updates without holding locks across ImGui calls.
+
+`SshSession::IsConnected()` means a connection handle is allocated,
+not that transport and authentication succeeded. Do not start a second
+phase while one is in flight. In-flight destruction must follow
+`SshSession`'s `AppMonitor::AppendTeardown` path so a worker never sees
+a freed connection.
+
+Downloaded traces are cached under
+`{config}/remote_cache/<connection-and-path-hash>/<filename>`.
+Permanent host-key trust uses the platform user's standard
+`.ssh/known_hosts`.
+
+### 13.2 Profiler launch stack (`src/view/src/profiler/`)
+
+- `IProfilerBackend` (`rocprofvis_profiler_backend.h`) is the extension
+  point. It validates settings, builds `ToolOption`/`TabDescriptor`
+  UI, flattens a `LaunchConfig` into execution arguments/environment,
+  reports warnings, parses the trace path from output, and exports
+  native config.
+- `RocprofSysBackend` is the currently registered backend. It supports
+  run/sample/instrument tools and owns the rocprof-sys option tabs and
+  `RocprofSysSettings`.
+- `LaunchConfig`, `TargetSpec`, and `ConnectionType` are the
+  serializable launch payload. SSH mode stores
+  `ssh_connection_ref`, not inline credentials.
+- `LaunchPresetManager` owns named launch profiles in
+  `profiles.json::launch_profiles`; this is independent of Compute's
+  per-project `PresetManager`.
+- `rocprofvis_launch_shared_tabs.*` provides reusable target,
+  environment, command-preview, output-console, and saved-profile UI.
+- `ProfilerLauncherDialog` authors configuration and renders UI. It
+  owns backends, launch presets, and `ProfilerLaunchOrchestrator`.
+- `ProfilerLaunchOrchestrator` is the UI-facing Launch/Cancel/Close/
+  Update entry point. It owns either `ProfilerSession` (local) or
+  `RemoteProfilerSession` (SSH).
+- `ProfilerSessionBase` owns controller profiler config/handle/future
+  resources and registers their status with `AppMonitor`.
+
+Profiler sessions are not `Project`s. On completion, the backend parses
+the trace path from profiler output; if auto-load is enabled, the
+orchestrator calls `AppWindow::OpenFile()`. Do not guess the newest
+filesystem trace when parsing fails: show the existing warning and
+leave manual open available.
+
+### 13.3 Launch workflows and extension rules
+
+Local:
+
+```
+ProfilerLauncherDialog
+  -> IProfilerBackend::FlattenToExecution
+  -> ProfilerLaunchOrchestrator::Launch
+  -> ProfilerSession -> rocprofvis_profiler_launch_async
+  -> AppMonitor -> ProfilerStatusEvent
+  -> ParseTraceOutputPath -> AppWindow::OpenFile
+```
+
+Remote:
+
+```
+RemoteProfilerSession
+  -> SshSession connect/authenticate
+  -> rocprofvis_profiler_launch_remote_async on the same connection
+  -> parse remote trace path
+  -> SshSession download
+  -> AppWindow::OpenFile(local cache path)
+```
+
+The SSH connection must outlive the remote profiler worker. Filter
+status events by operation ID because the remote workflow has several
+operations. To add a backend, implement `IProfilerBackend`, register it
+in `ProfilerLauncherDialog`, map its controller profiler type, and
+provide deterministic output-path parsing.
+
+## 14. Data Flow: Requests, Remote Operations, and Profiler Runs
 
 This is the canonical request lifecycle. Match this when adding new
 data-driven UI.
@@ -1419,7 +1735,7 @@ data-driven UI.
 ```
 User clicks on a track meta area
   -> TrackItem::RenderMetaArea sets m_meta_area_clicked
-  -> TimelineSelection::SelectTrack(track_graph)
+  -> TimelineSelection::SelectTrack(track_item)
   -> TimelineSelection::SendTrackSelectionChanged(...)
         emits TrackSelectionChangedEvent (kTimelineTrackSelectionChanged)
 
@@ -1460,8 +1776,12 @@ Things to honor in any new data path:
    `RootView::DetachProviderCleanup()` to return any in-flight work;
    `AppWindow` will drain it asynchronously
    (`StartProviderCleanup` / `UpdateProviderCleanups`).
+6. **SSH/profiler work goes through `AppMonitor`.** Do not poll
+   controller futures in a dialog or block `Render()`. Subscribe to
+   typed status events, filter by operation ID, and use deferred
+   teardown for resources that outlive the UI owner.
 
-## 14. Coding Conventions
+## 15. Coding Conventions
 
 `CODING.md` is authoritative. Highlights you must follow:
 
@@ -1559,7 +1879,7 @@ across translation units.
 - `.clang-tidy` validates additional rules.
 - Trailing newline at EOF. No other trailing whitespace.
 
-## 15. Comment & Documentation Style
+## 16. Comment & Documentation Style
 
 The codebase mixes plain `//` comments with Doxygen-style. Both are
 acceptable; consistency within a class is the only requirement.
@@ -1624,7 +1944,7 @@ Every new `src/` file starts with:
 There is no other required preamble. Do not duplicate the file path
 or class name in a header banner.
 
-## 16. Reuse Catalog: Before You Write a New X
+## 17. Reuse Catalog: Before You Write a New X
 
 The user's #1 rule for this repo is "do not duplicate code." Before
 adding **anything** new, check this list and reuse if at all possible.
@@ -1649,6 +1969,8 @@ adding **anything** new, check this list and reuse if at all possible.
 | Render a vertical separator                   | `VerticalSeparator(settings)`                                                                  |
 | Get a themed color                            | `settings.GetColor(Colors::kSomething)` / `ThemeColor(settings, Colors::..., alpha)`           |
 | Add a copyable text cell                      | `CopyableTextUnformatted(text, unique_id, COPY_DATA_NOTIFICATION)`                             |
+| Add consistent table cell/row copy menus      | `CellMenuTarget` + `RenderRowHitbox` + `BeginCellContextMenu` helpers                          |
+| Bind an ImGui input to `std::string`          | `InputTextString` / `InputTextStringWithHint`                                                  |
 | Truncate text with tooltip                    | `ElidedText(text, available_width, tooltip_width, alignment)`                                  |
 | Themed tooltip                                | `BeginTooltipStyled / EndTooltipStyled` or `SetTooltipStyled(fmt, ...)`                        |
 | Inline-editable label                         | `EditableTextField`                                                                            |
@@ -1657,18 +1979,24 @@ adding **anything** new, check this list and reuse if at all possible.
 | Display SOL / pinned compute metrics          | `MetricTable` / `PinnedMetricTable` / `MetricTableWidget`                                      |
 | Add a bookmark or save view state             | The `Project` + `ProjectSetting` system, JSON keys in `rocprofvis_project.h`                   |
 | Save user-customizable layouts (Compute)      | `PresetComponent` + `PresetManager` + `PresetBrowser`                                          |
+| Save profiler launch profiles                 | `LaunchPresetManager` + `ProfilesDocument`                                                     |
 | Convert ns to a display string                | `nanosecond_to_formatted_str(ns, settings_time_format, include_units)`                         |
 | Compute axis ticks                            | `calculate_nice_interval` / `fit_graph_axis_interval`                                          |
 | Map screen <-> time on the timeline           | `TimePixelTransform` (never recompute pixels-per-ns by hand)                                   |
 | Get the application config dir                | `get_application_config_path(create_dirs)`                                                     |
 | Open a URL in the user's browser              | `open_url(url)`                                                                                |
-| Detect SSH / remote display                   | `is_remote_display_session()`                                                                  |
+| Detect SSH/X11 remote display                 | `is_remote_display_session()` (file-dialog choice only; unrelated to SSH transfer)             |
 | Track selection state (system trace)          | `TimelineSelection` (call its setters, listen for the events it emits)                         |
 | Track selection state (compute)               | `ComputeSelection`                                                                             |
+| Measure between timeline points/events        | Shared `MeasurementController`                                                                 |
+| Open a two-trace compare project (dev mode)   | `CompareFilesDialog` -> `AppWindow::OpenCompare`                                               |
 | Find / scroll to a track                      | `TimelineView::ScrollToTrack(track_id)` or emit `ScrollToTrackEvent`                           |
 | Move/zoom the timeline                        | `TimelineView::MoveToPosition(start, end, y, center)` or `SetViewableRangeNS`                  |
 | Navigate to and highlight an event            | `TimelineSelection::NavigateToEvent(track_id, event_uuid, start_ns, dur_ns)`                   |
 | Pub/sub between widgets                       | `EventManager::Subscribe(id, handler)` / `AddEvent(make_shared<XxxEvent>(...))`                |
+| Keep the lazy render loop awake               | `RootView::WantsContinuousRender` / `AppWindow::WantsContinuousRender`                         |
+| Monitor controller operations without blocking| `AppMonitor::AddOperation` + typed status events                                               |
+| Show application logs                         | `LogViewer` (not the developer-only `DebugWindow`)                                             |
 | Add a hotkey                                  | Add to `HotkeyActionId`, declare info, read with `WasActionTriggered / IsActionHeld`           |
 | Disambiguate clicks across timeline layers    | `TimelineFocusManager::RequestLayerFocus / EvaluateFocusedLayer`                               |
 | Encode a request ID                           | `RequestIdBuilder::MakeRequestId(...)` or `MakeTrackDataRequestId(...)`                        |
@@ -1678,6 +2006,13 @@ adding **anything** new, check this list and reuse if at all possible.
 | Reuse a glyph                                 | One of the `ICON_*` macros in `icons/rocprovfis_icon_defines.h`                                |
 | Add a keyboard-driven label edit              | `EditableTextField` (used in `LineTrackItem::VerticalLimits`)                                  |
 | Persist a per-project flag/value              | Subclass `ProjectSetting`, register in ctor                                                    |
+| Read/write shared UI JSON safely              | `JsonUtils`                                                                                    |
+| Manage SSH connection profiles                | `SshConnectionStore` + `SshSettingsDialog` + `ProfilesDocument`                               |
+| Run SSH connect/auth/download/browse phases   | `SshSession` + `AppMonitor`                                                                    |
+| Open a remote trace end-to-end                | `RemoteTraceOrchestrator` + `RemoteUri`                                                        |
+| Render SSH auth/host-key prompts               | `RenderSshAuthModal(session)` every frame while active                                         |
+| Launch a profiler locally or over SSH         | `ProfilerLauncherDialog` + `ProfilerLaunchOrchestrator`                                        |
+| Add profiler-specific settings UI             | Implement `IProfilerBackend` and register it with the launcher                                 |
 | Render an embedded PNG/JPG                    | `EmbeddedImage(data, len)` then `Render(top_left, target_width)`                               |
 | Allocate a renderer texture                   | `GuiTexture::CreateRGBA32(pixels, w, h)`                                                       |
 | Wrap a constructor in compute UI guards       | `#ifdef COMPUTE_UI_SUPPORT` / `#endif`                                                         |
@@ -1687,7 +2022,7 @@ If a row above doesn't apply, search the source tree before writing
 new code. The `widgets/` and the existing track items have wrappers
 for nearly every common pattern.
 
-## 17. Common Pitfalls
+## 18. Common Pitfalls
 
 - **Forgetting to unsubscribe.** If you `Subscribe` to an event, store
   the token and `Unsubscribe` in your destructor. Otherwise the
@@ -1699,6 +2034,11 @@ for nearly every common pattern.
 - **Bypassing `TimelineSelection` / `ComputeSelection`.** They emit
   the events the rest of the UI relies on. Don't keep a private copy
   of "selected track" anywhere.
+- **Reintroducing `TrackGraph`.** Timeline ownership and display/
+  selection state now live directly on `TrackItem`; use
+  `TimelineView::GetTracks()`.
+- **Assuming every project ID is a file path.** Compare projects use a
+  synthetic ID and persist two source paths.
 - **Inventing your own request ID.** Use `RequestIdBuilder` /
   `IdGenerator`. The encoded layout is parsed by the controller.
 - **Adding a new modal popup.** Reuse `ConfirmationDialog`,
@@ -1715,13 +2055,30 @@ for nearly every common pattern.
   `AppWindow::ShowOpenFileDialog/ShowSaveFileDialog`. Don't call
   `nativefiledialog` or `ImGuiFileDialog` directly.
 - **Spawning std::thread.** Long-running work goes through controller
-  futures (preferred) or `std::async` futures held in
-  `AppWindow::m_provider_cleanup_jobs`-style storage. Threads owned by
-  random widgets are forbidden.
+  futures plus `AppMonitor` (preferred) or owned `std::async` cleanup
+  jobs. Threads owned by random widgets are forbidden.
 - **Including model headers from a widget.** The view depends on
   controller and view-side models only.
+- **Letting `LoadingTimer` sleep.** Call `Tick()` while it is active
+  and keep continuous rendering enabled for time-based UI.
+- **Handling monitor events without filtering operation ID.** Multiple
+  SSH/profiler phases can emit the same event type.
+- **Starting overlapping SSH phases.** One `SshSession` supports one
+  operation at a time; advance through its orchestrator.
+- **Rendering SSH authentication once.** `RenderSshAuthModal()` must
+  run every frame while requests may be pending.
+- **Freeing an SSH/profiler handle before its future resolves.** Use
+  `AppMonitor` deferred teardown; never capture a dead `this`.
+- **Confusing launch and Compute presets.** `LaunchPresetManager`
+  writes global `profiles.json`; `PresetManager` stores per-project
+  Compute layouts.
+- **Treating `profiles.json` as non-sensitive.** SSH credentials are
+  currently plaintext. Never log them or add a second ad-hoc store.
+- **Confusing remote display detection with remote I/O.**
+  `is_remote_display_session()` selects a file-dialog backend; it does
+  not represent an `SshSession`.
 
-## 18. Quick Reference Index of Every UI Class
+## 19. Quick Reference Index of Every UI Class
 
 For fast lookup. Each entry: class -> file -> one-line role.
 
@@ -1735,6 +2092,14 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `ComputeView`.
 - `FileFilter` (struct) -> `rocprofvis_appwindow.h` -> File-dialog
   filter spec.
+- `WelcomePage` -> `welcome/rocprofvis_welcome_page.h` -> Empty-state
+  landing page.
+- `CompareFilesDialog` -> `rocprofvis_compare_files_dialog.h` ->
+  Selects base/target traces for a compare project (`File > Compare`
+  entry point is dev-mode-only).
+- `AppMonitor`, `MonitorOperation`, `MonitorOperationType` ->
+  `rocprofvis_appmonitor.h` -> Background controller-operation polling
+  and deferred teardown.
 
 ### Top-level views
 
@@ -1765,6 +2130,9 @@ For fast lookup. Each entry: class -> file -> one-line role.
 - `TrackTopology` -> `rocprofvis_track_topology.h` -> Hierarchical
   topology builder + sidebar tree.
 - `SideBar` -> `rocprofvis_sidebar.h` -> Topology tree renderer.
+- `MeasurementController`, `MeasurementPoint`, `MeasurementState`,
+  `MeasureEdge` -> `rocprofvis_measurement_controller.h` -> Timeline
+  measurement state and anchors.
 
 ### Track items
 
@@ -1772,6 +2140,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
   track (description + chart + resize handle).
 - `Pill` -> same -> The small badge label inside a track meta area.
 - `TrackProjectSettings` -> same -> Persists track height per project.
+- `RenderCompareSourceBadge`, `CompareSourceBadgeWidth` -> same ->
+  Shared base/target badge helpers for timeline and sidebar.
 - `FlameTrackItem` -> `rocprofvis_flame_track_item.h` -> Flame chart
   for events; supports color modes and compact mode.
 - `FlameTrackProjectSettings` -> same.
@@ -1797,6 +2167,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
   detail tab.
 - `MultiTrackTable` -> `rocprofvis_multi_track_table.h` -> Cross-track
   event/sample table.
+- `TopEventsView`, `TopEventsView::TopEventsTable` ->
+  `rocprofvis_top_events_view.h` -> Category-specific top-event tables.
 - `EventSearch` -> `rocprofvis_event_search.h` -> Toolbar event search.
 - `AnnotationView` -> `rocprofvis_annotation_view.h` -> Sticky-note
   list tab.
@@ -1816,7 +2188,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
 
 - `SettingsManager` -> `rocprofvis_settings_manager.h`.
 - `UserSettings`, `DisplaySettings`, `UnitSettings`,
-  `InternalSettings`, `AppWindowSettings`, `Colors` -> same.
+  `InternalSettings`, `AppWindowSettings`, `LogViewerSettings`,
+  `ProfilerSettings`, `Colors` -> same.
 - `FontManager`, `FontType`, `FontSize` -> `rocprofvis_font_manager.h`.
 - `HotkeyManager`, `HotkeyActionId`, `HotkeyActionInfo`,
   `HotkeyBinding`, `ActionType` -> `rocprofvis_hotkey_manager.h`.
@@ -1825,6 +2198,11 @@ For fast lookup. Each entry: class -> file -> one-line role.
 - `SettingsPanel` -> `rocprofvis_settings_panel.h` -> Settings modal.
 - `PresetManager`, `PresetComponent`, `PresetBrowser` ->
   `rocprofvis_presets.h`.
+- `LogViewer` -> `widgets/rocprofvis_log_viewer.h` -> User-facing
+  application log overlay.
+- `ProfilesDocument` -> `rocprofvis_profiles_document.h` -> Shared
+  `profiles.json` owner.
+- `JsonUtils` -> `rocprofvis_json_utils.h` -> Typed JSON/file helpers.
 
 ### Events / pubsub
 
@@ -1838,7 +2216,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `EventHighlightChangedEvent`, `RangeEvent`,
   `RequestProgressUpdateEvent`, `ComputeSelectionChangedEvent`,
   `ComputeMetricsFetchedEvent`,
-  `ComputeAddMetricToKernelDetailsEvent`.
+  `ComputeAddMetricToKernelDetailsEvent`, `ProfilerStatusEvent`,
+  `RemoteStatusEvent`.
 
 ### Data plumbing
 
@@ -1849,8 +2228,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
 - `RequestType`, `RequestState`, `RequestInfo`, `RequestIdBuilder`,
   `IdGenerator`, `RequestParamsBase`, `TrackRequestParams`,
   `TableRequestParams`, `EventRequestParams`,
-  `AnalysisQueueUtilizationRequestParams`,
-  `MetricsRequestParams`, `ComputeTableRequestParams` ->
+  `AnalysisTrackStatisticsRequestParams`, `MetricsRequestParams`,
+  `ComputeTableRequestParams`, `PcSamplingRequestParams` ->
   `rocprofvis_requests.h`.
 
 ### View-side models
@@ -1869,8 +2248,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `QueueInfo`, `StreamInfo`, `StreamDeviceInfo`, `CounterInfo`,
   `SummaryInfo` (with `KernelMetrics`/`GPUMetrics`/`CPUMetrics`/
   `AggregateMetrics`), `TableInfo`, `FormattedColumnInfo`,
-  `TraceEventId`, `TopologyId`, `TrackGraph`, `GraphType`,
-  `AnalysisQueueUtilization` -> `model/rocprofvis_model_types.h`.
+  `TraceEventId`, `TopologyId`, `CompareSourceInfo`,
+  `AnalysisTrackStatistics` -> `model/rocprofvis_model_types.h`.
 
 ### Compute UI (`#ifdef COMPUTE_UI_SUPPORT`)
 
@@ -1891,6 +2270,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `compute/rocprofvis_compute_summary.h`.
 - `ComputeTester` (dev only) ->
   `compute/rocprofvis_compute_tester.h`.
+- `ComputeCodeView`, `SourceCodeWidget`, `IsaCodeWidget` (dev only) ->
+  `compute/rocprofvis_compute_code_view.h`.
 - `ComputeDataProvider`, `ComputeTableModel`, `ComputeTableCellModel`,
   `ComputePlotModel`, `ComputePlotAxisModel`, `ComputePlotSeriesModel`,
   `ComputeMetricModel` -> `compute/rocprofvis_compute_data_provider.h`.
@@ -1899,6 +2280,48 @@ For fast lookup. Each entry: class -> file -> one-line role.
 - `AvailableMetrics`, `KernelInfo`, `WorkloadInfo`, `MetricValue`,
   `MetricId`, `MetricIdHash`, `Point`, `ComputeTableInfo` ->
   `model/compute/rocprofvis_compute_model_types.h`.
+
+### Remote UI (`#ifdef ROCPROFVIS_ENABLE_REMOTE`)
+
+- `SshConnectionConfig` -> `remote/rocprofvis_ssh_connection_config.h`
+  -> Persisted connection profile.
+- `SshConnectionStore` -> `remote/rocprofvis_ssh_connection_store.h`
+  -> Profile registry backed by `ProfilesDocument`.
+- `RemoteUri` -> `remote/rocprofvis_ssh_uri.h` -> Per-operation remote
+  path/command/cache state.
+- `SshSession`, `SshOperation` -> `remote/rocprofvis_ssh_session.h` ->
+  One non-blocking controller SSH phase at a time.
+- `RemoteTraceOrchestrator` ->
+  `remote/rocprofvis_remote_trace_orchestrator.h` -> Connect/auth/
+  execute/download/browse workflow.
+- `RenderSshAuthModal` -> `remote/rocprofvis_ssh_auth_modal.h` ->
+  Keyboard-interactive and host-key UI.
+- `SshSettingsDialog`, `SshTestDialog` -> matching `remote/` headers ->
+  Profile editor and remote-trace window; `SshTestDialog` also requires
+  `ROCPROFVIS_DEVELOPER_MODE` at the `AppWindow` entry point.
+- `PromptRequest`, `HostKeyRequest`, `ExecutionOutput`, `FileStat`,
+  `RemoteDir` -> `remote/rocprofvis_ssh_fetch.h` -> Thread-safe UI
+  snapshots.
+
+### Profiler launch UI (`#ifdef ROCPROFVIS_ENABLE_PROFILER`)
+
+- `IProfilerBackend`, `ToolOption`, `TabDescriptor`, `WarningMessage` ->
+  `profiler/rocprofvis_profiler_backend.h`.
+- `RocprofSysBackend`, `RocprofSysSettings` ->
+  `profiler/rocprofvis_rocprof_sys_backend.h`.
+- `LaunchConfig`, `TargetSpec`, `ConnectionType` ->
+  `profiler/rocprofvis_launch_config.h`.
+- `LaunchPresetManager`, `PresetInfo` ->
+  `profiler/rocprofvis_launch_preset_manager.h`.
+- `ProfilerSessionBase`, `ProfilerSession` -> matching `profiler/`
+  headers. `RemoteProfilerSession` additionally requires
+  `ROCPROFVIS_ENABLE_REMOTE`.
+- `ProfilerLaunchOrchestrator` ->
+  `profiler/rocprofvis_profiler_launch_orchestrator.h`.
+- `ProfilerLauncherDialog` ->
+  `profiler/rocprofvis_profiler_launcher_dialog.h`.
+- Shared target/environment/preview/console/profile render helpers ->
+  `profiler/rocprofvis_launch_shared_tabs.h`.
 
 ### Widget library (`src/view/src/widgets/`)
 
@@ -1913,8 +2336,11 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `IconButton`, `CopyableTextUnformatted`, `IconMenuItem`,
   `IconBeginMenu`, `COPY_DATA_NOTIFICATION`,
   `COPY_ROW_DATA_NOTIFICATION`, `XButton`, `SectionTitle`,
-  `VerticalSeparator`, `ElidedText`, `Alignment`, `CenterNextItem`,
-  `InputTextWithClear`, `BeginTooltipStyled`, `BeginItemTooltipStyled`,
+  `VerticalSeparator`, `ElidedText`, `ElideWithEllipsis`, `Alignment`,
+  `CenterNextItem`, `InputTextWithClear`, `InputTextString`,
+  `InputTextStringWithHint`, `CellMenuTarget`, `RenderRowHitbox`,
+  `BeginCellContextMenu`, `EndCellContextMenu`,
+  `BeginTooltipStyled`, `BeginItemTooltipStyled`,
   `EndTooltipStyled`, `SetTooltipStyled`, `ApplyAlpha`, `ThemeColor`,
   `GetResponsiveWindowSize`, `PushComboStyles/PopComboStyles`,
   `TableRowHeight`, `IsMouseReleasedWithDragCheck`,
@@ -1929,6 +2355,7 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `MetricTableWidget`, `WorkloadMetricTableWidget` ->
   `rocprofvis_compute_widget.h`.
 - `DebugWindow` (dev only) -> `rocprofvis_debug_window.h`.
+- `LogViewer` -> `rocprofvis_log_viewer.h`.
 
 ### Tree types and constants
 
@@ -1950,8 +2377,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
 
 ---
 
-**End of AGENTS.md.** When you change the UI, update the section that
-covers the area you touched (especially the index in section 18).
+**End of UI.md.** When you change the UI, update the section that
+covers the area you touched (especially the index in section 19).
 Keep this file the single source of truth for "where does X live"
 and "what should I reuse instead of writing it." If you find a
 duplicate of something listed here, prefer to delete the duplicate

--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -430,7 +430,11 @@ File: `src/view/src/rocprofvis_appwindow.{h,cpp}`. Owns global UI state:
   helpers). Called by `rocprofvis_view_init`.
 - `void Render()` / `void Update()` - per-frame entry points.
 - `void OpenFile(std::string file_path)` - opens a trace or `.rpv`
-  project. Routes via `Project::Open()` and adds a tab.
+  project. Routes via `Project::Open()` and adds a tab. A duplicate
+  open (`OpenResult::Duplicate`) focuses the existing tab and shows a
+  "Trace Already Open" message rather than opening a second tab. While
+  the Compare dialog is open, dropped/opened files fill its slots
+  instead of opening standalone tabs.
 - `void OpenCompare(base_path, target_path)` / `MakeCompareId(files)` -
   creates a synthetic compare project containing two trace sources. The
   `File > Compare` entry point is currently gated behind
@@ -449,8 +453,14 @@ File: `src/view/src/rocprofvis_appwindow.{h,cpp}`. Owns global UI state:
 - `BeginAppShutdown()` - graceful shutdown that drains async
   `DataProvider` cleanup jobs and `AppMonitor` operations. Use this
   rather than terminating the process.
-- `WantsContinuousRender()` - keeps the lazy app loop awake while a
-  view, queued event, log stream, or monitored operation needs frames.
+- `WantsContinuousRender()` - keeps the lazy app loop awake while any
+  of these need frames: provider cleanup jobs, shutdown/disable flags,
+  pending events (`EventManager::HasPendingEvents()`), active
+  notifications, `AppMonitor::HasPendingOperations()`,
+  `LogViewer::IsLiveUpdating()`, any project still loading or with
+  pending requests, or the active `RootView::WantsContinuousRender()`
+  (which itself covers the `LoadingTimer`, an in-progress sticky-note
+  drag, and reorder auto-scroll).
 - `SetTabLabel(label, id)` - pushed to the `TabContainer` via the
   `Project` system; useful when a child view wants to indicate dirty
   state.
@@ -539,8 +549,12 @@ from `RootView`, fill `GetToolbar`, `RenderEditMenuOptions`, and
   collects base and target traces. `AppWindow::OpenCompare()` routes
   them through `Project::OpenCompare()`,
   `TraceDataModel::SetCompareSources()`, and per-track
-  `CompareSourceInfo` badges/colors. The `File > Compare` menu item is
-  currently behind `ROCPROFVIS_DEVELOPER_MODE`.
+  `CompareSourceInfo` badges/colors. `FileSlot {kFirst, kSecond}`
+  identifies the two drop targets; while the dialog `IsOpen()`,
+  `AppWindow::OpenFile()` routes files into it via `AddDroppedFile()`,
+  and `Validate()` rejects picking the same file twice. The
+  `File > Compare` menu item is currently behind
+  `ROCPROFVIS_DEVELOPER_MODE`.
 
 ## 7. Widget Library Reference (`src/view/src/widgets/`)
 
@@ -752,9 +766,14 @@ subclassing this; don't roll your own.**
   bounded ring buffer, level filter, regex search, relative time, and
   auto-scroll. `AppWindow::Update()` calls `Poll()` and `Render()` draws
   the overlay.
-- Settings live in `UserSettings::log_viewer`; use this viewer for
-  application logs. `DebugWindow` remains a separate developer-only
-  diagnostic surface.
+- Settings live in `UserSettings::log_viewer`
+  (`JSON_KEY_SETTINGS_LOG_VIEWER_*`); use this viewer for application
+  logs. `DebugWindow` remains a separate developer-only diagnostic
+  surface.
+- Opened via `View > Show Log Viewer`. `Poll()` pulls entries through
+  `rocprofvis_core_get_log_entries_ex`; `OpenLogFile()` opens the file
+  at `get_application_log_path()`. `IsLiveUpdating()` feeds
+  `AppWindow::WantsContinuousRender()`.
 
 ## 8. Track Item Hierarchy
 
@@ -802,7 +821,11 @@ Protected hooks every subclass implements:
 - `RenderMetaArea()` - left "description" column (default impl is
   reused).
 - `RenderMetaAreaScale()` - the in-meta numeric scale (per type).
-- `RenderMetaAreaOptions()` - the per-type options context menu.
+- `RenderMetaAreaOptions()` - the per-type options, shown under a
+  "Track Options" submenu of the meta-area right-click menu (the old
+  gear icon was removed). That right-click menu also copies the track
+  name / ID; the hover tooltip (Node ID + Process ID) is scoped to the
+  name-label hitbox only.
 - `RenderMetaAreaExpand()` - expand/collapse affordance.
 - `RenderChart(graph_width)` - the actual graph drawing.
 - `RenderResizeBar(parent_size)` - drag handle for height.
@@ -995,6 +1018,13 @@ Renders the topology tree in the left pane:
   `DataProvider`.
 - The active-node accent mirrors timeline node coloring when
   `SettingsManager::ShowNodeColors()` is enabled.
+- Right-click a leaf track (`##track_ctx`): Go to Track, Hide/Show
+  Track, Show All Tracks, Hide All But This Track, and Show/Hide
+  Selected Tracks (enabled when
+  `TimelineSelection::HasSelectedTracks()`). Right-click a branch
+  (`##branch_ctx`): Show All Tracks Below / Hide All Tracks Below.
+  Visibility changes refresh the histogram via
+  `UpdateHistogramForVisibility()`.
 
 ### `Minimap` (`rocprofvis_minimap.{h,cpp}`)
 
@@ -1041,7 +1071,10 @@ Renders the currently-selected event(s). Subsections rendered via
 `RenderBasicData / RenderEventExtData / RenderEventFlowInfo /
 RenderCallStackData / RenderArgumentData`. Tracks a
 `FlowHighlightState` so hovering an arg row in the flow table
-highlights the linked event.
+highlights the linked event. The call-stack table highlights the
+hovered row (`CallStackHoverState`), navigates on double-click / "Go To
+Event" (`TimelineSelection::NavigateToEvent`), and exposes per-row copy
+via `AddCopyRowCellMenuItems`.
 
 ### `MultiTrackTable` (`rocprofvis_multi_track_table.{h,cpp}`)
 
@@ -1062,8 +1095,10 @@ same cache used by track pills.
 
 Hosts five `TopEventsTable` instances for instrumented events,
 dispatches, memory allocations, memory copies, and sampled launches.
-Each table uses its dedicated analysis request/table type through the
-normal `DataProvider` + `TablesModel` pipeline.
+Each is filtered by `TrackInfo::operation_types` and stays hidden until
+a matching track is selected, and each maps to a dedicated
+`TableType::kAnalysisTop*` + `RequestType::kFetchAnalysisTop*` pair
+fetched through the normal `DataProvider` + `TablesModel` pipeline.
 
 ### `Annotations` and `StickyNote`
 
@@ -1081,6 +1116,15 @@ normal `DataProvider` + `TablesModel` pipeline.
   is a floating window with an inline-editable title (click to edit) and
   body; `BeginInlineEdit()` opens a freshly created note focused for
   typing.
+- Track binding + navigation: `TimelineView::BuildTrackLayout()` maps a
+  note's `track_id` (`INVALID_TRACK_ID` for free-floating notes) to a
+  lane. A note can be locked (`m_locked`), request "go to anchor"
+  navigation (`WantsNavigate()` -> a `NavigationEvent`), and
+  cross-highlight when its timeline marker is hovered. Persisted fields
+  (under `JSON_KEY_ANNOTATION_*` in `rocprofvis_project.h`): `time_ns`,
+  `y_offset`, `size_x/y`, `text`, `title`, `id`, `track_id`,
+  `view_start_ns`/`view_end_ns`, `is_minimized`, `is_locked` (the
+  expanded window's screen position is not persisted).
 - `AnnotationView` (`rocprofvis_annotation_view.{h,cpp}`) - the
   sub-tab in `AnalysisView` that lists notes and lets the user
   select/hide them.
@@ -1105,10 +1149,16 @@ tracks, tpt)` is called from `TimelineView::RenderTraceView`.
 
 `MeasurementController` owns the
 `kInactive | kWaitingForFirst | kWaitingForSecond | kComplete` state
-machine and two `MeasurementPoint`s. Points may be freehand or anchored
-to events; `TraceView` renders toolbar controls and `TimelineView`
-renders the overlay. Reuse this controller instead of storing a second
-measurement state in a widget.
+machine and two `MeasurementPoint`s. Two modes: event-anchored (snaps
+to event edges) or freehand (`SetFreehandMode()`, with `MeasureEdge
+{kStart, kEnd}` choosing which edge each ruler uses and per-point
+`m_freehand_offsets`). `GetEffectiveTimestamp()` resolves a point's
+time. `TraceView::RenderMeasurementControls()` draws the toolbar
+(Measure/Exit, Events vs Anywhere, an Options popup for the start/end
+edge, Clear, and the live duration); `TimelineView::RenderMeasurement()`
+draws the overlay and labels. Right-click a measurement label to copy
+it (`MeasurementCopyTarget` + the timeline context menu). Reuse this
+controller instead of storing measurement state in a widget.
 
 ### Click / focus arbitration: `TimelineFocusManager`
 
@@ -1207,7 +1257,9 @@ ImPlot-based roofline chart. Two modes:
   groups of items.
 - `ApplyPreset(type)` switches the active preset.
 - `RenderMenus(...)` draws the legend / options panels in
-  `InsideTopLeft|TopRight|BottomLeft|BottomRight|Outside` placements.
+  `InsideTopLeft|TopRight|BottomLeft|BottomRight|Outside` placements,
+  and exposes a "Line thickness" slider (`m_line_thickness`,
+  session-local, not persisted in settings).
 
 ### `ComputeMemoryChartView` (`rocprofvis_compute_memory_chart.{h,cpp}`)
 
@@ -1218,10 +1270,13 @@ inline via `DrawMetricRow`. The catalog of supported chart-only
 metrics is `enum MemChartMetric` (maps 1:1 to entries in compute
 metric table 3.1).
 
-If you need to add a new memory-hierarchy block:
-1. Add a `MemChartMetric` enum value (before `MEMCHART_METRIC_NA`).
-2. Add a `Draw*` method.
-3. Wire it into `ComputeLayout()` and `Render()`.
+Metric values bind data-driven: `METRIC_NAME_MAP` maps a compute
+metric `entry->name` to a `MemChartMetric` slot, and
+`FetchMemChartMetrics()` fills `m_metric_ptrs[]` from the fetched
+metrics. To surface a new metric on an existing block, add its name to
+`METRIC_NAME_MAP` (and make sure the controller returns that metric).
+Only add a new `MemChartMetric` value + `Draw*` method +
+`ComputeLayout()`/`Render()` wiring when you need a brand-new block.
 
 ### `KernelMetricTable` (`rocprofvis_compute_kernel_metric_table.{h,cpp}`)
 
@@ -1274,9 +1329,14 @@ production code from depending on it.
 ### `ComputeCodeView` (`rocprofvis_compute_code_view.{h,cpp}`) - dev only
 
 Correlates source code and ISA through `SourceCodeWidget` and
-`IsaCodeWidget`. PC-sampling data is fetched through
-`PcSamplingRequestParams` / `DataProvider::FetchPcSampling`; do not
-query the model directly from this view.
+`IsaCodeWidget`, which both derive from `BaseCodeWidget` and share a
+`LineSelection` so selecting a source line highlights the correlated
+ISA (and vice versa), laid out in an `HSplitContainer`.
+`RenderControlPanel()` hosts the source-file dropdown, and
+`FetchPcSamplingForCurrentFile()` re-fetches PC samples on file/kernel
+change. PC-sampling data is fetched through `PcSamplingRequestParams` /
+`DataProvider::FetchPcSampling`; do not query the model directly from
+this view.
 
 ### Compute data plumbing
 
@@ -1322,9 +1382,14 @@ controller results.
   - `struct SummaryInfo` with `KernelMetrics`, `GPUMetrics`,
     `CPUMetrics`, `AggregateMetrics`.
   - `struct TableInfo`, `FormattedColumnInfo`,
-    `AnalysisTrackStatistics` with `Stat`, queue utilization,
-    counter min/max/mean/standard deviation, and state machine
-    `kStale -> kPending -> kRequested -> kReady`.
+    `AnalysisTrackStatistics` with state machine `kStale -> kPending
+    -> kRequested -> kReady`, queue utilization, and counter
+    min/max/mean/standard deviation. Each `Stat` carries raw building
+    blocks (`name`/`compact_name`/`value`/`suffix` plus `compact`/
+    `full` strings); consumers compose labels via `CompactValue()`/
+    `CompactLabel()`/`FullValue()`/`FullLabel()`. Track pills use the
+    compact value with `SetExtendedLabel(CompactLabel())` and
+    `SetTooltip(FullLabel())`; Track Details uses `FullValue()`.
 
 - `rocprofvis_trace_data_model.{h,cpp}` - the **`TraceDataModel`
   facade**: aggregates `TopologyDataModel`, `TimelineModel`,
@@ -1449,8 +1514,9 @@ through this** - never hardcode `IM_COL32(...)` in feature code.
 - `GetUserSettings()` -> `UserSettings` (display, units, "don't ask"
   flags). `ApplyUserSettings(old, save_json)` writes JSON to disk.
 - `DisplaySettings::show_node_colors` /
-  `SettingsManager::ShowNodeColors()` controls matching node accents in
-  tracks and the sidebar.
+  `SettingsManager::ShowNodeColors()` enables node color-coding (only
+  when the trace has more than one node). It tints the track's node
+  pill and the sidebar tree connectors, not the chart lane itself.
 - `UserSettings::log_viewer` stores level mask, entry limit, search and
   presentation preferences for `LogViewer`.
 - `GetInternalSettings()` -> recent files (`MAX_RECENT_FILES = 5`).
@@ -1586,10 +1652,12 @@ Use these instead of writing your own.
   zoom looks right.
 - `TimeConstants::ns_per_us / ns_per_ms / ns_per_s / minute_in_s /
   minute_in_ns`.
-- `compact_number_format(double)` - SI-style "1.2K", "3.4M"
-  formatting.
-- `get_application_config_path(create_dirs)` -> the per-user config
-  dir.
+- `compact_number_format(double)` / `full_number_format(double)` -
+  SI-style "1.2K"/"3.4M" and full-precision number formatting.
+- `get_application_config_path(create_dirs)` /
+  `get_application_log_path(create_dirs)` -> platform-appropriate
+  per-user config and log directories (Windows `%LOCALAPPDATA%`, macOS
+  `~/Library/Application Support` + `~/Library/Logs`, Linux XDG).
 - `open_url(url)` - opens a browser. Reuse for "more info" links.
 - `get_executable_name(full_path)`.
 - `is_remote_display_session()` - detects SSH/X-forwarding for the
@@ -1667,65 +1735,168 @@ Permanent host-key trust uses the platform user's standard
 
 ### 13.2 Profiler launch stack (`src/view/src/profiler/`)
 
-- `IProfilerBackend` (`rocprofvis_profiler_backend.h`) is the extension
-  point. It validates settings, builds `ToolOption`/`TabDescriptor`
-  UI, flattens a `LaunchConfig` into execution arguments/environment,
-  reports warnings, parses the trace path from output, and exports
-  native config.
-- `RocprofSysBackend` is the currently registered backend. It supports
-  run/sample/instrument tools and owns the rocprof-sys option tabs and
-  `RocprofSysSettings`.
-- `LaunchConfig`, `TargetSpec`, and `ConnectionType` are the
-  serializable launch payload. SSH mode stores
-  `ssh_connection_ref`, not inline credentials.
-- `LaunchPresetManager` owns named launch profiles in
-  `profiles.json::launch_profiles`; this is independent of Compute's
-  per-project `PresetManager`.
-- `rocprofvis_launch_shared_tabs.*` provides reusable target,
-  environment, command-preview, output-console, and saved-profile UI.
-- `ProfilerLauncherDialog` authors configuration and renders UI. It
-  owns backends, launch presets, and `ProfilerLaunchOrchestrator`.
-- `ProfilerLaunchOrchestrator` is the UI-facing Launch/Cancel/Close/
-  Update entry point. It owns either `ProfilerSession` (local) or
-  `RemoteProfilerSession` (SSH).
-- `ProfilerSessionBase` owns controller profiler config/handle/future
-  resources and registers their status with `AppMonitor`.
+Layering, top to bottom: `ProfilerLauncherDialog` (authors config +
+renders) -> `ProfilerLaunchOrchestrator` (run engine, normalizes local
+vs remote) -> `ProfilerSession` / `RemoteProfilerSession` (both derive
+from `ProfilerSessionBase`) -> controller profiler C API
+(`rocprofvis_profiler.h`) -> `AppMonitor` -> status events. Profiler
+sessions are **not** `Project`s until a produced trace is handed to
+`AppWindow::OpenFile()`.
 
-Profiler sessions are not `Project`s. On completion, the backend parses
-the trace path from profiler output; if auto-load is enabled, the
-orchestrator calls `AppWindow::OpenFile()`. Do not guess the newest
-filesystem trace when parsing fails: show the existing warning and
-leave manual open available.
+**Backends (`IProfilerBackend`, `rocprofvis_profiler_backend.h`).** The
+pluggable extension point. Methods: `Id`, `DisplayName`, `GetTools`,
+`GetDefaultBinary`, `GetTabs` (returns `TabDescriptor`s that each carry
+an ImGui `render_fn` - the backend supplies renderers, the dialog draws
+the tab bar), `Validate` (empty string = OK), `FlattenToExecution`
+(curated settings -> env + argv; caller then merges `extra_env`),
+`LoadSettings`/`SaveSettings` (the JSON `backend_payload`), `ExportCfg`
+(native config text), and the default-implemented `GetWarnings`
+(`WarningMessage { Level {kInfo,kWarning,kError}, text }`) and
+`ParseTraceOutputPath` (scrape the trace path from stdout). Supporting
+structs: `ToolOption`, `TabDescriptor`, `WarningMessage`.
 
-### 13.3 Launch workflows and extension rules
+**`RocprofSysBackend`** is the only backend registered today (the
+`ProfilerLauncherDialog` ctor pushes one). `Id()` = `"rocprof-sys"`.
+Tools: `run` (`rocprof-sys-run`), `sample` (`rocprof-sys-sample`),
+`instrument` (`rocprof-sys-instrument`). Tabs: Quick, Sampling, ROCm,
+Process Sampling, Parallelism, Advanced, plus Instrument (only when the
+tool is `instrument`); the dialog appends a shared "Raw Env Vars" tab.
+Perfetto options are nested inside Advanced, not a top-level tab.
+`RocprofSysSettings` holds the serializable backend state (backends,
+sampling, ROCm domains, Perfetto, process sampling, parallelism,
+advanced, instrument) plus 11 built-in rocprof-sys `--preset=` names.
+
+**`LaunchConfig` (`rocprofvis_launch_config.h`)** is the serializable
+payload: `profiler_id`, `tool_id`, `connection` (`ConnectionType
+{kLocal, kSsh}`), `ssh_connection_ref` (an `SshConnectionConfig::id`,
+never inline credentials), `target` (`TargetSpec {executable, arguments,
+working_directory, output_directory, auto_load_trace}`), `extra_env`,
+`extra_argv`, and `backend_payload` (the backend's JSON).
+
+**Two independent preset systems - do not conflate:**
+- `LaunchPresetManager` - named Optiq launch profiles in the
+  `launch_profiles` section of `profiles.json`. CRUD over
+  `ProfilesDocument` (`ListPresets`/`SavePreset`/`LoadPreset`/
+  `DeletePreset`); `ExportCfg`/`ImportPreset` exist but are not wired
+  into the dialog yet. Distinct from Compute's per-project
+  `PresetManager`.
+- `RocprofSysSettings::rocprof_preset` - a rocprof-sys built-in preset
+  name emitted as `--preset=<name>`, which disables the overridden UI
+  controls while active.
+
+**Shared form helpers (`rocprofvis_launch_shared_tabs.h`)** - reuse
+these instead of re-authoring launcher UI: `RenderTargetSection`,
+`RenderRawEnvVarsTab`, `BuildCommandPreviewString`,
+`RenderCommandPreview`, `RenderOutputConsole` (+ `ConsoleStatusLevel
+{kIdle, kRunning, kSuccess, kError}`), `RenderSavedProfileBar`. The
+connection-mode selector and SSH UI live in the dialog
+(`RenderRemoteSection`), not here.
+
+**`ProfilerLauncherDialog`** owns `m_backends`, the
+`LaunchPresetManager`, the `ProfilerLaunchOrchestrator`, `m_config`, and
+an `ExecutionCache` (lazy `FlattenToExecution` result + command
+preview, rebuilt on a dirty flag). `AppWindow::ShowProfilerLauncher()`
+lazily creates it; the only entry point is `File > Launch Profiler...`
+(`#ifdef ROCPROFVIS_ENABLE_PROFILER`).
+
+**`ProfilerSessionBase`** owns the controller `config`/`profiler`/
+`future` handles and the `AppMonitor` op id. `GetState`, `GetOutput`,
+`GetExitCode`, `Cancel`, `Close`, and `GetOperationId` forward to the
+`rocprofvis_profiler_*` C API. `RegisterProfilerMonitor()` registers a
+`MonitorOperationType::ProfilerSession` op; `FreeProfilerObjects()`
+handles teardown (see 13.4). Subclasses set `m_extra_teardown` for
+resources that must outlive the profiler worker.
+
+### 13.3 Local vs remote profiling workflows
+
+**`ProfilerLaunchOrchestrator`** is the single UI-facing entry
+(`Launch` / `Cancel` / `Close` / `Update`) and the local/remote
+normalizer. It owns a local `ProfilerSession` and, for SSH, a
+`unique_ptr<RemoteProfilerSession>`, plus a `shared_ptr<RemoteUri>` so
+deferred teardown outlives the dialog's copy. `GetState()` reports a
+normalized `rocprofvis_profiler_state_t`; `GetRawOutput()` /
+`ConsumeOutputDirty()` expose stdout; `GetTracePath()` resolves the
+produced trace; `GetRemotePhaseBadge(...)` / `GetRemoteStatusMessage()`
+surface remote progress. `Update()` runs every frame to pump normalized
+state and output.
 
 Local:
 
 ```
-ProfilerLauncherDialog
-  -> IProfilerBackend::FlattenToExecution
-  -> ProfilerLaunchOrchestrator::Launch
-  -> ProfilerSession -> rocprofvis_profiler_launch_async
-  -> AppMonitor -> ProfilerStatusEvent
-  -> ParseTraceOutputPath -> AppWindow::OpenFile
+ProfilerLauncherDialog.OnLaunchClicked
+  -> RefreshExecutionCache (IProfilerBackend::FlattenToExecution + extra_env)
+  -> ProfilerLaunchOrchestrator::Launch(LaunchRequest)
+  -> ProfilerSession::Launch -> rocprofvis_profiler_launch_async
+  -> AppMonitor op (ProfilerSession) -> ProfilerStatusEvent
+  -> orchestrator OnProfilerStateChanged: on Completed,
+     ResolveLocalTracePath() (LaunchRequest.parse_trace ==
+     IProfilerBackend::ParseTraceOutputPath) -> AppWindow::OpenFile
+     when auto_load_trace
 ```
 
-Remote:
+Remote (`RemoteProfilerSession`, `#ifdef ROCPROFVIS_ENABLE_REMOTE`):
 
 ```
-RemoteProfilerSession
-  -> SshSession connect/authenticate
-  -> rocprofvis_profiler_launch_remote_async on the same connection
-  -> parse remote trace path
-  -> SshSession download
-  -> AppWindow::OpenFile(local cache path)
+ProfilerLaunchOrchestrator::Launch (is_remote)
+  -> RemoteProfilerSession::Launch: BuildConfig + SSH config,
+     SshSession::StartConnect
+Phase machine (event-driven, main thread):
+  Connecting -> Authenticating -> Profiling -> Downloading -> Done
+  - kRemoteStatusChanged (filtered by SshSession::GetActiveOperationId):
+      Connecting done   -> StartAuthenticate
+      Authenticating done -> StartProfiler
+      Downloading done  -> Done + on_open_file(local cache path)
+  - StartProfiler: rocprofvis_profiler_launch_remote_async(profiler,
+      config, SshSession::GetConnectionHandle(), future); registers a
+      profiler AppMonitor op
+  - kProfilerStatusChanged (filtered by m_profiler_op_id):
+      Completed -> StartDownload; Failed/Cancelled -> Fail
+  - StartDownload: parse the remote trace path from stdout only, then
+      SFTP-download over the same (now idle) connection
 ```
 
-The SSH connection must outlive the remote profiler worker. Filter
-status events by operation ID because the remote workflow has several
-operations. To add a backend, implement `IProfilerBackend`, register it
-in `ProfilerLauncherDialog`, map its controller profiler type, and
-provide deterministic output-path parsing.
+Key remote rules:
+- **`RemoteProfilerSession::Phase` = `{Idle, Connecting,
+  Authenticating, Profiling, Downloading, Done, Failed}`.** The console
+  badge only reads "Completed" at `Done` (after the download), never
+  when remote profiling itself finishes.
+- The remote session subscribes to **both** `kRemoteStatusChanged`
+  (SSH phases) and `kProfilerStatusChanged` (the remote run), each
+  filtered by its own operation id. The orchestrator's own
+  `kProfilerStatusChanged` subscription matches only the **local**
+  session's op id.
+- One `SshSession` connection is reused for connect, the profiler run
+  (passed as a raw connection handle), and the download; only one SSH
+  phase is ever in flight.
+- **No trace-path guessing** in either path: the path comes only from
+  the backend's stdout scraper (or a pre-set remote path). Empty ->
+  warning notification, manual open.
+- Auto-open differs by path: local fires from the orchestrator's
+  terminal-state handler; remote fires from the download-complete
+  callback inside `RemoteProfilerSession`.
+
+### 13.4 Async teardown for sessions
+
+Profiler and SSH work can outlive the dialog, so teardown defers
+through `AppMonitor` instead of blocking:
+- `ProfilerSessionBase::FreeProfilerObjects()` - if the profiler future
+  is still pending, it hands `config`/`profiler`/`future` and the
+  subclass `m_extra_teardown` to `AppMonitor::AddTeardownOp(...)`, which
+  cancels then frees them in order (future -> profiler -> config ->
+  extra) once the future resolves. If already resolved, it frees
+  immediately.
+- `RemoteProfilerSession::~RemoteProfilerSession()` moves its
+  `SshSession` into `m_extra_teardown` so the connection is freed
+  **last**, after the remote profiler worker has joined.
+- `SshSession::~SshSession()` uses `AppMonitor::AppendTeardown(...)` to
+  free the connection only after any in-flight SSH phase completes.
+- `ProfilerLaunchOrchestrator::Cancel()` for remote simply destroys the
+  session (running the deferred chain), not a direct
+  `rocprofvis_profiler_cancel`.
+
+To add a backend: implement `IProfilerBackend`, register it in
+`ProfilerLauncherDialog`, map its `rocprofvis_profiler_type_t` in
+`ResolveProfilerType`, and implement `ParseTraceOutputPath`.
 
 ## 14. Data Flow: Requests, Remote Operations, and Profiler Runs
 
@@ -2163,6 +2334,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
 - `EventItem` (struct) -> same -> Cached state per visible event.
 - `FlowHighlightState` (struct) -> same -> Hover state for flow
   arrows.
+- `CallStackHoverState` (struct) -> same -> Hover state for call-stack
+  rows.
 - `TrackDetails` -> `rocprofvis_track_details.h` -> Selected-track
   detail tab.
 - `MultiTrackTable` -> `rocprofvis_multi_track_table.h` -> Cross-track
@@ -2320,8 +2493,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `profiler/rocprofvis_profiler_launch_orchestrator.h`.
 - `ProfilerLauncherDialog` ->
   `profiler/rocprofvis_profiler_launcher_dialog.h`.
-- Shared target/environment/preview/console/profile render helpers ->
-  `profiler/rocprofvis_launch_shared_tabs.h`.
+- Shared target/environment/preview/console/profile render helpers +
+  `ConsoleStatusLevel` -> `profiler/rocprofvis_launch_shared_tabs.h`.
 
 ### Widget library (`src/view/src/widgets/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,10 @@
 # AGENTS.md - ROCm Optiq
 
-The AI/agent guides for this repo live in `.agents/`:
+The root file is the repo entry point. Layer-specific AI/agent guides
+live in `.agents/`:
 
-> - [`.agents/AGENTS.md`](./.agents/AGENTS.md) - whole-repo + View
->   layer guide (start here)
+> - [`.agents/UI.md`](./.agents/UI.md) - View-layer architecture,
+>   widgets, timelines, profiler launch, and remote UI
 > - [`.agents/CONTROLLER.md`](./.agents/CONTROLLER.md) - deep dive on
 >   `src/controller/` (C ABI, async fetch, memory manager, segment
 >   timeline)
@@ -12,18 +13,20 @@ The AI/agent guides for this repo live in `.agents/`:
 >   data model, topology, metadata versioning)
 
 **If you are an AI coding assistant** (Cursor, Codex, Claude Code,
-Copilot agent, etc.), read `.agents/AGENTS.md` in full before making
-non-trivial changes. If your change touches `src/controller/`, also
-read `.agents/CONTROLLER.md`. If your change touches `src/model/` (the
-database / data model layer), also read `.agents/DATABASE.md`.
-Together they are the single source of truth for:
+Copilot agent, etc.), read `.agents/UI.md` in full before making
+non-trivial changes under `src/view/` or to UI-facing app integration.
+If your change touches `src/controller/`, also read
+`.agents/CONTROLLER.md`. If it touches `src/model/` (the database /
+data-model layer), also read `.agents/DATABASE.md`. Together these
+guides are the single source of truth for:
 
 - Project identity, build, and repo layout
 - Module boundaries (`app` / `core` / `model` / `controller` / `view`)
 - The View layer top-down tour and full widget inventory
 - Track-item, trace-view, and compute-view internals
-- UI models and cross-cutting services (events, settings, hotkeys,
-  notifications)
+- UI models and cross-cutting services (events, settings, monitoring,
+  logging, hotkeys, notifications)
+- Compare, measurement, profiler-launch, and remote/SSH workflows
 - Data flow (click -> request -> event -> pixels)
 - Coding conventions, comment style, and reuse catalog
 - Common pitfalls and a quick-reference index of every UI class
@@ -34,8 +37,8 @@ Together they are the single source of truth for:
 2. [`BUILDING.md`](./BUILDING.md) - per-platform build steps
 3. [`CODING.md`](./CODING.md) - hard rules on style, naming, format
    (READ THIS FIRST before changing any C++)
-4. [`.agents/AGENTS.md`](./.agents/AGENTS.md) - architecture and reuse
-   guide (this is also the agent guide above)
+4. [`.agents/UI.md`](./.agents/UI.md) - View architecture and reuse
+   guide (read for UI work)
 5. [`.agents/CONTROLLER.md`](./.agents/CONTROLLER.md) - controller
    deep dive (read when working on `src/controller/`)
 6. [`.agents/DATABASE.md`](./.agents/DATABASE.md) - database / model


### PR DESCRIPTION
Rename .agents/AGENTS.md to .agents/UI.md and rescope it as the View-layer guide, updating the root AGENTS.md, CONTROLLER.md, and DATABASE.md cross-links to match. Refresh the guide against current source: remove TrackGraph/GraphType and AnalysisQueueUtilization, correct track/model/selection APIs, and document the profiler-launch, remote/SSH, AppMonitor, compare (dev-mode), measurement, top-events, and log-viewer subsystems added since the guides were written.
