### PR TITLE
Table API Refactor

### DIFF
--- a/.agents/DATABASE.md
+++ b/.agents/DATABASE.md
@@ -204,9 +204,9 @@ rocprofvis_dm_result_t rocprofvis_db_build_compute_query(
     database, compute_use_case, num_params, params, char** out_query);
 ```
 
-`rocprofvis_dm_table_use_case_enum_t` covers the four system table
+`rocprofvis_dm_table_use_case_enum_t` covers the three system table
 shapes (`kRPVDMTableUseCaseEventTrackTable`, `kRPVDMTableUseCaseSampleTrackTable`,
-`kRPVDMTableUseCaseEventSearch`, `kRPVDMTableUseCaseAnalysis`).
+`kRPVDMTableUseCaseEventSearch`).
 `rocprofvis_db_compute_use_case_enum_t` covers all the compute query
 shapes (workload list, top kernels, kernels list, metric definitions,
 roofline ceilings, kernel intensities, metric values, kernel metric

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -32,7 +32,8 @@ list(APPEND rocprofvis_controller_source_files
     src/system/rocprofvis_controller_timeline.cpp
     src/system/rocprofvis_controller_trace_system.cpp
     src/system/rocprofvis_controller_track.cpp
-    src/system/rocprofvis_controller_table_system.cpp	
+    src/system/rocprofvis_controller_table_system.cpp
+    src/system/rocprofvis_controller_table_system_search.cpp
     src/system/rocprofvis_controller_flow_control.cpp
     src/system/rocprofvis_controller_call_stack.cpp
     src/system/rocprofvis_controller_ext_data.cpp

--- a/src/controller/src/rocprofvis_controller_analysis.cpp
+++ b/src/controller/src/rocprofvis_controller_analysis.cpp
@@ -450,8 +450,13 @@ Analysis::EventsTable::EventsTable(uint64_t id, rocprofvis_dm_event_operation_t 
 , m_op(op)
 {}
 
-rocprofvis_result_t Analysis::EventsTable::UnpackArguments(Arguments& args, QueryArguments& out) const
+rocprofvis_result_t Analysis::EventsTable::UnpackArguments(Arguments& args, TableArguments*& out) const
 {
+    if(!out)
+    {
+        out = new SystemTableArguments();
+    }
+    SystemTableArguments* sys_out = (SystemTableArguments*)out;
     rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
     std::vector<uint32_t> tracks;
     uint64_t num_tracks = 0;
@@ -494,13 +499,21 @@ rocprofvis_result_t Analysis::EventsTable::UnpackArguments(Arguments& args, Quer
             }
         }
     }
-    const char* group = (m_op == kRocProfVisDmOperationLaunchSample) ? "name, COUNT(*) AS Invocations, SUM(duration) AS DurationTotal" :
-        "name, COUNT(*) AS Invocations, SUM(duration) AS DurationTotal, AVG(duration) AS DurationAvg, MIN(duration) AS DurationMin, MAX(duration) AS DurationMax";
     ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
     result = args.GetUInt64(kRPVControllerTableArgsSortColumn, 0, &sort_column_index);
     ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
     result = args.GetUInt64(kRPVControllerTableArgsSortOrder, 0, &sort_order);
-    out = {"", "__op = " + std::to_string(m_op), group, "name", sort_column_index, (rocprofvis_controller_sort_order_t)sort_order, tracks, {}, use_case, start_ts, end_ts};
+    sys_out->m_sort_column = sort_column_index;
+    sys_out->m_sort_order = (rocprofvis_controller_sort_order_t)sort_order;
+    sys_out->m_where = "";
+    sys_out->m_filter = "__op = " + std::to_string(m_op);
+    sys_out->m_group = (m_op == kRocProfVisDmOperationLaunchSample) ? "name, COUNT(*) AS Invocations, SUM(duration) AS DurationTotal" :
+        "name, COUNT(*) AS Invocations, SUM(duration) AS DurationTotal, AVG(duration) AS DurationAvg, MIN(duration) AS DurationMin, MAX(duration) AS DurationMax";
+    sys_out->m_group_cols = "name";
+    sys_out->m_tracks = std::move(tracks);
+    sys_out->m_use_case = use_case;
+    sys_out->m_start_ts = start_ts;
+    sys_out->m_end_ts = end_ts;
     return result;
 }
 

--- a/src/controller/src/rocprofvis_controller_analysis.h
+++ b/src/controller/src/rocprofvis_controller_analysis.h
@@ -163,7 +163,7 @@ private:
         EventsTable(uint64_t id, rocprofvis_dm_event_operation_t op);
 
     protected:
-        rocprofvis_result_t UnpackArguments(Arguments& args, QueryArguments& out) const final;
+        rocprofvis_result_t UnpackArguments(Arguments& args, TableArguments*& out) const final;
         rocprofvis_result_t UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t& out) const final;
 
     private:

--- a/src/controller/src/rocprofvis_controller_table.cpp
+++ b/src/controller/src/rocprofvis_controller_table.cpp
@@ -25,6 +25,16 @@ rocprofvis_controller_object_type_t Table::GetType(void)
 	return kRPVControllerObjectTypeTable;
 }
 
+void
+Table::Reset()
+{
+    m_num_items = 0;
+    m_sort_column = 0;
+    m_sort_order = kRPVControllerSortOrderAscending;
+    m_columns.clear();
+    m_rows.clear();
+}
+
 rocprofvis_result_t
 Table::SetupAndFetch(Trace& controller, Arguments& args, Array& array, Future* future)
 {
@@ -44,6 +54,47 @@ Table::SetupAndFetch(Trace& controller, Arguments& args, Array& array, Future* f
         result = Fetch(controller.GetDMHandle(), start_index, start_count, array, future);
     }
     return result;
+}
+
+rocprofvis_result_t
+Table::UnpackArguments(Arguments& args, TableArguments*& out) const
+{
+    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
+    if(!out)
+    {
+        out = new TableArguments();
+    }
+    uint64_t sort_column = 0;
+    uint64_t sort_order  = 0;
+    result = args.GetUInt64(kRPVControllerTableArgsSortColumn, 0, &sort_column);
+    if(result == kRocProfVisResultSuccess)
+    {
+        result = args.GetUInt64(kRPVControllerTableArgsSortOrder, 0, &sort_order);
+    }
+    if(result == kRocProfVisResultSuccess)
+    {
+        out->m_sort_column = sort_column;
+        out->m_sort_order = (rocprofvis_controller_sort_order_t)sort_order;
+    }
+    return result;
+}
+
+void
+Table::GetCurrentArguments(TableArguments*& out) const
+{
+    if(!out)
+    {
+        out = new TableArguments();
+    }
+    out->m_sort_column = m_sort_column;
+    out->m_sort_order = m_sort_order;
+}
+
+void
+Table::SetCurrentArguments(TableArguments& in)
+{
+    m_sort_column = in.m_sort_column;
+    m_sort_order = in.m_sort_order;
 }
 
 }

--- a/src/controller/src/rocprofvis_controller_table.h
+++ b/src/controller/src/rocprofvis_controller_table.h
@@ -30,6 +30,8 @@ public:
 
     virtual rocprofvis_controller_object_type_t GetType(void);
 
+    virtual void Reset();
+
     virtual rocprofvis_result_t SetupAndFetch(Trace& controller, Arguments& args, Array& array, Future* future);
     virtual rocprofvis_result_t ExportCSV(rocprofvis_dm_trace_t dm_handle, Arguments& args, Future* future, const char* path) const = 0;
 
@@ -39,16 +41,21 @@ protected:
         std::string m_name;
         rocprofvis_controller_primitive_type_t m_type;
     };
+    struct TableArguments
+    {
+        virtual ~TableArguments() = default;
+        uint64_t m_sort_column;
+        rocprofvis_controller_sort_order_t m_sort_order;
+    };
 
     virtual rocprofvis_result_t Setup(rocprofvis_dm_trace_t dm_handle, Arguments& args, Future* future) = 0;
     virtual rocprofvis_result_t Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t index, uint64_t count, Array& array, Future* future) = 0;
+    virtual rocprofvis_result_t UnpackArguments(Arguments& args, TableArguments*& out) const;
+    virtual void                GetCurrentArguments(TableArguments*& out) const;
+    virtual void                SetCurrentArguments(TableArguments& in);
 
     std::vector<ColumnDefintion> m_columns;
     std::map<uint64_t, std::vector<Data>> m_rows;
-    std::string m_where;
-    std::string m_filter;
-    std::string m_group;
-    std::string m_group_cols;
     uint64_t m_num_items;
     uint64_t m_id;
     uint64_t m_sort_column;

--- a/src/controller/src/system/rocprofvis_controller_summary.cpp
+++ b/src/controller/src/system/rocprofvis_controller_summary.cpp
@@ -4,7 +4,7 @@
 #include "rocprofvis_controller_summary.h"
 #include "rocprofvis_controller_future.h"
 #include "rocprofvis_controller_topology.h"
-#include "rocprofvis_controller_table_system.h"
+#include "rocprofvis_controller_table_system_search.h"
 #include "rocprofvis_controller_trace.h"
 #include "rocprofvis_controller_track.h"
 #include "rocprofvis_controller_arguments.h"
@@ -22,7 +22,7 @@ Summary::Summary(Trace* ctx)
 , m_end_ts(-1.0)
 , m_kernel_instance_table(nullptr)
 {
-    m_kernel_instance_table = new SystemTable(0);
+    m_kernel_instance_table = new EventSearchTable(0);
 }
 
 Summary::~Summary() 
@@ -383,9 +383,13 @@ rocprofvis_result_t Summary::FetchCounterAverage(rocprofvis_dm_trace_t dm_handle
                             rocprofvis_dm_result_t dm_result = kRocProfVisDmResultUnknownError;
                             rocprofvis_dm_table_id_t table_id = 0;
                             char* query = nullptr;
-                            dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseSampleTrackTable, static_cast<rocprofvis_dm_timestamp_t>(m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(m_end_ts), 1, (rocprofvis_db_track_selection_t)&track_id, nullptr, nullptr, 
+                            dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseSampleTrackTable, 
+                                                                        static_cast<rocprofvis_dm_timestamp_t>(m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(m_end_ts), 
+                                                                        1, (rocprofvis_db_track_selection_t)&track_id, 
+                                                                        nullptr, nullptr, 
                                                                         "counter, AVG(value) AS avg_value, MIN(value) AS min_value, MAX(value) AS max_value", "counter", 
-                                                                        nullptr, kRPVDMSortOrderAsc, 0, nullptr,  0, 0, false, &query);
+                                                                        nullptr, kRPVDMSortOrderAsc, 
+                                                                        0, 0, false, &query);
                             if(dm_result == kRocProfVisDmResultSuccess)
                             {
                                 dm_result = rocprofvis_db_execute_query_async(db, query, "Fetch counter summary", object2wait, &table_id);
@@ -525,12 +529,15 @@ rocprofvis_result_t Summary::FetchTopKernels(rocprofvis_dm_trace_t dm_handle, No
                 }
             }
             rocprofvis_dm_table_id_t table_id = 0;
-            rocprofvis_dm_charptr_t where = where_str.empty() ? nullptr : where_str.c_str();
             std::string sort_column = "total_duration";
             char* query = nullptr;
-            dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseEventTrackTable, static_cast<rocprofvis_dm_timestamp_t>(m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(m_end_ts), 1, (rocprofvis_db_track_selection_t)op, where, nullptr, 
-                                                        "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) AS total_duration", 
-                                                        "name", sort_column.c_str(), kRPVDMSortOrderDesc, 0, nullptr, 0, 0, false, &query);
+            dm_result = rocprofvis_db_build_table_query(db, kRPVDMTableUseCaseEventTrackTable, 
+                                                        static_cast<rocprofvis_dm_timestamp_t>(m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(m_end_ts), 
+                                                        1, (rocprofvis_db_track_selection_t)op, 
+                                                        where_str.empty() ? nullptr : where_str.c_str(), nullptr, 
+                                                        "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) AS total_duration", "name", 
+                                                        sort_column.c_str(), kRPVDMSortOrderDesc,
+                                                        0, 0, false, &query);
             if(dm_result == kRocProfVisDmResultSuccess)
             {
                 dm_result = rocprofvis_db_execute_query_async(db, query, "Fetch kernel summary", object2wait, &table_id);

--- a/src/controller/src/system/rocprofvis_controller_summary.h
+++ b/src/controller/src/system/rocprofvis_controller_summary.h
@@ -7,7 +7,6 @@
 #include "rocprofvis_controller.h"
 #include "rocprofvis_controller_handle.h"
 #include "rocprofvis_c_interface.h"
-#include <string>
 
 namespace RocProfVis
 {
@@ -18,9 +17,8 @@ class Trace;
 class Counter;
 class Node;
 class Processor;
-class SystemTable;
+class EventSearchTable;
 class Arguments;
-class Array;
 class Future;
 
 class Summary : public Handle
@@ -48,7 +46,7 @@ private:
     double m_end_ts;
 
     SummaryMetrics m_metrics;
-    SystemTable* m_kernel_instance_table;
+    EventSearchTable* m_kernel_instance_table;
 };
 
 }

--- a/src/controller/src/system/rocprofvis_controller_table_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_table_system.cpp
@@ -31,21 +31,15 @@ SystemTable::~SystemTable()
 
 void SystemTable::Reset()
 {
+    Table::Reset();
     m_start_ts = 0;
     m_end_ts = 0;
-    m_num_items = 0;
-    m_sort_column = 0;
-    m_sort_order = kRPVControllerSortOrderAscending;
     m_use_case = kRPVDMTableUseCaseEventTrackTable;
-    m_columns.clear();
-    m_rows.clear();
     m_tracks.clear();
     m_where.clear();
     m_filter.clear();
     m_group.clear();
     m_group_cols.clear();
-    m_string_table_filters.clear();
-    m_string_table_filters_ptr.clear();
 }
 
 rocprofvis_result_t SystemTable::SetupAndFetch(Trace& controller, Arguments& args, Array& array, Future* future)
@@ -67,89 +61,95 @@ rocprofvis_result_t SystemTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t
         rocprofvis_dm_database_t db    = rocprofvis_dm_get_property_as_handle(dm_handle, kRPVDMDatabaseHandle, 0);
         ROCPROFVIS_ASSERT(db);
 
-        char const* sort_column = m_columns.size() > m_sort_column ? m_columns[m_sort_column].m_name.c_str() : nullptr;
-
-        char* fetch_query = nullptr;
-        rocprofvis_dm_result_t dm_result = rocprofvis_db_build_table_query(
-            db, m_use_case, static_cast<rocprofvis_dm_timestamp_t>(m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(m_end_ts),
-            static_cast<rocprofvis_db_num_of_tracks_t>(m_tracks.size()), m_tracks.data(), m_where.c_str(),  m_filter.c_str(), m_group.c_str(), m_group_cols.c_str(), sort_column,
-            (rocprofvis_dm_sort_order_t)m_sort_order, static_cast<rocprofvis_dm_num_string_table_filters_t>(m_string_table_filters_ptr.size()), m_string_table_filters_ptr.data(), 
-            count, index, false, &fetch_query);
-        rocprofvis_dm_table_id_t table_id = 0;
+        TableArguments* fetch_args = nullptr;
+        GetCurrentArguments(fetch_args);
         uint64_t num_records = 0;
-        if(dm_result == kRocProfVisDmResultSuccess)
+
+        rocprofvis_dm_result_t dm_result = kRocProfVisDmResultUnknownError;
+        if(fetch_args)
         {
-            if(strlen(fetch_query) > 0)
+            char* fetch_query = nullptr;
+            dm_result = BuildQuery(db, *fetch_args, index, count, false, &fetch_query);
+            rocprofvis_dm_table_id_t table_id = 0;
+            
+            if(dm_result == kRocProfVisDmResultSuccess && fetch_query)
             {
-                dm_result = rocprofvis_db_execute_query_async(
-                    db, fetch_query, "Fetch table content", object2wait, &table_id);
-
-                if(dm_result == kRocProfVisDmResultSuccess)
+                if(strlen(fetch_query) > 0)
                 {
-                    future->AddDependentFuture(object2wait);
-                    dm_result = rocprofvis_db_future_wait(object2wait, UINT64_MAX);
-                }
+                    dm_result = rocprofvis_db_execute_query_async(
+                        db, fetch_query, "Fetch table content", object2wait, &table_id);
 
-                if(dm_result == kRocProfVisDmResultSuccess)
-                {
-                    uint64_t num_tables = rocprofvis_dm_get_property_as_uint64(
-                        dm_handle, kRPVDMNumberOfTablesUInt64, 0);
-                    if(num_tables > 0)
+                    if(dm_result == kRocProfVisDmResultSuccess)
                     {
-                        rocprofvis_dm_table_t table = rocprofvis_dm_get_property_as_handle(
-                            dm_handle, kRPVDMTableHandleByID, table_id);
-                        if(nullptr != table)
+                        future->AddDependentFuture(object2wait);
+                        dm_result = rocprofvis_db_future_wait(object2wait, UINT64_MAX);
+                    }
+
+                    if(dm_result == kRocProfVisDmResultSuccess)
+                    {
+                        uint64_t num_tables = rocprofvis_dm_get_property_as_uint64(
+                            dm_handle, kRPVDMNumberOfTablesUInt64, 0);
+                        if(num_tables > 0)
                         {
-                            if(!future->IsCancelled())
-                            {                    
-                                char* table_query = rocprofvis_dm_get_property_as_charptr(
-                                    table, kRPVDMExtTableQueryCharPtr, 0);
-                                uint64_t num_columns = rocprofvis_dm_get_property_as_uint64(
-                                    table, kRPVDMNumberOfTableColumnsUInt64, 0);
-                                uint64_t num_rows = rocprofvis_dm_get_property_as_uint64(
-                                    table, kRPVDMNumberOfTableRowsUInt64, 0);
-                                num_records = num_rows;
-                                if(strcmp(table_query, fetch_query) == 0)
-                                {
-                                    ROCPROFVIS_ASSERT(m_columns.size() == num_columns);
-
-                                    std::vector<Data> row;
-                                    row.resize(m_columns.size());
-                                    for (uint32_t i = 0; i < num_rows; i++)
+                            rocprofvis_dm_table_t table = rocprofvis_dm_get_property_as_handle(
+                                dm_handle, kRPVDMTableHandleByID, table_id);
+                            if(nullptr != table)
+                            {
+                                if(!future->IsCancelled())
+                                {                    
+                                    char* table_query = rocprofvis_dm_get_property_as_charptr(
+                                        table, kRPVDMExtTableQueryCharPtr, 0);
+                                    uint64_t num_columns = rocprofvis_dm_get_property_as_uint64(
+                                        table, kRPVDMNumberOfTableColumnsUInt64, 0);
+                                    uint64_t num_rows = rocprofvis_dm_get_property_as_uint64(
+                                        table, kRPVDMNumberOfTableRowsUInt64, 0);
+                                    num_records = num_rows;
+                                    if(strcmp(table_query, fetch_query) == 0)
                                     {
-                                        rocprofvis_dm_table_row_t table_row =
-                                            rocprofvis_dm_get_property_as_handle(
-                                                table, kRPVDMExtTableRowHandleIndexed, i);
-                                        if(table_row != nullptr)
+                                        ROCPROFVIS_ASSERT(m_columns.size() == num_columns);
+
+                                        std::vector<Data> row;
+                                        row.resize(m_columns.size());
+                                        for (uint32_t i = 0; i < num_rows; i++)
                                         {
-                                            uint64_t num_cells = rocprofvis_dm_get_property_as_uint64(
-                                                table_row, kRPVDMNumberOfTableRowCellsUInt64, 0);
-                                            ROCPROFVIS_ASSERT(num_cells == num_columns);
-                                            for(uint32_t j = 0; j < num_cells; j++)
+                                            rocprofvis_dm_table_row_t table_row =
+                                                rocprofvis_dm_get_property_as_handle(
+                                                    table, kRPVDMExtTableRowHandleIndexed, i);
+                                            if(table_row != nullptr)
                                             {
-                                                char const* value =
-                                                    rocprofvis_dm_get_property_as_charptr(
-                                                        table_row,
-                                                        kRPVDMExtTableRowCellValueCharPtrIndexed, j);
-                                                ROCPROFVIS_ASSERT(value);
+                                                uint64_t num_cells = rocprofvis_dm_get_property_as_uint64(
+                                                    table_row, kRPVDMNumberOfTableRowCellsUInt64, 0);
+                                                ROCPROFVIS_ASSERT(num_cells == num_columns);
+                                                for(uint32_t j = 0; j < num_cells; j++)
+                                                {
+                                                    char const* value =
+                                                        rocprofvis_dm_get_property_as_charptr(
+                                                            table_row,
+                                                            kRPVDMExtTableRowCellValueCharPtrIndexed, j);
+                                                    ROCPROFVIS_ASSERT(value);
 
-                                                Data& row_value = row[j];
-                                                row_value.SetType(m_columns[j].m_type);
-                                                row_value.SetString(value);
+                                                    Data& row_value = row[j];
+                                                    row_value.SetType(m_columns[j].m_type);
+                                                    row_value.SetString(value);
+                                                }
+
+                                                m_rows[index + i] = row;
                                             }
-
-                                            m_rows[index + i] = row;
-                                        }
-                                        else
-                                        {
-                                            dm_result = kRocProfVisDmResultUnknownError;
+                                            else
+                                            {
+                                                dm_result = kRocProfVisDmResultUnknownError;
+                                            }
                                         }
                                     }
+                                    else
+                                    {
+                                        dm_result = kRocProfVisDmResultUnknownError;
+                                    }
                                 }
-                                else
-                                {
-                                    dm_result = kRocProfVisDmResultUnknownError;
-                                }
+                            }
+                            else
+                            {
+                                dm_result = kRocProfVisDmResultUnknownError;
                             }
                         }
                         else
@@ -157,14 +157,12 @@ rocprofvis_result_t SystemTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t
                             dm_result = kRocProfVisDmResultUnknownError;
                         }
                     }
-                    else
-                    {
-                        dm_result = kRocProfVisDmResultUnknownError;
-                    }
+                    rocprofvis_dm_delete_table_at(dm_handle, table_id);
                 }
-                rocprofvis_dm_delete_table_at(dm_handle, table_id);
             }
-        }        
+            free(fetch_query);
+        }
+        delete fetch_args;
         
         if(!future->IsCancelled())
         {
@@ -214,7 +212,6 @@ rocprofvis_result_t SystemTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t
         }
         future->RemoveDependentFuture(object2wait);
         rocprofvis_db_future_free(object2wait);
-        free(fetch_query);
     }
     else
     {
@@ -227,53 +224,23 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
 {
     rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
     
-    QueryArguments query_args;
+    TableArguments* query_args = nullptr;
     result = future->IsCancelled() ? kRocProfVisResultCancelled : UnpackArguments(args, query_args);
 
-    if (result == kRocProfVisResultSuccess)
+    if(result == kRocProfVisResultSuccess && query_args)
     {
-        m_sort_column = query_args.m_sort_column;
-        m_sort_order  = (rocprofvis_controller_sort_order_t)query_args.m_sort_order;
-        if(m_tracks.size() == query_args.m_tracks.size() && m_start_ts == query_args.m_start_ts &&
-           m_end_ts == query_args.m_end_ts && m_where == query_args.m_where && m_filter == query_args.m_filter && 
-           m_group == query_args.m_group && m_group_cols == query_args.m_group_cols && 
-           m_string_table_filters == query_args.m_string_table_filters && m_use_case == query_args.m_use_case)
-        {
-            bool tracks_all_same = true;
-            for (int i = 0; i < query_args.m_tracks.size(); i++)
-            {
-                if(m_tracks[i] != query_args.m_tracks[i])
-                {
-                    tracks_all_same = false;
-                    break;
-                }
-            }
-            if(tracks_all_same)
-            {
-                m_rows.clear();
-                return kRocProfVisResultSuccess;
-            }
-        }
-        Reset();
+        Table::SetCurrentArguments(*query_args);
 
-        m_tracks      = query_args.m_tracks;       
-        m_start_ts    = query_args.m_start_ts;
-        m_end_ts      = query_args.m_end_ts;
-        m_where       = query_args.m_where;
-        m_filter      = query_args.m_filter;
-        m_group       = query_args.m_group;
-        m_group_cols  = query_args.m_group_cols;
-        m_string_table_filters = query_args.m_string_table_filters;
-        for(const std::string& filter : m_string_table_filters)
+        if(!ArgumentsChanged((SystemTableArguments&)*query_args))
         {
-            m_string_table_filters_ptr.push_back(filter.c_str());
+            m_rows.clear();
         }
-        m_use_case    = query_args.m_use_case;
-        m_sort_column = query_args.m_sort_column;
-        m_sort_order  = (rocprofvis_controller_sort_order_t)query_args.m_sort_order;
-
-        if(result == kRocProfVisResultSuccess)
+        else
         {
+            Reset();
+
+            SetCurrentArguments(*query_args);
+
             rocprofvis_dm_database_t db =
                 rocprofvis_dm_get_property_as_handle(dm_handle, kRPVDMDatabaseHandle, 0);
             ROCPROFVIS_ASSERT(db);
@@ -282,14 +249,7 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
             ROCPROFVIS_ASSERT(object2wait);
 
             char*                  count_query = nullptr;
-            rocprofvis_dm_result_t dm_result   = rocprofvis_db_build_table_query(
-                db, m_use_case, static_cast<rocprofvis_dm_timestamp_t>(m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(m_end_ts),
-                static_cast<rocprofvis_db_num_of_tracks_t>(m_tracks.size()),
-                m_tracks.data(), m_where.c_str(), m_filter.c_str(), m_group.c_str(), m_group_cols.c_str(), nullptr,
-                (rocprofvis_dm_sort_order_t) m_sort_order,
-                static_cast<rocprofvis_dm_num_string_table_filters_t>(m_string_table_filters_ptr.size()),
-                m_string_table_filters_ptr.data(),
-                0, 0, true, &count_query);
+            rocprofvis_dm_result_t dm_result = BuildQuery(db, *query_args, 0, 0, true, &count_query);
             if(dm_result == kRocProfVisDmResultSuccess)
             {
                 if(strlen(count_query) > 0)
@@ -378,6 +338,7 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
     {
         Reset();
     }
+    delete query_args;
     return result;
 }
 
@@ -385,10 +346,10 @@ rocprofvis_result_t SystemTable::ExportCSV(rocprofvis_dm_trace_t dm_handle, Argu
 {
     rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
     
-    QueryArguments query_args;
+    TableArguments* query_args = nullptr;
     result = future->IsCancelled() ? kRocProfVisResultCancelled : UnpackArguments(args, query_args);
 
-    if (result == kRocProfVisResultSuccess)
+    if(result == kRocProfVisResultSuccess && query_args)
     {
         rocprofvis_db_future_t object2wait = rocprofvis_db_future_alloc(Future::ProgressCallback, future);
         if(object2wait)
@@ -396,18 +357,8 @@ rocprofvis_result_t SystemTable::ExportCSV(rocprofvis_dm_trace_t dm_handle, Argu
             rocprofvis_dm_database_t db    = rocprofvis_dm_get_property_as_handle(dm_handle, kRPVDMDatabaseHandle, 0);
             ROCPROFVIS_ASSERT(db);
 
-            char const* sort_column = m_columns.size() > query_args.m_sort_column ? m_columns[query_args.m_sort_column].m_name.c_str() : nullptr;
-            std::vector<const char*> string_table_filters_ptr;
-            for(const std::string& filter : query_args.m_string_table_filters)
-            {
-                string_table_filters_ptr.push_back(filter.c_str());
-            }
-
             char* query = nullptr;
-            rocprofvis_dm_result_t dm_result = rocprofvis_db_build_table_query(
-                db, query_args.m_use_case, static_cast<rocprofvis_dm_timestamp_t>(query_args.m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(query_args.m_end_ts), (rocprofvis_db_num_of_tracks_t)query_args.m_tracks.size(), query_args.m_tracks.data(), query_args.m_where.c_str(), 
-                query_args.m_filter.c_str(), query_args.m_group.c_str(), query_args.m_group_cols.c_str(), sort_column, (rocprofvis_dm_sort_order_t)query_args.m_sort_order, 
-                (rocprofvis_dm_num_string_table_filters_t)string_table_filters_ptr.size(), string_table_filters_ptr.data(), 0, 0, false, &query);
+            rocprofvis_dm_result_t dm_result = BuildQuery(db, *query_args, 0, 0, false, &query);
             if(dm_result == kRocProfVisDmResultSuccess)
             {
                 dm_result = rocprofvis_db_export_table_csv_async(db, query, path, object2wait);
@@ -428,6 +379,7 @@ rocprofvis_result_t SystemTable::ExportCSV(rocprofvis_dm_trace_t dm_handle, Argu
             result = kRocProfVisResultMemoryAllocError;
         }
     }
+    delete query_args;
     return result;
 }
 
@@ -501,62 +453,55 @@ rocprofvis_result_t SystemTable::GetString(rocprofvis_property_t property, uint6
 }
 
 rocprofvis_result_t
-SystemTable::UnpackArguments(Arguments& args, QueryArguments& out) const
+SystemTable::UnpackArguments(Arguments& args, TableArguments*& out) const
 {
-    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
-    std::vector<uint32_t> tracks;
-    uint64_t sort_column = 0;
-    uint64_t sort_order  = 0;
-    uint64_t num_tracks = 0;
-    uint64_t num_op_types = 0;
-    double   end_ts     = 0;
-    double   start_ts   = 0;
-    std::string where;
-    std::string filter;
-    std::string group;
-    std::string group_cols;
-    uint64_t num_string_table_filters = 0;
-    std::vector<std::string> string_table_filters;
-    std::vector<const char*> string_table_filters_ptr;
-    rocprofvis_dm_table_use_case_enum_t use_case = kRPVDMTableUseCaseEventTrackTable;
-    rocprofvis_controller_track_type_t track_type = kRPVControllerTrackTypeEvents;
-    uint64_t table_type = static_cast<uint64_t>(kRPVControllerTableTypeEvents);
-
-    result = UnpackUseCase(args, use_case);
-    if (result == kRocProfVisResultSuccess)
+    if(!out)
     {
-        result = args.GetUInt64(kRPVControllerTableArgsType, 0, &table_type);
+        out = new SystemTableArguments();
     }
-    if (result == kRocProfVisResultSuccess)
+    SystemTableArguments* sys_out = (SystemTableArguments*)out;
+    rocprofvis_result_t result = Table::UnpackArguments(args, out);
+    if(result == kRocProfVisResultSuccess)
     {
-        switch (table_type)
+        std::vector<uint32_t> tracks;
+        uint64_t num_tracks = 0;
+        uint64_t num_op_types = 0;
+        double   end_ts     = 0;
+        double   start_ts   = 0;
+        std::string where;
+        std::string filter;
+        std::string group;
+        std::string group_cols;
+        rocprofvis_dm_table_use_case_enum_t use_case = kRPVDMTableUseCaseEventTrackTable;
+        rocprofvis_controller_track_type_t track_type = kRPVControllerTrackTypeEvents;
+        uint64_t table_type = static_cast<uint64_t>(kRPVControllerTableTypeEvents);
+
+        result = UnpackUseCase(args, use_case);
+        if (result == kRocProfVisResultSuccess)
         {
-            case kRPVControllerTableTypeEvents:
-            case kRPVControllerTableTypeSearchResults:
-            case kRPVControllerTableTypeSummaryKernelInstances:
+            result = args.GetUInt64(kRPVControllerTableArgsType, 0, &table_type);
+        }
+        if (result == kRocProfVisResultSuccess)
+        {
+            switch (table_type)
             {
-                track_type = kRPVControllerTrackTypeEvents;
-                break;
-            }
-            case kRPVControllerTableTypeSamples:
-            {
-                track_type = kRPVControllerTrackTypeSamples;
-                break;
-            }
-            default:
-            {
-                result = kRocProfVisResultInvalidArgument;
-                break;
+                case kRPVControllerTableTypeEvents:
+                {
+                    track_type = kRPVControllerTrackTypeEvents;
+                    break;
+                }
+                case kRPVControllerTableTypeSamples:
+                {
+                    track_type = kRPVControllerTrackTypeSamples;
+                    break;
+                }
+                default:
+                {
+                    break;
+                }
             }
         }
-    }
 
-    if(result == kRocProfVisResultSuccess &&
-       (table_type == kRPVControllerTableTypeEvents ||
-        table_type == kRPVControllerTableTypeSamples ||
-        table_type == kRPVControllerTableTypeSearchResults ||
-        table_type == kRPVControllerTableTypeSummaryKernelInstances))
-    {
         if(result == kRocProfVisResultSuccess)
         {
             result = args.GetDouble(kRPVControllerTableArgsStartTime, 0, &start_ts);
@@ -569,14 +514,13 @@ SystemTable::UnpackArguments(Arguments& args, QueryArguments& out) const
         
         if(result == kRocProfVisResultSuccess)
         {
-            result = args.GetUInt64(kRPVControllerTableArgsNumOpTypes, 0, &num_op_types);
+            args.GetUInt64(kRPVControllerTableArgsNumTracks, 0, &num_tracks);
+            args.GetUInt64(kRPVControllerTableArgsNumOpTypes, 0, &num_op_types);
         }
         
-        if(result == kRocProfVisResultSuccess && num_op_types == 0)
+        if(result == kRocProfVisResultSuccess)
         {
-            result = args.GetUInt64(kRPVControllerTableArgsNumTracks, 0, &num_tracks);
-
-            if (result == kRocProfVisResultSuccess && num_tracks > 0)
+            if(num_tracks > 0 && num_op_types == 0)
             {
                 for (uint32_t i = 0; i < num_tracks && (result == kRocProfVisResultSuccess); i++)
                 {
@@ -607,95 +551,134 @@ SystemTable::UnpackArguments(Arguments& args, QueryArguments& out) const
                     }
                 }
             }
-        }
-        else
-        {
-            for (uint32_t i = 0; i < num_op_types && (result == kRocProfVisResultSuccess); i++)
+            else if(num_tracks == 0 && num_op_types > 0)
             {
-                uint64_t op_type_uint64 = kRocProfVisDmOperationNoOp;
-                result = args.GetUInt64(kRPVControllerTableArgsOpTypesIndexed, i, &op_type_uint64);
-                if(result == kRocProfVisResultSuccess)
+                for (uint32_t i = 0; i < num_op_types && (result == kRocProfVisResultSuccess); i++)
                 {
-                    ROCPROFVIS_ASSERT(op_type_uint64 < kRocProfVisDmNumOperation);
-                    tracks.push_back(static_cast<uint32_t>(TABLE_QUERY_PACK_OP_TYPE(op_type_uint64)));
-                }                
-            }
-        }
-    }
-
-    if(result == kRocProfVisResultSuccess)
-    {
-        result = args.GetUInt64(kRPVControllerTableArgsSortColumn, 0, &sort_column);
-    }
-    if(result == kRocProfVisResultSuccess)
-    {
-        result = args.GetUInt64(kRPVControllerTableArgsSortOrder, 0, &sort_order);
-    }
-    if(result == kRocProfVisResultSuccess)
-    {
-        uint32_t length = 0;
-        result = args.GetString(kRPVControllerTableArgsWhere, 0, nullptr, &length);
-        if(result == kRocProfVisResultSuccess)
-        {
-            where.resize(length);
-            result = args.GetString(kRPVControllerTableArgsWhere, 0, where.data(), &length);
-        }
-    }
-    if(result == kRocProfVisResultSuccess)
-    {
-        uint32_t length = 0;
-        result = args.GetString(kRPVControllerTableArgsFilter, 0, nullptr, &length);
-        if(result == kRocProfVisResultSuccess)
-        {
-            filter.resize(length);
-            result = args.GetString(kRPVControllerTableArgsFilter, 0, filter.data(), &length);
-        }
-    }
-    if(result == kRocProfVisResultSuccess)
-    {
-        uint32_t length = 0;
-        result = args.GetString(kRPVControllerTableArgsGroup, 0, nullptr, &length);
-        if(result == kRocProfVisResultSuccess)
-        {
-            group.resize(length);
-            result = args.GetString(kRPVControllerTableArgsGroup, 0, group.data(), &length);
-        }
-    }
-    if(result == kRocProfVisResultSuccess)
-    {
-        uint32_t length = 0;
-        result = args.GetString(kRPVControllerTableArgsGroupColumns, 0, nullptr, &length);
-        if(result == kRocProfVisResultSuccess)
-        {
-            group_cols.resize(length);
-            result = args.GetString(kRPVControllerTableArgsGroupColumns, 0, group_cols.data(), &length);
-        }
-    }
-    if(num_op_types > 0 && result == kRocProfVisResultSuccess)
-    {
-        result = args.GetUInt64(kRPVControllerTableArgsNumStringTableFilters, 0, &num_string_table_filters);
-        if(result == kRocProfVisResultSuccess)
-        {
-            for (uint32_t i = 0; i < num_string_table_filters && (result == kRocProfVisResultSuccess); i++)
-            {
-                uint32_t length = 0;
-                result = args.GetString(kRPVControllerTableArgsStringTableFiltersIndexed, i, nullptr, &length);
-                if(result == kRocProfVisResultSuccess && length > 0)
-                {
-                    std::string f;
-                    f.resize(length);
-                    result = args.GetString(kRPVControllerTableArgsStringTableFiltersIndexed, i, f.data(), &length);
+                    uint64_t op_type_uint64 = kRocProfVisDmOperationNoOp;
+                    result = args.GetUInt64(kRPVControllerTableArgsOpTypesIndexed, i, &op_type_uint64);
                     if(result == kRocProfVisResultSuccess)
                     {
-                        string_table_filters.push_back(f);
-                    }
+                        ROCPROFVIS_ASSERT(op_type_uint64 < kRocProfVisDmNumOperation);
+                        tracks.push_back(static_cast<uint32_t>(TABLE_QUERY_PACK_OP_TYPE(op_type_uint64)));
+                    }                
                 }
+            }
+            else
+            {
+                result = kRocProfVisResultInvalidArgument;
+            }
+        }
+
+        if(result == kRocProfVisResultSuccess)
+        {
+            uint32_t length = 0;
+            result = args.GetString(kRPVControllerTableArgsWhere, 0, nullptr, &length);
+            if(result == kRocProfVisResultSuccess)
+            {
+                where.resize(length);
+                result = args.GetString(kRPVControllerTableArgsWhere, 0, where.data(), &length);
+            }
+        }
+        if(result == kRocProfVisResultSuccess)
+        {
+            uint32_t length = 0;
+            result = args.GetString(kRPVControllerTableArgsFilter, 0, nullptr, &length);
+            if(result == kRocProfVisResultSuccess)
+            {
+                filter.resize(length);
+                result = args.GetString(kRPVControllerTableArgsFilter, 0, filter.data(), &length);
+            }
+        }
+        if(result == kRocProfVisResultSuccess)
+        {
+            uint32_t length = 0;
+            result = args.GetString(kRPVControllerTableArgsGroup, 0, nullptr, &length);
+            if(result == kRocProfVisResultSuccess)
+            {
+                group.resize(length);
+                result = args.GetString(kRPVControllerTableArgsGroup, 0, group.data(), &length);
+            }
+        }
+        if(result == kRocProfVisResultSuccess)
+        {
+            uint32_t length = 0;
+            result = args.GetString(kRPVControllerTableArgsGroupColumns, 0, nullptr, &length);
+            if(result == kRocProfVisResultSuccess)
+            {
+                group_cols.resize(length);
+                result = args.GetString(kRPVControllerTableArgsGroupColumns, 0, group_cols.data(), &length);
+            }
+        }
+        if(result == kRocProfVisResultSuccess)
+        {
+            sys_out->m_where = std::move(where);
+            sys_out->m_filter = std::move(filter);
+            sys_out->m_group = std::move(group);
+            sys_out->m_group_cols = std::move(group_cols);
+            sys_out->m_tracks = std::move(tracks);
+            sys_out->m_use_case = use_case;
+            sys_out->m_start_ts = start_ts;
+            sys_out->m_end_ts = end_ts;
+        }   
+    }
+	return result;
+}
+
+void
+SystemTable::GetCurrentArguments(TableArguments*& out) const
+{
+    if(!out)
+    {
+        out = new SystemTableArguments();
+    }
+    SystemTableArguments* sys_out = (SystemTableArguments*)out;
+    Table::GetCurrentArguments(out);
+    sys_out->m_where = m_where;
+    sys_out->m_filter = m_filter;
+    sys_out->m_group = m_group;
+    sys_out->m_group_cols = m_group_cols;
+    sys_out->m_tracks = m_tracks;
+    sys_out->m_use_case = m_use_case;
+    sys_out->m_start_ts = m_start_ts;
+    sys_out->m_end_ts = m_end_ts;
+}
+
+void
+SystemTable::SetCurrentArguments(TableArguments& in)
+{
+    SystemTableArguments& sys_in = (SystemTableArguments&)in;
+    Table::SetCurrentArguments(sys_in);
+    m_where = sys_in.m_where;
+    m_filter = sys_in.m_filter;
+    m_group = sys_in.m_group;
+    m_group_cols = sys_in.m_group_cols;
+    m_tracks = sys_in.m_tracks;
+    m_use_case = sys_in.m_use_case;
+    m_start_ts = sys_in.m_start_ts;
+    m_end_ts = sys_in.m_end_ts;
+}
+
+bool
+SystemTable::ArgumentsChanged(SystemTableArguments& in) const
+{
+    bool result = true;
+    if(m_tracks.size() == in.m_tracks.size() && m_start_ts == in.m_start_ts &&
+        m_end_ts == in.m_end_ts && m_where == in.m_where && m_filter == in.m_filter && 
+        m_group == in.m_group && m_group_cols == in.m_group_cols && 
+        m_use_case == in.m_use_case)
+    {
+        result = false;
+        for (size_t i = 0; i < in.m_tracks.size(); i++)
+        {
+            if(m_tracks[i] != in.m_tracks[i])
+            {
+                result = true;
+                break;
             }
         }
     }
-    out = {where, filter, group, group_cols, sort_column, (rocprofvis_controller_sort_order_t)sort_order, tracks, std::move(string_table_filters), use_case, start_ts, end_ts};
-    
-	return result;
+    return result;
 }
 
 rocprofvis_result_t
@@ -733,6 +716,22 @@ SystemTable::UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t&
             }
         }
     }    
+    return result;
+}
+
+rocprofvis_dm_result_t
+SystemTable::BuildQuery(rocprofvis_dm_database_t db, TableArguments& args, uint64_t index, uint64_t count, bool count_only, char** out) const
+{
+    rocprofvis_dm_result_t result = kRocProfVisDmResultUnknownError;
+    SystemTableArguments& arguments = (SystemTableArguments&)args;
+    char const* sort_column = count_only ? nullptr : (m_columns.size() > arguments.m_sort_column ? m_columns[arguments.m_sort_column].m_name.c_str() : nullptr);
+    result = rocprofvis_db_build_table_query(db, arguments.m_use_case, 
+                                             static_cast<rocprofvis_dm_timestamp_t>(arguments.m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(arguments.m_end_ts),
+                                             static_cast<rocprofvis_db_num_of_tracks_t>(arguments.m_tracks.size()), arguments.m_tracks.data(), 
+                                             arguments.m_where.c_str(), arguments.m_filter.c_str(), 
+                                             arguments.m_group.c_str(), arguments.m_group_cols.c_str(), 
+                                             sort_column, (rocprofvis_dm_sort_order_t)arguments.m_sort_order,
+                                             count_only ? 0 : count, count_only ? 0 : index, count_only, out);
     return result;
 }
 

--- a/src/controller/src/system/rocprofvis_controller_table_system.h
+++ b/src/controller/src/system/rocprofvis_controller_table_system.h
@@ -4,12 +4,9 @@
 #pragma once
 
 #include "rocprofvis_controller.h"
-#include "rocprofvis_controller_handle.h"
-#include "rocprofvis_controller_data.h"
 #include "rocprofvis_controller_table.h"
 #include "rocprofvis_c_interface.h"
 #include <vector>
-#include <deque>
 
 namespace RocProfVis
 {
@@ -29,7 +26,7 @@ public:
 
     virtual ~SystemTable();
 
-    void Reset();
+    void Reset() override;
 
     rocprofvis_result_t SetupAndFetch(Trace& controller, Arguments& args, Array& array, Future* future) final;
     rocprofvis_result_t ExportCSV(rocprofvis_dm_trace_t dm_handle, Arguments& args, Future* future, const char* path) const final;
@@ -39,34 +36,38 @@ public:
     rocprofvis_result_t GetString(rocprofvis_property_t property, uint64_t index, char* value, uint32_t* length) final;
 
 protected:
-    struct QueryArguments
+    struct SystemTableArguments : TableArguments
     {
         std::string m_where;
         std::string m_filter;
         std::string m_group;
         std::string m_group_cols;
-        uint64_t m_sort_column;
-        rocprofvis_controller_sort_order_t m_sort_order;
         std::vector<uint32_t> m_tracks;
-        std::vector<std::string> m_string_table_filters;
         rocprofvis_dm_table_use_case_enum_t m_use_case;
         double m_start_ts;
         double m_end_ts;
     };
 
-    virtual rocprofvis_result_t UnpackArguments(Arguments& args, QueryArguments& out) const;
-    virtual rocprofvis_result_t UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t& out) const;
+    rocprofvis_result_t UnpackArguments(Arguments& args, TableArguments*& out) const override;
+    void                GetCurrentArguments(TableArguments*& out) const override;
+    void                SetCurrentArguments(TableArguments& in) override;
+
+    virtual bool                   ArgumentsChanged(SystemTableArguments& in) const;
+    virtual rocprofvis_result_t    UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t& out) const;
+    virtual rocprofvis_dm_result_t BuildQuery(rocprofvis_dm_database_t db, TableArguments& args, uint64_t index, uint64_t count, bool count_only, char** out) const;
 
 private:
     rocprofvis_result_t Setup(rocprofvis_dm_trace_t dm_handle, Arguments& args, Future* future) final;
     rocprofvis_result_t Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t index, uint64_t count, Array& array, Future* future) final;
 
     std::vector<uint32_t> m_tracks;
-    std::vector<std::string> m_string_table_filters;
-    std::vector<const char*> m_string_table_filters_ptr;
     rocprofvis_dm_table_use_case_enum_t m_use_case;
     double m_start_ts;
     double m_end_ts;
+    std::string m_where;
+    std::string m_filter;
+    std::string m_group;
+    std::string m_group_cols;
 };
 
 }

--- a/src/controller/src/system/rocprofvis_controller_table_system_search.cpp
+++ b/src/controller/src/system/rocprofvis_controller_table_system_search.cpp
@@ -1,0 +1,137 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_controller_table_system_search.h"
+#include "rocprofvis_controller_arguments.h"
+#include "rocprofvis_controller_reference.h"
+
+namespace RocProfVis
+{
+namespace Controller
+{
+
+EventSearchTable::EventSearchTable(uint64_t id)
+: SystemTable(id)
+{
+}
+
+EventSearchTable::~EventSearchTable()
+{
+}
+
+void EventSearchTable::Reset()
+{
+    SystemTable::Reset();
+    m_string_table_filters.clear();
+}
+
+rocprofvis_result_t
+EventSearchTable::UnpackArguments(Arguments& args, TableArguments*& out) const
+{
+    if(!out)
+    {
+        out = new EventSearchTableArguments();
+    }
+    EventSearchTableArguments* search_out = (EventSearchTableArguments*)out;
+    rocprofvis_result_t result = SystemTable::UnpackArguments(args, out);
+    if(result == kRocProfVisResultSuccess)
+    {
+        uint64_t num_string_table_filters = 0;
+        std::vector<std::string> string_table_filters;
+        uint64_t table_type = static_cast<uint64_t>(kRPVControllerTableTypeSearchResults);
+
+        if (result == kRocProfVisResultSuccess)
+        {
+            result = args.GetUInt64(kRPVControllerTableArgsType, 0, &table_type);
+        }
+
+        if(result == kRocProfVisResultSuccess &&
+           (table_type == kRPVControllerTableTypeSearchResults ||
+            table_type == kRPVControllerTableTypeSummaryKernelInstances))
+        {
+            result = args.GetUInt64(kRPVControllerTableArgsNumStringTableFilters, 0, &num_string_table_filters);
+            if(result == kRocProfVisResultSuccess)
+            {
+                for (uint32_t i = 0; i < num_string_table_filters && (result == kRocProfVisResultSuccess); i++)
+                {
+                    uint32_t length = 0;
+                    result = args.GetString(kRPVControllerTableArgsStringTableFiltersIndexed, i, nullptr, &length);
+                    if(result == kRocProfVisResultSuccess && length > 0)
+                    {
+                        std::string f;
+                        f.resize(length);
+                        result = args.GetString(kRPVControllerTableArgsStringTableFiltersIndexed, i, f.data(), &length);
+                        if(result == kRocProfVisResultSuccess)
+                        {
+                            string_table_filters.push_back(f);
+                        }
+                    }
+                }
+            }
+        }
+        if(result == kRocProfVisResultSuccess)
+        {
+            search_out->m_string_table_filters = std::move(string_table_filters);
+        }   
+    }
+	return result;
+}
+
+void
+EventSearchTable::GetCurrentArguments(TableArguments*& out) const
+{
+    if(!out)
+    {
+        out = new EventSearchTableArguments();
+    }
+    EventSearchTableArguments* search_out = (EventSearchTableArguments*)out;
+    SystemTable::GetCurrentArguments(out);    
+    search_out->m_string_table_filters = m_string_table_filters;
+}
+
+void
+EventSearchTable::SetCurrentArguments(TableArguments& in)
+{
+    EventSearchTableArguments& search_in = (EventSearchTableArguments&)in;
+    SystemTable::SetCurrentArguments(search_in);
+    m_string_table_filters = search_in.m_string_table_filters;
+}
+
+bool
+EventSearchTable::ArgumentsChanged(SystemTableArguments& in) const
+{
+    EventSearchTableArguments& search_in = (EventSearchTableArguments&)in;
+    return SystemTable::ArgumentsChanged(search_in) || m_string_table_filters != search_in.m_string_table_filters;
+}
+
+rocprofvis_result_t
+EventSearchTable::UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t& out) const
+{
+    (void) args;
+    out = kRPVDMTableUseCaseEventSearch;
+    return kRocProfVisResultSuccess;
+}
+
+rocprofvis_dm_result_t
+EventSearchTable::BuildQuery(rocprofvis_dm_database_t db, TableArguments& args, uint64_t index, uint64_t count, bool count_only, char** out) const
+{
+    rocprofvis_dm_result_t result = kRocProfVisDmResultUnknownError;
+    EventSearchTableArguments& arguments = (EventSearchTableArguments&)args;
+    char const* sort_column = count_only ? nullptr : (m_columns.size() > arguments.m_sort_column ? m_columns[arguments.m_sort_column].m_name.c_str() : nullptr);
+    std::vector<const char*> string_table_filters_ptr;
+    for(const std::string& filter : arguments.m_string_table_filters)
+    {
+        string_table_filters_ptr.push_back(filter.c_str());
+    }
+    result = rocprofvis_db_build_event_search_query(db, 
+                                                    static_cast<rocprofvis_dm_timestamp_t>(arguments.m_start_ts), static_cast<rocprofvis_dm_timestamp_t>(arguments.m_end_ts), 
+                                                    static_cast<rocprofvis_db_num_of_tracks_t>(arguments.m_tracks.size()), arguments.m_tracks.data(),
+                                                    arguments.m_where.c_str(),
+                                                    static_cast<rocprofvis_dm_num_string_table_filters_t>(string_table_filters_ptr.size()), string_table_filters_ptr.data(), 
+                                                    sort_column, (rocprofvis_dm_sort_order_t)arguments.m_sort_order, 
+                                                    count_only ? 0 : count, count_only ? 0 : index, count_only, out);
+    return result;
+}
+
+}
+}

--- a/src/controller/src/system/rocprofvis_controller_table_system_search.cpp
+++ b/src/controller/src/system/rocprofvis_controller_table_system_search.cpp
@@ -3,7 +3,6 @@
 
 #include "rocprofvis_controller_table_system_search.h"
 #include "rocprofvis_controller_arguments.h"
-#include "rocprofvis_controller_reference.h"
 
 namespace RocProfVis
 {
@@ -40,11 +39,7 @@ EventSearchTable::UnpackArguments(Arguments& args, TableArguments*& out) const
         std::vector<std::string> string_table_filters;
         uint64_t table_type = static_cast<uint64_t>(kRPVControllerTableTypeSearchResults);
 
-        if (result == kRocProfVisResultSuccess)
-        {
-            result = args.GetUInt64(kRPVControllerTableArgsType, 0, &table_type);
-        }
-
+        result = args.GetUInt64(kRPVControllerTableArgsType, 0, &table_type);
         if(result == kRocProfVisResultSuccess &&
            (table_type == kRPVControllerTableTypeSearchResults ||
             table_type == kRPVControllerTableTypeSummaryKernelInstances))

--- a/src/controller/src/system/rocprofvis_controller_table_system_search.h
+++ b/src/controller/src/system/rocprofvis_controller_table_system_search.h
@@ -1,0 +1,47 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocprofvis_controller.h"
+#include "rocprofvis_controller_table_system.h"
+#include "rocprofvis_c_interface.h"
+#include <vector>
+
+namespace RocProfVis
+{
+namespace Controller
+{
+
+class Arguments;
+
+class EventSearchTable : public SystemTable
+{
+public:
+    EventSearchTable(uint64_t id);
+
+    virtual ~EventSearchTable();
+
+    void Reset() override;
+
+protected:
+    struct EventSearchTableArguments : SystemTableArguments
+    {       
+        std::vector<std::string> m_string_table_filters;
+    };
+
+    rocprofvis_result_t UnpackArguments(Arguments& args, TableArguments*& out) const override;
+    void                GetCurrentArguments(TableArguments*& out) const override;
+    void                SetCurrentArguments(TableArguments& in) override;
+
+    virtual bool                   ArgumentsChanged(SystemTableArguments& in) const;
+    virtual rocprofvis_result_t    UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t& out) const;
+    virtual rocprofvis_dm_result_t BuildQuery(rocprofvis_dm_database_t db, TableArguments& args, uint64_t index, uint64_t count, bool count_only, char** out) const;
+
+private:
+    std::vector<std::string> m_string_table_filters;
+
+};
+
+}
+}

--- a/src/controller/src/system/rocprofvis_controller_table_system_search.h
+++ b/src/controller/src/system/rocprofvis_controller_table_system_search.h
@@ -34,9 +34,9 @@ protected:
     void                GetCurrentArguments(TableArguments*& out) const override;
     void                SetCurrentArguments(TableArguments& in) override;
 
-    virtual bool                   ArgumentsChanged(SystemTableArguments& in) const;
-    virtual rocprofvis_result_t    UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t& out) const;
-    virtual rocprofvis_dm_result_t BuildQuery(rocprofvis_dm_database_t db, TableArguments& args, uint64_t index, uint64_t count, bool count_only, char** out) const;
+    virtual bool                   ArgumentsChanged(SystemTableArguments& in) const override;
+    virtual rocprofvis_result_t    UnpackUseCase(Arguments& args, rocprofvis_dm_table_use_case_enum_t& out) const override;
+    virtual rocprofvis_dm_result_t BuildQuery(rocprofvis_dm_database_t db, TableArguments& args, uint64_t index, uint64_t count, bool count_only, char** out) const override;
 
 private:
     std::vector<std::string> m_string_table_filters;

--- a/src/controller/src/system/rocprofvis_controller_trace_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_trace_system.cpp
@@ -12,6 +12,7 @@
 #include "rocprofvis_controller_summary.h"
 #include "rocprofvis_controller_summary_metrics.h"
 #include "rocprofvis_controller_table_system.h"
+#include "rocprofvis_controller_table_system_search.h"
 #include "rocprofvis_controller_timeline.h"
 #include "rocprofvis_controller_track.h"
 #include "rocprofvis_controller_topology.h"
@@ -68,7 +69,7 @@ rocprofvis_result_t SystemTrace::Init()
 
         m_sample_table = new SystemTable(1);
 
-        m_search_table = new SystemTable(2);
+        m_search_table = new EventSearchTable(2);
         
         m_summary = new Summary(this);
 
@@ -1123,7 +1124,7 @@ rocprofvis_result_t SystemTrace::SetObject(rocprofvis_property_t property, uint6
                 SystemTableRef table(value);
                 if(table.IsValid())
                 {
-                    m_search_table = table.Get();
+                    m_search_table = (EventSearchTable*)(table.Get());
                     result = kRocProfVisResultSuccess;
                 }
                 break;

--- a/src/controller/src/system/rocprofvis_controller_trace_system.h
+++ b/src/controller/src/system/rocprofvis_controller_trace_system.h
@@ -27,6 +27,7 @@ class Graph;
 class Timeline;
 class Event;
 class Table;
+class EventSearchTable;
 class SystemTable;
 class Summary;
 class SummaryMetrics;
@@ -91,7 +92,7 @@ private:
     Timeline*                                      m_timeline;
     SystemTable*                                   m_event_table;
     SystemTable*                                   m_sample_table;
-    SystemTable*                                   m_search_table;
+    EventSearchTable*                              m_search_table;
     Summary*                                       m_summary;
     MemoryManager*                                 m_mem_mgmt;
     TopologyNode*                                  m_topology_root;

--- a/src/model/inc/rocprofvis_interface.h
+++ b/src/model/inc/rocprofvis_interface.h
@@ -198,8 +198,25 @@ rocprofvis_dm_result_t rocprofvis_db_build_table_query(
     rocprofvis_dm_charptr_t group_cols, 
     rocprofvis_dm_charptr_t sort_column, 
     rocprofvis_dm_sort_order_t sort_order, 
+    uint64_t max_count, 
+    uint64_t offset, 
+    bool count_only,
+    char** out_query);
+
+/****************************************************************************************************
+* @note caller is responsible for freeing out_query
+* ***************************************************************************************************/
+rocprofvis_dm_result_t rocprofvis_db_build_event_search_query(
+    rocprofvis_dm_database_t database,
+    rocprofvis_dm_timestamp_t start,
+    rocprofvis_dm_timestamp_t end, 
+    rocprofvis_db_num_of_tracks_t num,
+    rocprofvis_db_track_selection_t ops,
+    rocprofvis_dm_charptr_t where,
     rocprofvis_dm_num_string_table_filters_t num_string_table_filters, 
     rocprofvis_dm_string_table_filters_t string_table_filters,
+    rocprofvis_dm_charptr_t sort_column, 
+    rocprofvis_dm_sort_order_t sort_order,
     uint64_t max_count, 
     uint64_t offset, 
     bool count_only,

--- a/src/model/inc/rocprofvis_interface_types.h
+++ b/src/model/inc/rocprofvis_interface_types.h
@@ -402,7 +402,6 @@ typedef enum rocprofvis_dm_table_use_case_enum_t {
     kRPVDMTableUseCaseEventTrackTable,
     kRPVDMTableUseCaseSampleTrackTable,
     kRPVDMTableUseCaseEventSearch,
-    kRPVDMTableUseCaseAnalysis,
     kRPVDMTableNumUsecases,
 } rocprofvis_dm_table_use_case_enum_t;
 

--- a/src/model/src/common/rocprofvis_c_interface.cpp
+++ b/src/model/src/common/rocprofvis_c_interface.cpp
@@ -368,7 +368,6 @@ rocprofvis_dm_result_t rocprofvis_db_build_table_query(
     rocprofvis_dm_charptr_t where, rocprofvis_dm_charptr_t filter, 
     rocprofvis_dm_charptr_t group, rocprofvis_dm_charptr_t group_cols, 
     rocprofvis_dm_charptr_t sort_column, rocprofvis_dm_sort_order_t sort_order, 
-    rocprofvis_dm_num_string_table_filters_t num_string_table_filters, rocprofvis_dm_string_table_filters_t string_table_filters, 
     uint64_t max_count, uint64_t offset, bool count_only, 
     char** out_query)
 {
@@ -380,8 +379,49 @@ rocprofvis_dm_result_t rocprofvis_db_build_table_query(
                                  kRocProfVisDmResultInvalidParameter);
     RocProfVis::DataModel::Database* db = (RocProfVis::DataModel::Database*) database;
     std::string query;
-    rocprofvis_dm_result_t result = db->BuildTableQuery(use_case, start, end, num, tracks, where, filter, group, group_cols, sort_column, sort_order, 
-                                                        num_string_table_filters, string_table_filters, max_count, offset, count_only, query);
+    rocprofvis_dm_result_t result = db->BuildTableQuery(use_case, 
+                                                        start, end, 
+                                                        num, tracks, 
+                                                        where, filter, 
+                                                        group, group_cols, 
+                                                        sort_column, sort_order, 
+                                                        max_count, offset, count_only, query);
+    if (result == kRocProfVisDmResultSuccess)
+    {
+        char* ptr = (char*) calloc(query.length() + 1, 1);
+        ROCPROFVIS_ASSERT_MSG_RETURN(ptr, "Error! Couldn't allocate query string.",
+                                     kRocProfVisDmResultAllocFailure);
+        std::memcpy(ptr, query.c_str(), query.length());
+        ptr[query.length()] = '\0';
+        *out_query = ptr;
+    }
+    return result;
+}
+
+rocprofvis_dm_result_t rocprofvis_db_build_event_search_query(
+    rocprofvis_dm_database_t database, 
+    rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end, 
+    rocprofvis_db_num_of_tracks_t num, rocprofvis_db_track_selection_t ops,
+    rocprofvis_dm_charptr_t where,
+    rocprofvis_dm_num_string_table_filters_t num_string_table_filters, rocprofvis_dm_string_table_filters_t string_table_filters, 
+    rocprofvis_dm_charptr_t sort_column, rocprofvis_dm_sort_order_t sort_order,
+    uint64_t max_count, uint64_t offset, bool count_only, 
+    char** out_query)
+{
+    PROFILE;
+    ROCPROFVIS_ASSERT_MSG_RETURN(database,
+                                 RocProfVis::DataModel::ERROR_DATABASE_CANNOT_BE_NULL,
+                                 kRocProfVisDmResultInvalidParameter);
+    ROCPROFVIS_ASSERT_MSG_RETURN(out_query, "Error! Query cannot be null.",
+                                 kRocProfVisDmResultInvalidParameter);
+    RocProfVis::DataModel::Database* db = (RocProfVis::DataModel::Database*) database;
+    std::string query;
+    rocprofvis_dm_result_t result = db->BuildEventSearchQuery(start, end, 
+                                                              num, ops,
+                                                              where,
+                                                              num_string_table_filters, string_table_filters, 
+                                                              sort_column, sort_order, 
+                                                              max_count, offset, count_only, query);
     if (result == kRocProfVisDmResultSuccess)
     {
         char* ptr = (char*) calloc(query.length() + 1, 1);

--- a/src/model/src/database/rocprofvis_db.cpp
+++ b/src/model/src/database/rocprofvis_db.cpp
@@ -159,6 +159,30 @@ rocprofvis_dm_result_t   Database::ReadEventPropertyAsync(
     return kRocProfVisDmResultSuccess;
 }
 
+rocprofvis_dm_result_t Database::BuildEventSearchQuery(
+    rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end,
+    rocprofvis_db_num_of_tracks_t num, rocprofvis_db_track_selection_t ops,
+    rocprofvis_dm_charptr_t where,
+    rocprofvis_dm_num_string_table_filters_t num_string_table_filters, rocprofvis_dm_string_table_filters_t string_table_filters,
+    rocprofvis_dm_charptr_t sort_column, rocprofvis_dm_sort_order_t sort_order,
+    uint64_t max_count, uint64_t offset, bool count_only, rocprofvis_dm_string_t& query)
+{
+    (void) start;
+    (void) end;
+    (void) num;
+    (void) ops;
+    (void) where;
+    (void) num_string_table_filters;
+    (void) string_table_filters;
+    (void) sort_column;
+    (void) sort_order;
+    (void) max_count;
+    (void) offset;
+    (void) count_only;
+    (void) query;
+    return kRocProfVisDmResultNotSupported;
+}
+
 rocprofvis_dm_result_t Database::ExportTableCSVAsync(rocprofvis_dm_string_t query,
                                                      rocprofvis_dm_string_t file_path,
                                                      rocprofvis_db_future_t object)

--- a/src/model/src/database/rocprofvis_db.h
+++ b/src/model/src/database/rocprofvis_db.h
@@ -213,12 +213,25 @@ class Database
                                                                 rocprofvis_dm_charptr_t group_cols, 
                                                                 rocprofvis_dm_charptr_t sort_column, 
                                                                 rocprofvis_dm_sort_order_t sort_order,
-                                                                rocprofvis_dm_num_string_table_filters_t num_string_table_filters, 
-                                                                rocprofvis_dm_string_table_filters_t string_table_filters,
                                                                 uint64_t max_count, 
                                                                 uint64_t offset,
                                                                 bool count_only,
                                                                 rocprofvis_dm_string_t& query) = 0;
+
+       virtual rocprofvis_dm_result_t BuildEventSearchQuery(    
+                                                                rocprofvis_dm_timestamp_t start, 
+                                                                rocprofvis_dm_timestamp_t end,
+                                                                rocprofvis_db_num_of_tracks_t num, 
+                                                                rocprofvis_db_track_selection_t ops,
+                                                                rocprofvis_dm_charptr_t where,
+                                                                rocprofvis_dm_num_string_table_filters_t num_string_table_filters,
+                                                                rocprofvis_dm_string_table_filters_t string_table_filters,
+                                                                rocprofvis_dm_charptr_t sort_column,
+                                                                rocprofvis_dm_sort_order_t sort_order,
+                                                                uint64_t max_count,
+                                                                uint64_t offset,
+                                                                bool count_only,
+                                                                rocprofvis_dm_string_t& query);
 
 
         // Asynchronously writes the results of a table query to .CSV

--- a/src/model/src/database/rocprofvis_db_compute.h
+++ b/src/model/src/database/rocprofvis_db_compute.h
@@ -227,8 +227,6 @@ namespace DataModel
             rocprofvis_dm_charptr_t /*group_cols*/,
             rocprofvis_dm_charptr_t /*sort_column*/,
             rocprofvis_dm_sort_order_t /*sort_order*/,
-            rocprofvis_dm_num_string_table_filters_t /*num_string_table_filters*/,
-            rocprofvis_dm_string_table_filters_t /*string_table_filters*/,
             uint64_t /*max_count*/,
             uint64_t /*offset*/,
             bool /*count_only*/,

--- a/src/model/src/database/rocprofvis_db_profile.cpp
+++ b/src/model/src/database/rocprofvis_db_profile.cpp
@@ -951,12 +951,10 @@ ProfileDatabase::ExecuteQueriesAsync(
     return result;
 }
 
-void ProfileDatabase::BuildSliceQueryMap(slice_query_map_t& slice_query_map, rocprofvis_dm_track_params_t* props)
+void ProfileDatabase::BuildSliceQueryMap(slice_query_map_t& slice_query_map, rocprofvis_dm_track_params_t* props, rocprofvis_db_query_type_t query_type)
 {
-    int slice_query_category = props->track_indentifiers.category ==  kRocProfVisDmStreamTrack? kRPVQuerySliceByStream : kRPVQuerySliceByQueue;
-
-    for (int j = 0; j < props->query[slice_query_category].size(); j++) {
-        std::string q = props->query[slice_query_category][j]; 
+    for (int j = 0; j < props->query[query_type].size(); j++) {
+        std::string q = props->query[query_type][j]; 
 
         std::string tuple = "(";
         for (int k = 0; k < NUMBER_OF_TRACK_IDENTIFICATION_PARAMETERS; k++) {
@@ -989,6 +987,206 @@ void ProfileDatabase::BuildSliceQueryMap(slice_query_map_t& slice_query_map, roc
     }
 }
 
+rocprofvis_dm_result_t
+ProfileDatabase::BuildCompoundQuery(
+    rocprofvis_dm_table_use_case_enum_t use_case, rocprofvis_dm_timestamp_t start,
+    rocprofvis_dm_timestamp_t end, rocprofvis_db_num_of_tracks_t num,
+    rocprofvis_db_track_selection_t tracks,
+    std::vector<slice_query_map_t>& slice_query_map_array, rocprofvis_dm_charptr_t where,
+    rocprofvis_dm_charptr_t filter, rocprofvis_dm_charptr_t group,
+    rocprofvis_dm_charptr_t group_cols, rocprofvis_dm_charptr_t sort_column,
+    rocprofvis_dm_sort_order_t sort_order, uint64_t max_count, uint64_t offset,
+    bool count_only, rocprofvis_dm_string_t& query)
+{
+    query = "";
+
+    size_t thread_count = std::thread::hardware_concurrency();
+    bool   event_table  = false;
+    for(int i = 0; i < slice_query_map_array.size(); i++)
+    {
+        rocprofvis_dm_index_t track = tracks[i];
+        track                       = TABLE_QUERY_UNPACK_TRACK_ID(track);
+
+        int divider = static_cast<int>(thread_count / slice_query_map_array.size());
+        if(divider == 0) divider = 1;
+        for(auto it_query = slice_query_map_array[i].begin();
+            it_query != slice_query_map_array[i].end(); ++it_query)
+        {
+            auto op = GetTableQueryOperation(it_query->first);
+            if(op > kRocProfVisDmOperationNoOp)
+            {
+                event_table = true;
+            }
+            if(TABLE_QUERY_UNPACK_OP_TYPE(track) == 0)
+            {
+                rocprofvis_dm_track_params_t* props = TrackPropertiesAt(track);
+                if(props->record_count < SINGLE_THREAD_RECORDS_COUNT_LIMIT ||
+                   op == kRocProfVisDmOperationMemoryAllocate ||
+                   op == kRocProfVisDmOperationMemoryCopy)
+                    divider = 1;
+            }
+            uint64_t step = (end - start) / divider;
+            for(auto it_instance = it_query->second.begin();
+                it_instance != it_query->second.end(); ++it_instance)
+            {
+                DbInstance* db_inst = DbInstancePtrAt(it_instance->first);
+                ROCPROFVIS_ASSERT_MSG_RETURN(db_inst, ERROR_NODE_KEY_CANNOT_BE_NULL,
+                                             kRocProfVisDmResultUnknownError);
+                uint64_t begin =
+                    start + TraceProperties()->db_inst_start_time[db_inst->GuidIndex()];
+                for(int j = 0; j < divider; j++)
+                {
+                    uint64_t fetch_start = begin + (step * j);
+                    uint64_t fetch_end   = begin + (step * j) + step;
+                    if(IsEmptyRange(tracks[i], fetch_start, fetch_end)) continue;
+                    query += it_query->first;
+                    if(it_instance->second.empty())
+                    {
+                        query += " WHERE ";
+                    }
+                    else
+                    {
+                        query += it_instance->second;
+                        query += ") and ";
+                    }
+
+                    query += Builder::END_SERVICE_NAME;
+                    query += " >= ";
+                    query += std::to_string(fetch_start);
+                    query += " and ";
+                    query += Builder::START_SERVICE_NAME;
+                    query += (j == divider - 1) ? " <= " : " < ";
+                    query += std::to_string(fetch_end);
+                    if(where && strlen(where))
+                    {
+                        query += " AND ";
+                        query += where;
+                    }
+                    query += ";";
+                    query += std::to_string(tracks[i]);
+                    query += ";";
+                    query += std::to_string(it_instance->first);
+                    query += "\n";
+                }
+            }
+        }
+    }
+    if(query.empty())
+    {
+        return kRocProfVisDmResultSuccess;
+    }
+    query += "-- CMD: TYPE ";
+    switch(use_case)
+    {
+        case kRPVDMTableUseCaseEventTrackTable:
+        {
+            query += std::to_string(kRPVTableDataTypeEvent);
+            break;
+        }
+        case kRPVDMTableUseCaseSampleTrackTable:
+        {
+            query += std::to_string(kRPVTableDataTypeSample);
+            break;
+        }
+        case kRPVDMTableUseCaseEventSearch:
+        {
+            query += std::to_string(kRPVTableDataTypeSearch);
+            break;
+        }
+        default:
+        {
+            return kRocProfVisDmResultInvalidParameter;
+            break;
+        }
+    }
+    query += "\n";
+
+    if(group && strlen(group))
+    {
+        query += "-- CMD: GROUP ";
+        if(group_cols && strlen(group_cols))
+        {
+            if(!FilterExpression::StartsWithSubstring(group, group_cols))
+            {
+                query += group_cols;
+                query += ", ";
+            }
+            query += group;
+        }
+        else
+        {
+            query += group;
+            bool sample_query = false;
+            if(TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == 0)
+            {
+                sample_query =
+                    TrackPropertiesAt(tracks[0])->track_indentifiers.category ==
+                    kRocProfVisDmPmcTrack;
+            }
+            else
+            {
+                sample_query =
+                    (rocprofvis_dm_event_operation_t) TABLE_QUERY_UNPACK_OP_TYPE(
+                        tracks[0]) == kRocProfVisDmOperationNoOp;
+            }
+            if(sample_query)
+            {
+                query += ", COUNT(*) as count, AVG(value) as avg_value, MIN(value) as "
+                         "min_value, MAX(value) as max_value";
+            }
+            else
+            {
+                query += ", COUNT(*) as num_invocations, AVG(duration) as avg_duration, "
+                         "MIN(duration) as min_duration, MAX(duration) as max_duration";
+            }
+        }
+        query += "\n";
+    }
+
+    if(filter && strlen(filter))
+    {
+        query += "-- CMD: FILTER ";
+        query += filter;
+        query += "\n";
+    }
+
+    if(sort_column && strlen(sort_column))
+    {
+        query += "-- CMD: SORT";
+        if(sort_order == kRPVDMSortOrderAsc)
+        {
+            query += " ASC ";
+        }
+        else
+        {
+            query += " DESC ";
+        }
+        query += sort_column;
+        query += "\n";
+    }
+    if(count_only)
+    {
+        query += "-- CMD: COUNT";
+        query += "\n";
+    }
+    else
+    {
+        if(max_count)
+        {
+            query += "-- CMD: LIMIT ";
+            query += std::to_string(max_count);
+            query += "\n";
+        }
+        if(offset)
+        {
+            query += "-- CMD: OFFSET ";
+            query += std::to_string(offset);
+            query += "\n";
+        }
+    }
+    return kRocProfVisDmResultSuccess;
+}
+
 rocprofvis_dm_result_t ProfileDatabase::BuildCounterSliceLeftNeighbourQuery(rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end, rocprofvis_dm_index_t track_index, rocprofvis_dm_string_t& query) {
     slice_query_map_t slice_query_map;
     rocprofvis_dm_track_params_t* props = TrackPropertiesAt(track_index);
@@ -997,7 +1195,7 @@ rocprofvis_dm_result_t ProfileDatabase::BuildCounterSliceLeftNeighbourQuery(rocp
     start += TraceProperties()->db_inst_start_time[db_instance->GuidIndex()];
     end += TraceProperties()->db_inst_start_time[db_instance->GuidIndex()];
     
-    BuildSliceQueryMap(slice_query_map, props);
+    BuildSliceQueryMap(slice_query_map, props, props->track_indentifiers.category ==  kRocProfVisDmStreamTrack? kRPVQuerySliceByStream : kRPVQuerySliceByQueue);
 
     if (!slice_query_map.empty()) {
         auto it_query = slice_query_map.begin();
@@ -1024,7 +1222,7 @@ rocprofvis_dm_result_t ProfileDatabase::BuildCounterSliceRightNeighbourQuery(roc
     start += TraceProperties()->db_inst_start_time[db_instance->GuidIndex()];
     end += TraceProperties()->db_inst_start_time[db_instance->GuidIndex()];
 
-    BuildSliceQueryMap(slice_query_map, props);
+    BuildSliceQueryMap(slice_query_map, props, props->track_indentifiers.category ==  kRocProfVisDmStreamTrack? kRPVQuerySliceByStream : kRPVQuerySliceByQueue);
 
     if (!slice_query_map.empty()) {
         auto it_query = slice_query_map.begin();
@@ -1059,7 +1257,7 @@ rocprofvis_dm_result_t ProfileDatabase::BuildSliceQuery(rocprofvis_dm_timestamp_
     {
         pmc_query = true;
     }
-    BuildSliceQueryMap(slice_query_map, props);
+    BuildSliceQueryMap(slice_query_map, props, props->track_indentifiers.category ==  kRocProfVisDmStreamTrack? kRPVQuerySliceByStream : kRPVQuerySliceByQueue);
     if (start > props->min_ts || end < props->max_ts)
     {
         timed_query = true;
@@ -1104,92 +1302,34 @@ rocprofvis_dm_result_t ProfileDatabase::BuildSliceQuery(rocprofvis_dm_timestamp_
 
 rocprofvis_dm_result_t
 ProfileDatabase::BuildTableQuery(
-    rocprofvis_dm_table_use_case_enum_t use_case,
-    rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end,
+    rocprofvis_dm_table_use_case_enum_t use_case, 
+    rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end, 
     rocprofvis_db_num_of_tracks_t num, rocprofvis_db_track_selection_t tracks, 
     rocprofvis_dm_charptr_t where, rocprofvis_dm_charptr_t filter,
-    rocprofvis_dm_charptr_t group, rocprofvis_dm_charptr_t group_cols, 
-    rocprofvis_dm_charptr_t sort_column, rocprofvis_dm_sort_order_t sort_order, 
-    rocprofvis_dm_num_string_table_filters_t num_string_table_filters, rocprofvis_dm_string_table_filters_t string_table_filters,
-    uint64_t max_count, uint64_t offset, bool count_only, 
-    rocprofvis_dm_string_t& query)
+    rocprofvis_dm_charptr_t group, rocprofvis_dm_charptr_t group_cols,
+    rocprofvis_dm_charptr_t sort_column, rocprofvis_dm_sort_order_t sort_order,
+    uint64_t max_count, uint64_t offset, bool count_only, rocprofvis_dm_string_t& query)
 {
     std::vector<slice_query_map_t> slice_query_map_array;
-    table_string_id_filter_map_t string_id_filter_map;
-    
-    bool sample_query = false;
-    if(TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == 0)
-    {
-        sample_query = TrackPropertiesAt(tracks[0])->track_indentifiers.category == kRocProfVisDmPmcTrack;
-    }
-    else
-    {
-        sample_query = (rocprofvis_dm_event_operation_t)TABLE_QUERY_UNPACK_OP_TYPE(tracks[0]) == kRocProfVisDmOperationNoOp;
-    }
-    rocprofvis_dm_result_t string_filter_result = BuildTableStringIdFilter(num_string_table_filters, string_table_filters, string_id_filter_map);
     slice_query_map_array.resize(num);
-    for (int i = 0; i < num; i++){
+    for(int i = 0; i < num; i++)
+    {
         rocprofvis_dm_index_t track = tracks[i];
         if(TABLE_QUERY_UNPACK_OP_TYPE(track) == 0)
         {
-            track = TABLE_QUERY_UNPACK_TRACK_ID(track);
+            track                               = TABLE_QUERY_UNPACK_TRACK_ID(track);
             rocprofvis_dm_track_params_t* props = TrackPropertiesAt(track);
-            DbInstance* instance = (DbInstance*)props->track_indentifiers.db_instance;
-            for(int j = 0; j < props->query[kRPVQueryTable].size(); j++)
-            {
-                std::string q     = props->query[kRPVQueryTable][j]; 
-                std::string tuple = "(";
-                for (int k = 0; k < NUMBER_OF_TRACK_IDENTIFICATION_PARAMETERS; k++) {
-                    if (props->track_indentifiers.tag[k] != "const") {
-                        if (tuple.length() > 1) tuple += ",";
-                        tuple += props->track_indentifiers.tag[k];
-                    }
-                }
-                tuple += ")";
-                q += " where ";
-                if(props->track_indentifiers.category == kRocProfVisDmRegionMainTrack)
-                {
-                    q += "SAMPLE.id IS NULL and ";
-                }
-                q += tuple;
-                q += " IN (";
-                tuple = "(";
-                for (int k = 0; k < NUMBER_OF_TRACK_IDENTIFICATION_PARAMETERS; k++) {
-                    if (props->track_indentifiers.tag[k] != "const") {
-                        if (tuple.length() > 1) tuple += ",";
-                        std::string id = props->track_indentifiers.is_numeric[k] ? std::to_string(props->track_indentifiers.id[k]) : std::string("'") + props->track_indentifiers.name[k] + "'";
-                        tuple += id;
-                      
-                    }
-                }
-                tuple += ")";
-                if (slice_query_map_array[i][q][instance->GuidIndex()].length() > 0) slice_query_map_array[i][q][instance->GuidIndex()] += ", ";
-                slice_query_map_array[i][q][instance->GuidIndex()] += tuple;
-            }
+            BuildSliceQueryMap(slice_query_map_array[i], props, kRPVQueryTable);
         }
         else 
         {
             track = TABLE_QUERY_UNPACK_OP_TYPE(track);
-            if (num_string_table_filters > 0)
+            for(auto db_inst : DbInstances())
             {
-                if (string_filter_result == kRocProfVisDmResultSuccess && string_id_filter_map.count((rocprofvis_dm_event_operation_t)track) > 0)
-                {
-                    auto filters = string_id_filter_map.at((rocprofvis_dm_event_operation_t)track);
-                    for (auto it = filters.begin(); it != filters.end(); ++it)
-                    {
-                        slice_query_map_array[i][GetEventOperationQuery((rocprofvis_dm_event_operation_t)track)][it->first] = std::string(" WHERE ") + it->second;
-                    }
-                }
-            }
-            else
-            {
-                for (auto db_inst : DbInstances())
-                {
-                    slice_query_map_array[i][GetEventOperationQuery((rocprofvis_dm_event_operation_t)track)][db_inst.first.GuidIndex()];
-                }
+                slice_query_map_array[i][GetEventOperationQuery(
+                    (rocprofvis_dm_event_operation_t) track)][db_inst.first.GuidIndex()];
             }
         }
-        
     }
     bool slice_query_map_empty = true;
     for(slice_query_map_t& query_map : slice_query_map_array)
@@ -1204,185 +1344,57 @@ ProfileDatabase::BuildTableQuery(
     {
         return kRocProfVisDmResultSuccess;    
     }
-    query = "";
+    return BuildCompoundQuery(use_case, start, end, num, tracks, slice_query_map_array,
+                              where, filter, group, group_cols, sort_column, sort_order,
+                              max_count, offset, count_only, query);
+}
 
-    size_t thread_count = std::thread::hardware_concurrency();
-    bool event_table = false;
-    for (int i = 0; i < num; i++)
+rocprofvis_dm_result_t
+ProfileDatabase::BuildEventSearchQuery(
+    rocprofvis_dm_timestamp_t start, rocprofvis_dm_timestamp_t end,
+    rocprofvis_db_num_of_tracks_t num, rocprofvis_db_track_selection_t ops,
+    rocprofvis_dm_charptr_t where,
+    rocprofvis_dm_num_string_table_filters_t num_string_table_filters,
+    rocprofvis_dm_string_table_filters_t     string_table_filters,
+    rocprofvis_dm_charptr_t sort_column, rocprofvis_dm_sort_order_t sort_order,
+    uint64_t max_count, uint64_t offset, bool count_only, rocprofvis_dm_string_t& query)
+{
+    std::vector<slice_query_map_t> slice_query_map_array;
+    table_string_id_filter_map_t string_id_filter_map;
+    rocprofvis_dm_result_t string_filter_result = BuildTableStringIdFilter(num_string_table_filters, string_table_filters, string_id_filter_map);
+    slice_query_map_array.resize(num);
+    for(int i = 0; i < num; i++)
     {
-        rocprofvis_dm_index_t track = tracks[i];
-        track = TABLE_QUERY_UNPACK_TRACK_ID(track);
-        
-        int divider = static_cast<int>(thread_count / num);
-        if (divider == 0) divider = 1;
-        for (auto it_query = slice_query_map_array[i].begin(); it_query != slice_query_map_array[i].end(); ++it_query) 
+        rocprofvis_dm_index_t op = TABLE_QUERY_UNPACK_OP_TYPE(ops[i]);
+        if (num_string_table_filters > 0)
         {
-            auto op = GetTableQueryOperation(it_query->first);
-            if (op > kRocProfVisDmOperationNoOp)
+            if (string_filter_result == kRocProfVisDmResultSuccess && string_id_filter_map.count((rocprofvis_dm_event_operation_t)op) > 0)
             {
-                event_table = true;
-            }
-            if (TABLE_QUERY_UNPACK_OP_TYPE(track) == 0)
-            {
-                rocprofvis_dm_track_params_t* props = TrackPropertiesAt(track);
-                if (props->record_count < SINGLE_THREAD_RECORDS_COUNT_LIMIT ||
-                    op == kRocProfVisDmOperationMemoryAllocate ||
-                    op == kRocProfVisDmOperationMemoryCopy)
-                    divider = 1;
-            }
-            uint64_t step = (end - start) / divider;
-            for (auto it_instance = it_query->second.begin(); it_instance != it_query->second.end(); ++it_instance)
-            {
-                DbInstance* db_inst = DbInstancePtrAt(it_instance->first);
-                ROCPROFVIS_ASSERT_MSG_RETURN(db_inst, ERROR_NODE_KEY_CANNOT_BE_NULL, kRocProfVisDmResultUnknownError);
-                uint64_t begin = start + TraceProperties()->db_inst_start_time[db_inst->GuidIndex()];
-                for (int j = 0; j < divider; j++)
+                auto filters = string_id_filter_map.at((rocprofvis_dm_event_operation_t)op);
+                for (auto it = filters.begin(); it != filters.end(); ++it)
                 {
-                    uint64_t fetch_start = begin + (step * j);
-                    uint64_t fetch_end = begin + (step * j) + step;
-                    if (IsEmptyRange(tracks[i], fetch_start, fetch_end)) continue;
-                    query += it_query->first;
-                    if(it_instance->second.empty())
-                    {
-                        query += " WHERE ";
-                    }
-                    else
-                    {
-                        query += it_instance->second;
-                        query += ") and ";
-                    }
-
-                    query += Builder::END_SERVICE_NAME;
-                    query += " >= ";
-                    query += std::to_string(fetch_start);
-                    query += " and ";
-                    query += Builder::START_SERVICE_NAME;
-                    query += (j == divider - 1) ? " <= " : " < ";
-                    query += std::to_string(fetch_end);
-                    if (where && strlen(where))
-                    {
-                        query += " AND ";
-                        query += where;
-                    }
-                    query += ";";
-                    query += std::to_string(tracks[i]);
-                    query += ";";
-                    query += std::to_string(it_instance->first);
-                    query += "\n";
+                    slice_query_map_array[i][GetEventOperationQuery((rocprofvis_dm_event_operation_t)op)][it->first] = std::string(" WHERE ") + it->second;
                 }
             }
-
         }
     }
-    if(query.empty())
+    bool slice_query_map_empty = true;
+    for(slice_query_map_t& query_map : slice_query_map_array)
+    {
+        if(!query_map.empty())
+        {
+            slice_query_map_empty = false;
+            break;
+        }
+    }
+    if(slice_query_map_empty)
     {
         return kRocProfVisDmResultSuccess;
     }
-    query += "-- CMD: TYPE ";
-    switch(use_case)
-    {
-        case kRPVDMTableUseCaseEventTrackTable:
-        {
-            query += std::to_string(kRPVTableDataTypeEvent);
-            break;
-        }
-        case kRPVDMTableUseCaseSampleTrackTable:
-        {
-            query += std::to_string(kRPVTableDataTypeSample);
-            break;
-        }
-        case kRPVDMTableUseCaseEventSearch:
-        {
-            query += std::to_string(kRPVTableDataTypeSearch);
-            break;
-        }
-        case kRPVDMTableUseCaseAnalysis:
-        {
-            query += std::to_string(kRPVTableDataTypeAnalysis);
-            break;
-        }
-        default:
-        {
-            return kRocProfVisDmResultInvalidParameter; 
-            break;
-        }
-    }
-    query += "\n";
-
-    if(group && strlen(group))
-    {
-        query += "-- CMD: GROUP ";
-        if (group_cols && strlen(group_cols))
-        {
-            if (!FilterExpression::StartsWithSubstring(group, group_cols))
-            {
-                query += group_cols;
-                query += ", ";
-            }
-            query += group;
-        }
-        else
-        {
-            query += group;
-            if(sample_query)
-            {
-                query += ", COUNT(*) as count, AVG(value) as avg_value, MIN(value) as "
-                         "min_value, MAX(value) as max_value";
-            }
-            else
-            {
-                query += ", COUNT(*) as num_invocations, AVG(duration) as avg_duration, "
-                         "MIN(duration) as min_duration, MAX(duration) as max_duration";
-            }
-        }
-        query += "\n";
-    }
-
-    if (filter && strlen(filter))
-    {
-        query += "-- CMD: FILTER ";
-        query += filter;
-        query += "\n";
-    }
-
-    if (sort_column && strlen(sort_column))
-    {
-        query += "-- CMD: SORT";
-        if (sort_order == kRPVDMSortOrderAsc)
-        {
-            query += " ASC ";
-        }
-        else
-        {
-            query += " DESC ";
-        }
-        query += sort_column;
-        query += "\n";
-
-    }
-    if(count_only)
-    {
-        query += "-- CMD: COUNT";
-        query += "\n";
-    } else
-    {
-        if(max_count)
-        {
-            query += "-- CMD: LIMIT ";
-            query += std::to_string(max_count);
-            query += "\n";
-        }
-        if(offset)
-        {
-            query += "-- CMD: OFFSET ";
-            query += std::to_string(offset);
-            query += "\n";
-        }
-    }
-    
-    return kRocProfVisDmResultSuccess;
+    return BuildCompoundQuery(kRPVDMTableUseCaseEventSearch, start, end, num, ops, slice_query_map_array,
+                              where, nullptr, nullptr, nullptr, sort_column, sort_order,
+                              max_count, offset, count_only, query);
 }
-
 
 bool ProfileDatabase::IsEmptyRange(uint32_t track, uint64_t start, uint64_t end) {
     if (TABLE_QUERY_UNPACK_OP_TYPE(track) != 0)

--- a/src/model/src/database/rocprofvis_db_profile.h
+++ b/src/model/src/database/rocprofvis_db_profile.h
@@ -72,7 +72,7 @@ class ProfileDatabase : public SqliteDatabase
         // @param path - full path to database file
         ProfileDatabase( rocprofvis_db_filename_t path) : 
                         SqliteDatabase(path), 
-            m_table_processor{TableProcessor(this),TableProcessor(this),TableProcessor(this), TableProcessor(this)} {};
+            m_table_processor{TableProcessor(this),TableProcessor(this),TableProcessor(this)} {};
         // ProfileDatabase destructor, must be defined as virtual to free resources of derived classes 
         virtual ~ProfileDatabase() {}
         // worker method to read time slice
@@ -148,7 +148,23 @@ class ProfileDatabase : public SqliteDatabase
        
         static rocprofvis_dm_event_operation_t GetTableQueryOperation(std::string query);
         
-        void BuildSliceQueryMap(slice_query_map_t& slice_query_map, rocprofvis_dm_track_params_t* props);
+        void BuildSliceQueryMap(slice_query_map_t& slice_query_map, rocprofvis_dm_track_params_t* props, rocprofvis_db_query_type_t query_type);
+        rocprofvis_dm_result_t BuildCompoundQuery(rocprofvis_dm_table_use_case_enum_t use_case,
+                                rocprofvis_dm_timestamp_t start, 
+                                rocprofvis_dm_timestamp_t end,
+                                rocprofvis_db_num_of_tracks_t num,
+                                rocprofvis_db_track_selection_t tracks,
+                                std::vector<slice_query_map_t>& slice_query_map_array,
+                                rocprofvis_dm_charptr_t where,
+                                rocprofvis_dm_charptr_t filter,
+                                rocprofvis_dm_charptr_t group,
+                                rocprofvis_dm_charptr_t group_cols, 
+                                rocprofvis_dm_charptr_t sort_column, 
+                                rocprofvis_dm_sort_order_t sort_order,
+                                uint64_t max_count, 
+                                uint64_t offset,
+                                bool count_only,
+                                rocprofvis_dm_string_t& query);
 
         bool IsEmptyRange(uint32_t track, uint64_t start, uint64_t end);
 
@@ -216,8 +232,21 @@ class ProfileDatabase : public SqliteDatabase
                             rocprofvis_dm_charptr_t group_cols, 
                             rocprofvis_dm_charptr_t sort_column, 
                             rocprofvis_dm_sort_order_t sort_order,
+                            uint64_t max_count, 
+                            uint64_t offset,
+                            bool count_only,
+                            rocprofvis_dm_string_t& query) override;
+
+        rocprofvis_dm_result_t BuildEventSearchQuery(
+                            rocprofvis_dm_timestamp_t start, 
+                            rocprofvis_dm_timestamp_t end,
+                            rocprofvis_db_num_of_tracks_t num,
+                            rocprofvis_db_track_selection_t ops,
+                            rocprofvis_dm_charptr_t where,
                             rocprofvis_dm_num_string_table_filters_t num_string_table_filters, 
                             rocprofvis_dm_string_table_filters_t string_table_filters,
+                            rocprofvis_dm_charptr_t sort_column, 
+                            rocprofvis_dm_sort_order_t sort_order,
                             uint64_t max_count, 
                             uint64_t offset,
                             bool count_only,

--- a/src/model/src/database/rocprofvis_db_table_processor.h
+++ b/src/model/src/database/rocprofvis_db_table_processor.h
@@ -33,7 +33,6 @@ namespace DataModel
         kRPVTableDataTypeEvent,
         kRPVTableDataTypeSample,
         kRPVTableDataTypeSearch,
-        kRPVTableDataTypeAnalysis,
         kRPVTableDataTypesNum
     } rocprofvis_db_compound_table_type;
 

--- a/src/model/src/tests/rocprofvis_dm_system_tests.cpp
+++ b/src/model/src/tests/rocprofvis_dm_system_tests.cpp
@@ -1088,8 +1088,7 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisDMFixture, "System Trace Data-Model Tests
             "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, "
             "MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) "
             "AS total_duration",
-            "name", sort_column.c_str(), kRPVDMSortOrderDesc, 0, nullptr, 0, 0, false,
-            &built_query);
+            "name", sort_column.c_str(), kRPVDMSortOrderDesc, 0, 0, false, &built_query);
         REQUIRE(kRocProfVisDmResultSuccess == build_result);
         REQUIRE(built_query != nullptr);
 
@@ -1158,8 +1157,7 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisDMFixture, "System Trace Data-Model Tests
             "name, COUNT(*) AS num_invocations, AVG(duration) AS avg_duration, "
             "MIN(duration) AS min_duration, MAX(duration) AS max_duration, SUM(duration) "
             "AS total_duration",
-            "name", sort_column.c_str(), kRPVDMSortOrderDesc, 0, nullptr, 0, 0, false,
-            &csv_query);
+            "name", sort_column.c_str(), kRPVDMSortOrderDesc, 0, 0, false, &csv_query);
         REQUIRE(kRocProfVisDmResultSuccess == build_result);
         REQUIRE(csv_query != nullptr);
 

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -1597,9 +1597,9 @@ DataProvider::FetchSingleTrackSampleTable(uint64_t track_id, double start_ts,
                                           uint64_t sort_column_index,
                                           rocprofvis_controller_sort_order_t sort_order)
 {
-    return FetchSingleTrackTable(TableRequestParams(
-        kRPVControllerTableTypeSamples, { track_id }, {}, start_ts, end_ts, "", filter,
-        "", "", {}, start_row, req_row_count, sort_column_index, sort_order));
+    return FetchTable(TrackTableRequestParams(
+        kRPVControllerTableTypeSamples, { track_id }, start_ts, end_ts, "", filter, "",
+        "", start_row, req_row_count, sort_column_index, sort_order));
 }
 
 bool
@@ -1610,161 +1610,9 @@ DataProvider::FetchSingleTrackEventTable(uint64_t track_id, double start_ts,
                                          uint64_t sort_column_index,
                                          rocprofvis_controller_sort_order_t sort_order)
 {
-    return FetchSingleTrackTable(TableRequestParams(
-        kRPVControllerTableTypeEvents, { track_id }, {}, start_ts, end_ts, "", filter,
-        group, group_cols, {}, start_row, req_row_count, sort_column_index, sort_order));
-}
-
-bool
-DataProvider::FetchSingleTrackTable(const TableRequestParams& table_params)
-{
-    if(m_state != ProviderState::kReady)
-    {
-        spdlog::warn("Cannot fetch, provider not ready or error, state: {}",
-                     static_cast<int>(m_state));
-        return false;
-    }
-
-    if(table_params.m_track_ids.empty())
-    {
-        spdlog::debug("Cannot fetch table, no track id provided");
-        return false;
-    }
-
-    uint64_t         track_id = table_params.m_track_ids[0];
-    const TrackInfo* metadata = m_model.GetTimeline().GetTrack(track_id);
-
-    if(metadata)
-    {
-        uint64_t request_id = table_params.m_table_type == kRPVControllerTableTypeEvents
-                                  ? EVENT_TABLE_REQUEST_ID
-                                  : SAMPLE_TABLE_REQUEST_ID;
-
-        auto it = m_requests.find(request_id);
-
-        // check if track is an event track
-        if(table_params.m_table_type == kRPVControllerTableTypeEvents &&
-           metadata->track_type != kRPVControllerTrackTypeEvents)
-        {
-            spdlog::warn("Cannot fetch event table, track {} is not an event track",
-                         track_id);
-            return false;
-        }
-        // check if track is a sample track
-        if(table_params.m_table_type == kRPVControllerTableTypeSamples &&
-           metadata->track_type != kRPVControllerTrackTypeSamples)
-        {
-            spdlog::warn("Cannot fetch sample table, track {} is not a sample track",
-                         track_id);
-            return false;
-        }
-
-        // only allow load if a request for this table type is not pending
-        if(it == m_requests.end())
-        {
-            // get the table handle
-            rocprofvis_handle_t* table_handle = nullptr;
-            rocprofvis_result_t  result       = kRocProfVisResultUnknownError;
-
-            if(table_params.m_table_type == kRPVControllerTableTypeEvents)
-            {
-                result = rocprofvis_controller_get_object(
-                    m_trace_controller, kRPVControllerSystemEventTable, 0, &table_handle);
-            }
-            else if(table_params.m_table_type == kRPVControllerTableTypeSamples)
-            {
-                result = rocprofvis_controller_get_object(
-                    m_trace_controller, kRPVControllerSystemSampleTable, 0, &table_handle);
-            }
-            else
-            {
-                spdlog::error("Unsupported table type: {}",
-                              static_cast<int>(table_params.m_table_type));
-                return false;
-            }
-            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            ROCPROFVIS_ASSERT(table_handle);
-
-            // get the track handle
-            rocprofvis_handle_t* track_handle = nullptr;
-            result                            = rocprofvis_controller_get_object(
-                metadata->graph_handle, kRPVControllerGraphTrack, 0, &track_handle);
-
-            // setup arguments for event table request
-            rocprofvis_controller_arguments_t* args =
-                rocprofvis_controller_arguments_alloc();
-            ROCPROFVIS_ASSERT(args != nullptr);
-
-            if(SetupCommonTableArguments(args, table_params))
-            {
-                result = rocprofvis_controller_set_uint64(
-                    args, kRPVControllerTableArgsNumTracks, 0, 1);
-                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-
-                result = rocprofvis_controller_set_object(
-                    args, kRPVControllerTableArgsTracksIndexed, 0, track_handle);
-                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            }
-            else
-            {
-                spdlog::error("Failed to setup event table common arguments");
-                // free the args
-                rocprofvis_controller_arguments_free(args);
-                return false;
-            }
-
-            // prepare to fetch the table
-            rocprofvis_controller_array_t* array = rocprofvis_controller_array_alloc(0);
-            ROCPROFVIS_ASSERT(array != nullptr);
-
-            rocprofvis_controller_future_t* future = rocprofvis_controller_future_alloc();
-            ROCPROFVIS_ASSERT(future != nullptr);
-
-            result = rocprofvis_controller_table_fetch_async(
-                m_trace_controller, table_handle, args, future, array);
-            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-
-            // create the request info
-            RequestInfo request_info;
-            request_info.request_array      = array;
-            request_info.request_future     = future;
-            request_info.request_obj_handle = nullptr;
-            request_info.request_args       = args;
-            request_info.request_id         = request_id;
-            request_info.loading_state      = RequestState::kLoading;
-            request_info.request_type =
-                (table_params.m_table_type == kRPVControllerTableTypeEvents)
-                    ? RequestType::kFetchTrackEventTable
-                    : RequestType::kFetchTrackSampleTable;
-
-            std::vector<uint64_t> track_ids;
-            track_ids.push_back(track_id);
-
-            auto params         = std::make_shared<TableRequestParams>(table_params);
-            params->m_track_ids = std::move(track_ids);
-            request_info.custom_params = params;
-
-            m_requests.emplace(request_id, request_info);
-            spdlog::debug("Fetching {} table data",
-                          (table_params.m_table_type == kRPVControllerTableTypeEvents)
-                              ? "event"
-                              : "sample");
-
-            return true;
-        }
-        else
-        {
-            // request for item already exists
-            spdlog::debug("Request for this table, type {}, is already pending",
-                          static_cast<uint64_t>(table_params.m_table_type));
-            return false;
-        }
-    }
-    else
-    {
-        spdlog::debug("Cannot fetch track, index {} is out of range", track_id);
-        return false;
-    }
+    return FetchTable(TrackTableRequestParams(
+        kRPVControllerTableTypeEvents, { track_id }, start_ts, end_ts, "", filter, group,
+        group_cols, start_row, req_row_count, sort_column_index, sort_order));
 }
 
 bool
@@ -1775,9 +1623,9 @@ DataProvider::FetchMultiTrackSampleTable(const std::vector<uint64_t>& track_ids,
                                          uint64_t sort_column_index,
                                          rocprofvis_controller_sort_order_t sort_order)
 {
-    return FetchTable(TableRequestParams(
-        kRPVControllerTableTypeSamples, track_ids, {}, start_ts, end_ts, "", filter, "",
-        "", {}, start_row, req_row_count, sort_column_index, sort_order));
+    return FetchTable(TrackTableRequestParams(
+        kRPVControllerTableTypeSamples, track_ids, start_ts, end_ts, "", filter, "", "",
+        start_row, req_row_count, sort_column_index, sort_order));
 }
 
 bool
@@ -1790,13 +1638,28 @@ DataProvider::FetchMultiTrackEventTable(const std::vector<uint64_t>& track_ids,
                                         rocprofvis_controller_sort_order_t sort_order)
 
 {
-    return FetchTable(TableRequestParams(
-        kRPVControllerTableTypeEvents, track_ids, {}, start_ts, end_ts, "", filter, group,
-        group_cols, {}, start_row, req_row_count, sort_column_index, sort_order));
+    return FetchTable(TrackTableRequestParams(
+        kRPVControllerTableTypeEvents, track_ids, start_ts, end_ts, "", filter, group,
+        group_cols, start_row, req_row_count, sort_column_index, sort_order));
 }
 
 bool
 DataProvider::FetchTable(const TableRequestParams& table_params)
+{
+    if(table_params.m_table_type == kRPVControllerTableTypeSearchResults ||
+       table_params.m_table_type == kRPVControllerTableTypeSummaryKernelInstances)
+    {
+        return FetchEventSearch(
+            static_cast<const EventSearchRequestParams&>(table_params));
+    }
+    else
+    {
+        return FetchTrackTable(static_cast<const TrackTableRequestParams&>(table_params));
+    }
+}
+
+bool
+DataProvider::FetchTrackTable(const TrackTableRequestParams& table_params)
 {
     if(m_state != ProviderState::kReady)
     {
@@ -1823,16 +1686,6 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
             case kRPVControllerTableTypeSamples:
             {
                 request_id = SAMPLE_TABLE_REQUEST_ID;
-                break;
-            }
-            case kRPVControllerTableTypeSearchResults:
-            {
-                request_id = EVENT_SEARCH_REQUEST_ID;
-                break;
-            }
-            case kRPVControllerTableTypeSummaryKernelInstances:
-            {
-                request_id = SUMMARY_KERNEL_INSTANCE_TABLE_REQUEST_ID;
                 break;
             }
             case kRPVControllerTableTypeInstrumentedEvents:
@@ -1879,202 +1732,111 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
         rocprofvis_result_t   result       = kRocProfVisResultUnknownError;
         rocprofvis_handle_t*  table_handle = nullptr;
         std::vector<uint64_t> filtered_track_ids;
-        std::vector<rocprofvis_dm_event_operation_t> filtered_op_types;
         if(SetupCommonTableArguments(args, table_params))
         {
-            if(table_params.m_table_type == kRPVControllerTableTypeEvents ||
-               table_params.m_table_type == kRPVControllerTableTypeSamples ||
-               table_params.m_table_type == kRPVControllerTableTypeInstrumentedEvents ||
-               table_params.m_table_type == kRPVControllerTableTypeDispatchEvents ||
-               table_params.m_table_type ==
-                   kRPVControllerTableTypeMemoryAllocationEvents ||
-               table_params.m_table_type == kRPVControllerTableTypeMemoryCopyEvents ||
-               table_params.m_table_type == kRPVControllerTableTypeSampledEvents)
+            // get the table handle
+            switch(table_params.m_table_type)
             {
-                // get the table handle
-                switch(table_params.m_table_type)
-                {
-                    case kRPVControllerTableTypeEvents:
-                        result = rocprofvis_controller_get_object(
-                            m_trace_controller, kRPVControllerSystemEventTable, 0,
-                            &table_handle);
-                        break;
-                    case kRPVControllerTableTypeSamples:
-                        result = rocprofvis_controller_get_object(
-                            m_trace_controller, kRPVControllerSystemSampleTable, 0,
-                            &table_handle);
-                        break;
-                    case kRPVControllerTableTypeInstrumentedEvents:
-                        result = rocprofvis_analysis_get_instrumented_events_table(
-                            m_trace_controller, &table_handle);
-                        break;
-                    case kRPVControllerTableTypeDispatchEvents:
-                        result = rocprofvis_analysis_get_dispatch_events_table(
-                            m_trace_controller, &table_handle);
-                        break;
-                    case kRPVControllerTableTypeMemoryAllocationEvents:
-                        result = rocprofvis_analysis_get_memory_allocation_events_table(
-                            m_trace_controller, &table_handle);
-                        break;
-                    case kRPVControllerTableTypeMemoryCopyEvents:
-                        result = rocprofvis_analysis_get_memory_copy_events_table(
-                            m_trace_controller, &table_handle);
-                        break;
-                    case kRPVControllerTableTypeSampledEvents:
-                        result = rocprofvis_analysis_get_sampled_events_table(
-                            m_trace_controller, &table_handle);
-                        break;
-                    default: break;
-                }
-                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-                ROCPROFVIS_ASSERT(table_handle);
-                for(const auto& track_id : table_params.m_track_ids)
-                {
-                    const TrackInfo* metadata = m_model.GetTimeline().GetTrack(track_id);
-                    // skip track if id is invalid
-                    if(!metadata)
-                    {
-                        spdlog::warn("Cannot fetch table, track id {} is invalid",
-                                     track_id);
-                        continue;
-                    }
-
-
-                    // check if track is an event track
-                    if((table_params.m_table_type == kRPVControllerTableTypeEvents ||
-                        table_params.m_table_type ==
-                            kRPVControllerTableTypeInstrumentedEvents ||
-                        table_params.m_table_type ==
-                            kRPVControllerTableTypeDispatchEvents ||
-                        table_params.m_table_type ==
-                            kRPVControllerTableTypeMemoryAllocationEvents ||
-                        table_params.m_table_type ==
-                            kRPVControllerTableTypeMemoryCopyEvents ||
-                        table_params.m_table_type ==
-                            kRPVControllerTableTypeSampledEvents) &&
-                       metadata->track_type != kRPVControllerTrackTypeEvents)
-                    {
-                        spdlog::warn("Cannot fetch event table, track id {} is not a "
-                                     "event track",
-                                     track_id);
-                        continue;
-                    }
-
-                    // check if track is a sample track
-                    if(table_params.m_table_type == kRPVControllerTableTypeSamples &&
-                       metadata->track_type != kRPVControllerTrackTypeSamples)
-                    {
-                        spdlog::warn("Cannot fetch sample table, track id {} is not an "
-                                     "sample track",
-                                     track_id);
-                        continue;
-                    }
-
-                    // get the track handle
-                    rocprofvis_handle_t* track_handle = nullptr;
-                    result = rocprofvis_controller_get_object(metadata->graph_handle,
-                                                              kRPVControllerGraphTrack, 0,
-                                                              &track_handle);
-                    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-                    ROCPROFVIS_ASSERT(track_handle != nullptr);
-
-                    result = rocprofvis_controller_set_object(
-                        args, kRPVControllerTableArgsTracksIndexed,
-                        filtered_track_ids.size(), track_handle);
-                    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-
-                    filtered_track_ids.push_back(track_id);
-                    spdlog::debug("Adding track id {} to table request", track_id);
-                }
-                if(filtered_track_ids.empty())
-                {
-                    spdlog::debug("No valid tracks found for table request, aborting");
-                    // free the args
-                    rocprofvis_controller_arguments_free(args);
-                    return false;
-                }
-                else
-                {
-                    // set the number of tracks in the request
-                    result = rocprofvis_controller_set_uint64(
-                        args, kRPVControllerTableArgsNumTracks, 0,
-                        filtered_track_ids.size());
-                    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-
-                    // set the number of op types in the request
-                    result = rocprofvis_controller_set_uint64(
-                        args, kRPVControllerTableArgsNumOpTypes, 0, 0);
-                    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-
-                    // set the number of string filters in request
-                    result = rocprofvis_controller_set_uint64(
-                        args, kRPVControllerTableArgsNumStringTableFilters, 0, 0);
-                    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-                }
-            }
-            else if(table_params.m_table_type == kRPVControllerTableTypeSearchResults ||
-                    table_params.m_table_type ==
-                        kRPVControllerTableTypeSummaryKernelInstances)
-            {
-                // get the table handle
-                if(table_params.m_table_type == kRPVControllerTableTypeSearchResults)
-                {
+                case kRPVControllerTableTypeEvents:
                     result = rocprofvis_controller_get_object(
-                        m_trace_controller, kRPVControllerSystemSearchResultsTable, 0,
+                        m_trace_controller, kRPVControllerSystemEventTable, 0,
                         &table_handle);
-                }
-                else
-                {
-                    rocprofvis_handle_t* summary_handle = nullptr;
-                    result = rocprofvis_controller_get_object(m_trace_controller,
-                                                              kRPVControllerSystemSummary,
-                                                              0, &summary_handle);
-                    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess &&
-                                      summary_handle);
+                    break;
+                case kRPVControllerTableTypeSamples:
                     result = rocprofvis_controller_get_object(
-                        summary_handle, kRPVControllerSummaryPropertyKernelInstanceTable,
-                        0, &table_handle);
-                }
-                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-                ROCPROFVIS_ASSERT(table_handle);
-                for(const rocprofvis_dm_event_operation_t& op : table_params.m_op_types)
+                        m_trace_controller, kRPVControllerSystemSampleTable, 0,
+                        &table_handle);
+                    break;
+                case kRPVControllerTableTypeInstrumentedEvents:
+                    result = rocprofvis_analysis_get_instrumented_events_table(
+                        m_trace_controller, &table_handle);
+                    break;
+                case kRPVControllerTableTypeDispatchEvents:
+                    result = rocprofvis_analysis_get_dispatch_events_table(
+                        m_trace_controller, &table_handle);
+                    break;
+                case kRPVControllerTableTypeMemoryAllocationEvents:
+                    result = rocprofvis_analysis_get_memory_allocation_events_table(
+                        m_trace_controller, &table_handle);
+                    break;
+                case kRPVControllerTableTypeMemoryCopyEvents:
+                    result = rocprofvis_analysis_get_memory_copy_events_table(
+                        m_trace_controller, &table_handle);
+                    break;
+                case kRPVControllerTableTypeSampledEvents:
+                    result = rocprofvis_analysis_get_sampled_events_table(
+                        m_trace_controller, &table_handle);
+                    break;
+                default: break;
+            }
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            ROCPROFVIS_ASSERT(table_handle);
+            for(const auto& track_id : table_params.m_track_ids)
+            {
+                const TrackInfo* metadata = m_model.GetTimeline().GetTrack(track_id);
+                // skip track if id is invalid
+                if(!metadata)
                 {
-                    result = rocprofvis_controller_set_uint64(
-                        args, kRPVControllerTableArgsOpTypesIndexed,
-                        filtered_op_types.size(), op);
-                    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-                    filtered_op_types.push_back(op);
+                    spdlog::warn("Cannot fetch table, track id {} is invalid", track_id);
+                    continue;
                 }
-                // set the number of tracks in the request
-                result = rocprofvis_controller_set_uint64(
-                    args, kRPVControllerTableArgsNumTracks, 0, 0);
-                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
 
-                // set the number of op types in the request
-                result = rocprofvis_controller_set_uint64(
-                    args, kRPVControllerTableArgsNumOpTypes, 0, filtered_op_types.size());
-                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-
-                // set the number of string filters in request
-                result = rocprofvis_controller_set_uint64(
-                    args, kRPVControllerTableArgsNumStringTableFilters, 0,
-                    table_params.m_string_table_filters.size());
-                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-
-                // set the string filters in request
-                for(int i = 0; i < table_params.m_string_table_filters.size(); i++)
+                // check if track is an event track
+                if((table_params.m_table_type == kRPVControllerTableTypeEvents ||
+                    table_params.m_table_type ==
+                        kRPVControllerTableTypeInstrumentedEvents ||
+                    table_params.m_table_type == kRPVControllerTableTypeDispatchEvents ||
+                    table_params.m_table_type ==
+                        kRPVControllerTableTypeMemoryAllocationEvents ||
+                    table_params.m_table_type ==
+                        kRPVControllerTableTypeMemoryCopyEvents ||
+                    table_params.m_table_type == kRPVControllerTableTypeSampledEvents) &&
+                   metadata->track_type != kRPVControllerTrackTypeEvents)
                 {
-                    result = rocprofvis_controller_set_string(
-                        args, kRPVControllerTableArgsStringTableFiltersIndexed, i,
-                        table_params.m_string_table_filters[i].data());
-                    ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                    spdlog::warn("Cannot fetch event table, track id {} is not a "
+                                 "event track",
+                                 track_id);
+                    continue;
                 }
+
+                // check if track is a sample track
+                if(table_params.m_table_type == kRPVControllerTableTypeSamples &&
+                   metadata->track_type != kRPVControllerTrackTypeSamples)
+                {
+                    spdlog::warn("Cannot fetch sample table, track id {} is not an "
+                                 "sample track",
+                                 track_id);
+                    continue;
+                }
+
+                // get the track handle
+                rocprofvis_handle_t* track_handle = nullptr;
+                result                            = rocprofvis_controller_get_object(
+                    metadata->graph_handle, kRPVControllerGraphTrack, 0, &track_handle);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                ROCPROFVIS_ASSERT(track_handle != nullptr);
+
+                result = rocprofvis_controller_set_object(
+                    args, kRPVControllerTableArgsTracksIndexed, filtered_track_ids.size(),
+                    track_handle);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+
+                filtered_track_ids.push_back(track_id);
+                spdlog::debug("Adding track id {} to table request", track_id);
+            }
+            if(filtered_track_ids.empty())
+            {
+                spdlog::debug("No valid tracks found for table request, aborting");
+                // free the args
+                rocprofvis_controller_arguments_free(args);
+                return false;
             }
             else
             {
-                spdlog::error("Unsupported table type: {}",
-                              static_cast<int>(table_params.m_table_type));
-                return false;
+                // set the number of tracks in the request
+                result = rocprofvis_controller_set_uint64(
+                    args, kRPVControllerTableArgsNumTracks, 0, filtered_track_ids.size());
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
             }
         }
         else
@@ -2088,7 +1850,6 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
         rocprofvis_controller_array_t*  array  = nullptr;
         rocprofvis_controller_future_t* future = rocprofvis_controller_future_alloc();
         ROCPROFVIS_ASSERT(future != nullptr);
-
         if(export_to_file)
         {
             if(table_params.m_table_type == kRPVControllerTableTypeInstrumentedEvents ||
@@ -2113,20 +1874,16 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
         {
             array = rocprofvis_controller_array_alloc(0);
             ROCPROFVIS_ASSERT(array != nullptr);
-            if(table_params.m_table_type == kRPVControllerTableTypeInstrumentedEvents ||
-               table_params.m_table_type == kRPVControllerTableTypeDispatchEvents ||
-               table_params.m_table_type ==
-                   kRPVControllerTableTypeMemoryAllocationEvents ||
-               table_params.m_table_type == kRPVControllerTableTypeMemoryCopyEvents ||
-               table_params.m_table_type == kRPVControllerTableTypeSampledEvents)
-            {
-                result = rocprofvis_analysis_fetch_table(m_trace_controller, table_handle,
-                                                         args, future, array);
-            }
-            else
+            if(table_params.m_table_type == kRPVControllerTableTypeEvents ||
+               table_params.m_table_type == kRPVControllerTableTypeSamples)
             {
                 result = rocprofvis_controller_table_fetch_async(
                     m_trace_controller, table_handle, args, future, array);
+            }
+            else
+            {
+                result = rocprofvis_analysis_fetch_table(m_trace_controller, table_handle,
+                                                         args, future, array);
             }
         }
         ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
@@ -2139,7 +1896,6 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
         request_info.request_args       = args;
         request_info.request_id         = request_id;
         request_info.loading_state      = RequestState::kLoading;
-
         if(export_to_file)
         {
             request_info.request_type = RequestType::kTableExport;
@@ -2156,17 +1912,6 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
                 case kRPVControllerTableTypeSamples:
                 {
                     request_info.request_type = RequestType::kFetchTrackSampleTable;
-                    break;
-                }
-                case kRPVControllerTableTypeSearchResults:
-                {
-                    request_info.request_type = RequestType::kFetchEventSearchTable;
-                    break;
-                }
-                case kRPVControllerTableTypeSummaryKernelInstances:
-                {
-                    request_info.request_type =
-                        RequestType::kFetchSummaryKernelInstanceTable;
                     break;
                 }
                 case kRPVControllerTableTypeInstrumentedEvents:
@@ -2201,9 +1946,8 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
             }
         }
 
-        auto params                = std::make_shared<TableRequestParams>(table_params);
-        params->m_track_ids        = std::move(filtered_track_ids);
-        params->m_op_types         = std::move(filtered_op_types);
+        auto params         = std::make_shared<TrackTableRequestParams>(table_params);
+        params->m_track_ids = std::move(filtered_track_ids);
         request_info.custom_params = params;
 
         m_requests.emplace(request_id, request_info);
@@ -2224,16 +1968,6 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
                 case kRPVControllerTableTypeSamples:
                 {
                     spdlog::debug("Fetching sample table data");
-                    break;
-                }
-                case kRPVControllerTableTypeSearchResults:
-                {
-                    spdlog::debug("Fetching search table data");
-                    break;
-                }
-                case kRPVControllerTableTypeSummaryKernelInstances:
-                {
-                    spdlog::debug("Fetching summary table data");
                     break;
                 }
                 case kRPVControllerTableTypeInstrumentedEvents:
@@ -2264,6 +1998,182 @@ DataProvider::FetchTable(const TableRequestParams& table_params)
                     break;
                 }
             }
+        }
+
+        return true;
+    }
+    else
+    {
+        // request for item already exists
+        spdlog::debug("Request for this table, type {}, is already pending",
+                      static_cast<uint64_t>(table_params.m_table_type));
+        return false;
+    }
+}
+
+bool
+DataProvider::FetchEventSearch(const EventSearchRequestParams& table_params)
+{
+    if(m_state != ProviderState::kReady)
+    {
+        spdlog::warn("Cannot fetch, provider not ready or error, state: {}",
+                     static_cast<int>(m_state));
+        return false;
+    }
+
+    bool     export_to_file = !table_params.m_export_to_file_path.empty();
+    uint64_t request_id;
+    if(export_to_file)
+    {
+        request_id = TABLE_EXPORT_REQUEST_ID;
+    }
+    else
+    {
+        switch(table_params.m_table_type)
+        {
+            case kRPVControllerTableTypeSearchResults:
+            {
+                request_id = EVENT_SEARCH_REQUEST_ID;
+                break;
+            }
+            case kRPVControllerTableTypeSummaryKernelInstances:
+            {
+                request_id = SUMMARY_KERNEL_INSTANCE_TABLE_REQUEST_ID;
+                break;
+            }
+            default:
+            {
+                spdlog::error("Unsupported table type: {}",
+                              static_cast<int>(table_params.m_table_type));
+                return false;
+            }
+        }
+    }
+
+    auto it = m_requests.find(request_id);
+    // only allow load if a request for a table of this type is not pending
+    if(it == m_requests.end())
+    {
+        // setup arguments for event table request
+        rocprofvis_controller_arguments_t* args = rocprofvis_controller_arguments_alloc();
+        ROCPROFVIS_ASSERT(args != nullptr);
+        rocprofvis_result_t  result       = kRocProfVisResultUnknownError;
+        rocprofvis_handle_t* table_handle = nullptr;
+        std::vector<rocprofvis_dm_event_operation_t> filtered_op_types;
+        if(SetupCommonTableArguments(args, table_params))
+        {
+            // get the table handle
+            if(table_params.m_table_type == kRPVControllerTableTypeSearchResults)
+            {
+                result = rocprofvis_controller_get_object(
+                    m_trace_controller, kRPVControllerSystemSearchResultsTable, 0,
+                    &table_handle);
+            }
+            else
+            {
+                rocprofvis_handle_t* summary_handle = nullptr;
+                result                              = rocprofvis_controller_get_object(
+                    m_trace_controller, kRPVControllerSystemSummary, 0, &summary_handle);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess && summary_handle);
+                result = rocprofvis_controller_get_object(
+                    summary_handle, kRPVControllerSummaryPropertyKernelInstanceTable, 0,
+                    &table_handle);
+            }
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            ROCPROFVIS_ASSERT(table_handle);
+            for(const rocprofvis_dm_event_operation_t& op : table_params.m_op_types)
+            {
+                result = rocprofvis_controller_set_uint64(
+                    args, kRPVControllerTableArgsOpTypesIndexed, filtered_op_types.size(),
+                    op);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                filtered_op_types.push_back(op);
+            }
+
+            // set the number of op types in the request
+            result = rocprofvis_controller_set_uint64(
+                args, kRPVControllerTableArgsNumOpTypes, 0, filtered_op_types.size());
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+
+            // set the number of string filters in request
+            result = rocprofvis_controller_set_uint64(
+                args, kRPVControllerTableArgsNumStringTableFilters, 0,
+                table_params.m_string_table_filters.size());
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+
+            // set the string filters in request
+            for(int i = 0; i < table_params.m_string_table_filters.size(); i++)
+            {
+                result = rocprofvis_controller_set_string(
+                    args, kRPVControllerTableArgsStringTableFiltersIndexed, i,
+                    table_params.m_string_table_filters[i].data());
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            }
+        }
+        else
+        {
+            spdlog::error("Failed to setup table common arguments");
+            // free the args
+            rocprofvis_controller_arguments_free(args);
+            return false;
+        }
+        // prepare to fetch the table
+        rocprofvis_controller_array_t*  array  = nullptr;
+        rocprofvis_controller_future_t* future = rocprofvis_controller_future_alloc();
+        ROCPROFVIS_ASSERT(future != nullptr);
+        if(export_to_file)
+        {
+            result = rocprofvis_controller_table_export_csv(
+                m_trace_controller, table_handle, args, future,
+                table_params.m_export_to_file_path.c_str());
+        }
+        else
+        {
+            array = rocprofvis_controller_array_alloc(0);
+            ROCPROFVIS_ASSERT(array != nullptr);
+            result = rocprofvis_controller_table_fetch_async(
+                m_trace_controller, table_handle, args, future, array);
+        }
+        ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+
+        // create the request info
+        RequestInfo request_info;
+        request_info.request_array      = array;
+        request_info.request_future     = future;
+        request_info.request_obj_handle = nullptr;
+        request_info.request_args       = args;
+        request_info.request_id         = request_id;
+        request_info.loading_state      = RequestState::kLoading;
+        if(export_to_file)
+        {
+            request_info.request_type = RequestType::kTableExport;
+        }
+        else if(table_params.m_table_type == kRPVControllerTableTypeSearchResults)
+        {
+            request_info.request_type = RequestType::kFetchEventSearchTable;
+        }
+        else
+        {
+            request_info.request_type = RequestType::kFetchSummaryKernelInstanceTable;
+        }
+
+        auto params        = std::make_shared<EventSearchRequestParams>(table_params);
+        params->m_op_types = std::move(filtered_op_types);
+        request_info.custom_params = params;
+
+        m_requests.emplace(request_id, request_info);
+
+        if(export_to_file)
+        {
+            spdlog::debug("Exporting table data");
+        }
+        else if(table_params.m_table_type == kRPVControllerTableTypeSearchResults)
+        {
+            spdlog::debug("Fetching search table data");
+        }
+        else
+        {
+            spdlog::debug("Fetching summary table data");
         }
         return true;
     }

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -167,12 +167,6 @@ public:
         uint64_t                           sort_column_index = 0,
         rocprofvis_controller_sort_order_t sort_order = kRPVControllerSortOrderAscending);
 
-    /*
-     * Fetches a table from the controller for a single track.
-     * @param table_params: The parameters for the table request
-     */
-    bool FetchSingleTrackTable(const TableRequestParams& table_params);
-
     bool FetchMultiTrackSampleTable(
         const std::vector<uint64_t>& track_ids, double start_ts, double end_ts,
         char const* filter, uint64_t start_row = -1, uint64_t req_row_count = -1,
@@ -272,8 +266,11 @@ private:
         size_t counter_count;
     };
 
+    bool FetchTrackTable(const TrackTableRequestParams& table_params);
+    bool FetchEventSearch(const EventSearchRequestParams& table_params);
     /* Helper called by FetchEvent()*/
     bool FetchEventExtData(uint64_t event_id);
+
     void HandleLoadSystemTopology();
     bool ParseNodeData(rocprofvis_handle_t* node_handle, NodeInfo& node_info);
     bool ParseDeviceData(rocprofvis_handle_t* processor_handle, DeviceInfo& device_info,

--- a/src/view/src/rocprofvis_event_search.cpp
+++ b/src/view/src/rocprofvis_event_search.cpp
@@ -175,14 +175,15 @@ EventSearch::Search()
         {
             const TimelineModel& timeline = m_data_provider.DataModel().GetTimeline();
             m_data_provider.CancelRequest(m_request_id);
-            m_search_deferred = !m_data_provider.FetchTable(TableRequestParams(
-                m_request_table_type, {},
-                { kRocProfVisDmOperationLaunch, kRocProfVisDmOperationDispatch,
-                  kRocProfVisDmOperationLaunchSample },
-                timeline.GetStartTime(), timeline.GetEndTime(), "", "", "", "", { terms },
-                0, m_fetch_chunk_size, m_sort_column_index, m_sort_order));
-            m_searched        = true;
-            m_should_open     = true;
+            m_search_deferred =
+                !m_data_provider.FetchTable(EventSearchRequestParams(
+                    m_request_table_type,
+                    { kRocProfVisDmOperationLaunch, kRocProfVisDmOperationDispatch,
+                      kRocProfVisDmOperationLaunchSample },
+                    timeline.GetStartTime(), timeline.GetEndTime(), "", { terms }, 0,
+                    m_fetch_chunk_size, m_sort_column_index, m_sort_order));
+            m_searched    = true;
+            m_should_open = true;
         }
         else
         {

--- a/src/view/src/rocprofvis_multi_track_table.cpp
+++ b/src/view/src/rocprofvis_multi_track_table.cpp
@@ -71,7 +71,9 @@ MultiTrackTable::Render()
     ImGui::BeginChild("multitrack_table", ImVec2(0.0f, 0.0f), ImGuiChildFlags_Borders,
                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
     ImGui::PopStyleVar();
-    auto table_params = m_table_model().GetTableParams(m_table_type);
+    std::shared_ptr<TrackTableRequestParams> table_params =
+        std::static_pointer_cast<TrackTableRequestParams>(
+            m_table_model().GetTableParams(m_table_type));
     if(m_display_filters || table_params)
     {
         const ImGuiStyle& style = ImGui::GetStyle();
@@ -471,13 +473,11 @@ MultiTrackTable::FetchSelectionData()
     else
     {
         // Fetch table data for the selected tracks
-        TableRequestParams table_params(
-            m_request_table_type, included_tracks, {}, start_ns, end_ns,
+        fetch_result = m_data_provider.FetchTable(TrackTableRequestParams{
+            m_request_table_type, included_tracks, start_ns, end_ns,
             m_filter_options.where, m_filter_options.filter,
-            m_filter_options.group_by.c_str(), m_filter_options.group_columns, {}, 0,
-            m_fetch_chunk_size, m_sort_column_index, m_sort_order);
-
-        fetch_result = m_data_provider.FetchTable(table_params);
+            m_filter_options.group_by.c_str(), m_filter_options.group_columns, 0,
+            m_fetch_chunk_size, m_sort_column_index, m_sort_order });
     }
 
     if(!fetch_result)

--- a/src/view/src/rocprofvis_requests.h
+++ b/src/view/src/rocprofvis_requests.h
@@ -158,8 +158,6 @@ class TableRequestParams : public RequestParamsBase
 {
 public:
     rocprofvis_controller_table_type_t m_table_type;  // type of the table
-    std::vector<uint64_t>              m_track_ids;   // ids of the tracks in the table
-    std::vector<rocprofvis_dm_event_operation_t> m_op_types;  // op types in the table
     double   m_start_ts;           // starting time stamp of the data in the table
     double   m_end_ts;             // ending time stamp of the data in the table
     uint64_t m_start_row;          // starting row of the data in the table
@@ -168,28 +166,23 @@ public:
     rocprofvis_controller_sort_order_t m_sort_order;  // sort order of the column
     std::string                        m_where;       // SQL where clause
     std::string                        m_filter;      // CMD filter
-    std::vector<std::string>
-                m_string_table_filters;  // strings to use for string table filtering.
-    std::string m_group;
-    std::string m_group_columns;
-    std::string m_export_to_file_path;
+    std::string                        m_group;
+    std::string                        m_group_columns;
+    std::string                        m_export_to_file_path;
 
+protected:
+    // Constructed only via derives...
     TableRequestParams(const TableRequestParams& table_params)            = default;
     TableRequestParams& operator=(const TableRequestParams& table_params) = default;
 
     TableRequestParams(
-        rocprofvis_controller_table_type_t                  table_type,
-        const std::vector<uint64_t>&                        track_ids,
-        const std::vector<rocprofvis_dm_event_operation_t>& op_types, double start_ts,
-        double end_ts, const char* where, char const* filter, char const* group,
-        char const* group_cols, const std::vector<std::string> string_table_filters = {},
+        rocprofvis_controller_table_type_t table_type, double start_ts, double end_ts,
+        const char* where, char const* filter, char const* group, char const* group_cols,
         uint64_t start_row = -1, uint64_t req_row_count = -1,
         uint64_t                           sort_column_index = 0,
         rocprofvis_controller_sort_order_t sort_order = kRPVControllerSortOrderAscending,
-        std::string export_to_file_path = "")
+        std::string                        export_to_file_path = "")
     : m_table_type(table_type)
-    , m_track_ids(track_ids)
-    , m_op_types(op_types)
     , m_start_ts(start_ts)
     , m_end_ts(end_ts)
     , m_start_row(start_row)
@@ -200,8 +193,59 @@ public:
     , m_filter(filter)
     , m_group(group)
     , m_group_columns(group_cols)
-    , m_string_table_filters(string_table_filters)
     , m_export_to_file_path(export_to_file_path)
+    {}
+};
+
+class TrackTableRequestParams : public TableRequestParams
+{
+public:
+    std::vector<uint64_t> m_track_ids;  // ids of the tracks in the table
+
+    TrackTableRequestParams(const TrackTableRequestParams& table_params) = default;
+    TrackTableRequestParams& operator=(const TrackTableRequestParams& table_params) =
+        default;
+
+    TrackTableRequestParams(
+        rocprofvis_controller_table_type_t table_type,
+        const std::vector<uint64_t>& track_ids, double start_ts, double end_ts,
+        const char* where, char const* filter, char const* group, char const* group_cols,
+        uint64_t start_row = -1, uint64_t req_row_count = -1,
+        uint64_t                           sort_column_index = 0,
+        rocprofvis_controller_sort_order_t sort_order = kRPVControllerSortOrderAscending,
+        std::string                        export_to_file_path = "")
+    : TableRequestParams(table_type, start_ts, end_ts, where, filter, group, group_cols, start_row,
+                         req_row_count, sort_column_index, sort_order,
+                         export_to_file_path)
+    , m_track_ids(track_ids)
+    {}
+};
+
+class EventSearchRequestParams : public TableRequestParams
+{
+public:
+    std::vector<rocprofvis_dm_event_operation_t>
+        m_op_types;  // op types to include in search
+    std::vector<std::string>
+        m_string_table_filters;  // strings to use for string table filtering.
+
+    EventSearchRequestParams(const EventSearchRequestParams& table_params) = default;
+    EventSearchRequestParams& operator=(const EventSearchRequestParams& table_params) =
+        default;
+
+    EventSearchRequestParams(
+        rocprofvis_controller_table_type_t                  table_type,
+        const std::vector<rocprofvis_dm_event_operation_t>& op_types, double start_ts,
+        double end_ts, const char* where,
+        const std::vector<std::string> string_table_filters = {}, uint64_t start_row = -1,
+        uint64_t req_row_count = -1, uint64_t sort_column_index = 0,
+        rocprofvis_controller_sort_order_t sort_order = kRPVControllerSortOrderAscending,
+        std::string                        export_to_file_path = "")
+    : TableRequestParams(table_type, start_ts, end_ts, where, "", "", "", start_row,
+                         req_row_count, sort_column_index, sort_order,
+                         export_to_file_path)
+    , m_op_types(op_types)
+    , m_string_table_filters(string_table_filters)
     {}
 };
 

--- a/src/view/src/rocprofvis_summary_view.cpp
+++ b/src/view/src/rocprofvis_summary_view.cpp
@@ -1205,10 +1205,10 @@ KernelInstanceTable::Fetch()
 {
     m_data_provider.CancelRequest(m_request_id);
     const TimelineModel& tlm = m_data_provider.DataModel().GetTimeline();
-    m_fetch_deferred         = !m_data_provider.FetchTable(TableRequestParams(
-        m_request_table_type, {}, { kRocProfVisDmOperationDispatch }, tlm.GetStartTime(),
-        tlm.GetEndTime(), m_where.c_str(), "", "", "", { m_kernel_name }, 0,
-        m_fetch_chunk_size, m_sort_column_index, m_sort_order));
+    m_fetch_deferred         = !m_data_provider.FetchTable(EventSearchRequestParams(
+        m_request_table_type, { kRocProfVisDmOperationDispatch }, tlm.GetStartTime(),
+        tlm.GetEndTime(), m_where.c_str(), { m_kernel_name }, 0, m_fetch_chunk_size,
+        m_sort_column_index, m_sort_order));
     m_fetched                = true;
 }
 

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -1106,7 +1106,7 @@ TraceView::RenderEventSearch()
             ImGui::SetKeyboardFocusHere();
         }
         std::pair<bool, bool> search_bar = InputTextWithClear(
-            "search_bar", "Search events, kernels, tracks...",
+            "search_bar", "Search: hipLaunchKernel or \"hip\"\"kernel\"",
             m_event_search->TextInput(), m_event_search->TextInputLimit(),
             settings.GetFontManager().GetFont(FontType::kIcon),
             settings.GetColor(Colors::kBgMain), settings.GetDefaultStyle(),

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -422,7 +422,7 @@ InfiniteScrollTable::Render()
 
                 // only check if we need to fetch based on the scroll position if we don't
                 // have all the data
-                if(!m_skip_data_fetch && table_data.size() < total_row_count - 1)
+                if(!m_skip_data_fetch && table_data.size() < total_row_count - 1 && table_params)
                 {
                     if(!m_data_provider.IsRequestPending(m_request_id))
                     {
@@ -452,16 +452,9 @@ InfiniteScrollTable::Render()
                                 "{}, frame count: {}, chunk size: {}, scroll y: {}",
                                 new_start_pos, frame_count, m_fetch_chunk_size, scroll_y);
 
-                            m_data_provider.FetchTable(TableRequestParams(
-                                m_request_table_type, table_params->m_track_ids,
-                                table_params->m_op_types, table_params->m_start_ts,
-                                table_params->m_end_ts, table_params->m_where.c_str(),
-                                table_params->m_filter.c_str(),
-                                table_params->m_group.c_str(),
-                                table_params->m_group_columns.c_str(),
-                                table_params->m_string_table_filters, new_start_pos,
-                                m_fetch_chunk_size, table_params->m_sort_column_index,
-                                table_params->m_sort_order));
+                            table_params->m_start_row     = new_start_pos;
+                            table_params->m_req_row_count = m_fetch_chunk_size;
+                            m_data_provider.FetchTable(*table_params);
                         }
                         else if((scroll_y + ImGui::GetWindowHeight() >
                                  end_row_position -
@@ -491,16 +484,9 @@ InfiniteScrollTable::Render()
                                 "{}, frame count: {}, chunk size: {}, scroll y: {}",
                                 new_start_pos, frame_count, m_fetch_chunk_size, scroll_y);
 
-                            m_data_provider.FetchTable(TableRequestParams(
-                                m_request_table_type, table_params->m_track_ids,
-                                table_params->m_op_types, table_params->m_start_ts,
-                                table_params->m_end_ts, table_params->m_where.c_str(),
-                                table_params->m_filter.c_str(),
-                                table_params->m_group.c_str(),
-                                table_params->m_group_columns.c_str(),
-                                table_params->m_string_table_filters, new_start_pos,
-                                m_fetch_chunk_size, table_params->m_sort_column_index,
-                                table_params->m_sort_order));
+                            table_params->m_start_row     = new_start_pos;
+                            table_params->m_req_row_count = m_fetch_chunk_size;
+                            m_data_provider.FetchTable(*table_params);
                         }
                     }
                 }
@@ -686,15 +672,8 @@ InfiniteScrollTable::ProcessSortOrFilterRequest(
 
             spdlog::debug("Fetching data for sort, frame count: {}", frame_count);
 
-                // Fetch the event table with the updated params
-            m_data_provider.FetchTable(TableRequestParams(
-                m_request_table_type, table_params->m_track_ids, table_params->m_op_types,
-                table_params->m_start_ts, table_params->m_end_ts,
-                table_params->m_where.c_str(), table_params->m_filter.c_str(),
-                table_params->m_group.c_str(), table_params->m_group_columns.c_str(),
-                table_params->m_string_table_filters, table_params->m_start_row,
-                table_params->m_req_row_count, table_params->m_sort_column_index,
-                table_params->m_sort_order));
+            // Fetch the event table with the updated params
+            m_data_provider.FetchTable(*table_params);
 
             m_filter_options = filter;
         }
@@ -971,20 +950,16 @@ InfiniteScrollTable::ExportToFile() const
         "Export Table", file_filters, "", [this](std::string file_path) -> void {
             std::shared_ptr<TableRequestParams> table_params =
                 m_table_model_mutable().GetTableParams(m_table_type);
-            if(table_params &&
-               m_data_provider.FetchTable(TableRequestParams(
-                   m_request_table_type, table_params->m_track_ids,
-                   table_params->m_op_types, table_params->m_start_ts,
-                   table_params->m_end_ts, table_params->m_where.c_str(),
-                   table_params->m_filter.c_str(), table_params->m_group.c_str(),
-                   table_params->m_group_columns.c_str(),
-                   table_params->m_string_table_filters, INVALID_UINT64_INDEX,
-                   INVALID_UINT64_INDEX, table_params->m_sort_column_index,
-                   table_params->m_sort_order, file_path)))
+            if(table_params)
             {
-                NotificationManager::GetInstance().ShowPersistent(
-                    m_export_notification_id, "Exporting: " + file_path,
-                    NotificationLevel::Info);
+                table_params->m_export_to_file_path = file_path;
+                if(m_data_provider.FetchTable(*table_params))
+                {
+                    NotificationManager::GetInstance().ShowPersistent(
+                        m_export_notification_id, "Exporting: " + file_path,
+                        NotificationLevel::Info);
+                }
+                table_params->m_export_to_file_path.clear();
             }
         });
 }


### PR DESCRIPTION
This change split the table api into event search and "regular" paths while maintaining code reuse for common functionality. This will allow these use cases to be independently expanded without changes spilling over to the other. There are no functional changes.

### DM
- Moved search specific parameters of `rocprofvis_db_build_table_query` into new API `rocprofvis_db_build_event_search_query`
- `BuildTableQuery`:
  - Previous implementation had 2 parts; building the SQL; building the CMD.
    - "Regular" SQL was duplicate of `BuildSliceQueryMap`, but with the `kRPVQueryTable` query type. Replaced with call to BuildSliceQueryMap with added query type parameter. 
    - Search specific SQL moved into new function `BuildEventSearchQuery`
    - CMD moved into new function `BuildCompoundQuery`
- Flow: 
  - `rocprofvis_db_build_table_query` -> `BuildTableQuery` -> `BuildSliceQueryMap` + `BuildCompoundQuery`
  - `rocprofvis_db_build_event_search_query` -> `BuildEventSearchQuery` -> `BuildSliceQueryMap` + inject search filter + `BuildCompoundQuery` 
- Removed unused analysis `TableProcessor` (leftover from queue utilization V2).

### Controller
- `Table`
  - Added `SystemTable:EventSearchTable`
  - Redistributed existing members among hierarchy where applicable.
  - Virtualized all input arguments and areas that deal with arguments. This is so base classes can operate on generic argument objects while specific handling is routed to appropriate derives.
    - `TableArguments`, `SystemTableArguments:TableArguments`,  `EventSearchTableArguments:SystemTableArguments`

### View
- Added `TrackTableRequestParams:TableRequestParams`, `EventSearchRequestParams:TableRequestParams`
- Redistributed logic of `FetchTable` into newly added `FetchTrackTable`, `FetchEventSearch`.
- Reverted misleading search bar hint text.