### PR TITLE
Fix remote file browser SSH auth hang; centralize auth prompts

### DIFF
--- a/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
+++ b/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
@@ -707,7 +707,10 @@ namespace Controller
             {
                 spdlog::info("[ssh] no password supplied; prompting UI for password");
                 PromptRequest req;
-                req.instruction = "Password";
+                std::string target = user.empty() ? connection->GetHost()
+                                                   : user + "@" + connection->GetHost();
+                req.instruction = target.empty() ? std::string("Enter your password")
+                                                 : "Enter the password for " + target;
                 PromptItem item;
                 item.text = "Password: ";
                 item.echo = false;  // mask input

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -958,10 +958,10 @@ void ProfilerLauncherDialog::RenderRemotePopups()
         m_remote_file_browser->Render();
     }
 
+    // Auth prompts / host-key requests are rendered centrally for every live
+    // session by AppWindow (RenderSshAuthModals); this dialog only owns the
+    // download-progress popup below.
     SshSession* ssh_session = m_orchestrator.GetRemoteSshSession();
-
-    // Auth prompts / host-key requests.
-    RenderSshAuthModal(ssh_session);
 
     // Open the download-progress popup once the workflow enters the download
     // phase. Whether/when individual FileStat progress snapshots arrive is

--- a/src/view/src/remote/rocprofvis_remote_file_browser.cpp
+++ b/src/view/src/remote/rocprofvis_remote_file_browser.cpp
@@ -4,6 +4,8 @@
 #include "rocprofvis_remote_file_browser.h"
 #include "rocprofvis_core_string_utils.h"
 #include "rocprofvis_settings_manager.h"
+#include "rocprofvis_ssh_auth_modal.h"
+#include "rocprofvis_ssh_session.h"
 #include "rocprofvis_utils.h"
 #include "widgets/rocprofvis_widget.h"
 #include "widgets/rocprofvis_gui_helpers.h"
@@ -293,6 +295,16 @@ void RemoteFileBrowser::Render()
     if (!m_show_remote_filesystem_popup)
     {
         return;
+    }
+
+    // This browser is itself a modal popup, so its own SSH session's auth prompt
+    // must be rendered nested inside it (see below) to stack above it.
+    if (m_orchestrator)
+    {
+        if (SshSession* browser_session = m_orchestrator->GetSession())
+        {
+            browser_session->SetAuthModalSelfManaged(true);
+        }
     }
 
     const bool dir_mode = (m_mode == PickMode::kDirectory);
@@ -1042,6 +1054,15 @@ void RemoteFileBrowser::Render()
         else if (open_pressed)
         {
             commit_selection();
+        }
+
+        // Nested SSH auth prompt for this browser's own session. 
+        if (m_orchestrator)
+        {
+            if (SshSession* browser_session = m_orchestrator->GetSession())
+            {
+                RenderSshAuthModal(browser_session);
+            }
         }
 
         if (m_should_close_browser_popup)

--- a/src/view/src/remote/rocprofvis_ssh_auth_modal.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_auth_modal.cpp
@@ -13,7 +13,6 @@
 #include <spdlog/spdlog.h>
 
 #include <cfloat>
-#include <cstring>
 #include <vector>
 
 namespace RocProfVis
@@ -53,20 +52,33 @@ void RenderAuthHeaderCard(const char* id, const char* title, const char* subtitl
 }
 }  // namespace
 
-void RenderSshAuthModal(SshSession* ssh_session)
+bool RenderSshAuthModal(SshSession* ssh_session)
 {
-    if (!ssh_session) return;
+    if (!ssh_session)
+    {
+        return false;
+    }
 
     // ---- kbdint ----
     if (auto req = ssh_session->GetPromptRequest()->ConsumeIfUpdated())
     {
         auto& st = KbdintForFrame();
+        // The kbdint answer buffer is a single process-wide scratch shared by
+        // every session's prompt (only one auth modal is ever visible at a
+        // time). Reconcile it to the current request's prompt count every frame
+        // - not just when opening - so a buffer left over from a different
+        // session's prompt can never be too small to index below. Only reassign
+        // when the count changes, so typed input is preserved across frames for
+        // the same prompt.
+        if(st.answers.size() != req->prompts.size())
+        {
+            st.answers.assign(req->prompts.size(), "");
+        }
         // Gate on ImGui's own popup state rather than a persistent latch: if the
         // op is torn down without a button press, the un-Begin'd modal
         // auto-closes and a fresh request re-opens it (no wedged latch).
         if(!ImGui::IsPopupOpen("SSH Authentication"))
         {
-            st.answers.assign(req->prompts.size(), "");
             spdlog::info("[ssh-ui] kbdint pending: {} prompt(s); calling OpenPopup",
                          req->prompts.size());
             ImGui::OpenPopup("SSH Authentication");
@@ -118,14 +130,9 @@ void RenderSshAuthModal(SshSession* ssh_session)
                     ImGui::SetNextItemWidth(-FLT_MIN);
                     ImGuiInputTextFlags flags =
                         req->prompts[i].echo ? 0 : ImGuiInputTextFlags_Password;
-                    char buf[256];
-                    std::strncpy(buf, st.answers[i].c_str(), sizeof(buf));
-                    buf[sizeof(buf) - 1] = '\0';
                     std::string id = "##kbd" + std::to_string(i);
-                    if(ImGui::InputText(id.c_str(), buf, sizeof(buf), flags))
-                    {
-                        st.answers[i] = buf;
-                    }
+                    // Writes directly into the answer string via CallbackResize.
+                    InputTextString(id.c_str(), st.answers[i], flags);
                 }
             }
             EndPanelCard();
@@ -164,7 +171,7 @@ void RenderSshAuthModal(SshSession* ssh_session)
         }
         ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
         popup_style.PopStyles();
-        return;
+        return true;
     }
 
     // ---- host key confirmation ----
@@ -299,12 +306,43 @@ void RenderSshAuthModal(SshSession* ssh_session)
         }
         ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
         popup_style.PopStyles();
-        return;
+        return true;
     }
 
     // No pending request; reset latched modal state in case a previous
     // one was just dismissed.
     KbdintForFrame() = {};
+    return false;
+}
+
+void RenderSshAuthModals()
+{
+    // A session whose owner renders its own auth modal nested inside its own
+    // modal window (e.g. the remote file browser) must not be rendered here:
+    // opening a second top-level modal would dismiss the owner's modal. While
+    // any such self-managed modal is up, defer every other session's prompt too
+    // for the same reason - requests are level-held, so they resurface once the
+    // owning modal closes.
+    for (SshSession* session : SshSession::ActiveSessions())
+    {
+        if (session->IsAuthModalSelfManaged())
+        {
+            return;
+        }
+    }
+
+    // ImGui modals are exclusive and each request is level-held (the flag
+    // persists until the user submits/cancels), so render at most one session's
+    // modal per frame; other pending sessions are serviced on later frames once
+    // this one resolves. This also keeps the shared popup IDs / kbdint input
+    // buffer owned by a single session at a time.
+    for (SshSession* session : SshSession::ActiveSessions())
+    {
+        if (RenderSshAuthModal(session))
+        {
+            break;
+        }
+    }
 }
 
 }  // namespace View

--- a/src/view/src/remote/rocprofvis_ssh_auth_modal.h
+++ b/src/view/src/remote/rocprofvis_ssh_auth_modal.h
@@ -10,14 +10,24 @@ namespace View
 
 	class SshSession;
 
-// Polls the bridge each frame; if a kbdint prompt or host-key request is
-// pending, opens the corresponding modal popup. Submits the user's response
-// (or Cancel) back to the bridge.
+// Polls one session's bridge; if a kbdint prompt or host-key request is
+// pending, opens the corresponding modal popup and submits the user's response
+// (or Cancel) back to the bridge. Returns true when a request was pending (and
+// its modal rendered) this frame, so callers can serialize across sessions.
 //
-// Must be called every frame from AppWindow::Render(), after any user-
-// initiated SSH connection has been started.
+// Handle every *blocking* SshBridge rendezvous here (currently the kbdint
+// prompt and host-key confirmation); non-blocking status popups (download
+// progress, execution output) stay with the workflow that initiated them.
+	bool RenderSshAuthModal(SshSession* ssh_session);
 
-	void RenderSshAuthModal(SshSession* ssh_session);
+// Renders the auth modal for every live SshSession (see
+// SshSession::ActiveSessions), so any session - including one owned privately
+// by a widget such as the remote file browser - has its blocking prompts drawn
+// and can never wedge its worker. Renders at most one session's modal per frame
+// (ImGui modals are exclusive and each request is level-held until answered).
+//
+// Must be called every frame from AppWindow::Render(), at top-level popup scope.
+	void RenderSshAuthModals();
 
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/remote/rocprofvis_ssh_session.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_session.cpp
@@ -6,19 +6,26 @@
 #include "rocprofvis_controller.h"
 #include "rocprofvis_core_assert.h"
 #include "rocprofvis_events.h"
+#include <algorithm>
 #include <cfloat>
 #include <memory>
+#include <vector>
 
 namespace RocProfVis
 {
 namespace View
 {
 
-    size_t SshSession::s_active_session_count = 0;
+    std::vector<SshSession*> SshSession::s_active_sessions;
 
     size_t SshSession::ActiveSessionCount()
     {
-        return s_active_session_count;
+        return s_active_sessions.size();
+    }
+
+    const std::vector<SshSession*>& SshSession::ActiveSessions()
+    {
+        return s_active_sessions;
     }
 
     SshSession::SshSession(std::shared_ptr<RemoteUri> uri)
@@ -29,7 +36,7 @@ namespace View
     , m_last_result(kRocProfVisResultSuccess)
     , m_auth_request_built(false)
     {
-        ++s_active_session_count;
+        s_active_sessions.push_back(this);
         if (m_uri)
         {
             AllocateConnection(m_uri->GetRemoteHostString().c_str(), m_uri->GetRemotePortInt());
@@ -38,9 +45,11 @@ namespace View
     }
 
     SshSession::~SshSession() {
-        if (s_active_session_count > 0)
+        std::vector<SshSession*>::iterator it =
+            std::find(s_active_sessions.begin(), s_active_sessions.end(), this);
+        if (it != s_active_sessions.end())
         {
-            --s_active_session_count;
+            s_active_sessions.erase(it);
         }
         // If a phase is still in flight, the worker may still be using the
         // connection. Hand the connection-free to the monitor so it runs only

--- a/src/view/src/remote/rocprofvis_ssh_session.h
+++ b/src/view/src/remote/rocprofvis_ssh_session.h
@@ -11,6 +11,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace RocProfVis
 {
@@ -49,6 +50,13 @@ namespace View
         // thread only (sessions are created/destroyed by UI code).
         static size_t ActiveSessionCount();
 
+        // All live SshSession objects, in creation order. Backs the centralized
+        // SSH auth-modal render path: AppWindow renders the blocking prompt /
+        // host-key modal for every session each frame, so no session (including
+        // one owned privately by a widget like the remote file browser) can
+        // wedge its worker waiting on a prompt nobody draws. Main thread only.
+        static const std::vector<SshSession*>& ActiveSessions();
+
         // Phase starters. Return the monitor operation id, or 0 on failure.
         uint64_t StartConnect();
         uint64_t StartAuthenticate();
@@ -72,6 +80,15 @@ namespace View
         {
             return reinterpret_cast<rocprofvis_controller_connection_t*>(m_connection);
         }
+
+        // When true, this session's auth prompt / host-key modal is rendered by
+        // its owner nested inside the owner's own modal window (e.g. the remote
+        // file browser, which is itself a BeginPopupModal). The centralized
+        // RenderSshAuthModals path must then skip this session - opening a second
+        // top-level modal for it would dismiss the owner's modal - and defer any
+        // other session's prompt until the owning modal closes. Main thread only.
+        void SetAuthModalSelfManaged(bool self_managed) { m_auth_modal_self_managed = self_managed; }
+        bool IsAuthModalSelfManaged() const { return m_auth_modal_self_managed; }
 
         rocprofvis_result_t SubmitPromptResponses(std::vector<std::string>& responses);
         rocprofvis_result_t CancelRequest();
@@ -128,13 +145,16 @@ namespace View
         // (it persists while a request is pending), so this guards against
         // rebuilding the request every frame.
         bool                m_auth_request_built;
+        // See SetAuthModalSelfManaged: owner renders this session's auth modal
+        // nested, so the centralized path skips it.
+        bool                m_auth_modal_self_managed = false;
         // Pending command/paths captured for the active operation so the start
         // happens lazily inside BeginOperation's start_fn.
         std::string         m_pending_command;
         std::string         m_pending_remote_path;
         std::string         m_pending_local_path;
 
-        static size_t       s_active_session_count;
+        static std::vector<SshSession*> s_active_sessions;
     };
 
 

--- a/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
@@ -386,10 +386,11 @@ SshTestDialog::Render()
         }
     }
 
-    // Auth prompts / host-key requests, and download/output popups. The download
-    // and output popups are suppressed while the browser is open so the recursive
-    // search (which reuses the execute path) does not open the stdout popup.
-    RenderSshAuthModal(m_orchestrator ? m_orchestrator->GetSession() : nullptr);
+    // Auth prompts / host-key requests are rendered centrally for every live
+    // session by AppWindow (RenderSshAuthModals), so this dialog only owns its
+    // download/output popups. Those are suppressed while the browser is open so
+    // the recursive search (which reuses the execute path) does not open the
+    // stdout popup.
     if (!m_file_browser.IsOpen())
     {
         RenderProgressPopup();

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -810,6 +810,14 @@ AppWindow::Render()
     RenderDebugOuput();
 #endif
 
+#ifdef ROCPROFVIS_ENABLE_REMOTE
+    // Centralized SSH auth prompts: draw the blocking prompt / host-key modal
+    // for every live session (including connections owned privately by widgets
+    // such as the remote file browser), so no session can wedge its worker
+    // waiting on a prompt that no dialog happens to render.
+    RenderSshAuthModals();
+#endif
+
     // render notifications last
     NotificationManager::GetInstance().Render();
 


### PR DESCRIPTION
## Issue

The remote file browser owns its own SSH session, but auth prompts were only rendered for the launch/test dialogs' sessions, so browsing a host that needs a password (or unknown host-key) wedged the worker on a prompt nobody drew.

<img width="702" height="342" alt="image" src="https://github.com/user-attachments/assets/c1d74919-c2a1-47c1-8220-5f9a466ca8e5" />

To Reproduce - remove the password (use blank) from the connection setup dialog, forcing password prompt when using connection.  Then browse remote file system with this passwordless connection (session).

## FIxes

- SshSession: add a live-session registry (ActiveSessions) alongside the existing count.
- ssh_auth_modal: RenderSshAuthModal now returns whether it rendered; add RenderSshAuthModals() which draws the prompt for every live session (one per frame). AppWindow calls it centrally; drop the per-dialog calls.
- RemoteFileBrowser is itself a modal, so it renders its own session's auth nested inside its popup and marks the session self-managed; the central path skips it (and defers others) so a second top-level modal can't dismiss the browser.
- Reconcile the shared kbdint answer buffer to the request's prompt count every frame, fixing an out-of-range crash when switching between sessions' prompts.
- Replace the deprecated fixed-buffer strncpy/InputText with the std::string-backed InputTextString helper.
- ssh_client: password fallback prompt now shows "Enter the password for user@host" instead of a redundant second "Password" line.

