### PR TITLE
View: add RenderScheduler to drive lazy-render wake-ups

### DIFF
--- a/src/view/src/rocprofvis_appmonitor.cpp
+++ b/src/view/src/rocprofvis_appmonitor.cpp
@@ -4,6 +4,7 @@
 #include "rocprofvis_appmonitor.h"
 #include "rocprofvis_event_manager.h"
 #include "rocprofvis_controller.h"
+#include "rocprofvis_render_scheduler.h"
 
 #include <spdlog/spdlog.h>
 
@@ -318,6 +319,12 @@ AppMonitor::Update()
         {
             ++it;
         }
+    }
+
+    // Operations resolve on background threads; keep rendering to poll them.
+    if(HasPendingOperations())
+    {
+        RenderScheduler::GetInstance().RequestRender();
     }
 }
 

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -15,6 +15,7 @@
 #include "rocprofvis_project.h"
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_hotkey_manager.h"
+#include "rocprofvis_render_scheduler.h"
 #include "rocprofvis_settings_panel.h"
 #include "rocprofvis_version.h"
 #include "rocprofvis_utils.h"
@@ -635,6 +636,8 @@ AppWindow::RequestExitIfProviderCleanupsComplete()
 void
 AppWindow::Update()
 {
+    RenderScheduler::GetInstance().BeginFrame();
+
 #ifdef ROCPROFVIS_HAVE_NATIVE_FILE_DIALOG
     UpdateNativeFileDialog();
 #endif
@@ -671,17 +674,16 @@ AppWindow::Update()
 bool
 AppWindow::WantsContinuousRender()
 {
-    if(!m_provider_cleanup_jobs.empty() || m_disable_app_interaction ||
-       m_shutdown_requested || EventManager::GetInstance()->HasPendingEvents() ||
-       NotificationManager::GetInstance().HasActiveNotifications() ||
-       AppMonitor::GetInstance()->HasPendingOperations())
+    // Animations and render-driven work push a frame request from their own
+    // Update()/Render() via RenderScheduler, so no per-feature branch is needed
+    // here.
+    if(RenderScheduler::GetInstance().WantsRender())
     {
         return true;
     }
 
-    // Keep rendering while the log viewer is open and unpaused so new log lines
-    // appear live instead of waiting for the next input to wake the idle loop.
-    if(LogViewer::GetInstance()->IsLiveUpdating())
+    if(!m_provider_cleanup_jobs.empty() || m_disable_app_interaction ||
+       m_shutdown_requested || EventManager::GetInstance()->HasPendingEvents())
     {
         return true;
     }
@@ -694,19 +696,9 @@ AppWindow::WantsContinuousRender()
     }
 #endif
 
-    // Only the active tab renders, so only it can have render-driven work with
-    // no events/requests yet (e.g. the timeline loading-timer debounce).
-    Project* current_project = GetCurrentProject();
-    if(current_project)
-    {
-        RootView* current_root =
-            dynamic_cast<RootView*>(current_project->GetView().get());
-        if(current_root && current_root->WantsContinuousRender())
-        {
-            return true;
-        }
-    }
-
+    // Polled across every tab (not just the active one) so background loads keep
+    // progressing. kLoading spans the whole load even when the pending count
+    // briefly hits zero between stages, so we never freeze mid-load.
     bool wants_render = false;
     for(const auto& [id, project] : m_projects)
     {
@@ -714,8 +706,6 @@ AppWindow::WantsContinuousRender()
         if(root_view)
         {
             DataProvider* data_provider = root_view->GetDataProvider();
-            // kLoading spans the whole initial load, even when the pending count
-            // briefly drops to zero between stages, so we never freeze mid-load.
             if(data_provider &&
                (data_provider->GetState() == ProviderState::kLoading ||
                 data_provider->GetPendingRequestCount() > 0))

--- a/src/view/src/rocprofvis_render_scheduler.h
+++ b/src/view/src/rocprofvis_render_scheduler.h
@@ -1,0 +1,68 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <chrono>
+
+namespace RocProfVis
+{
+namespace View
+{
+
+// Keeps the lazy render loop awake. The app renders on demand and otherwise
+// sleeps until the next OS event; anything that animates or does render-driven
+// work asks here to keep rendering. Requests are level-triggered and
+// self-expiring, so there is nothing to release:
+//   - RequestRender(): render one more frame; call every frame while active.
+//   - RequestRenderUntil() / RequestRenderForSeconds(): render until a deadline.
+class RenderScheduler
+{
+public:
+    using Clock     = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    static RenderScheduler& GetInstance()
+    {
+        static RenderScheduler instance;
+        return instance;
+    }
+
+    RenderScheduler(const RenderScheduler&) = delete;
+    void operator=(const RenderScheduler&)  = delete;
+
+    void RequestRender() { m_render_requested = true; }
+
+    // Extends, never shortens, the current deadline.
+    void RequestRenderUntil(TimePoint deadline)
+    {
+        if(deadline > m_render_deadline)
+        {
+            m_render_deadline = deadline;
+        }
+    }
+
+    void RequestRenderForSeconds(double seconds)
+    {
+        RequestRenderUntil(Clock::now() + std::chrono::duration_cast<Clock::duration>(
+                                              std::chrono::duration<double>(seconds)));
+    }
+
+    // Clears the per-frame request; call once at the top of each frame. The
+    // deadline is not cleared - it expires on its own.
+    void BeginFrame() { m_render_requested = false; }
+
+    bool WantsRender() const
+    {
+        return m_render_requested || Clock::now() < m_render_deadline;
+    }
+
+private:
+    RenderScheduler() = default;
+
+    bool      m_render_requested = false;
+    TimePoint m_render_deadline{};
+};
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/rocprofvis_root_view.h
+++ b/src/view/src/rocprofvis_root_view.h
@@ -29,10 +29,6 @@ public:
 
     virtual DataProvider* GetDataProvider() { return nullptr; };
 
-    // True when this view has render-driven work that emits no events yet (e.g.
-    // a debounce timer that only advances while rendering). Drives lazy render.
-    virtual bool WantsContinuousRender() const { return false; }
-
 protected:
     void RenderLoadingScreen(const char* progress_label);
 

--- a/src/view/src/rocprofvis_timeline_selection.cpp
+++ b/src/view/src/rocprofvis_timeline_selection.cpp
@@ -3,6 +3,7 @@
 #include "rocprofvis_timeline_selection.h"
 #include "rocprofvis_data_provider.h"
 #include "rocprofvis_event_manager.h"
+#include "rocprofvis_render_scheduler.h"
 #include "rocprofvis_track_item.h"
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
@@ -333,7 +334,8 @@ TimelineSelection::IsHighlightPersistent(uint64_t event_id) const
 void
 TimelineSelection::UpdateHighlightTimer()
 {
-    auto now = std::chrono::steady_clock::now();
+    auto now                  = std::chrono::steady_clock::now();
+    bool has_active_transient = false;
     for(auto it = m_highlighted_events.begin(); it != m_highlighted_events.end();)
     {
         if(it->second.persistent)
@@ -349,8 +351,15 @@ TimelineSelection::UpdateHighlightTimer()
         }
         else
         {
+            has_active_transient = true;
             ++it;
         }
+    }
+
+    // A transient highlight pulses every frame; keep rendering while it lasts.
+    if(has_active_transient)
+    {
+        RenderScheduler::GetInstance().RequestRender();
     }
 }
 

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -12,6 +12,7 @@
 #include "rocprofvis_font_manager.h"
 #include "rocprofvis_line_track_item.h"
 #include "rocprofvis_measurement_controller.h"
+#include "rocprofvis_render_scheduler.h"
 #include "rocprofvis_settings_manager.h"
 #include "rocprofvis_timeline_selection.h"
 #include "rocprofvis_timeline_track_options.h"
@@ -1153,6 +1154,14 @@ TimelineView::Update()
             }
         }
     }
+
+    // Loading-timer debounce, sticky-note drag and reorder auto-scroll advance
+    // only while rendering; keep rendering while any is active.
+    if(m_loading_timer.IsRunning() || m_dragged_sticky_id != INVALID_STICKY_ID ||
+       m_reorder_auto_scrolling)
+    {
+        RenderScheduler::GetInstance().RequestRender();
+    }
 }
 
 void
@@ -1669,17 +1678,6 @@ TimelineView::RenderGraphView()
     TrackItem::SetSidebarSize(m_sidebar_size);
     ImGui::EndChild();
     ImGui::PopStyleColor();
-}
-
-bool
-TimelineView::WantsContinuousRender() const
-{
-    // The loading-timer debounce gates track-data requests and only advances
-    // while rendering, so keep rendering until it expires or the load stalls.
-    // Anchor drag and reorder auto-scroll both advance per frame, so keep
-    // rendering while either is active.
-    return m_loading_timer.IsRunning() || m_dragged_sticky_id != INVALID_STICKY_ID ||
-           m_reorder_auto_scrolling;
 }
 
 bool

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -88,7 +88,6 @@ public:
     ~TimelineView();
     virtual void                                     Render() override;
     void                                             Update() override;
-    bool                                             WantsContinuousRender() const;
     void                                             MakeGraphView();
     void                                             ResetView();
     void                                             DestroyGraphs();

--- a/src/view/src/rocprofvis_trace_view.h
+++ b/src/view/src/rocprofvis_trace_view.h
@@ -53,10 +53,6 @@ public:
 
     void Update() override;
     void Render() override;
-    bool WantsContinuousRender() const override
-    {
-        return m_timeline_view && m_timeline_view->WantsContinuousRender();
-    }
 
     bool LoadTrace(rocprofvis_controller_t* controller, const std::string& file_path);
 

--- a/src/view/src/widgets/rocprofvis_log_viewer.cpp
+++ b/src/view/src/widgets/rocprofvis_log_viewer.cpp
@@ -8,6 +8,7 @@
 #include "rocprofvis_core.h"
 #include "rocprofvis_gui_helpers.h"
 #include "rocprofvis_notification_manager.h"
+#include "rocprofvis_render_scheduler.h"
 
 #include <algorithm>
 #include <cctype>
@@ -287,6 +288,12 @@ LogViewer::Poll()
         rocprofvis_core_get_log_entries_ex(this, &LogViewer::ProcessEntry);
     }
     SaveUiState();
+
+    // Keep rendering while live so new log lines appear promptly.
+    if(IsLiveUpdating())
+    {
+        RenderScheduler::GetInstance().RequestRender();
+    }
 }
 
 bool

--- a/src/view/src/widgets/rocprofvis_notification_manager.cpp
+++ b/src/view/src/widgets/rocprofvis_notification_manager.cpp
@@ -4,6 +4,7 @@
 #include "rocprofvis_notification_manager.h"
 #include "imgui.h"
 #include "rocprofvis_gui_helpers.h"
+#include "rocprofvis_render_scheduler.h"
 #include "rocprofvis_settings_manager.h"
 #include <algorithm>
 
@@ -155,6 +156,12 @@ NotificationManager::ClearAll()
 void
 NotificationManager::Render()
 {
+    // Toasts fade over time; keep rendering while any is present.
+    if(!m_notifications.empty())
+    {
+        RenderScheduler::GetInstance().RequestRender();
+    }
+
     const ImGuiViewport* viewport = ImGui::GetMainViewport();
     const ImGuiStyle&    style    = ImGui::GetStyle();
     ImVec2               base_pos = viewport->WorkPos;

--- a/src/view/src/widgets/rocprofvis_notification_manager.h
+++ b/src/view/src/widgets/rocprofvis_notification_manager.h
@@ -73,9 +73,6 @@ public:
     void ClearAll();
     void Render();
 
-    // True while any toast is showing/fading (keeps lazy render animating it).
-    bool HasActiveNotifications() const { return !m_notifications.empty(); }
-
 private:
     NotificationManager();
 


### PR DESCRIPTION
## Motivation

The lazy render loop sleeps when idle, and every feature that animates had to
add its own branch to `WantsContinuousRender()` to stay awake. That doesn't
scale and is easy to miss — the pulsing event highlight was never wired in, so
it stuttered when the mouse was idle.

## Technical Details

Add `RenderScheduler`: subsystems push a frame request from their own per-frame
code instead of `WantsContinuousRender()` polling each one. Requests are
level-triggered and self-expiring (nothing to release).

- Fix idle pulse stutter (`TimelineSelection` requests frames while a transient
  highlight is active).
- Migrate notifications, log viewer, app monitor, and timeline
  (loading debounce / sticky drag / reorder) to push; remove
  `RootView`/`TraceView`/`TimelineView::WantsContinuousRender()`.
- `WantsContinuousRender()` now checks `RenderScheduler` plus the foundational
  conditions and the cross-tab data-provider load poll.