### PR TITLE
Remote Profiling Mini Fixes

### DIFF
--- a/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
+++ b/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
@@ -1184,36 +1184,26 @@ namespace Controller
         return Result::Success;
     }
 
-    // libssh2's SFTP teardown entry points can report EAGAIN on a non-blocking
-    // session, so releasing a handle needs the same bounded socket wait as the
-    // rest of the transport. These guards own that retry loop, so a listing
-    // releases its handles exactly once on every exit path - success, error or
-    // cancel - without repeating the teardown at each return. WaitSocket is
-    // injected as a function pointer to keep the guards local to this file.
-    using wait_socket_fn_t = bool (*)(SshConnection*);
-
+    // SFTP teardown can report EAGAIN on a non-blocking session, so closing a
+    // handle needs the same bounded socket wait as the rest of the transport.
     class SftpSessionGuard
     {
     public:
-        SftpSessionGuard(SshConnection* connection, LIBSSH2_SFTP* sftp,
-                         wait_socket_fn_t wait_socket)
+        SftpSessionGuard(SshConnection* connection, LIBSSH2_SFTP* sftp)
             : m_connection(connection)
             , m_sftp(sftp)
-            , m_wait_socket(wait_socket)
         {
         }
 
         ~SftpSessionGuard()
         {
-            if (m_sftp != nullptr)
+            while (m_sftp != nullptr &&
+                   libssh2_sftp_shutdown(m_sftp) == LIBSSH2_ERROR_EAGAIN)
             {
-                while (libssh2_sftp_shutdown(m_sftp) == LIBSSH2_ERROR_EAGAIN)
+                if (!SshClient::WaitSocket(m_connection))
                 {
-                    if (!m_wait_socket(m_connection))
-                    {
-                        spdlog::warn("[ssh] network failure while shutting down SFTP");
-                        break;
-                    }
+                    spdlog::warn("[ssh] network failure while shutting down SFTP");
+                    break;
                 }
             }
         }
@@ -1222,33 +1212,28 @@ namespace Controller
         SftpSessionGuard& operator=(const SftpSessionGuard&) = delete;
 
     private:
-        SshConnection*   m_connection;
-        LIBSSH2_SFTP*    m_sftp;
-        wait_socket_fn_t m_wait_socket;
+        SshConnection* m_connection;
+        LIBSSH2_SFTP*  m_sftp;
     };
 
     class SftpDirGuard
     {
     public:
-        SftpDirGuard(SshConnection* connection, LIBSSH2_SFTP_HANDLE* dir,
-                     wait_socket_fn_t wait_socket)
+        SftpDirGuard(SshConnection* connection, LIBSSH2_SFTP_HANDLE* dir)
             : m_connection(connection)
             , m_dir(dir)
-            , m_wait_socket(wait_socket)
         {
         }
 
         ~SftpDirGuard()
         {
-            if (m_dir != nullptr)
+            while (m_dir != nullptr &&
+                   libssh2_sftp_closedir(m_dir) == LIBSSH2_ERROR_EAGAIN)
             {
-                while (libssh2_sftp_closedir(m_dir) == LIBSSH2_ERROR_EAGAIN)
+                if (!SshClient::WaitSocket(m_connection))
                 {
-                    if (!m_wait_socket(m_connection))
-                    {
-                        spdlog::warn("[ssh] network failure while closing remote directory");
-                        break;
-                    }
+                    spdlog::warn("[ssh] network failure while closing remote directory");
+                    break;
                 }
             }
         }
@@ -1259,7 +1244,6 @@ namespace Controller
     private:
         SshConnection*       m_connection;
         LIBSSH2_SFTP_HANDLE* m_dir;
-        wait_socket_fn_t     m_wait_socket;
     };
 
     SshClient::Result SshClient::BrowseRemoteDirectory(SshConnection * connection, const std::string& path, Future* future)
@@ -1281,9 +1265,8 @@ namespace Controller
             return Result::SessionError;
         }
 
-        // Non-blocking for the whole listing (init included) so every libssh2
-        // EAGAIN is followed by a bounded WaitSocket and the cancel flag is
-        // checked each iteration - matches the channel flow in ExecuteCommand.
+        // Non-blocking from the start so the init loop below can honour a cancel
+        // instead of stalling inside libssh2.
         libssh2_session_set_blocking(connection->GetSession(), 0);
 
         // --- Init SFTP (non-blocking) ---
@@ -1309,11 +1292,8 @@ namespace Controller
             }
         }
 
-        // The loop above only falls through with a live handle, so from here on
-        // the guard shuts the session down on whichever path leaves the function.
-        SftpSessionGuard sftp_guard(connection, sftp, &SshClient::WaitSocket);
+        SftpSessionGuard sftp_guard(connection, sftp);
 
-        // --- Open the directory (non-blocking) ---
         LIBSSH2_SFTP_HANDLE* dir = nullptr;
         while ((dir = libssh2_sftp_opendir(sftp, path.c_str())) == nullptr)
         {
@@ -1335,7 +1315,7 @@ namespace Controller
             }
         }
 
-        SftpDirGuard dir_guard(connection, dir, &SshClient::WaitSocket);
+        SftpDirGuard dir_guard(connection, dir);
 
         constexpr size_t SFTP_NAME_BUFFER_SIZE = 512;
         char mem[SFTP_NAME_BUFFER_SIZE];
@@ -1389,7 +1369,7 @@ namespace Controller
 
             if (rc == 0)
             {
-                break;  // end of listing
+                break;  // done
             }
             if (rc < 0)
             {

--- a/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
+++ b/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
@@ -1253,6 +1253,23 @@ namespace Controller
             }
         }
 
+        // The opendir loop can exit with a null handle when it was cancelled or
+        // broke on a network error. There is nothing to list in that case, so
+        // skip realpath / readdir / closedir (all of which would dereference the
+        // null handle) and shut the SFTP session down cleanly.
+        if (dir == NULL)
+        {
+            while (libssh2_sftp_shutdown(sftp) == LIBSSH2_ERROR_EAGAIN)
+            {
+                if (!WaitSocket(connection))
+                {
+                    break;
+                }
+            }
+            return IsCancelRequested(connection, future) ? Result::Cancelled
+                                                         : Result::SessionError;
+        }
+
         constexpr size_t SFTP_NAME_BUFFER_SIZE = 512;
         char mem[SFTP_NAME_BUFFER_SIZE];
         LIBSSH2_SFTP_ATTRIBUTES attrs;
@@ -1264,12 +1281,15 @@ namespace Controller
             char real_path[SFTP_NAME_BUFFER_SIZE];
             int  real_rc;
             while ((real_rc = libssh2_sftp_realpath(sftp, path.c_str(), real_path,
-                                                    sizeof(real_path) - 1)) == LIBSSH2_ERROR_EAGAIN) {
-                if (IsCancelRequested(connection, future) || !WaitSocket(connection)) {
+                                                    sizeof(real_path) - 1)) == LIBSSH2_ERROR_EAGAIN)
+            {
+                if (IsCancelRequested(connection, future) || !WaitSocket(connection))
+                {
                     break;
                 }
             }
-            if (real_rc > 0) {
+            if (real_rc > 0)
+            {
                 connection->GetSshBridge()->SetResolvedPath(
                     std::string(real_path, static_cast<size_t>(real_rc)));
             }

--- a/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
+++ b/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
@@ -1184,6 +1184,84 @@ namespace Controller
         return Result::Success;
     }
 
+    // libssh2's SFTP teardown entry points can report EAGAIN on a non-blocking
+    // session, so releasing a handle needs the same bounded socket wait as the
+    // rest of the transport. These guards own that retry loop, so a listing
+    // releases its handles exactly once on every exit path - success, error or
+    // cancel - without repeating the teardown at each return. WaitSocket is
+    // injected as a function pointer to keep the guards local to this file.
+    using wait_socket_fn_t = bool (*)(SshConnection*);
+
+    class SftpSessionGuard
+    {
+    public:
+        SftpSessionGuard(SshConnection* connection, LIBSSH2_SFTP* sftp,
+                         wait_socket_fn_t wait_socket)
+            : m_connection(connection)
+            , m_sftp(sftp)
+            , m_wait_socket(wait_socket)
+        {
+        }
+
+        ~SftpSessionGuard()
+        {
+            if (m_sftp != nullptr)
+            {
+                while (libssh2_sftp_shutdown(m_sftp) == LIBSSH2_ERROR_EAGAIN)
+                {
+                    if (!m_wait_socket(m_connection))
+                    {
+                        spdlog::warn("[ssh] network failure while shutting down SFTP");
+                        break;
+                    }
+                }
+            }
+        }
+
+        SftpSessionGuard(const SftpSessionGuard&) = delete;
+        SftpSessionGuard& operator=(const SftpSessionGuard&) = delete;
+
+    private:
+        SshConnection*   m_connection;
+        LIBSSH2_SFTP*    m_sftp;
+        wait_socket_fn_t m_wait_socket;
+    };
+
+    class SftpDirGuard
+    {
+    public:
+        SftpDirGuard(SshConnection* connection, LIBSSH2_SFTP_HANDLE* dir,
+                     wait_socket_fn_t wait_socket)
+            : m_connection(connection)
+            , m_dir(dir)
+            , m_wait_socket(wait_socket)
+        {
+        }
+
+        ~SftpDirGuard()
+        {
+            if (m_dir != nullptr)
+            {
+                while (libssh2_sftp_closedir(m_dir) == LIBSSH2_ERROR_EAGAIN)
+                {
+                    if (!m_wait_socket(m_connection))
+                    {
+                        spdlog::warn("[ssh] network failure while closing remote directory");
+                        break;
+                    }
+                }
+            }
+        }
+
+        SftpDirGuard(const SftpDirGuard&) = delete;
+        SftpDirGuard& operator=(const SftpDirGuard&) = delete;
+
+    private:
+        SshConnection*       m_connection;
+        LIBSSH2_SFTP_HANDLE* m_dir;
+        wait_socket_fn_t     m_wait_socket;
+    };
+
     SshClient::Result SshClient::BrowseRemoteDirectory(SshConnection * connection, const std::string& path, Future* future)
     {
         std::string output;
@@ -1203,72 +1281,61 @@ namespace Controller
             return Result::SessionError;
         }
 
-
-        LIBSSH2_SFTP* sftp = NULL;
+        // Non-blocking for the whole listing (init included) so every libssh2
+        // EAGAIN is followed by a bounded WaitSocket and the cancel flag is
+        // checked each iteration - matches the channel flow in ExecuteCommand.
+        libssh2_session_set_blocking(connection->GetSession(), 0);
 
         // --- Init SFTP (non-blocking) ---
-        while ((sftp = libssh2_sftp_init(connection->GetSession())) == NULL) {
+        LIBSSH2_SFTP* sftp = nullptr;
+        while ((sftp = libssh2_sftp_init(connection->GetSession())) == nullptr)
+        {
             int err = libssh2_session_last_errno(connection->GetSession());
-
-            if (err == LIBSSH2_ERROR_EAGAIN) {
-                if (!WaitSocket(connection))
-                {
-                    output = "Network failure while initializing SFTP";
-                    connection->GetSshBridge()->SaveError(output);
-                    break;
-                }
-            } else {
+            if (err != LIBSSH2_ERROR_EAGAIN)
+            {
                 output = "SFTP init failed: " + std::to_string(err);
                 connection->GetSshBridge()->SaveError(output);
                 return Result::SessionError;
             }
-            if (IsCancelRequested(connection, future))
+            if (!WaitSocket(connection))
             {
-                break;
-            }
-        }
-
-        LIBSSH2_SFTP_HANDLE* dir = NULL;
-
-        libssh2_session_set_blocking(connection->GetSession(), 0);
-
-
-        while ((dir = libssh2_sftp_opendir(sftp, path.c_str())) == NULL) {
-            if (libssh2_session_last_errno(connection->GetSession()) == LIBSSH2_ERROR_EAGAIN) {
-                if (!WaitSocket(connection))
-                {
-                    output = "Network failure while opening remote directory";
-                    connection->GetSshBridge()->SaveError(output);
-                    break;
-                }
-            } else {
-                output = "Unable to open directory ";
+                output = "Network failure while initializing SFTP";
                 connection->GetSshBridge()->SaveError(output);
-                libssh2_sftp_shutdown(sftp);
                 return Result::SessionError;
             }
             if (IsCancelRequested(connection, future))
             {
-                break;
+                return Result::Cancelled;
             }
         }
 
-        // The opendir loop can exit with a null handle when it was cancelled or
-        // broke on a network error. There is nothing to list in that case, so
-        // skip realpath / readdir / closedir (all of which would dereference the
-        // null handle) and shut the SFTP session down cleanly.
-        if (dir == NULL)
+        // The loop above only falls through with a live handle, so from here on
+        // the guard shuts the session down on whichever path leaves the function.
+        SftpSessionGuard sftp_guard(connection, sftp, &SshClient::WaitSocket);
+
+        // --- Open the directory (non-blocking) ---
+        LIBSSH2_SFTP_HANDLE* dir = nullptr;
+        while ((dir = libssh2_sftp_opendir(sftp, path.c_str())) == nullptr)
         {
-            while (libssh2_sftp_shutdown(sftp) == LIBSSH2_ERROR_EAGAIN)
+            if (libssh2_session_last_errno(connection->GetSession()) != LIBSSH2_ERROR_EAGAIN)
             {
-                if (!WaitSocket(connection))
-                {
-                    break;
-                }
+                output = "Unable to open directory " + path;
+                connection->GetSshBridge()->SaveError(output);
+                return Result::SessionError;
             }
-            return IsCancelRequested(connection, future) ? Result::Cancelled
-                                                         : Result::SessionError;
+            if (!WaitSocket(connection))
+            {
+                output = "Network failure while opening remote directory";
+                connection->GetSshBridge()->SaveError(output);
+                return Result::SessionError;
+            }
+            if (IsCancelRequested(connection, future))
+            {
+                return Result::Cancelled;
+            }
         }
+
+        SftpDirGuard dir_guard(connection, dir, &SshClient::WaitSocket);
 
         constexpr size_t SFTP_NAME_BUFFER_SIZE = 512;
         char mem[SFTP_NAME_BUFFER_SIZE];
@@ -1295,78 +1362,61 @@ namespace Controller
             }
         }
 
-        while (true) {
-            int rc;
+        while (true)
+        {
             if (IsCancelRequested(connection, future))
             {
-                break;
+                return Result::Cancelled;
             }
 
-            do {
+            int rc;
+            do
+            {
                 // Reserve the final byte for the NUL terminator written below:
                 // libssh2_sftp_readdir returns the filename length capped at the
                 // buffer size we pass, so bounding it to size-1 keeps mem[rc]
                 // in range even when the name would otherwise fill the buffer.
                 rc = libssh2_sftp_readdir(dir, mem, sizeof(mem) - 1, &attrs);
 
-                if (rc == LIBSSH2_ERROR_EAGAIN) {
-                    if (!WaitSocket(connection))
-                    {
-                        output = "Network failure while reading remote directory content";
-                        connection->GetSshBridge()->SaveError(output);
-                        break;
-                    }
+                if (rc == LIBSSH2_ERROR_EAGAIN && !WaitSocket(connection))
+                {
+                    output = "Network failure while reading remote directory content";
+                    connection->GetSshBridge()->SaveError(output);
+                    return Result::ReadError;
                 }
 
             } while (rc == LIBSSH2_ERROR_EAGAIN);
 
-            if (rc > 0) {
-                mem[rc] = '\0';
-
-                if (strcmp(mem, ".") == 0 || strcmp(mem, "..") == 0)
-                    continue;
-
-                int isDir = 0;
-                if (attrs.flags & LIBSSH2_SFTP_ATTR_PERMISSIONS) {
-                    isDir = LIBSSH2_SFTP_S_ISDIR(attrs.permissions);
-                }
-
-                connection->GetSshBridge()->SetFileInfo(mem, attrs.filesize, attrs.mtime, isDir);
-
+            if (rc == 0)
+            {
+                break;  // end of listing
             }
-            else if (rc == 0) {
-                break; // done
-            }
-            else {
+            if (rc < 0)
+            {
                 output = "Directory read error";
                 connection->GetSshBridge()->SaveError(output);
-                break;
+                return Result::ReadError;
             }
-        }
 
+            mem[rc] = '\0';
 
-        while (libssh2_sftp_closedir(dir) == LIBSSH2_ERROR_EAGAIN) {
-            if (!WaitSocket(connection))
+            if (strcmp(mem, ".") == 0 || strcmp(mem, "..") == 0)
             {
-                output = "Network failure while closing remote directory";
-                connection->GetSshBridge()->SaveError(output);
-                break;
+                continue;
             }
-        }
 
-        while (libssh2_sftp_shutdown(sftp) == LIBSSH2_ERROR_EAGAIN) {
-            if (!WaitSocket(connection))
+            int is_dir = 0;
+            if (attrs.flags & LIBSSH2_SFTP_ATTR_PERMISSIONS)
             {
-                output = "Network failure while shutting down SFTP";
-                connection->GetSshBridge()->SaveError(output);
-                break;
+                is_dir = LIBSSH2_SFTP_S_ISDIR(attrs.permissions);
             }
-        }
 
+            connection->GetSshBridge()->SetFileInfo(mem, attrs.filesize, attrs.mtime, is_dir);
+        }
 
         if (IsCancelRequested(connection, future))
         {
-            return SshClient::Result::Cancelled;
+            return Result::Cancelled;
         }
 
         return Result::Success;

--- a/src/controller/src/remote/rocprofvis_controller_ssh_client.h
+++ b/src/controller/src/remote/rocprofvis_controller_ssh_client.h
@@ -143,6 +143,10 @@ namespace Controller
         static bool IsCancelRequested(SshConnection * connection, Future* future);
         static void SetKeepAlive(SshConnection * connection, int interval_seconds);
 
+        // Waits (bounded) for the session socket to be ready in the direction
+        // libssh2 is blocked on. False on timeout or socket error.
+        static bool WaitSocket(SshConnection* connection);
+
     private:
 
         static bool MethodListed(const char* methods, const char* needle);
@@ -163,7 +167,6 @@ namespace Controller
 
         static bool Reconnect(SshConnection* connection, Future* future);
         static socket_t CreateTcpConnection(const std::string& host, int port);
-        static bool WaitSocket(SshConnection* connection);
 
         std::vector<std::unique_ptr<SshConnection>> m_connections;
 

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -232,7 +232,8 @@ void StatusPill(const char* label, ImU32 bg_color)
     float        rnd = size.y * 0.5f;
 
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y), bg_color, rnd);
-    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), IM_COL32(255, 255, 255, 255), label);
+    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y),
+                SettingsManager::Get().GetColor(Colors::kTextOnAccent), label);
 
     ImGui::Dummy(size);
 }
@@ -294,7 +295,8 @@ bool ToggleSwitch(const char* label, bool* value)
 
     float  knob_x = bar_min.x + radius + t * (width - 2.0f * radius);
     ImVec2 knob_c(knob_x, bar_min.y + radius);
-    dl->AddCircleFilled(knob_c, radius - kToggleKnobInset, IM_COL32(255, 255, 255, 255));
+    dl->AddCircleFilled(knob_c, radius - kToggleKnobInset,
+                        settings.GetColor(Colors::kTextOnAccent));
 
     ImGui::PopID();
 
@@ -351,7 +353,10 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
     // Disabled only in remote mode without a remote-browse handler; local mode
     // and remote-with-handler both keep the button live.
     const bool exe_disabled = is_remote && !remote_browse_exe;
-    if (exe_disabled) ImGui::BeginDisabled();
+    if (exe_disabled)
+    {
+        ImGui::BeginDisabled();
+    }
     if (ImGui::Button("Browse##TargetExe", ImVec2(browse_w, 0)))
     {
         if (remote_browse_exe)
@@ -365,7 +370,10 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
                 [&target](std::string const& path) { target.executable = path; });
         }
     }
-    if (exe_disabled) ImGui::EndDisabled();
+    if (exe_disabled)
+    {
+        ImGui::EndDisabled();
+    }
 
     if (has_recent)
     {
@@ -426,7 +434,10 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
     }
     ImGui::SameLine();
     const bool out_disabled = is_remote && !remote_browse_out;
-    if (out_disabled) ImGui::BeginDisabled();
+    if (out_disabled)
+    {
+        ImGui::BeginDisabled();
+    }
     if (ImGui::Button("Browse##OutputDir", ImVec2(browse_w, 0)))
     {
         if (remote_browse_out)
@@ -440,7 +451,10 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
                 [&target](std::string const& path) { target.output_directory = path; });
         }
     }
-    if (out_disabled) ImGui::EndDisabled();
+    if (out_disabled)
+    {
+        ImGui::EndDisabled();
+    }
 
     ImGui::Spacing();
     if (ImGui::Checkbox("Open the trace automatically when profiling finishes",
@@ -588,7 +602,7 @@ bool RenderOutputConsole(
     float output_height = std::max(ImGui::GetContentRegionAvail().y - 30.0f, 60.0f);
 
     // Terminal-style panel: darker background, soft corners, monospaced text.
-    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 8.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, settings.GetDefaultStyle().ChildRounding);
     ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
     ImGui::BeginChild("OutputText", ImVec2(0, output_height), ImGuiChildFlags_Borders,
                       output_flags);

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -79,9 +79,8 @@ ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
     m_config.backend_payload = m_backends[0]->SaveSettings();
 
 #ifdef ROCPROFVIS_ENABLE_REMOTE
-    // Must precede LoadFromSettings(): rehydrating the remembered profile
-    // validates its connection ref against this store, which would reject every
-    // ref while the store is still empty.
+    // Before LoadFromSettings() so it can validate the saved profile's
+    // connection ref against the store.
     m_connection_store.Load();
 #endif
 
@@ -992,10 +991,8 @@ void ProfilerLauncherDialog::RenderRemotePopups()
         }
     }
 
-    // Render the shared, theme-styled download progress modal. It closes as soon
-    // as the download phase ends (completed, failed, or the session was torn
-    // down); relying on the final "downloaded == size" snapshot is unreliable for
-    // small/fast transfers.
+    // Closing on the download phase ending (rather than on downloaded == size)
+    // avoids hanging open when the final progress snapshot never arrives.
     RenderRemoteDownloadPopup("Remote Trace Download", m_remote_last_progress.name.c_str(),
                               m_remote_last_progress.downloaded, m_remote_last_progress.size,
                               !downloading, m_remote_show_progress_popup);
@@ -1534,15 +1531,12 @@ void ProfilerLauncherDialog::LoadFromSettings()
                 }
             }
 #ifdef ROCPROFVIS_ENABLE_REMOTE
-            // Only rebind the remote section when the profile references a
-            // connection that still exists; a stale ref (deleted connection) is
-            // left unbound rather than silently mapped to another connection.
-            // Mirrors the combo-select load path in RenderToolbar().
+            // A ref to a since-deleted connection is left unbound rather than
+            // remapped onto whichever connection is selected.
             if (!m_config.ssh_connection_ref.empty() &&
                 m_connection_store.Get(m_config.ssh_connection_ref) != nullptr)
             {
                 m_selected_connection_id = m_config.ssh_connection_ref;
-                ApplySelectedConnection();
             }
 #endif
         }

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -78,11 +78,17 @@ ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
     m_backends[0]->LoadSettings(jt::Json());
     m_config.backend_payload = m_backends[0]->SaveSettings();
 
+#ifdef ROCPROFVIS_ENABLE_REMOTE
+    // Must precede LoadFromSettings(): rehydrating the remembered profile
+    // validates its connection ref against this store, which would reject every
+    // ref while the store is still empty.
+    m_connection_store.Load();
+#endif
+
     LoadFromSettings();
     RefreshExecutionCache();
 
 #ifdef ROCPROFVIS_ENABLE_REMOTE
-    m_connection_store.Load();
     if(m_connection_store.Get(m_selected_connection_id) == nullptr && !m_connection_store.Empty())
     {
         m_selected_connection_id = m_connection_store.List().front().id;

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -240,25 +240,27 @@ void ProfilerLauncherDialog::RenderConfigureView()
     // Warnings from backend
     if (!warnings.empty())
     {
+        SettingsManager& settings = SettingsManager::Get();
         for (auto const& w : warnings)
         {
-            ImVec4 color;
+            Colors      color_id;
             const char* prefix;
             switch (w.level)
             {
                 case WarningMessage::kError:
-                    color = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
-                    prefix = "Error: ";
+                    color_id = Colors::kTextError;
+                    prefix   = "Error: ";
                     break;
                 case WarningMessage::kWarning:
-                    color = ImVec4(1.0f, 0.8f, 0.0f, 1.0f);
-                    prefix = "Warning: ";
+                    color_id = Colors::kTextWarning;
+                    prefix   = "Warning: ";
                     break;
                 default:
-                    color = ImVec4(0.4f, 0.7f, 1.0f, 1.0f);
-                    prefix = "Hint: ";
+                    color_id = Colors::kAccent;
+                    prefix   = "Hint: ";
                     break;
             }
+            ImVec4 color = ImGui::ColorConvertU32ToFloat4(settings.GetColor(color_id));
             ImGui::TextColored(color, "%s%s", prefix, w.text.c_str());
         }
     }
@@ -984,90 +986,13 @@ void ProfilerLauncherDialog::RenderRemotePopups()
         }
     }
 
-    // Mirrors SshTestDialog::RenderProgressPopup so the remote download popup
-    // looks identical whether launched from the trace opener or the profiler.
-    if (m_remote_show_progress_popup)
-    {
-        SettingsManager&  settings = SettingsManager::GetInstance();
-        const ImGuiStyle& style    = ImGui::GetStyle();
-
-        PopUpStyle popup_style;
-        popup_style.PushPopupStyles();
-        popup_style.PushTitlebarColors();
-        popup_style.CenterPopup();
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
-        ImGui::SetNextWindowSize(ImVec2(440, 0));
-
-        if (ImGui::BeginPopupModal("Remote Trace Download", nullptr,
-            ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar))
-        {
-            const auto& fetch = m_remote_last_progress;
-            uint64_t    done  = fetch.downloaded;
-            uint64_t    total = fetch.size;
-
-            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                                ImVec2(style.ItemSpacing.x, 4.0f));
-
-            BeginPanelCard("##profiler_dl_header", PanelCardTone::kFrame,
-                           ImVec2(16.0f, 10.0f), true, &settings);
-            {
-                PanelIcon(ICON_ARROW_DOWN, Colors::kAccent, &settings);
-                ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
-                ImGui::BeginGroup();
-                ImGui::PushFont(nullptr,
-                                settings.GetFontManager().GetFontSize(FontSize::kMedLarge));
-                ImGui::TextUnformatted("Remote Download");
-                ImGui::PopFont();
-                ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
-                ImGui::TextUnformatted("Fetching the trace over SSH.");
-                ImGui::PopStyleColor();
-                ImGui::EndGroup();
-            }
-            EndPanelCard();
-
-            BeginPanelCard("##profiler_dl_body", PanelCardTone::kPanel,
-                           ImVec2(14.0f, 10.0f), true, &settings);
-            {
-                ImGui::TextWrapped("%s", fetch.name.c_str());
-                ImGui::Spacing();
-                if (total > 0)
-                {
-                    float frac = static_cast<float>(done) / static_cast<float>(total);
-                    if (frac > 1.0f) { frac = 1.0f; }
-                    std::string label = std::to_string(done / 1024) + " / " +
-                                        std::to_string(total / 1024) + " KiB";
-                    ImGui::ProgressBar(frac, ImVec2(-FLT_MIN, 0), label.c_str());
-                }
-                else
-                {
-                    PanelFieldLabel("Starting...", false, &settings);
-                }
-            }
-            EndPanelCard();
-
-            // Close as soon as the download phase ends (completed, failed, or the
-            // session was torn down). This avoids hanging open when the final
-            // "downloaded == size" snapshot never arrives for fast transfers.
-            if (!downloading)
-            {
-                ImGui::CloseCurrentPopup();
-                m_remote_show_progress_popup = false;
-            }
-
-            ImGui::PopStyleVar();  // ItemSpacing
-            ImGui::EndPopup();
-        }
-        else
-        {
-            // Popup not actually open (e.g. dismissed); clear our flag so it can
-            // be reopened on the next download.
-            m_remote_show_progress_popup = false;
-        }
-        ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
-        popup_style.PopStyles();
-    }
+    // Render the shared, theme-styled download progress modal. It closes as soon
+    // as the download phase ends (completed, failed, or the session was torn
+    // down); relying on the final "downloaded == size" snapshot is unreliable for
+    // small/fast transfers.
+    RenderRemoteDownloadPopup("Remote Trace Download", m_remote_last_progress.name.c_str(),
+                              m_remote_last_progress.downloaded, m_remote_last_progress.size,
+                              !downloading, m_remote_show_progress_popup);
 }
 #endif  // ROCPROFVIS_ENABLE_REMOTE
 
@@ -1097,12 +1022,18 @@ void ProfilerLauncherDialog::RenderButtonRow()
     bool valid      = readiness.empty();
     bool can_launch = state_ready && valid;
 
-    if (!can_launch) ImGui::BeginDisabled();
+    if (!can_launch)
+    {
+        ImGui::BeginDisabled();
+    }
     if (AccentButton("Launch Profiler", ImVec2(160, 0)))
     {
         OnLaunchClicked();
     }
-    if (!can_launch) ImGui::EndDisabled();
+    if (!can_launch)
+    {
+        ImGui::EndDisabled();
+    }
 
     // If a run is in flight or a previous run's output is available, let the
     // user jump straight to the focused run view.
@@ -1142,7 +1073,8 @@ void ProfilerLauncherDialog::RenderButtonRow()
         }
         else
         {
-            ImGui::TextColored(ImVec4(1.0f, 0.78f, 0.25f, 1.0f), "%s", readiness.c_str());
+            ImVec4 warn = ImGui::ColorConvertU32ToFloat4(settings.GetColor(Colors::kTextWarning));
+            ImGui::TextColored(warn, "%s", readiness.c_str());
         }
     }
 }
@@ -1596,9 +1528,15 @@ void ProfilerLauncherDialog::LoadFromSettings()
                 }
             }
 #ifdef ROCPROFVIS_ENABLE_REMOTE
-            if (!m_config.ssh_connection_ref.empty())
+            // Only rebind the remote section when the profile references a
+            // connection that still exists; a stale ref (deleted connection) is
+            // left unbound rather than silently mapped to another connection.
+            // Mirrors the combo-select load path in RenderToolbar().
+            if (!m_config.ssh_connection_ref.empty() &&
+                m_connection_store.Get(m_config.ssh_connection_ref) != nullptr)
             {
                 m_selected_connection_id = m_config.ssh_connection_ref;
+                ApplySelectedConnection();
             }
 #endif
         }

--- a/src/view/src/remote/rocprofvis_remote_file_browser.cpp
+++ b/src/view/src/remote/rocprofvis_remote_file_browser.cpp
@@ -730,7 +730,9 @@ void RemoteFileBrowser::Render()
                 {
                     m_selected_name = "..";
                     if (ImGui::IsMouseDoubleClicked(0))
+                    {
                         NavigateBrowserTo(posix_parent_path(m_browser_dir), true);
+                    }
                 }
                 const ImU32 c = parent_selected ? text_on_accent : accent;
                 ImGui::SameLine(0, 0);
@@ -793,9 +795,13 @@ void RemoteFileBrowser::Render()
                 {
                     m_selected_name = f.name;
                     if (!inert && IconMenuItem(ICON_OPEN, f.is_dir ? "Open folder" : "Open"))
+                    {
                         ActivateBrowserEntry(f);
+                    }
                     if (IconMenuItem(ICON_COPY, "Copy path"))
+                    {
                         ImGui::SetClipboardText(full_path.c_str());
+                    }
                     ImGui::EndPopup();
                 }
 

--- a/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
@@ -403,7 +403,10 @@ void
 SshTestDialog::RenderProgressPopup()
 {
     SshSession* ssh_session = m_orchestrator ? m_orchestrator->GetSession() : nullptr;
-    if(!ssh_session) return;
+    if(!ssh_session)
+    {
+        return;
+    }
 
     if(auto fetch = ssh_session->GetFileStat()->ConsumeIfUpdated())
     {
@@ -416,85 +419,12 @@ SshTestDialog::RenderProgressPopup()
         }
     }
 
-    if(m_show_progress_popup)
-    {
-        SettingsManager&  settings = SettingsManager::GetInstance();
-        const ImGuiStyle& style    = ImGui::GetStyle();
-
-        PopUpStyle popup_style;
-        popup_style.PushPopupStyles();
-        popup_style.PushTitlebarColors();
-        popup_style.CenterPopup();
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
-        ImGui::SetNextWindowSize(ImVec2(440, 0));
-
-        if(ImGui::BeginPopupModal("Remote Download", nullptr,
-            ImGuiWindowFlags_AlwaysAutoResize |
-            ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoTitleBar |
-            ImGuiWindowFlags_NoScrollbar))
-        {
-            const auto& fetch = m_last_progress;
-
-            uint64_t done  = fetch.downloaded;
-            uint64_t total = fetch.size;
-
-            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                                ImVec2(style.ItemSpacing.x, 4.0f));
-
-            BeginPanelCard("##remote_dl_header", PanelCardTone::kFrame, ImVec2(16.0f, 10.0f),
-                           true, &settings);
-            {
-                PanelIcon(ICON_ARROW_DOWN, Colors::kAccent, &settings);
-                ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
-                ImGui::BeginGroup();
-                ImGui::PushFont(nullptr,
-                                settings.GetFontManager().GetFontSize(FontSize::kMedLarge));
-                ImGui::TextUnformatted("Remote Download");
-                ImGui::PopFont();
-                ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
-                ImGui::TextUnformatted("Fetching the trace over SSH.");
-                ImGui::PopStyleColor();
-                ImGui::EndGroup();
-            }
-            EndPanelCard();
-
-            BeginPanelCard("##remote_dl_body", PanelCardTone::kPanel, ImVec2(14.0f, 10.0f),
-                           true, &settings);
-            {
-                ImGui::TextWrapped("%s", fetch.name.c_str());
-                ImGui::Spacing();
-                if(total > 0)
-                {
-                    float frac = static_cast<float>(done) / static_cast<float>(total);
-
-                    std::string label =
-                        std::to_string(done / 1024) + " / " +
-                        std::to_string(total / 1024) + " KiB";
-
-                    ImGui::ProgressBar(frac, ImVec2(-FLT_MIN, 0), label.c_str());
-                }
-                else
-                {
-                    PanelFieldLabel("Connecting...", false, &settings);
-                }
-            }
-            EndPanelCard();
-
-            if(total > 0 && done >= total)
-            {
-                ImGui::CloseCurrentPopup();
-                m_show_progress_popup = false;
-            }
-
-            ImGui::PopStyleVar();  // ItemSpacing
-            ImGui::EndPopup();
-        }
-
-        ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
-        popup_style.PopStyles();
-    }
+    // The download phase is done once every reported byte has arrived.
+    const bool finished =
+        m_last_progress.size > 0 && m_last_progress.downloaded >= m_last_progress.size;
+    RenderRemoteDownloadPopup("Remote Download", m_last_progress.name.c_str(),
+                              m_last_progress.downloaded, m_last_progress.size, finished,
+                              m_show_progress_popup);
 }
 
 void

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -28,6 +28,7 @@ constexpr std::array DARK_THEME_COLORS = {
     IM_COL32(0, 0, 0, 0),          // Colors::kTransparent
     IM_COL32(244, 96, 110, 255),   // Colors::kTextError
     IM_COL32(120, 220, 144, 255),  // Colors::kTextSuccess
+    IM_COL32(255, 199, 64, 255),   // Colors::kTextWarning
     IM_COL32(120, 162, 255, 220),  // Colors::kFlameChartColor
     IM_COL32(120, 130, 150, 32),   // Colors::kGridColor
     IM_COL32(142, 176, 236, 255),  // Colors::kGridRed
@@ -150,6 +151,7 @@ constexpr std::array LIGHT_THEME_COLORS = {
     IM_COL32(0, 0, 0, 0),          // Colors::kTransparent
     IM_COL32(214, 56, 64, 255),    // Colors::kTextError
     IM_COL32(36, 150, 82, 255),    // Colors::kTextSuccess
+    IM_COL32(176, 118, 0, 255),    // Colors::kTextWarning
     IM_COL32(88, 132, 245, 225),   // Colors::kFlameChartColor
     IM_COL32(140, 150, 170, 28),   // Colors::kGridColor
     IM_COL32(120, 162, 220, 255),  // Colors::kGridRed

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -86,6 +86,7 @@ enum class Colors
     kTransparent,
     kTextError,
     kTextSuccess,
+    kTextWarning,
     kFlameChartColor,
     kGridColor,
     kGridRed,

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -7,7 +7,9 @@
 #include "rocprofvis_utils.h"
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_notification_manager.h"
+#include "widgets/rocprofvis_widget.h"
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 
 namespace RocProfVis
@@ -652,6 +654,92 @@ AccentButton(const char* label, ImVec2 size, SettingsManager* settings)
     bool clicked = ImGui::Button(label, size);
     ImGui::PopStyleColor(4);
     return clicked;
+}
+
+void
+RenderRemoteDownloadPopup(const char* popup_id, const char* file_name,
+                          uint64_t downloaded, uint64_t total, bool finished,
+                          bool& show)
+{
+    if(!show)
+    {
+        return;
+    }
+
+    SettingsManager&  settings = SettingsManager::GetInstance();
+    const ImGuiStyle& style    = ImGui::GetStyle();
+
+    PopUpStyle popup_style;
+    popup_style.PushPopupStyles();
+    popup_style.PushTitlebarColors();
+    popup_style.CenterPopup();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
+    ImGui::SetNextWindowSize(ImVec2(440.0f, 0.0f));
+
+    if(ImGui::BeginPopupModal(popup_id, nullptr,
+                              ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove |
+                                  ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar))
+    {
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(style.ItemSpacing.x, 4.0f));
+
+        BeginPanelCard("##remote_dl_header", PanelCardTone::kFrame, ImVec2(16.0f, 10.0f), true,
+                       &settings);
+        {
+            PanelIcon(ICON_ARROW_DOWN, Colors::kAccent, &settings);
+            ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+            ImGui::BeginGroup();
+            ImGui::PushFont(nullptr, settings.GetFontManager().GetFontSize(FontSize::kMedLarge));
+            ImGui::TextUnformatted("Remote Download");
+            ImGui::PopFont();
+            ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
+            ImGui::TextUnformatted("Fetching the trace over SSH.");
+            ImGui::PopStyleColor();
+            ImGui::EndGroup();
+        }
+        EndPanelCard();
+
+        BeginPanelCard("##remote_dl_body", PanelCardTone::kPanel, ImVec2(14.0f, 10.0f), true,
+                       &settings);
+        {
+            ImGui::TextWrapped("%s", file_name ? file_name : "");
+            ImGui::Spacing();
+            if(total > 0)
+            {
+                float frac = static_cast<float>(downloaded) / static_cast<float>(total);
+                if(frac > 1.0f)
+                {
+                    frac = 1.0f;
+                }
+                std::string label = std::to_string(downloaded / 1024) + " / " +
+                                    std::to_string(total / 1024) + " KiB";
+                ImGui::ProgressBar(frac, ImVec2(-FLT_MIN, 0.0f), label.c_str());
+            }
+            else
+            {
+                PanelFieldLabel("Starting...", false, &settings);
+            }
+        }
+        EndPanelCard();
+
+        if(finished)
+        {
+            ImGui::CloseCurrentPopup();
+            show = false;
+        }
+
+        ImGui::PopStyleVar();  // ItemSpacing
+        ImGui::EndPopup();
+    }
+    else
+    {
+        // Popup not actually open (e.g. dismissed); clear the flag so it can be
+        // reopened on the next download.
+        show = false;
+    }
+
+    ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
+    popup_style.PopStyles();
 }
 
 #ifdef ROCPROFVIS_ENABLE_INTERNAL_BANNER

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -191,13 +191,9 @@ bool
 AccentButton(const char* label, ImVec2 size = ImVec2(0.0f, 0.0f),
              SettingsManager* settings = nullptr);
 
-// Renders the shared, theme-styled "remote download" progress modal used by both
-// the SSH test dialog and the profiler launcher (a rounded, stacked-card popup
-// with an accent header and a byte-count progress bar). The caller owns the
-// visibility flag: it must have called ImGui::OpenPopup(popup_id) on the frame
-// it set show=true. Call this every frame while show is true. Once finished is
-// true the popup is closed and show is set to false. total==0 renders a
-// "Starting..." placeholder in place of the progress bar.
+// Remote download progress modal, shared by the SSH test dialog and the
+// profiler launcher. The caller opens the popup (ImGui::OpenPopup) and owns
+// show, which is cleared once finished. A total of 0 renders "Starting...".
 void
 RenderRemoteDownloadPopup(const char* popup_id, const char* file_name,
                           uint64_t downloaded, uint64_t total, bool finished,

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "imgui.h"
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <string_view>
@@ -189,6 +190,18 @@ PanelIcon(const char* glyph, Colors color, SettingsManager* settings = nullptr);
 bool
 AccentButton(const char* label, ImVec2 size = ImVec2(0.0f, 0.0f),
              SettingsManager* settings = nullptr);
+
+// Renders the shared, theme-styled "remote download" progress modal used by both
+// the SSH test dialog and the profiler launcher (a rounded, stacked-card popup
+// with an accent header and a byte-count progress bar). The caller owns the
+// visibility flag: it must have called ImGui::OpenPopup(popup_id) on the frame
+// it set show=true. Call this every frame while show is true. Once finished is
+// true the popup is closed and show is set to false. total==0 renders a
+// "Starting..." placeholder in place of the progress bar.
+void
+RenderRemoteDownloadPopup(const char* popup_id, const char* file_name,
+                          uint64_t downloaded, uint64_t total, bool finished,
+                          bool& show);
 
 float
 TableRowHeight();


### PR DESCRIPTION
## Summary
Addresses review feedback on the remote panel revamp. No behavior changes
beyond the noted robustness fixes; all theming/dedup work is cosmetic-neutral.
## Changes
- **Themed warning color:** Added `Colors::kTextWarning` (dark + light theme
  entries) and routed the launcher readiness label plus backend warning
  messages through the theme instead of hardcoded amber/red/blue literals.
- **De-duplicated download popup:** Extracted the copy-pasted remote-download
  progress modal into a shared `RenderRemoteDownloadPopup` helper in
  `gui_helpers`, now used by both `SshTestDialog` and the profiler launcher.
- **Brace style:** Added braces to brace-less control flow in the remote file
  browser, shared launch tabs, launcher dialog, and the SSH client realpath
  block (per `CODING.md`).
- **More themed literals:** `StatusPill` text and the toggle-switch knob now use
  `Colors::kTextOnAccent`; `RenderOutputConsole` uses the shared
  `ChildRounding` instead of a hardcoded `8.0f`.
- **SFTP null-handle guard:** Bail out of the directory listing when `opendir`
  returns a null handle, guarding `realpath`/`readdir`/`closedir` against a null
  dereference (also fixes a latent case where a network-failed listing returned
  `Success`).
- **Safer profile rehydrate:** `LoadFromSettings` now validates the profile's
  SSH connection ref against the connection store (matching the toolbar load
  path), so a deleted connection is left unbound instead of silently rebound.
