### PR TITLE
Fix JobSystem 

### DIFF
--- a/src/controller/src/rocprofvis_controller_job_system.cpp
+++ b/src/controller/src/rocprofvis_controller_job_system.cpp
@@ -28,53 +28,43 @@ Job::~Job()
 
 void Job::Execute()
 {
-    m_result = m_function(m_future);
+    rocprofvis_result_t result = m_function(m_future);
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_result = result;
+    }
     m_condition_variable.notify_all();
 }
 
 void Job::Cancel()
 {
-    m_result = kRocProfVisResultCancelled;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_result = kRocProfVisResultCancelled;
+    }
     m_condition_variable.notify_all();
 }
 
 rocprofvis_result_t Job::GetResult() const
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     return m_result;
 }
 
 rocprofvis_result_t Job::Wait(float timeout)
 {
-    rocprofvis_result_t result = kRocProfVisResultUnknownError;
-    if(m_result == kRocProfVisResultPending)
+    std::unique_lock<std::mutex> lock(m_mutex);
+    if(timeout == FLT_MAX)
     {
-        if(timeout == FLT_MAX)
-        {
-            std::unique_lock<std::mutex> lock(m_mutex);
-            m_condition_variable.wait(lock);
-            result = kRocProfVisResultSuccess;
-        }
-        else
-        {
-            std::unique_lock<std::mutex> lock(m_mutex);
-            std::chrono::microseconds    time =
-                std::chrono::microseconds(uint64_t(timeout * 1000000.0));
-            std::cv_status status = m_condition_variable.wait_for(lock, time);
-            if(status == std::cv_status::timeout)
-            {
-                result = kRocProfVisResultTimeout;
-            }
-            else
-            {
-                result = kRocProfVisResultSuccess;
-            }
-        }
+        m_condition_variable.wait(
+            lock, [this]() { return m_result != kRocProfVisResultPending; });
+        return kRocProfVisResultSuccess;
     }
-    else
-    {
-        result = kRocProfVisResultSuccess;
-    }
-    return result;
+    std::chrono::microseconds time =
+        std::chrono::microseconds(uint64_t(timeout * 1000000.0));
+    bool done = m_condition_variable.wait_for(
+        lock, time, [this]() { return m_result != kRocProfVisResultPending; });
+    return done ? kRocProfVisResultSuccess : kRocProfVisResultTimeout;
 }
 
 JobSystem JobSystem::s_self;

--- a/src/controller/src/rocprofvis_controller_job_system.h
+++ b/src/controller/src/rocprofvis_controller_job_system.h
@@ -34,7 +34,7 @@ public:
 
 private:
     JobFunction m_function;
-    std::mutex m_mutex;
+    mutable std::mutex m_mutex;
     std::condition_variable m_condition_variable;
     rocprofvis_result_t m_result;
     Future* m_future;

--- a/src/controller/tests/rocprofvis_controller_system_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_system_tests.cpp
@@ -3,11 +3,13 @@
 
 #include "rocprofvis_c_interface.h"
 #include "rocprofvis_controller.h"
+#include "rocprofvis_controller_job_system.h"
 #include "rocprofvis_core.h"
 #include "system/rocprofvis_controller_event.h"
 #include "system/rocprofvis_controller_mem_mgmt.h"
 #include "system/rocprofvis_controller_segment.h"
 #include <algorithm>
+#include <atomic>
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cfloat>
@@ -3214,4 +3216,96 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
         spdlog::info("Free Controller");
         rocprofvis_controller_free(m_controller);
     }
+}
+
+// Regression coverage for the JobSystem Job::Wait primitive (lost-wakeup /
+// spurious-wakeup / m_result data race fix). The Job is exercised directly so
+// the tests target the synchronization primitive rather than the full async
+// pipeline. A null Future is passed because these job bodies never touch it.
+TEST_CASE("JobSystem Job blocking wait overlaps completion")
+{
+    using RocProfVis::Controller::Future;
+    using RocProfVis::Controller::Job;
+
+    // Race a blocking Wait(FLT_MAX) against Execute() finishing after a short,
+    // jittered delay, repeated many times to reliably hit the check-then-block
+    // window that previously produced a lost-wakeup hang. Each iteration must
+    // return Success and never hang (run under TSan to also catch the race).
+    const int iterations = 2000;
+    for(int i = 0; i < iterations; ++i)
+    {
+        int jitter_us = i % 7;
+        Job job(
+            [jitter_us](Future*) -> rocprofvis_result_t {
+                if(jitter_us > 0)
+                {
+                    std::this_thread::sleep_for(std::chrono::microseconds(jitter_us));
+                }
+                return kRocProfVisResultSuccess;
+            },
+            nullptr);
+
+        std::thread worker([&job]() { job.Execute(); });
+
+        rocprofvis_result_t result = job.Wait(FLT_MAX);
+        REQUIRE(result == kRocProfVisResultSuccess);
+
+        worker.join();
+        REQUIRE(job.GetResult() == kRocProfVisResultSuccess);
+    }
+}
+
+TEST_CASE("JobSystem Job cancel-then-wait teardown")
+{
+    using RocProfVis::Controller::Future;
+    using RocProfVis::Controller::Job;
+
+    // Queued job that never runs: Cancel() then a blocking Wait() must return
+    // immediately (result is no longer Pending) with the cancelled result
+    // recorded.
+    SECTION("cancelled queued job")
+    {
+        Job job([](Future*) { return kRocProfVisResultSuccess; }, nullptr);
+        job.Cancel();
+        REQUIRE(job.Wait(FLT_MAX) == kRocProfVisResultSuccess);
+        REQUIRE(job.GetResult() == kRocProfVisResultCancelled);
+    }
+
+    // Actively-running job: mirror the data-provider cleanup ordering where a
+    // blocking wait overlaps a job that is still running. Wait must observe
+    // completion and return without hanging or freeing a live job.
+    SECTION("running job then blocking wait")
+    {
+        const int iterations = 500;
+        for(int i = 0; i < iterations; ++i)
+        {
+            Job job(
+                [](Future*) {
+                    std::this_thread::sleep_for(std::chrono::microseconds(50));
+                    return kRocProfVisResultSuccess;
+                },
+                nullptr);
+
+            std::thread worker([&job]() { job.Execute(); });
+            REQUIRE(job.Wait(FLT_MAX) == kRocProfVisResultSuccess);
+            worker.join();
+            REQUIRE(job.GetResult() == kRocProfVisResultSuccess);
+        }
+    }
+}
+
+TEST_CASE("JobSystem Job polling contract unchanged")
+{
+    using RocProfVis::Controller::Future;
+    using RocProfVis::Controller::Job;
+
+    // While still Pending, an immediate poll (timeout == 0) must return Timeout
+    // without blocking.
+    Job job([](Future*) { return kRocProfVisResultSuccess; }, nullptr);
+    REQUIRE(job.Wait(0.0f) == kRocProfVisResultTimeout);
+
+    // Once resolved, the same poll must report Success.
+    job.Execute();
+    REQUIRE(job.Wait(0.0f) == kRocProfVisResultSuccess);
+    REQUIRE(job.GetResult() == kRocProfVisResultSuccess);
 }

--- a/src/controller/tests/rocprofvis_controller_system_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_system_tests.cpp
@@ -15,8 +15,10 @@
 #include <cfloat>
 #include <chrono>
 #include <filesystem>
+#include <memory>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 std::string g_input_file = "sample/trace_70b_1024_32.rpd";
 
@@ -3308,4 +3310,89 @@ TEST_CASE("JobSystem Job polling contract unchanged")
     job.Execute();
     REQUIRE(job.Wait(0.0f) == kRocProfVisResultSuccess);
     REQUIRE(job.GetResult() == kRocProfVisResultSuccess);
+}
+
+// Lost-wakeup stress test for Job::Wait(FLT_MAX). Races many worker/waiter
+// pairs at once to reproduce the rare CI hang (seen most on the arm64 macOS
+// runner, occasionally on the few-core Windows runner):
+//   * unfixed code -> a lost wakeup eventually parks a waiter forever, wedging
+//     the join() below (the exact hang CI hits); kill the process to confirm.
+//   * fixed code   -> always runs to completion and passes.
+// Heavy oversubscription forces a waiter to be preempted between the unlocked
+// m_result read and cv.wait (as on few-core runners); the simultaneous release
+// gate with no delay maximizes the odds the worker's unlocked notify_all()
+// lands in that window (which weak-ordering arm64 exposes most readily).
+TEST_CASE("JobSystem Job lost-wakeup stress repro")
+{
+    using RocProfVis::Controller::Future;
+    using RocProfVis::Controller::Job;
+
+    const unsigned hw = std::max(2u, std::thread::hardware_concurrency());
+    // Oversubscribe: many more runnable threads than cores so the scheduler
+    // frequently preempts a waiter mid-Wait, mimicking the few-core CI runners.
+    // Round count is kept modest so the fixed branch finishes quickly; on the
+    // unfixed branch the very first lost wakeup wedges the run, so more rounds
+    // only cost time on the (already-correct) fixed branch. Bump `rounds` if
+    // you need a longer soak to reproduce on a strongly-ordered x86 box.
+    const int pairs  = int(hw) * 4;
+    const int rounds = 1000;
+
+    for(int r = 0; r < rounds; ++r)
+    {
+        std::vector<std::unique_ptr<Job>> jobs;
+        jobs.reserve(size_t(pairs));
+        for(int p = 0; p < pairs; ++p)
+        {
+            jobs.emplace_back(std::make_unique<Job>(
+                [](Future*) { return kRocProfVisResultSuccess; }, nullptr));
+        }
+
+        std::atomic<bool>        go{ false };
+        std::atomic<int>         successes{ 0 };
+        std::vector<std::thread> threads;
+        threads.reserve(size_t(pairs) * 2);
+
+        spdlog::info("Round {}: Launching {} jobs", r, pairs);
+
+        for(int p = 0; p < pairs; ++p)
+        {
+            Job* job = jobs[size_t(p)].get();
+
+            // Worker: on release, immediately publish + notify (no delay), so
+            // the notify can race straight into the waiter's (A)->(B) window.
+            threads.emplace_back([job, &go]() {
+                while(!go.load(std::memory_order_acquire))
+                {
+                }
+                job->Execute();
+            });
+
+            // Waiter: on release, block on the CV with no timeout. On unfixed
+            // code a lost wakeup parks this thread forever. NOTE: Catch2 macros
+            // are not thread-safe, so results are tallied atomically here and
+            // asserted on the main thread after the join.
+            threads.emplace_back([job, &go, &successes]() {
+                while(!go.load(std::memory_order_acquire))
+                {
+                }
+                if(job->Wait(FLT_MAX) == kRocProfVisResultSuccess)
+                {
+                    successes.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+        }
+
+        // Thundering-herd release: all pairs race at once to maximize churn.
+        go.store(true, std::memory_order_release);
+
+        // On unfixed code this join() is where the process wedges forever once
+        // any waiter has lost its wakeup -- exactly the CI hang being chased.
+        spdlog::info("Joining threads");
+        for(std::thread& t : threads)
+        {
+            t.join();
+        }
+
+        REQUIRE(successes.load(std::memory_order_relaxed) == pairs);
+    }
 }

--- a/src/controller/tests/rocprofvis_controller_system_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_system_tests.cpp
@@ -3335,7 +3335,7 @@ TEST_CASE("JobSystem Job lost-wakeup stress repro")
     // only cost time on the (already-correct) fixed branch. Bump `rounds` if
     // you need a longer soak to reproduce on a strongly-ordered x86 box.
     const int pairs  = int(hw) * 4;
-    const int rounds = 1000;
+    const int rounds = 500;
 
     for(int r = 0; r < rounds; ++r)
     {


### PR DESCRIPTION
## Motivation

Fix JobSystem `Job::Wait` lost/spurious wakeup + `m_result` data race.

This should fix the intermittent test failures (timeouts) that occur on our CI system, most commonly on Mac OS builds.

## Technical Details

The shared `JobSystem` primitive
(`src/controller/src/rocprofvis_controller_job_system.cpp`) had a latent
concurrency bug in `Job::Wait`/`Execute`/`Cancel`. `Wait()` read the shared
result outside the lock and blocked on a condition variable with no predicate,
while `Execute()`/`Cancel()` wrote the result and called `notify_all()` without
holding the lock. This produced three defects:

1. **Lost wakeup → hang** — a job completing in the window between the unlocked
   `m_result` read and `cv.wait` loses the notification; the `FLT_MAX` blocking
   wait then parks forever (the rare CI hang, most frequent on the arm64 macOS
   runner).
2. **Spurious wakeup → premature "success" → use-after-free** — the
   predicate-less `cv.wait` could return success while the job was still
   running, letting a caller free a live job.
3. **Data race on `m_result`** — non-atomic, unsynchronized read/write (UB;
   benign on x86, not portable).

### Changes

- **`Execute()`** computes the result outside the lock, then publishes
  `m_result` under `m_mutex` before `notify_all()` (job bodies stay
  unserialized).
- **`Cancel()`** writes `m_result` under the lock before `notify_all()`.
- **`Wait()`** takes the lock up front and waits on a predicate
  (`m_result != Pending`) for both the `FLT_MAX` and timed branches; preserves
  the `timeout == 0` immediate-poll contract.
- **`GetResult()`** reads under the lock (`m_mutex` made `mutable`).

## Tests

Added to `rocprofvis_controller_system_tests.cpp`:

- Blocking-wait-overlaps-completion, cancel-then-wait teardown, and
  polling-contract regression tests.
- A lost-wakeup stress reproducer that races many oversubscribed worker/waiter
  pairs — hangs on unfixed code, passes on fixed.
