### PR TITLE
View: Add zoom-to-fit for measurements and time range selections

### DIFF
--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -17,6 +17,7 @@ constexpr ImWchar icon_ranges[] = {
     0xF13D, 0xF13D,
     0xF1FE, 0xF1FE,
     0xF218, 0xF218,
+    0xF25E, 0xF25E,
     0xF267, 0xF267,
     0xF273, 0xF273,
     0xF2B5, 0xF2B5,
@@ -53,6 +54,7 @@ inline constexpr const char* ICON_EYE           = u8"\uF133";
 inline constexpr const char* ICON_GEAR          = u8"\uF13D";
 inline constexpr const char* ICON_CHAIN         = u8"\uF1FE";
 inline constexpr const char* ICON_ADD_NOTE      = u8"\uF218";
+inline constexpr const char* ICON_ARROWS_EXPAND = u8"\uF25E";
 inline constexpr const char* ICON_ARROWS_SHRINK = u8"\uF267";
 inline constexpr const char* ICON_COMPASS       = u8"\uF273";
 inline constexpr const char* ICON_CHART_BAR     = u8"\uF2B5";

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -37,7 +37,6 @@ constexpr float    SCROLL_SPEED                  = 100.0f;
 constexpr uint64_t DEFAULT_LOADING_TIMER         = 150;  // milliseconds
 constexpr float    ARTIFICIAL_SCROLLBAR_HEIGHT   = 18.0f;
 constexpr float    SIDEBAR_SPLITTER_WIDTH        = 5.0f;
-
 // Build a text block mirroring the on-hover tooltip (name, timing, and id)
 // for the clipboard.
 static std::string
@@ -549,11 +548,22 @@ TimelineView::RenderMeasurement(ImDrawList* draw_list, ImVec2 window_position)
                               ARTIFICIAL_SCROLLBAR_HEIGHT) / 2.0f;
     float label_y = visible_bot - ImGui::CalcTextSize("0").y - LABEL_PAD;
 
+    float graph_min_x = window_position.x;
+    float graph_max_x = window_position.x + m_tpt->GetGraphSizeX();
+
     // Draws a small timestamp label centered on a ruler line, capturing its rect
     // (index 0 = start ruler, 1 = end ruler) for the context-menu hit-test.
     auto draw_ruler_label = [&](int index, float x, const char* text) {
         ImVec2 sz = ImGui::CalcTextSize(text);
         float  lx = x - sz.x * 0.5f;
+
+        float label_min_x = graph_min_x + RULER_LABEL_PAD_X;
+        float label_max_x = graph_max_x - sz.x - RULER_LABEL_PAD_X;
+        if(x >= graph_min_x && x <= graph_max_x && label_min_x < label_max_x)
+        {
+            lx = std::clamp(lx, label_min_x, label_max_x);
+        }
+
         ImVec2 mn(lx - RULER_LABEL_PAD_X, label_y - RULER_LABEL_PAD_Y);
         ImVec2 mx(lx + sz.x + RULER_LABEL_PAD_X, label_y + sz.y + RULER_LABEL_PAD_Y);
         draw_list->AddRectFilled(mn, mx, label_bg, RULER_LABEL_ROUND);
@@ -738,6 +748,15 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
         if(m_highlighted_region.first != TimelineSelection::INVALID_SELECTION_TIME ||
            m_highlighted_region.second != TimelineSelection::INVALID_SELECTION_TIME)
         {
+            if(m_highlighted_region.first != TimelineSelection::INVALID_SELECTION_TIME &&
+               m_highlighted_region.second != TimelineSelection::INVALID_SELECTION_TIME)
+            {
+                if(IconMenuItem(ICON_ARROWS_EXPAND, "Zoom to Time Range Selection"))
+                {
+                    ZoomToTimeRangeSelection();
+                }
+            }
+
             if(IconMenuItem(ICON_TRASH_CAN, "Remove Time Range Selection"))
             {
                 ClearTimeRangeSelection();
@@ -827,6 +846,14 @@ TimelineView::RenderTimelineViewOptionsMenu(ImVec2 window_position)
                             .c_str());
                     NotificationManager::GetInstance().Show("End timestamp was copied",
                                                             NotificationLevel::Info);
+                }
+            }
+
+            if(has_start && has_end)
+            {
+                if(IconMenuItem(ICON_ARROWS_EXPAND, "Zoom to Measurement"))
+                {
+                    ZoomToMeasurement();
                 }
             }
 
@@ -1003,6 +1030,58 @@ TimelineView::SetViewableRangeNS(double start_ns, double end_ns)
 
     // Mark grid for recalculation since scale changed.
     m_recalculate_grid_interval = true;
+}
+
+void
+TimelineView::ZoomToTimeSpan(double start_ns, double end_ns)
+{
+    double span_ns = end_ns - start_ns;
+    if(span_ns <= 0.0)
+    {
+        return;
+    }
+
+    // Zoom is capped at one pixel per nanosecond, so center a span too narrow
+    // to fill the viewport rather than let the clamp pin it to the left edge.
+    double margin_ns   = 0.0;
+    double min_span_ns = static_cast<double>(m_tpt->GetGraphSizeX());
+    if(span_ns < min_span_ns)
+    {
+        margin_ns = (min_span_ns - span_ns) * 0.5;
+    }
+
+    SetViewableRangeNS(std::max(m_tpt->GetMinX(), start_ns - margin_ns),
+                       std::min(m_tpt->GetMaxX(), end_ns + margin_ns));
+}
+
+void
+TimelineView::ZoomToMeasurement()
+{
+    MeasurementController& fm = *m_measurement;
+    if(!fm.GetPoint(0).valid || !fm.GetPoint(1).valid)
+    {
+        return;
+    }
+
+    double first_ns = fm.GetEffectiveTimestamp(0);
+    double last_ns  = fm.GetEffectiveTimestamp(1);
+    ZoomToTimeSpan(std::min(first_ns, last_ns), std::max(first_ns, last_ns));
+}
+
+void
+TimelineView::ZoomToTimeRangeSelection()
+{
+    if(m_highlighted_region.first == TimelineSelection::INVALID_SELECTION_TIME ||
+       m_highlighted_region.second == TimelineSelection::INVALID_SELECTION_TIME)
+    {
+        return;
+    }
+
+    // The highlighted region is kept in normalized time, the zoom helper works
+    // in absolute timestamps.
+    double first_ns = m_tpt->DenormalizeTime(m_highlighted_region.first);
+    double last_ns  = m_tpt->DenormalizeTime(m_highlighted_region.second);
+    ZoomToTimeSpan(std::min(first_ns, last_ns), std::max(first_ns, last_ns));
 }
 
 TimelineView::~TimelineView()

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -190,6 +190,9 @@ private:
     void                            ClearTimeRangeSelection();
     void                            CopySelectedEventNames();
     void                            CopySelectedEventDetails();
+    void                            ZoomToTimeSpan(double start_ns, double end_ns);
+    void                            ZoomToMeasurement();
+    void                            ZoomToTimeRangeSelection();
 
     TrackLayout                     BuildTrackLayout();
     EventManager::SubscriptionToken m_scroll_to_track_token;


### PR DESCRIPTION
## Motivation

After measuring a span on the timeline, there was no way to focus the view on
it short of zooming and panning by hand.

## Technical Details

Two right-click entries: **Zoom to Measurement** (both measurement points
placed) and **Zoom to Time Range Selection** (highlighted region present).
Both call `TimelineView::ZoomToTimeSpan()`, which feeds absolute timestamps to
the existing `SetViewableRangeNS()`, so the span fills the graph edge to edge.

- Zoom is capped at one pixel per nanosecond, so a span too narrow to fill the
  viewport is centered rather than pinned to the left edge by the clamp.
- Measurement ruler labels are kept inside the graph area, since a marker on
  the view edge would otherwise have half its timestamp cut off.
- Adds `ICON_ARROWS_EXPAND` (`ion-arrow-expand`) and its `icon_ranges[]` entry.