### PR TITLE
Roofline: single-click filtering for kernels, memory levels, and bandwidth peaks

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -70,6 +70,7 @@ Roofline::Roofline(DataProvider& data_provider, KernelMode kernel_mode)
 , m_menus_placement(InsideTopRight)
 , m_scale_intensity(true)
 , m_line_thickness(LINE_THICKNESS_DEFAULT)
+, m_memory_peak_filter(std::nullopt)
 , m_menus_rendered_height(0.0f)
 , m_hovered_item_distance(FLT_MAX)
 , m_workload_changed(false)
@@ -436,7 +437,8 @@ Roofline::Render()
                     {
                         display =
                             m_items[i].info.intensity &&
-                            (m_kernel ? m_items[i].parent_info.kernel == m_kernel : true);
+                            (m_kernel ? m_items[i].parent_info.kernel == m_kernel : true) &&
+                            IntensityMatchesMemoryFilter(m_items[i]);
                     }
                 }
                 display &= m_items[i].visible;
@@ -787,7 +789,7 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         ImGui::EndGroup();
         float header_height = ImGui::GetItemRectSize().y + 2 * style.WindowPadding.y;
         float footer_height =
-            (m_kernel_mode == AllKernels ? 6 : 5) * ImGui::GetFrameHeightWithSpacing() +
+            (m_kernel_mode == AllKernels ? 8 : 7) * ImGui::GetFrameHeightWithSpacing() +
             2 * style.WindowPadding.y;
         ImGui::SetNextWindowSizeConstraints(
             ImVec2(menus_content_width, 0),
@@ -820,7 +822,8 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                 {
                     display =
                         m_items[i].info.intensity &&
-                        (m_kernel ? m_items[i].parent_info.kernel == m_kernel : true);
+                        (m_kernel ? m_items[i].parent_info.kernel == m_kernel : true) &&
+                        IntensityMatchesMemoryFilter(m_items[i]);
                     break;
                 }
             }
@@ -912,6 +915,32 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         if(m_menus_mode == Options)
         {
             ImGui::SeparatorText("Options");
+            ImGui::PushID("memory_peak");
+            ElidedText("Kernel intensity", ImGui::GetContentRegionAvail().x,
+                       plot_size.x * 0.5f, Alignment_Left, true);
+            ImGui::SetNextItemWidth(-1.0f);
+            int intensity_filter_idx =
+                m_memory_peak_filter
+                    ? static_cast<int>(m_memory_peak_filter.value()) + 1
+                    : 0;
+            PushComboStyles();
+            // Order must match the intensity enum: All, HBM, L2, L1, LDS.
+            if(ImGui::Combo("##memory_peak", &intensity_filter_idx,
+                            "All\0HBM\0L2\0L1\0LDS\0\0"))
+            {
+                if(intensity_filter_idx == 0)
+                {
+                    m_memory_peak_filter = std::nullopt;
+                }
+                else
+                {
+                    m_memory_peak_filter = static_cast<
+                        rocprofvis_controller_roofline_kernel_intensity_type_t>(
+                        intensity_filter_idx - 1);
+                }
+            }
+            PopComboStyles();
+            ImGui::PopID();
             if(m_kernel_mode == AllKernels)
             {
                 ImGui::PushID("kernel_scale");
@@ -969,7 +998,7 @@ Roofline::PlotHoverIdx()
         // Pick the closest visible item after plotting all candidates.
         for(size_t i = 0; i < m_items.size(); i++)
         {
-            if(m_items[i].visible)
+            if(m_items[i].visible && IntensityMatchesMemoryFilter(m_items[i]))
             {
                 switch(m_items[i].type)
                 {
@@ -1057,6 +1086,17 @@ Roofline::ApplyPreset(PresetModel::Type type)
         m_items[i].visible = true;
     }
     m_options_changed = true;
+}
+
+bool
+Roofline::IntensityMatchesMemoryFilter(const ItemModel& item) const
+{
+    bool matches = true;
+    if(item.type == ItemModel::Type::Intensity && m_memory_peak_filter)
+    {
+        matches = item.subtype.intensity == m_memory_peak_filter.value();
+    }
+    return matches;
 }
 
 }  // namespace View

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -83,6 +83,7 @@ Roofline::Roofline(DataProvider& data_provider, KernelMode kernel_mode)
 , m_kernel(nullptr)
 , m_requested_kernel_id(0)
 , m_isolated_kernel(nullptr)
+, m_isolated_bandwidth(std::nullopt)
 {
     m_widget_name = GenUniqueName("roofline");
     m_items.resize(static_cast<size_t>(__KRPVControllerRooflineCeilingComputeTypeLast +
@@ -123,7 +124,8 @@ Roofline::Update()
     if(m_workload_changed)
     {
         // Kernel pointers are rebuilt below, so drop any stale isolation.
-        m_isolated_kernel = nullptr;
+        m_isolated_kernel    = nullptr;
+        m_isolated_bandwidth = std::nullopt;
         m_workload =
             m_data_provider.ComputeModel().GetWorkload(m_requested_workload_id);
         if(m_workload)
@@ -433,7 +435,8 @@ Roofline::Render()
                     case ItemModel::Type::CeilingCompute:
                     case ItemModel::Type::CeilingBandwidth:
                     {
-                        display = m_items[i].info.ceiling;
+                        display = m_items[i].info.ceiling &&
+                                  BandwidthPassesIsolation(m_items[i]);
                         break;
                     }
                     case ItemModel::Type::Intensity:
@@ -611,15 +614,27 @@ Roofline::Render()
         bool dot_hovered =
             !menus_item_hovered && m_kernel_mode == AllKernels && m_hovered_item_idx &&
             m_items[m_hovered_item_idx.value()].type == ItemModel::Type::Intensity;
-        // Drag check so panning a zoomed plot is not treated as a dot click.
-        if(dot_hovered && roofline_hovered &&
-           IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
+        bool bandwidth_line_hovered =
+            !menus_item_hovered && m_hovered_item_idx &&
+            m_items[m_hovered_item_idx.value()].type ==
+                ItemModel::Type::CeilingBandwidth;
+        // Drag check so panning a zoomed plot is not treated as a click.
+        if(roofline_hovered && IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
         {
-            ToggleKernelIsolation(
-                m_items[m_hovered_item_idx.value()].parent_info.kernel);
+            if(dot_hovered)
+            {
+                ToggleKernelIsolation(
+                    m_items[m_hovered_item_idx.value()].parent_info.kernel);
+            }
+            else if(bandwidth_line_hovered)
+            {
+                ToggleBandwidthIsolation(
+                    m_items[m_hovered_item_idx.value()].subtype.bandwidth);
+            }
         }
         if(!m_plot_zoom_enabled && roofline_hovered && !dot_hovered &&
-           !menus_item_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left))
+           !bandwidth_line_hovered && !menus_item_hovered &&
+           ImGui::IsMouseClicked(ImGuiMouseButton_Left))
         {
             m_plot_zoom_enabled = true;
         }
@@ -853,9 +868,13 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                                       m_settings.GetColor(Colors::kHighlightChart));
                 ImGui::PushStyleColor(ImGuiCol_HeaderActive,
                                       m_settings.GetColor(Colors::kHighlightChart));
-                ImVec2 pos         = ImGui::GetCursorPos();
-                bool   row_clicked = ImGui::Selectable(
-                    "", false,
+                ImVec2 pos          = ImGui::GetCursorPos();
+                bool   row_isolated = m_isolated_bandwidth &&
+                                    m_items[i].type == ItemModel::Type::CeilingBandwidth &&
+                                    m_items[i].subtype.bandwidth ==
+                                        m_isolated_bandwidth.value();
+                bool row_clicked = ImGui::Selectable(
+                    "", row_isolated,
                     m_hovered_item_idx && m_hovered_item_idx.value() == i
                           ? ImGuiSelectableFlags_Highlight
                           : ImGuiSelectableFlags_None);
@@ -922,6 +941,10 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                                 m_items[i].type == ItemModel::Type::Intensity)
                         {
                             ToggleKernelIsolation(m_items[i].parent_info.kernel);
+                        }
+                        else if(m_items[i].type == ItemModel::Type::CeilingBandwidth)
+                        {
+                            ToggleBandwidthIsolation(m_items[i].subtype.bandwidth);
                         }
                     }
                 }
@@ -1022,7 +1045,7 @@ Roofline::PlotHoverIdx()
         for(size_t i = 0; i < m_items.size(); i++)
         {
             if(m_items[i].visible && IntensityMatchesMemoryFilter(m_items[i]) &&
-               KernelPassesIsolation(m_items[i]))
+               KernelPassesIsolation(m_items[i]) && BandwidthPassesIsolation(m_items[i]))
             {
                 switch(m_items[i].type)
                 {
@@ -1137,6 +1160,31 @@ Roofline::KernelPassesIsolation(const ItemModel& item) const
        item.type == ItemModel::Type::Intensity)
     {
         passes = item.parent_info.kernel == m_isolated_kernel;
+    }
+    return passes;
+}
+
+void
+Roofline::ToggleBandwidthIsolation(
+    rocprofvis_controller_roofline_ceiling_bandwidth_type_t bandwidth)
+{
+    if(m_isolated_bandwidth && m_isolated_bandwidth.value() == bandwidth)
+    {
+        m_isolated_bandwidth = std::nullopt;
+    }
+    else
+    {
+        m_isolated_bandwidth = bandwidth;
+    }
+}
+
+bool
+Roofline::BandwidthPassesIsolation(const ItemModel& item) const
+{
+    bool passes = true;
+    if(m_isolated_bandwidth && item.type == ItemModel::Type::CeilingBandwidth)
+    {
+        passes = item.subtype.bandwidth == m_isolated_bandwidth.value();
     }
     return passes;
 }

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -53,6 +53,9 @@ constexpr const char* DISPLAY_NAMES_KERNEL_INTENSITY[] = {
 };
 constexpr const char* MEMORY_LEVEL_NAMES[] = { "HBM", "L2", "L1", "LDS" };
 constexpr const char* FILTER_OPTION_ALL    = "All";
+// Shown by every dropdown once visibility has been hand-edited via Custom, so
+// the toolbar does not claim a selection that no longer matches the plot.
+constexpr const char* FILTER_OPTION_CUSTOM = "-";
 constexpr const char* DISPLAY_NAMES_PRESET[] = {
     "FP4",   // PresetModel::Type::FP4
     "FP6",   // PresetModel::Type::FP6
@@ -87,6 +90,7 @@ Roofline::Roofline(DataProvider& data_provider, KernelMode kernel_mode)
 , m_requested_kernel_id(0)
 , m_isolated_kernel(nullptr)
 , m_isolated_bandwidth(std::nullopt)
+, m_custom_visibility(false)
 {
     m_widget_name = GenUniqueName("roofline");
     m_items.resize(static_cast<size_t>(__KRPVControllerRooflineCeilingComputeTypeLast +
@@ -752,7 +756,9 @@ Roofline::RenderToolbar()
     ImGui::PushID("compute_peak");
     label_cell("Compute peak");
     PushComboStyles();
-    if(ImGui::BeginCombo("##compute_peak", DISPLAY_NAMES_PRESET[m_active_preset]))
+    if(ImGui::BeginCombo("##compute_peak",
+                         m_custom_visibility ? FILTER_OPTION_CUSTOM
+                                             : DISPLAY_NAMES_PRESET[m_active_preset]))
     {
         for(PresetModel& preset : m_presets)
         {
@@ -778,7 +784,8 @@ Roofline::RenderToolbar()
         label_cell("Bandwidth peak");
         PushComboStyles();
         if(ImGui::BeginCombo("##bandwidth_peak",
-                             m_isolated_bandwidth
+                             m_custom_visibility ? FILTER_OPTION_CUSTOM
+                             : m_isolated_bandwidth
                                  ? MEMORY_LEVEL_NAMES[m_isolated_bandwidth.value()]
                                  : FILTER_OPTION_ALL))
         {
@@ -814,8 +821,9 @@ Roofline::RenderToolbar()
         label_cell("Kernel");
         PushComboStyles();
         if(ImGui::BeginCombo("##kernel",
-                             m_isolated_kernel ? m_isolated_kernel->name.c_str()
-                                               : FILTER_OPTION_ALL))
+                             m_custom_visibility ? FILTER_OPTION_CUSTOM
+                             : m_isolated_kernel  ? m_isolated_kernel->name.c_str()
+                                                  : FILTER_OPTION_ALL))
         {
             if(ImGui::Selectable(FILTER_OPTION_ALL, !m_isolated_kernel))
             {
@@ -858,7 +866,8 @@ Roofline::RenderToolbar()
         label_cell("Kernel bandwidth");
         PushComboStyles();
         if(ImGui::BeginCombo("##kernel_bandwidth",
-                             m_memory_peak_filter
+                             m_custom_visibility ? FILTER_OPTION_CUSTOM
+                             : m_memory_peak_filter
                                  ? MEMORY_LEVEL_NAMES[m_memory_peak_filter.value()]
                                  : FILTER_OPTION_ALL))
         {
@@ -1133,8 +1142,9 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                     {
                         if(m_menus_mode == Options)
                         {
-                            m_items[i].visible = !m_items[i].visible;
-                            m_options_changed  = true;
+                            m_items[i].visible  = !m_items[i].visible;
+                            m_custom_visibility = true;
+                            m_options_changed   = true;
                         }
                         else if(m_kernel_mode == AllKernels &&
                                 m_items[i].type == ItemModel::Type::Intensity)
@@ -1319,6 +1329,8 @@ Roofline::RecomputeVisibility()
     {
         m_items[item_idx].visible = true;
     }
+    // Visibility now matches the dropdown selections again.
+    m_custom_visibility = false;
     // Visibility can change which ceilings are shown, so recompute the ridges.
     m_options_changed = true;
 }

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -1043,7 +1043,9 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         ImGui::EndGroup();
         float header_height = ImGui::GetItemRectSize().y + 2 * style.WindowPadding.y;
         float footer_height =
-            (m_kernel_mode == AllKernels ? 6 : 5) * ImGui::GetFrameHeightWithSpacing() +
+            (m_menus_mode == Legend ? 0.0f
+                                    : (m_kernel_mode == AllKernels ? 6 : 5) *
+                                          ImGui::GetFrameHeightWithSpacing()) +
             2 * style.WindowPadding.y;
         ImGui::SetNextWindowSizeConstraints(
             ImVec2(menus_content_width, 0),

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -995,20 +995,34 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         }
         ImGui::SetCursorPos(button_pos +
                             ImVec2(0.0f, menus_on_bottom ? -button_size : button_size));
-        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
-        if(ImGui::Button(m_menus_mode == Legend ? ICON_GEAR : ICON_LIST,
-                         ImVec2(button_size, button_size)))
+        // Draw the icon manually so it stays centered: ImGui::Button left-clamps
+        // a glyph that is wider than the (main-font-sized) button.
+        const char* mode_icon    = m_menus_mode == Legend ? ICON_GEAR : ICON_LIST;
+        ImVec2      mode_min      = ImGui::GetCursorScreenPos();
+        ImVec2      mode_size     = ImVec2(button_size, button_size);
+        bool        mode_clicked  = ImGui::InvisibleButton("menu_mode", mode_size);
+        ImU32       mode_bg =
+            ImGui::IsItemActive()    ? ImGui::GetColorU32(ImGuiCol_ButtonActive)
+            : ImGui::IsItemHovered() ? ImGui::GetColorU32(ImGuiCol_ButtonHovered)
+                                     : ImGui::GetColorU32(ImGuiCol_Button);
+        ImDrawList* mode_draw = ImGui::GetWindowDrawList();
+        mode_draw->AddRectFilled(mode_min, mode_min + mode_size, mode_bg,
+                                 style.FrameRounding);
+        if(style.FrameBorderSize > 0.0f)
         {
-            if(m_menus_mode == Legend)
-            {
-                m_menus_mode = Options;
-            }
-            else
-            {
-                m_menus_mode = Legend;
-            }
+            mode_draw->AddRect(mode_min, mode_min + mode_size,
+                               ImGui::GetColorU32(ImGuiCol_Border), style.FrameRounding, 0,
+                               style.FrameBorderSize);
         }
+        ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
+        ImVec2 mode_icon_size = ImGui::CalcTextSize(mode_icon);
+        mode_draw->AddText(mode_min + (mode_size - mode_icon_size) * 0.5f,
+                           ImGui::GetColorU32(ImGuiCol_Text), mode_icon);
         ImGui::PopFont();
+        if(mode_clicked)
+        {
+            m_menus_mode = m_menus_mode == Legend ? Options : Legend;
+        }
         ImGui::SetCursorPos(window_pos);
 
         ImGui::SetNextWindowSizeConstraints(ImVec2(menus_width, button_size * 2.0f),

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -82,6 +82,7 @@ Roofline::Roofline(DataProvider& data_provider, KernelMode kernel_mode)
 , m_requested_workload_id(0)
 , m_kernel(nullptr)
 , m_requested_kernel_id(0)
+, m_isolated_kernel(nullptr)
 {
     m_widget_name = GenUniqueName("roofline");
     m_items.resize(static_cast<size_t>(__KRPVControllerRooflineCeilingComputeTypeLast +
@@ -121,6 +122,8 @@ Roofline::Update()
 {
     if(m_workload_changed)
     {
+        // Kernel pointers are rebuilt below, so drop any stale isolation.
+        m_isolated_kernel = nullptr;
         m_workload =
             m_data_provider.ComputeModel().GetWorkload(m_requested_workload_id);
         if(m_workload)
@@ -438,7 +441,8 @@ Roofline::Render()
                         display =
                             m_items[i].info.intensity &&
                             (m_kernel ? m_items[i].parent_info.kernel == m_kernel : true) &&
-                            IntensityMatchesMemoryFilter(m_items[i]);
+                            IntensityMatchesMemoryFilter(m_items[i]) &&
+                            KernelPassesIsolation(m_items[i]);
                     }
                 }
                 display &= m_items[i].visible;
@@ -604,8 +608,18 @@ Roofline::Render()
         }
         bool menus_item_hovered = false;
         RenderMenus(region, plot_pos, plot_size, style, plot_style, menus_item_hovered);
-        if(!m_plot_zoom_enabled && roofline_hovered &&
-           ImGui::IsMouseClicked(ImGuiMouseButton_Left))
+        bool dot_hovered =
+            !menus_item_hovered && m_kernel_mode == AllKernels && m_hovered_item_idx &&
+            m_items[m_hovered_item_idx.value()].type == ItemModel::Type::Intensity;
+        // Drag check so panning a zoomed plot is not treated as a dot click.
+        if(dot_hovered && roofline_hovered &&
+           IsMouseReleasedWithDragCheck(ImGuiMouseButton_Left))
+        {
+            ToggleKernelIsolation(
+                m_items[m_hovered_item_idx.value()].parent_info.kernel);
+        }
+        if(!m_plot_zoom_enabled && roofline_hovered && !dot_hovered &&
+           !menus_item_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Left))
         {
             m_plot_zoom_enabled = true;
         }
@@ -823,7 +837,8 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                     display =
                         m_items[i].info.intensity &&
                         (m_kernel ? m_items[i].parent_info.kernel == m_kernel : true) &&
-                        IntensityMatchesMemoryFilter(m_items[i]);
+                        IntensityMatchesMemoryFilter(m_items[i]) &&
+                        KernelPassesIsolation(m_items[i]);
                     break;
                 }
             }
@@ -896,10 +911,18 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                 {
                     m_hovered_item_idx = i;
                     item_hovered       = true;
-                    if(row_clicked && m_menus_mode == Options)
+                    if(row_clicked)
                     {
-                        m_items[i].visible = !m_items[i].visible;
-                        m_options_changed  = true;
+                        if(m_menus_mode == Options)
+                        {
+                            m_items[i].visible = !m_items[i].visible;
+                            m_options_changed  = true;
+                        }
+                        else if(m_kernel_mode == AllKernels &&
+                                m_items[i].type == ItemModel::Type::Intensity)
+                        {
+                            ToggleKernelIsolation(m_items[i].parent_info.kernel);
+                        }
                     }
                 }
                 ImGui::PopStyleColor(3);
@@ -998,7 +1021,8 @@ Roofline::PlotHoverIdx()
         // Pick the closest visible item after plotting all candidates.
         for(size_t i = 0; i < m_items.size(); i++)
         {
-            if(m_items[i].visible && IntensityMatchesMemoryFilter(m_items[i]))
+            if(m_items[i].visible && IntensityMatchesMemoryFilter(m_items[i]) &&
+               KernelPassesIsolation(m_items[i]))
             {
                 switch(m_items[i].type)
                 {
@@ -1097,6 +1121,24 @@ Roofline::IntensityMatchesMemoryFilter(const ItemModel& item) const
         matches = item.subtype.intensity == m_memory_peak_filter.value();
     }
     return matches;
+}
+
+void
+Roofline::ToggleKernelIsolation(const KernelInfo* kernel)
+{
+    m_isolated_kernel = (kernel && m_isolated_kernel != kernel) ? kernel : nullptr;
+}
+
+bool
+Roofline::KernelPassesIsolation(const ItemModel& item) const
+{
+    bool passes = true;
+    if(m_kernel_mode == AllKernels && m_isolated_kernel &&
+       item.type == ItemModel::Type::Intensity)
+    {
+        passes = item.parent_info.kernel == m_isolated_kernel;
+    }
+    return passes;
 }
 
 }  // namespace View

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -379,6 +379,15 @@ Roofline::Render()
                       ImGuiChildFlags_Borders |
                           ImGuiChildFlags_AlwaysUseWindowPadding);
     SectionTitle("Roofline Analysis");
+    bool has_roofline =
+        m_workload && !m_workload->roofline.ceiling_bandwidth.empty() &&
+        !m_workload->roofline.ceiling_compute.empty() &&
+        !(m_kernel_mode == SingleKernel &&
+          (!m_kernel || m_kernel->roofline.intensities.empty()));
+    if(has_roofline)
+    {
+        RenderToolbar();
+    }
     ImGui::BeginChild("roofline");
     const ImVec2       region     = ImGui::GetContentRegionAvail();
     const ImGuiStyle&  style      = ImGui::GetStyle();
@@ -708,6 +717,176 @@ Roofline::SetKernel(uint32_t id)
 }
 
 void
+Roofline::RenderToolbar()
+{
+    const ImGuiStyle& style = ImGui::GetStyle();
+    int               count = 1;  // Compute peak is always present.
+    if(!m_available_bandwidths.empty())
+    {
+        count++;
+    }
+    if(m_kernel_mode == AllKernels)
+    {
+        count++;
+    }
+    if(!m_available_intensities.empty())
+    {
+        count++;
+    }
+    float cell = (ImGui::GetContentRegionAvail().x -
+                  style.ItemSpacing.x * static_cast<float>(count - 1)) /
+                 static_cast<float>(count);
+    cell = std::max(cell, ImGui::GetFontSize() * 4.0f);
+
+    // Draw "<label>" to the left, then size the next combo to fill the cell.
+    auto label_cell = [&](const char* label) {
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted(label);
+        ImGui::SameLine();
+        float combo_width = cell - ImGui::GetItemRectSize().x - style.ItemSpacing.x;
+        ImGui::SetNextItemWidth(std::max(combo_width, ImGui::GetFontSize() * 2.0f));
+    };
+
+    // Compute peak (preset)...
+    ImGui::BeginGroup();
+    ImGui::PushID("compute_peak");
+    label_cell("Compute peak");
+    PushComboStyles();
+    if(ImGui::BeginCombo("##compute_peak", DISPLAY_NAMES_PRESET[m_active_preset]))
+    {
+        for(PresetModel& preset : m_presets)
+        {
+            if(!preset.item_indices.empty() &&
+               ImGui::Selectable(DISPLAY_NAMES_PRESET[preset.type],
+                                 preset.type == m_active_preset))
+            {
+                ApplyPreset(preset.type);
+            }
+        }
+        ImGui::EndCombo();
+    }
+    PopComboStyles();
+    ImGui::PopID();
+    ImGui::EndGroup();
+
+    // Bandwidth peak...
+    if(!m_available_bandwidths.empty())
+    {
+        ImGui::SameLine();
+        ImGui::BeginGroup();
+        ImGui::PushID("bandwidth_peak");
+        label_cell("Bandwidth peak");
+        PushComboStyles();
+        if(ImGui::BeginCombo("##bandwidth_peak",
+                             m_isolated_bandwidth
+                                 ? MEMORY_LEVEL_NAMES[m_isolated_bandwidth.value()]
+                                 : FILTER_OPTION_ALL))
+        {
+            if(ImGui::Selectable(FILTER_OPTION_ALL, !m_isolated_bandwidth))
+            {
+                m_isolated_bandwidth = std::nullopt;
+                RecomputeVisibility();
+            }
+            for(rocprofvis_controller_roofline_ceiling_bandwidth_type_t bandwidth :
+                m_available_bandwidths)
+            {
+                if(ImGui::Selectable(MEMORY_LEVEL_NAMES[bandwidth],
+                                     m_isolated_bandwidth &&
+                                         m_isolated_bandwidth.value() == bandwidth))
+                {
+                    m_isolated_bandwidth = bandwidth;
+                    RecomputeVisibility();
+                }
+            }
+            ImGui::EndCombo();
+        }
+        PopComboStyles();
+        ImGui::PopID();
+        ImGui::EndGroup();
+    }
+
+    // Kernel (workload roofline only)...
+    if(m_kernel_mode == AllKernels)
+    {
+        ImGui::SameLine();
+        ImGui::BeginGroup();
+        ImGui::PushID("kernel");
+        label_cell("Kernel");
+        PushComboStyles();
+        if(ImGui::BeginCombo("##kernel",
+                             m_isolated_kernel ? m_isolated_kernel->name.c_str()
+                                               : FILTER_OPTION_ALL))
+        {
+            if(ImGui::Selectable(FILTER_OPTION_ALL, !m_isolated_kernel))
+            {
+                m_isolated_kernel = nullptr;
+                RecomputeVisibility();
+            }
+            for(const KernelInfo* kernel : m_workload->ordered_kernels)
+            {
+                // Kernels without roofline data do not belong in this list.
+                if(kernel->roofline.intensities.empty())
+                {
+                    continue;
+                }
+                // Long/mangled names: elide so the popup stays the toolbar width.
+                ImGui::PushID(kernel);
+                ImVec2 pos     = ImGui::GetCursorPos();
+                bool   clicked = ImGui::Selectable("", m_isolated_kernel == kernel);
+                ImGui::SetCursorPos(pos);
+                ElidedText(kernel->name.c_str(), ImGui::GetContentRegionAvail().x, cell);
+                if(clicked)
+                {
+                    m_isolated_kernel = kernel;
+                    RecomputeVisibility();
+                }
+                ImGui::PopID();
+            }
+            ImGui::EndCombo();
+        }
+        PopComboStyles();
+        ImGui::PopID();
+        ImGui::EndGroup();
+    }
+
+    // Kernel bandwidth (intensity memory level)...
+    if(!m_available_intensities.empty())
+    {
+        ImGui::SameLine();
+        ImGui::BeginGroup();
+        ImGui::PushID("kernel_bandwidth");
+        label_cell("Kernel bandwidth");
+        PushComboStyles();
+        if(ImGui::BeginCombo("##kernel_bandwidth",
+                             m_memory_peak_filter
+                                 ? MEMORY_LEVEL_NAMES[m_memory_peak_filter.value()]
+                                 : FILTER_OPTION_ALL))
+        {
+            if(ImGui::Selectable(FILTER_OPTION_ALL, !m_memory_peak_filter))
+            {
+                m_memory_peak_filter = std::nullopt;
+                RecomputeVisibility();
+            }
+            for(rocprofvis_controller_roofline_kernel_intensity_type_t level :
+                m_available_intensities)
+            {
+                if(ImGui::Selectable(MEMORY_LEVEL_NAMES[level],
+                                     m_memory_peak_filter &&
+                                         m_memory_peak_filter.value() == level))
+                {
+                    m_memory_peak_filter = level;
+                    RecomputeVisibility();
+                }
+            }
+            ImGui::EndCombo();
+        }
+        PopComboStyles();
+        ImGui::PopID();
+        ImGui::EndGroup();
+    }
+}
+
+void
 Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                        const ImGuiStyle& style, const ImPlotStyle& plot_style,
                        bool& item_hovered)
@@ -836,131 +1015,6 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         ImGui::BeginGroup();
         if(m_menus_mode == Options)
         {
-            ImGui::SeparatorText("Presets");
-            ImGui::PushID("preset");
-            ElidedText("Preset", ImGui::GetContentRegionAvail().x, plot_size.x * 0.5f,
-                       Alignment_Left, true);
-            ImGui::SetNextItemWidth(-1.0f);
-            PushComboStyles();
-            if(ImGui::BeginCombo("##preset", DISPLAY_NAMES_PRESET[m_active_preset]))
-            {
-                for(PresetModel& preset : m_presets)
-                {
-                    if(!preset.item_indices.empty() &&
-                       ImGui::Selectable(DISPLAY_NAMES_PRESET[preset.type],
-                                         preset.type == m_active_preset))
-                    {
-                        ApplyPreset(preset.type);
-                    }
-                }
-                ImGui::EndCombo();
-            }
-            PopComboStyles();
-            ImGui::PopID();
-            if(!m_available_intensities.empty())
-            {
-                ImGui::PushID("kernel_intensity");
-                ElidedText("Kernel intensity", ImGui::GetContentRegionAvail().x,
-                           plot_size.x * 0.5f, Alignment_Left, true);
-                ImGui::SetNextItemWidth(-1.0f);
-                PushComboStyles();
-                if(ImGui::BeginCombo("##kernel_intensity",
-                                     m_memory_peak_filter
-                                         ? MEMORY_LEVEL_NAMES[m_memory_peak_filter.value()]
-                                         : FILTER_OPTION_ALL))
-                {
-                    if(ImGui::Selectable(FILTER_OPTION_ALL, !m_memory_peak_filter))
-                    {
-                        m_memory_peak_filter = std::nullopt;
-                        RecomputeVisibility();
-                    }
-                    for(rocprofvis_controller_roofline_kernel_intensity_type_t level :
-                        m_available_intensities)
-                    {
-                        if(ImGui::Selectable(MEMORY_LEVEL_NAMES[level],
-                                             m_memory_peak_filter &&
-                                                 m_memory_peak_filter.value() == level))
-                        {
-                            m_memory_peak_filter = level;
-                            RecomputeVisibility();
-                        }
-                    }
-                    ImGui::EndCombo();
-                }
-                PopComboStyles();
-                ImGui::PopID();
-            }
-            if(m_kernel_mode == AllKernels && m_workload)
-            {
-                ImGui::PushID("kernel");
-                ElidedText("Kernel", ImGui::GetContentRegionAvail().x, plot_size.x * 0.5f,
-                           Alignment_Left, true);
-                ImGui::SetNextItemWidth(-1.0f);
-                PushComboStyles();
-                if(ImGui::BeginCombo("##kernel",
-                                     m_isolated_kernel ? m_isolated_kernel->name.c_str()
-                                                       : FILTER_OPTION_ALL))
-                {
-                    if(ImGui::Selectable(FILTER_OPTION_ALL, !m_isolated_kernel))
-                    {
-                        m_isolated_kernel = nullptr;
-                        RecomputeVisibility();
-                    }
-                    for(const KernelInfo* kernel : m_workload->ordered_kernels)
-                    {
-                        // Kernel names are long/mangled; elide them so the combo
-                        // popup stays the width of the menu.
-                        ImGui::PushID(kernel);
-                        ImVec2 pos     = ImGui::GetCursorPos();
-                        bool   clicked = ImGui::Selectable("", m_isolated_kernel == kernel);
-                        ImGui::SetCursorPos(pos);
-                        ElidedText(kernel->name.c_str(),
-                                   ImGui::GetContentRegionAvail().x, plot_size.x * 0.5f);
-                        if(clicked)
-                        {
-                            m_isolated_kernel = kernel;
-                            RecomputeVisibility();
-                        }
-                        ImGui::PopID();
-                    }
-                    ImGui::EndCombo();
-                }
-                PopComboStyles();
-                ImGui::PopID();
-            }
-            if(!m_available_bandwidths.empty())
-            {
-                ImGui::PushID("bandwidth_peak");
-                ElidedText("Bandwidth peak", ImGui::GetContentRegionAvail().x,
-                           plot_size.x * 0.5f, Alignment_Left, true);
-                ImGui::SetNextItemWidth(-1.0f);
-                PushComboStyles();
-                if(ImGui::BeginCombo("##bandwidth_peak",
-                                     m_isolated_bandwidth
-                                         ? MEMORY_LEVEL_NAMES[m_isolated_bandwidth.value()]
-                                         : FILTER_OPTION_ALL))
-                {
-                    if(ImGui::Selectable(FILTER_OPTION_ALL, !m_isolated_bandwidth))
-                    {
-                        m_isolated_bandwidth = std::nullopt;
-                        RecomputeVisibility();
-                    }
-                    for(rocprofvis_controller_roofline_ceiling_bandwidth_type_t bandwidth :
-                        m_available_bandwidths)
-                    {
-                        if(ImGui::Selectable(MEMORY_LEVEL_NAMES[bandwidth],
-                                             m_isolated_bandwidth &&
-                                                 m_isolated_bandwidth.value() == bandwidth))
-                        {
-                            m_isolated_bandwidth = bandwidth;
-                            RecomputeVisibility();
-                        }
-                    }
-                    ImGui::EndCombo();
-                }
-                PopComboStyles();
-                ImGui::PopID();
-            }
             ImGui::SeparatorText("Custom");
         }
         ImGui::EndGroup();
@@ -971,7 +1025,7 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         ImGui::SetNextWindowSizeConstraints(
             ImVec2(menus_content_width, 0),
             ImVec2(menus_content_width,
-                   std::max(0.0f, max_menus_height - header_height - footer_height)));
+                   max_menus_height - header_height - footer_height));
         ImGui::BeginChild("menus_scroll_view", ImVec2(menus_content_width, 0),
                           ImGuiChildFlags_AutoResizeY);
         float icon_width = ImGui::GetFontSize();

--- a/src/view/src/compute/rocprofvis_compute_roofline.cpp
+++ b/src/view/src/compute/rocprofvis_compute_roofline.cpp
@@ -51,6 +51,8 @@ constexpr const char* DISPLAY_NAMES_KERNEL_INTENSITY[] = {
     "L1 Intensity",   // kRPVControllerRooflineKernelIntensityTypeL1
     "LDS Intensity",  // kRPVControllerRooflineKernelIntensityTypeLDS
 };
+constexpr const char* MEMORY_LEVEL_NAMES[] = { "HBM", "L2", "L1", "LDS" };
+constexpr const char* FILTER_OPTION_ALL    = "All";
 constexpr const char* DISPLAY_NAMES_PRESET[] = {
     "FP4",   // PresetModel::Type::FP4
     "FP6",   // PresetModel::Type::FP6
@@ -70,6 +72,7 @@ Roofline::Roofline(DataProvider& data_provider, KernelMode kernel_mode)
 , m_menus_placement(InsideTopRight)
 , m_scale_intensity(true)
 , m_line_thickness(LINE_THICKNESS_DEFAULT)
+, m_active_preset(PresetModel::FP32)
 , m_memory_peak_filter(std::nullopt)
 , m_menus_rendered_height(0.0f)
 , m_hovered_item_distance(FLT_MAX)
@@ -123,9 +126,10 @@ Roofline::Update()
 {
     if(m_workload_changed)
     {
-        // Kernel pointers are rebuilt below, so drop any stale isolation.
+        // Kernel pointers are rebuilt below, so drop any stale filters.
         m_isolated_kernel    = nullptr;
         m_isolated_bandwidth = std::nullopt;
+        m_memory_peak_filter = std::nullopt;
         m_workload =
             m_data_provider.ComputeModel().GetWorkload(m_requested_workload_id);
         if(m_workload)
@@ -259,6 +263,41 @@ Roofline::Update()
                             static_cast<double>(kernel_duration_scale)) });
                 }
             }
+            // Build filter dropdown options from what the workload actually has;
+            // empty memory levels should not be offered.
+            m_available_intensities.clear();
+            m_available_bandwidths.clear();
+            bool intensity_present[IM_ARRAYSIZE(MEMORY_LEVEL_NAMES)] = {};
+            for(const std::pair<const uint32_t, KernelInfo>& kernel : m_workload->kernels)
+            {
+                for(const std::pair<
+                        const rocprofvis_controller_roofline_kernel_intensity_type_t,
+                        KernelInfo::Roofline::Intensity>& intensity :
+                    kernel.second.roofline.intensities)
+                {
+                    intensity_present[intensity.second.type] = true;
+                }
+            }
+            for(uint32_t i = 0; i < IM_ARRAYSIZE(MEMORY_LEVEL_NAMES); i++)
+            {
+                if(intensity_present[i])
+                {
+                    m_available_intensities.emplace_back(
+                        static_cast<
+                            rocprofvis_controller_roofline_kernel_intensity_type_t>(i));
+                }
+            }
+            for(uint32_t i = __KRPVControllerRooflineCeilingBandwidthTypeFirst;
+                i < __KRPVControllerRooflineCeilingBandwidthTypeLast; i++)
+            {
+                rocprofvis_controller_roofline_ceiling_bandwidth_type_t bandwidth =
+                    static_cast<rocprofvis_controller_roofline_ceiling_bandwidth_type_t>(
+                        i);
+                if(m_workload->roofline.ceiling_bandwidth.count(bandwidth) > 0)
+                {
+                    m_available_bandwidths.emplace_back(bandwidth);
+                }
+            }
             ApplyPreset(PresetModel::FP32);
         }
         m_workload_changed = false;
@@ -270,6 +309,7 @@ Roofline::Update()
         {
             m_kernel = &m_workload->kernels.at(m_requested_kernel_id);
         }
+        RecomputeVisibility();
         m_kernel_changed = false;
     }
     if(m_options_changed)
@@ -435,17 +475,12 @@ Roofline::Render()
                     case ItemModel::Type::CeilingCompute:
                     case ItemModel::Type::CeilingBandwidth:
                     {
-                        display = m_items[i].info.ceiling &&
-                                  BandwidthPassesIsolation(m_items[i]);
+                        display = m_items[i].info.ceiling;
                         break;
                     }
                     case ItemModel::Type::Intensity:
                     {
-                        display =
-                            m_items[i].info.intensity &&
-                            (m_kernel ? m_items[i].parent_info.kernel == m_kernel : true) &&
-                            IntensityMatchesMemoryFilter(m_items[i]) &&
-                            KernelPassesIsolation(m_items[i]);
+                        display = m_items[i].info.intensity;
                     }
                 }
                 display &= m_items[i].visible;
@@ -802,28 +837,141 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         if(m_menus_mode == Options)
         {
             ImGui::SeparatorText("Presets");
-            for(PresetModel& preset : m_presets)
+            ImGui::PushID("preset");
+            ElidedText("Preset", ImGui::GetContentRegionAvail().x, plot_size.x * 0.5f,
+                       Alignment_Left, true);
+            ImGui::SetNextItemWidth(-1.0f);
+            PushComboStyles();
+            if(ImGui::BeginCombo("##preset", DISPLAY_NAMES_PRESET[m_active_preset]))
             {
-                if(!preset.item_indices.empty())
+                for(PresetModel& preset : m_presets)
                 {
-                    if(ImGui::Button(DISPLAY_NAMES_PRESET[preset.type],
-                                     ImVec2(-1.0f, 0.0f)))
+                    if(!preset.item_indices.empty() &&
+                       ImGui::Selectable(DISPLAY_NAMES_PRESET[preset.type],
+                                         preset.type == m_active_preset))
                     {
                         ApplyPreset(preset.type);
                     }
                 }
+                ImGui::EndCombo();
+            }
+            PopComboStyles();
+            ImGui::PopID();
+            if(!m_available_intensities.empty())
+            {
+                ImGui::PushID("kernel_intensity");
+                ElidedText("Kernel intensity", ImGui::GetContentRegionAvail().x,
+                           plot_size.x * 0.5f, Alignment_Left, true);
+                ImGui::SetNextItemWidth(-1.0f);
+                PushComboStyles();
+                if(ImGui::BeginCombo("##kernel_intensity",
+                                     m_memory_peak_filter
+                                         ? MEMORY_LEVEL_NAMES[m_memory_peak_filter.value()]
+                                         : FILTER_OPTION_ALL))
+                {
+                    if(ImGui::Selectable(FILTER_OPTION_ALL, !m_memory_peak_filter))
+                    {
+                        m_memory_peak_filter = std::nullopt;
+                        RecomputeVisibility();
+                    }
+                    for(rocprofvis_controller_roofline_kernel_intensity_type_t level :
+                        m_available_intensities)
+                    {
+                        if(ImGui::Selectable(MEMORY_LEVEL_NAMES[level],
+                                             m_memory_peak_filter &&
+                                                 m_memory_peak_filter.value() == level))
+                        {
+                            m_memory_peak_filter = level;
+                            RecomputeVisibility();
+                        }
+                    }
+                    ImGui::EndCombo();
+                }
+                PopComboStyles();
+                ImGui::PopID();
+            }
+            if(m_kernel_mode == AllKernels && m_workload)
+            {
+                ImGui::PushID("kernel");
+                ElidedText("Kernel", ImGui::GetContentRegionAvail().x, plot_size.x * 0.5f,
+                           Alignment_Left, true);
+                ImGui::SetNextItemWidth(-1.0f);
+                PushComboStyles();
+                if(ImGui::BeginCombo("##kernel",
+                                     m_isolated_kernel ? m_isolated_kernel->name.c_str()
+                                                       : FILTER_OPTION_ALL))
+                {
+                    if(ImGui::Selectable(FILTER_OPTION_ALL, !m_isolated_kernel))
+                    {
+                        m_isolated_kernel = nullptr;
+                        RecomputeVisibility();
+                    }
+                    for(const KernelInfo* kernel : m_workload->ordered_kernels)
+                    {
+                        // Kernel names are long/mangled; elide them so the combo
+                        // popup stays the width of the menu.
+                        ImGui::PushID(kernel);
+                        ImVec2 pos     = ImGui::GetCursorPos();
+                        bool   clicked = ImGui::Selectable("", m_isolated_kernel == kernel);
+                        ImGui::SetCursorPos(pos);
+                        ElidedText(kernel->name.c_str(),
+                                   ImGui::GetContentRegionAvail().x, plot_size.x * 0.5f);
+                        if(clicked)
+                        {
+                            m_isolated_kernel = kernel;
+                            RecomputeVisibility();
+                        }
+                        ImGui::PopID();
+                    }
+                    ImGui::EndCombo();
+                }
+                PopComboStyles();
+                ImGui::PopID();
+            }
+            if(!m_available_bandwidths.empty())
+            {
+                ImGui::PushID("bandwidth_peak");
+                ElidedText("Bandwidth peak", ImGui::GetContentRegionAvail().x,
+                           plot_size.x * 0.5f, Alignment_Left, true);
+                ImGui::SetNextItemWidth(-1.0f);
+                PushComboStyles();
+                if(ImGui::BeginCombo("##bandwidth_peak",
+                                     m_isolated_bandwidth
+                                         ? MEMORY_LEVEL_NAMES[m_isolated_bandwidth.value()]
+                                         : FILTER_OPTION_ALL))
+                {
+                    if(ImGui::Selectable(FILTER_OPTION_ALL, !m_isolated_bandwidth))
+                    {
+                        m_isolated_bandwidth = std::nullopt;
+                        RecomputeVisibility();
+                    }
+                    for(rocprofvis_controller_roofline_ceiling_bandwidth_type_t bandwidth :
+                        m_available_bandwidths)
+                    {
+                        if(ImGui::Selectable(MEMORY_LEVEL_NAMES[bandwidth],
+                                             m_isolated_bandwidth &&
+                                                 m_isolated_bandwidth.value() == bandwidth))
+                        {
+                            m_isolated_bandwidth = bandwidth;
+                            RecomputeVisibility();
+                        }
+                    }
+                    ImGui::EndCombo();
+                }
+                PopComboStyles();
+                ImGui::PopID();
             }
             ImGui::SeparatorText("Custom");
         }
         ImGui::EndGroup();
         float header_height = ImGui::GetItemRectSize().y + 2 * style.WindowPadding.y;
         float footer_height =
-            (m_kernel_mode == AllKernels ? 8 : 7) * ImGui::GetFrameHeightWithSpacing() +
+            (m_kernel_mode == AllKernels ? 6 : 5) * ImGui::GetFrameHeightWithSpacing() +
             2 * style.WindowPadding.y;
         ImGui::SetNextWindowSizeConstraints(
             ImVec2(menus_content_width, 0),
             ImVec2(menus_content_width,
-                   max_menus_height - header_height - footer_height));
+                   std::max(0.0f, max_menus_height - header_height - footer_height)));
         ImGui::BeginChild("menus_scroll_view", ImVec2(menus_content_width, 0),
                           ImGuiChildFlags_AutoResizeY);
         float icon_width = ImGui::GetFontSize();
@@ -849,11 +997,12 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                 }
                 case ItemModel::Type::Intensity:
                 {
-                    display =
-                        m_items[i].info.intensity &&
-                        (m_kernel ? m_items[i].parent_info.kernel == m_kernel : true) &&
-                        IntensityMatchesMemoryFilter(m_items[i]) &&
-                        KernelPassesIsolation(m_items[i]);
+                    // The menu always lists the full data set; in single-kernel
+                    // mode that data set is just the selected kernel.
+                    display = m_items[i].info.intensity &&
+                              (m_kernel_mode == SingleKernel
+                                   ? m_items[i].parent_info.kernel == m_kernel
+                                   : true);
                     break;
                 }
             }
@@ -868,13 +1017,9 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                                       m_settings.GetColor(Colors::kHighlightChart));
                 ImGui::PushStyleColor(ImGuiCol_HeaderActive,
                                       m_settings.GetColor(Colors::kHighlightChart));
-                ImVec2 pos          = ImGui::GetCursorPos();
-                bool   row_isolated = m_isolated_bandwidth &&
-                                    m_items[i].type == ItemModel::Type::CeilingBandwidth &&
-                                    m_items[i].subtype.bandwidth ==
-                                        m_isolated_bandwidth.value();
-                bool row_clicked = ImGui::Selectable(
-                    "", row_isolated,
+                ImVec2 pos         = ImGui::GetCursorPos();
+                bool   row_clicked = ImGui::Selectable(
+                    "", false,
                     m_hovered_item_idx && m_hovered_item_idx.value() == i
                           ? ImGuiSelectableFlags_Highlight
                           : ImGuiSelectableFlags_None);
@@ -961,32 +1106,6 @@ Roofline::RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
         if(m_menus_mode == Options)
         {
             ImGui::SeparatorText("Options");
-            ImGui::PushID("memory_peak");
-            ElidedText("Kernel intensity", ImGui::GetContentRegionAvail().x,
-                       plot_size.x * 0.5f, Alignment_Left, true);
-            ImGui::SetNextItemWidth(-1.0f);
-            int intensity_filter_idx =
-                m_memory_peak_filter
-                    ? static_cast<int>(m_memory_peak_filter.value()) + 1
-                    : 0;
-            PushComboStyles();
-            // Order must match the intensity enum: All, HBM, L2, L1, LDS.
-            if(ImGui::Combo("##memory_peak", &intensity_filter_idx,
-                            "All\0HBM\0L2\0L1\0LDS\0\0"))
-            {
-                if(intensity_filter_idx == 0)
-                {
-                    m_memory_peak_filter = std::nullopt;
-                }
-                else
-                {
-                    m_memory_peak_filter = static_cast<
-                        rocprofvis_controller_roofline_kernel_intensity_type_t>(
-                        intensity_filter_idx - 1);
-                }
-            }
-            PopComboStyles();
-            ImGui::PopID();
             if(m_kernel_mode == AllKernels)
             {
                 ImGui::PushID("kernel_scale");
@@ -1044,8 +1163,7 @@ Roofline::PlotHoverIdx()
         // Pick the closest visible item after plotting all candidates.
         for(size_t i = 0; i < m_items.size(); i++)
         {
-            if(m_items[i].visible && IntensityMatchesMemoryFilter(m_items[i]) &&
-               KernelPassesIsolation(m_items[i]) && BandwidthPassesIsolation(m_items[i]))
+            if(m_items[i].visible)
             {
                 switch(m_items[i].type)
                 {
@@ -1106,62 +1224,56 @@ Roofline::PlotHoverIdx()
 void
 Roofline::ApplyPreset(PresetModel::Type type)
 {
-    // Disable all compute cielings...
-    for(size_t i = 0;
-        i < static_cast<size_t>(__KRPVControllerRooflineCeilingComputeTypeLast); i++)
+    m_active_preset = type;
+    RecomputeVisibility();
+}
+
+void
+Roofline::RecomputeVisibility()
+{
+    for(ItemModel& item : m_items)
     {
-        m_items[i].visible = false;
+        switch(item.type)
+        {
+            case ItemModel::Type::CeilingCompute:
+            {
+                // Enabled below from the active preset.
+                item.visible = false;
+                break;
+            }
+            case ItemModel::Type::CeilingBandwidth:
+            {
+                item.visible = !m_isolated_bandwidth ||
+                               item.subtype.bandwidth == m_isolated_bandwidth.value();
+                break;
+            }
+            case ItemModel::Type::Intensity:
+            {
+                bool level_ok = !m_memory_peak_filter ||
+                                item.subtype.intensity == m_memory_peak_filter.value();
+                bool kernel_ok =
+                    m_kernel_mode == SingleKernel
+                        ? item.parent_info.kernel == m_kernel
+                        : (!m_isolated_kernel ||
+                           item.parent_info.kernel == m_isolated_kernel);
+                item.visible = level_ok && kernel_ok;
+                break;
+            }
+        }
     }
-    // Enable preset's compute ceilings...
-    for(const size_t& item_idx : m_presets[type].item_indices)
+    for(const size_t& item_idx : m_presets[m_active_preset].item_indices)
     {
         m_items[item_idx].visible = true;
     }
-    // Enable all bandwidth ceilings...
-    for(size_t i = static_cast<size_t>(__KRPVControllerRooflineCeilingComputeTypeLast);
-        i < static_cast<size_t>(__KRPVControllerRooflineCeilingComputeTypeLast +
-                                __KRPVControllerRooflineCeilingBandwidthTypeLast);
-        i++)
-    {
-        m_items[i].visible = true;
-    }
-    // Enable all kernels...
-    for(size_t i = static_cast<size_t>(__KRPVControllerRooflineCeilingComputeTypeLast +
-                                       __KRPVControllerRooflineCeilingBandwidthTypeLast);
-        i < m_items.size(); i++)
-    {
-        m_items[i].visible = true;
-    }
+    // Visibility can change which ceilings are shown, so recompute the ridges.
     m_options_changed = true;
-}
-
-bool
-Roofline::IntensityMatchesMemoryFilter(const ItemModel& item) const
-{
-    bool matches = true;
-    if(item.type == ItemModel::Type::Intensity && m_memory_peak_filter)
-    {
-        matches = item.subtype.intensity == m_memory_peak_filter.value();
-    }
-    return matches;
 }
 
 void
 Roofline::ToggleKernelIsolation(const KernelInfo* kernel)
 {
     m_isolated_kernel = (kernel && m_isolated_kernel != kernel) ? kernel : nullptr;
-}
-
-bool
-Roofline::KernelPassesIsolation(const ItemModel& item) const
-{
-    bool passes = true;
-    if(m_kernel_mode == AllKernels && m_isolated_kernel &&
-       item.type == ItemModel::Type::Intensity)
-    {
-        passes = item.parent_info.kernel == m_isolated_kernel;
-    }
-    return passes;
+    RecomputeVisibility();
 }
 
 void
@@ -1176,17 +1288,7 @@ Roofline::ToggleBandwidthIsolation(
     {
         m_isolated_bandwidth = bandwidth;
     }
-}
-
-bool
-Roofline::BandwidthPassesIsolation(const ItemModel& item) const
-{
-    bool passes = true;
-    if(m_isolated_bandwidth && item.type == ItemModel::Type::CeilingBandwidth)
-    {
-        passes = item.subtype.bandwidth == m_isolated_bandwidth.value();
-    }
-    return passes;
+    RecomputeVisibility();
 }
 
 }  // namespace View

--- a/src/view/src/compute/rocprofvis_compute_roofline.h
+++ b/src/view/src/compute/rocprofvis_compute_roofline.h
@@ -96,6 +96,8 @@ private:
         std::vector<size_t> item_indices;
     };
 
+    // Always-visible horizontal filter toolbar drawn above the plot.
+    void RenderToolbar();
     void RenderMenus(ImVec2 region, ImVec2 plot_pos, ImVec2 plot_size,
                      const ImGuiStyle& style, const ImPlotStyle& plot_style,
                      bool& item_hovered);

--- a/src/view/src/compute/rocprofvis_compute_roofline.h
+++ b/src/view/src/compute/rocprofvis_compute_roofline.h
@@ -111,6 +111,9 @@ private:
     // Whether an item survives the active kernel isolation (non-intensity
     // items, and everything outside AllKernels mode, always pass).
     bool KernelPassesIsolation(const ItemModel& item) const;
+    void ToggleBandwidthIsolation(
+        rocprofvis_controller_roofline_ceiling_bandwidth_type_t bandwidth);
+    bool BandwidthPassesIsolation(const ItemModel& item) const;
 
     // Internal models...
     std::vector<ItemModel>   m_items;
@@ -135,6 +138,8 @@ private:
     const KernelInfo*     m_kernel;
     uint32_t              m_requested_kernel_id;
     const KernelInfo*     m_isolated_kernel;
+    std::optional<rocprofvis_controller_roofline_ceiling_bandwidth_type_t>
+        m_isolated_bandwidth;
     bool                  m_options_changed;
     bool                  m_plot_zoom_enabled;
     std::optional<size_t> m_hovered_item_idx;

--- a/src/view/src/compute/rocprofvis_compute_roofline.h
+++ b/src/view/src/compute/rocprofvis_compute_roofline.h
@@ -142,6 +142,8 @@ private:
     const KernelInfo*     m_isolated_kernel;
     std::optional<rocprofvis_controller_roofline_ceiling_bandwidth_type_t>
         m_isolated_bandwidth;
+    // Set when Custom toggles diverge visibility from the dropdown selections.
+    bool                  m_custom_visibility;
     bool                  m_options_changed;
     bool                  m_plot_zoom_enabled;
     std::optional<size_t> m_hovered_item_idx;

--- a/src/view/src/compute/rocprofvis_compute_roofline.h
+++ b/src/view/src/compute/rocprofvis_compute_roofline.h
@@ -101,31 +101,31 @@ private:
                      bool& item_hovered);
     void PlotHoverIdx();
     void ApplyPreset(PresetModel::Type type);
-    // Kernel intensity dots exist per memory level; this decides whether a
-    // given item survives the active memory-peak filter (non-intensity items
-    // always pass).
-    bool IntensityMatchesMemoryFilter(const ItemModel& item) const;
-    // Isolate a single kernel's dots in the workload roofline. Clicking the
-    // same kernel again clears isolation and restores the whole workload.
+    // Recompute every item's visibility from the active preset and the
+    // intensity/kernel/bandwidth filters. The chart, legend, and hover read
+    // visibility; the Options menu always lists the full data set.
+    void RecomputeVisibility();
     void ToggleKernelIsolation(const KernelInfo* kernel);
-    // Whether an item survives the active kernel isolation (non-intensity
-    // items, and everything outside AllKernels mode, always pass).
-    bool KernelPassesIsolation(const ItemModel& item) const;
     void ToggleBandwidthIsolation(
         rocprofvis_controller_roofline_ceiling_bandwidth_type_t bandwidth);
-    bool BandwidthPassesIsolation(const ItemModel& item) const;
 
     // Internal models...
     std::vector<ItemModel>   m_items;
     std::vector<PresetModel> m_presets;
+    // Filter options actually present in the workload (non-empty only).
+    std::vector<rocprofvis_controller_roofline_kernel_intensity_type_t>
+        m_available_intensities;
+    std::vector<rocprofvis_controller_roofline_ceiling_bandwidth_type_t>
+        m_available_bandwidths;
 
     // User options...
-    bool           m_show_menus;
-    MenusMode      m_menus_mode;
-    MenusPlacement m_menus_placement;
-    bool           m_scale_intensity;
-    float          m_line_thickness;
-    // Which memory level's kernel intensity dots to show. nullopt = all levels.
+    bool               m_show_menus;
+    MenusMode          m_menus_mode;
+    MenusPlacement     m_menus_placement;
+    bool               m_scale_intensity;
+    float              m_line_thickness;
+    PresetModel::Type  m_active_preset;
+    // Selected filters. nullopt = show all of that category.
     std::optional<rocprofvis_controller_roofline_kernel_intensity_type_t>
         m_memory_peak_filter;
 

--- a/src/view/src/compute/rocprofvis_compute_roofline.h
+++ b/src/view/src/compute/rocprofvis_compute_roofline.h
@@ -105,6 +105,12 @@ private:
     // given item survives the active memory-peak filter (non-intensity items
     // always pass).
     bool IntensityMatchesMemoryFilter(const ItemModel& item) const;
+    // Isolate a single kernel's dots in the workload roofline. Clicking the
+    // same kernel again clears isolation and restores the whole workload.
+    void ToggleKernelIsolation(const KernelInfo* kernel);
+    // Whether an item survives the active kernel isolation (non-intensity
+    // items, and everything outside AllKernels mode, always pass).
+    bool KernelPassesIsolation(const ItemModel& item) const;
 
     // Internal models...
     std::vector<ItemModel>   m_items;
@@ -128,6 +134,7 @@ private:
     bool                  m_kernel_changed;
     const KernelInfo*     m_kernel;
     uint32_t              m_requested_kernel_id;
+    const KernelInfo*     m_isolated_kernel;
     bool                  m_options_changed;
     bool                  m_plot_zoom_enabled;
     std::optional<size_t> m_hovered_item_idx;

--- a/src/view/src/compute/rocprofvis_compute_roofline.h
+++ b/src/view/src/compute/rocprofvis_compute_roofline.h
@@ -101,6 +101,10 @@ private:
                      bool& item_hovered);
     void PlotHoverIdx();
     void ApplyPreset(PresetModel::Type type);
+    // Kernel intensity dots exist per memory level; this decides whether a
+    // given item survives the active memory-peak filter (non-intensity items
+    // always pass).
+    bool IntensityMatchesMemoryFilter(const ItemModel& item) const;
 
     // Internal models...
     std::vector<ItemModel>   m_items;
@@ -112,6 +116,9 @@ private:
     MenusPlacement m_menus_placement;
     bool           m_scale_intensity;
     float          m_line_thickness;
+    // Which memory level's kernel intensity dots to show. nullopt = all levels.
+    std::optional<rocprofvis_controller_roofline_kernel_intensity_type_t>
+        m_memory_peak_filter;
 
     // Internal state...
     bool                  m_workload_changed;


### PR DESCRIPTION
## Motivation

The roofline shows every kernel's dot for every memory level plus all
bandwidth ceilings at once, which is noisy and takes many clicks to pare
down. This PR adds single-click ways to focus the view; they compose and
don't change the default.

## Technical Details

All in `src/view/src/compute/rocprofvis_compute_roofline.{h,cpp}`:

1. **Kernel-intensity filter** – Options dropdown (All / HBM / L2 / L1 / LDS)
   limits kernel dots to one memory level.
2. **Kernel isolation** – click a kernel's dot or legend row to show only that
   kernel; click again to restore all.
3. **Bandwidth-peak isolation** – click a bandwidth row or its plot line to show
   only that peak; the legend keeps all rows and highlights the active one.

Filters apply to the plot, legend, and hover; plot clicks use a drag check so
panning isn't treated as a click; state resets on workload change.