### PR TITLE
Sw remote cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,8 @@ list(APPEND VIEW_FILES
     src/view/src/remote/rocprofvis_ssh_test_dialog.h
     src/view/src/remote/rocprofvis_remote_file_browser.cpp
     src/view/src/remote/rocprofvis_remote_file_browser.h
+    src/view/src/remote/rocprofvis_remote_download_popup.cpp
+    src/view/src/remote/rocprofvis_remote_download_popup.h
 )
 endif(ROCPROFVIS_ENABLE_REMOTE)
 

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -25,38 +25,24 @@ static char s_save_preset_name[128] = {};
 // Color tints and intrinsic widget geometry only. Padding/spacing come from the
 // shared app style (GetDefaultStyle / frame padding) so the launcher matches the
 // rest of the application rather than inventing its own spacing rules.
-constexpr float kAccentBarWidth     = 4.0f;   // card-header leading accent bar
-constexpr float kAccentBarGap       = 8.0f;
-constexpr float kChipBgAlpha        = 0.16f;
-constexpr float kChipEdgeAlpha      = 0.55f;
-constexpr float kPillGap            = 7.0f;   // gap between pill label and close "x"
-constexpr float kPillCloseScale     = 0.75f;  // close glyph size, fraction of font
-constexpr float kPillBgAlpha        = 0.16f;
-constexpr float kPillBgHoverAlpha   = 0.30f;
-constexpr float kPillCloseIdleAlpha = 0.6f;
-constexpr float kToggleHeightScale  = 0.82f;  // of frame height
-constexpr float kToggleWidthScale   = 1.75f;  // of toggle height
-constexpr float kToggleAnimSpeed    = 10.0f;
-constexpr float kToggleKnobInset    = 2.0f;   // knob padding inside the track
+constexpr float ACCENT_BAR_WIDTH      = 4.0f;   // card-header leading accent bar
+constexpr float ACCENT_BAR_GAP        = 8.0f;
+constexpr float CHIP_BG_ALPHA         = 0.16f;
+constexpr float CHIP_EDGE_ALPHA       = 0.55f;
+constexpr float PILL_GAP              = 7.0f;   // gap between pill label and close "x"
+constexpr float PILL_CLOSE_SCALE      = 0.75f;  // close glyph size, fraction of font
+constexpr float PILL_BG_ALPHA         = 0.16f;
+constexpr float PILL_BG_HOVER_ALPHA   = 0.30f;
+constexpr float PILL_CLOSE_IDLE_ALPHA = 0.6f;
+constexpr float TOGGLE_HEIGHT_SCALE   = 0.82f;  // of frame height
+constexpr float TOGGLE_WIDTH_SCALE    = 1.75f;  // of toggle height
+constexpr float TOGGLE_ANIM_SPEED     = 10.0f;
+constexpr float TOGGLE_KNOB_INSET     = 2.0f;   // knob padding inside the track
 
 // Card interior vertical padding (horizontal padding still follows the app
 // style). Tighter than the app default so the stacked cards read as one compact
 // form instead of a column of tall panels.
-constexpr float kCardPadY = 5.0f;
-
-// A dimmed "(?)" that shows a wrapped tooltip on hover.
-void HelpTip(const char* tooltip)
-{
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
-    if (ImGui::BeginItemTooltip())
-    {
-        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 25.0f);
-        ImGui::TextUnformatted(tooltip);
-        ImGui::PopTextWrapPos();
-        ImGui::EndTooltip();
-    }
-}
+constexpr float CARD_PADDING_Y = 5.0f;
 
 // Linear blend between two packed colors (t in [0,1]).
 ImU32 LerpColor(ImU32 a, ImU32 b, float t)
@@ -74,10 +60,10 @@ void BeginLaunchCard(const char* id)
 {
     // Delegate to the shared design-language panel card so the launcher tracks
     // the same rounded/bordered/tiered look as the remote dialogs. The tighter
-    // kCardPadY keeps the stacked launcher cards reading as one compact form.
+    // CARD_PADDING_Y keeps the stacked launcher cards reading as one compact form.
     SettingsManager&  settings = SettingsManager::Get();
     const ImGuiStyle& def      = settings.GetDefaultStyle();
-    BeginPanelCard(id, PanelCardTone::kPanel, ImVec2(def.WindowPadding.x, kCardPadY), true,
+    BeginPanelCard(id, PanelCardTone::kPanel, ImVec2(def.WindowPadding.x, CARD_PADDING_Y), true,
                    &settings);
 }
 
@@ -99,10 +85,10 @@ void LaunchCardHeader(const char* icon, const char* title, const char* help)
     const float  bar_h = ImGui::GetFontSize();
     ImVec2       p     = ImGui::GetCursorScreenPos();
     ImDrawList*  dl    = ImGui::GetWindowDrawList();
-    dl->AddRectFilled(ImVec2(p.x, p.y), ImVec2(p.x + kAccentBarWidth, p.y + bar_h),
+    dl->AddRectFilled(ImVec2(p.x, p.y), ImVec2(p.x + ACCENT_BAR_WIDTH, p.y + bar_h),
                       settings.GetColor(Colors::kAccent), 2.0f);
 
-    ImGui::Indent(kAccentBarWidth + kAccentBarGap);
+    ImGui::Indent(ACCENT_BAR_WIDTH + ACCENT_BAR_GAP);
 
     // Optional leading icon (drawn from the icon font, in the accent color).
     if (icon && icon[0])
@@ -113,7 +99,7 @@ void LaunchCardHeader(const char* icon, const char* title, const char* help)
         ImGui::TextUnformatted(icon);
         ImGui::PopStyleColor();
         ImGui::PopFont();
-        ImGui::SameLine(0.0f, kAccentBarGap);
+        ImGui::SameLine(0.0f, ACCENT_BAR_GAP);
     }
 
     ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextMain));
@@ -123,9 +109,9 @@ void LaunchCardHeader(const char* icon, const char* title, const char* help)
 
     if (help && help[0])
     {
-        HelpTip(help);
+        HelpMarker(help);
     }
-    ImGui::Unindent(kAccentBarWidth + kAccentBarGap);
+    ImGui::Unindent(ACCENT_BAR_WIDTH + ACCENT_BAR_GAP);
 }
 
 void Chip(const char* label, ImU32 accent_color)
@@ -138,9 +124,9 @@ void Chip(const char* label, ImU32 accent_color)
     float        rnd = size.y * 0.5f;
 
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y),
-                      ApplyAlpha(accent_color, kChipBgAlpha), rnd);
+                      ApplyAlpha(accent_color, CHIP_BG_ALPHA), rnd);
     dl->AddRect(p, ImVec2(p.x + size.x, p.y + size.y),
-                ApplyAlpha(accent_color, kChipEdgeAlpha), rnd);
+                ApplyAlpha(accent_color, CHIP_EDGE_ALPHA), rnd);
     dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), accent_color, label);
 
     ImGui::Dummy(size);
@@ -150,9 +136,9 @@ PillAction EditablePill(const char* label, ImU32 accent_color)
 {
     const ImVec2 pad       = ImGui::GetStyle().FramePadding;
     const ImVec2 text_size = ImGui::CalcTextSize(label);
-    const float  x_size    = ImGui::GetFontSize() * kPillCloseScale;
+    const float  x_size    = ImGui::GetFontSize() * PILL_CLOSE_SCALE;
 
-    ImVec2 size(pad.x * 2.0f + text_size.x + kPillGap + x_size,
+    ImVec2 size(pad.x * 2.0f + text_size.x + PILL_GAP + x_size,
                 text_size.y + pad.y * 2.0f);
     ImVec2 p = ImGui::GetCursorScreenPos();
 
@@ -165,14 +151,14 @@ PillAction EditablePill(const char* label, ImU32 accent_color)
     ImDrawList* dl  = ImGui::GetWindowDrawList();
     float       rnd = size.y * 0.5f;
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y),
-                      ApplyAlpha(accent_color, hovered ? kPillBgHoverAlpha : kPillBgAlpha),
+                      ApplyAlpha(accent_color, hovered ? PILL_BG_HOVER_ALPHA : PILL_BG_ALPHA),
                       rnd);
     dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), accent_color, label);
 
     // Trailing "x" - brightens when hovered so removal is obvious.
     ImVec2 xc(x_left + x_size * 0.5f, p.y + size.y * 0.5f);
     float  arm  = x_size * 0.3f;
-    ImU32  xcol = ApplyAlpha(accent_color, over_x ? 1.0f : kPillCloseIdleAlpha);
+    ImU32  xcol = ApplyAlpha(accent_color, over_x ? 1.0f : PILL_CLOSE_IDLE_ALPHA);
     dl->AddLine(ImVec2(xc.x - arm, xc.y - arm), ImVec2(xc.x + arm, xc.y + arm), xcol, 1.6f);
     dl->AddLine(ImVec2(xc.x - arm, xc.y + arm), ImVec2(xc.x + arm, xc.y - arm), xcol, 1.6f);
 
@@ -231,8 +217,9 @@ void StatusPill(const char* label, ImU32 bg_color)
     ImDrawList*  dl  = ImGui::GetWindowDrawList();
     float        rnd = size.y * 0.5f;
 
+    const ImU32 text_color = SettingsManager::Get().GetColor(Colors::kTextOnAccent);
     dl->AddRectFilled(p, ImVec2(p.x + size.x, p.y + size.y), bg_color, rnd);
-    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), IM_COL32(255, 255, 255, 255), label);
+    dl->AddText(ImVec2(p.x + pad.x, p.y + pad.y), text_color, label);
 
     ImGui::Dummy(size);
 }
@@ -246,7 +233,7 @@ void LaunchSubHeader(const char* text, const char* help)
     ImGui::PopStyleColor();
     if (help && help[0])
     {
-        HelpTip(help);
+        HelpMarker(help);
     }
 }
 
@@ -255,8 +242,8 @@ bool ToggleSwitch(const char* label, bool* value)
     SettingsManager& settings = SettingsManager::Get();
 
     const float frame_h = ImGui::GetFrameHeight();
-    const float height  = frame_h * kToggleHeightScale;
-    const float width   = height * kToggleWidthScale;
+    const float height  = frame_h * TOGGLE_HEIGHT_SCALE;
+    const float width   = height * TOGGLE_WIDTH_SCALE;
     const float radius  = height * 0.5f;
 
     ImGui::PushID(label);
@@ -276,7 +263,7 @@ bool ToggleSwitch(const char* label, bool* value)
     ImGuiStorage* storage = ImGui::GetStateStorage();
     float         target  = *value ? 1.0f : 0.0f;
     float         t       = storage->GetFloat(id, target);
-    float         step    = ImGui::GetIO().DeltaTime * kToggleAnimSpeed;
+    float         step    = ImGui::GetIO().DeltaTime * TOGGLE_ANIM_SPEED;
     if (t < target) { t = std::min(t + step, target); }
     else if (t > target) { t = std::max(t - step, target); }
     storage->SetFloat(id, t);
@@ -294,7 +281,8 @@ bool ToggleSwitch(const char* label, bool* value)
 
     float  knob_x = bar_min.x + radius + t * (width - 2.0f * radius);
     ImVec2 knob_c(knob_x, bar_min.y + radius);
-    dl->AddCircleFilled(knob_c, radius - kToggleKnobInset, IM_COL32(255, 255, 255, 255));
+    dl->AddCircleFilled(knob_c, radius - TOGGLE_KNOB_INSET,
+                        settings.GetColor(Colors::kTextOnAccent));
 
     ImGui::PopID();
 

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -10,6 +10,7 @@
 #include "rocprofvis_rocprof_sys_backend.h"
 // TEMPORARY (remote/SSH): remove guard when remote graduates.
 #ifdef ROCPROFVIS_ENABLE_REMOTE
+#include "remote/rocprofvis_remote_download_popup.h"
 #include "remote/rocprofvis_ssh_auth_modal.h"
 #endif
 #include "widgets/rocprofvis_widget.h"
@@ -33,10 +34,10 @@ namespace
 // Configure-view split: the form and the command-preview panel are divided by a
 // draggable splitter, seeded to a 3:2 (form:preview) ratio on first open and
 // clamped so neither side collapses.
-constexpr float kSplitterWidth       = 6.0f;
-constexpr float kMinPreviewWidth     = 300.0f;
-constexpr float kMinFormWidth        = 320.0f;
-constexpr float kInitialPreviewRatio = 2.0f / 5.0f;
+constexpr float SPLITTER_WIDTH        = 6.0f;
+constexpr float MIN_PREVIEW_WIDTH     = 300.0f;
+constexpr float MIN_FORM_WIDTH        = 320.0f;
+constexpr float INITIAL_PREVIEW_RATIO = 2.0f / 5.0f;
 }  // namespace
 
 ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
@@ -237,29 +238,32 @@ void ProfilerLauncherDialog::RenderConfigureView()
     RenderMainContent();
     ImGui::EndChild();
 
-    // Warnings from backend
+    // Warnings from the backend, tinted from the theme so they track light/dark.
     if (!warnings.empty())
     {
+        SettingsManager& settings = SettingsManager::GetInstance();
         for (auto const& w : warnings)
         {
-            ImVec4 color;
+            Colors      color_id;
             const char* prefix;
             switch (w.level)
             {
                 case WarningMessage::kError:
-                    color = ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
-                    prefix = "Error: ";
+                    color_id = Colors::kTextError;
+                    prefix   = "Error: ";
                     break;
                 case WarningMessage::kWarning:
-                    color = ImVec4(1.0f, 0.8f, 0.0f, 1.0f);
-                    prefix = "Warning: ";
+                    color_id = Colors::kTextWarning;
+                    prefix   = "Warning: ";
                     break;
                 default:
-                    color = ImVec4(0.4f, 0.7f, 1.0f, 1.0f);
-                    prefix = "Hint: ";
+                    color_id = Colors::kTextInfo;
+                    prefix   = "Hint: ";
                     break;
             }
-            ImGui::TextColored(color, "%s%s", prefix, w.text.c_str());
+            ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(color_id));
+            ImGui::Text("%s%s", prefix, w.text.c_str());
+            ImGui::PopStyleColor();
         }
     }
 
@@ -500,17 +504,17 @@ void ProfilerLauncherDialog::RenderMainContent()
     // Seed the split on first layout; afterwards the width follows the splitter.
     if (!m_preview_width_initialized && avail > 0.0f)
     {
-        m_preview_width             = (avail - kSplitterWidth) * kInitialPreviewRatio;
+        m_preview_width             = (avail - SPLITTER_WIDTH) * INITIAL_PREVIEW_RATIO;
         m_preview_width_initialized = true;
     }
 
-    float max_preview = avail - kSplitterWidth - kMinFormWidth;
-    if (max_preview < kMinPreviewWidth)
+    float max_preview = avail - SPLITTER_WIDTH - MIN_FORM_WIDTH;
+    if (max_preview < MIN_PREVIEW_WIDTH)
     {
-        max_preview = kMinPreviewWidth;
+        max_preview = MIN_PREVIEW_WIDTH;
     }
-    m_preview_width  = std::clamp(m_preview_width, kMinPreviewWidth, max_preview);
-    float left_w     = avail - kSplitterWidth - m_preview_width;
+    m_preview_width  = std::clamp(m_preview_width, MIN_PREVIEW_WIDTH, max_preview);
+    float left_w     = avail - SPLITTER_WIDTH - m_preview_width;
 
     // --- Left: the configuration form (scrolls if it overflows) ---
     ImGui::BeginChild("cfg_form", ImVec2(left_w, 0.0f), ImGuiChildFlags_None);
@@ -604,7 +608,7 @@ void ProfilerLauncherDialog::RenderMainContent()
     ImGui::PushStyleColor(ImGuiCol_Button, settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, settings.GetColor(Colors::kSplitterColor));
     ImGui::PushStyleColor(ImGuiCol_ButtonActive, settings.GetColor(Colors::kAccent));
-    ImGui::Button("##cfg_splitter", ImVec2(kSplitterWidth, ImGui::GetContentRegionAvail().y));
+    ImGui::Button("##cfg_splitter", ImVec2(SPLITTER_WIDTH, ImGui::GetContentRegionAvail().y));
     if (ImGui::IsItemHovered() || ImGui::IsItemActive())
     {
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
@@ -984,90 +988,13 @@ void ProfilerLauncherDialog::RenderRemotePopups()
         }
     }
 
-    // Mirrors SshTestDialog::RenderProgressPopup so the remote download popup
-    // looks identical whether launched from the trace opener or the profiler.
-    if (m_remote_show_progress_popup)
-    {
-        SettingsManager&  settings = SettingsManager::GetInstance();
-        const ImGuiStyle& style    = ImGui::GetStyle();
-
-        PopUpStyle popup_style;
-        popup_style.PushPopupStyles();
-        popup_style.PushTitlebarColors();
-        popup_style.CenterPopup();
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
-        ImGui::SetNextWindowSize(ImVec2(440, 0));
-
-        if (ImGui::BeginPopupModal("Remote Trace Download", nullptr,
-            ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar))
-        {
-            const auto& fetch = m_remote_last_progress;
-            uint64_t    done  = fetch.downloaded;
-            uint64_t    total = fetch.size;
-
-            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                                ImVec2(style.ItemSpacing.x, 4.0f));
-
-            BeginPanelCard("##profiler_dl_header", PanelCardTone::kFrame,
-                           ImVec2(16.0f, 10.0f), true, &settings);
-            {
-                PanelIcon(ICON_ARROW_DOWN, Colors::kAccent, &settings);
-                ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
-                ImGui::BeginGroup();
-                ImGui::PushFont(nullptr,
-                                settings.GetFontManager().GetFontSize(FontSize::kMedLarge));
-                ImGui::TextUnformatted("Remote Download");
-                ImGui::PopFont();
-                ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
-                ImGui::TextUnformatted("Fetching the trace over SSH.");
-                ImGui::PopStyleColor();
-                ImGui::EndGroup();
-            }
-            EndPanelCard();
-
-            BeginPanelCard("##profiler_dl_body", PanelCardTone::kPanel,
-                           ImVec2(14.0f, 10.0f), true, &settings);
-            {
-                ImGui::TextWrapped("%s", fetch.name.c_str());
-                ImGui::Spacing();
-                if (total > 0)
-                {
-                    float frac = static_cast<float>(done) / static_cast<float>(total);
-                    if (frac > 1.0f) { frac = 1.0f; }
-                    std::string label = std::to_string(done / 1024) + " / " +
-                                        std::to_string(total / 1024) + " KiB";
-                    ImGui::ProgressBar(frac, ImVec2(-FLT_MIN, 0), label.c_str());
-                }
-                else
-                {
-                    PanelFieldLabel("Starting...", false, &settings);
-                }
-            }
-            EndPanelCard();
-
-            // Close as soon as the download phase ends (completed, failed, or the
-            // session was torn down). This avoids hanging open when the final
-            // "downloaded == size" snapshot never arrives for fast transfers.
-            if (!downloading)
-            {
-                ImGui::CloseCurrentPopup();
-                m_remote_show_progress_popup = false;
-            }
-
-            ImGui::PopStyleVar();  // ItemSpacing
-            ImGui::EndPopup();
-        }
-        else
-        {
-            // Popup not actually open (e.g. dismissed); clear our flag so it can
-            // be reopened on the next download.
-            m_remote_show_progress_popup = false;
-        }
-        ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
-        popup_style.PopStyles();
-    }
+    // Close as soon as the download phase ends (completed, failed, or the session
+    // was torn down); waiting for a final "downloaded == size" snapshot would hang
+    // the popup open on fast transfers. Rendering is shared with the remote trace
+    // opener via RenderRemoteDownloadPopup.
+    RenderRemoteDownloadPopup("Remote Trace Download", "##profiler_dl",
+                              m_remote_last_progress, "Starting...", !downloading,
+                              m_remote_show_progress_popup);
 }
 #endif  // ROCPROFVIS_ENABLE_REMOTE
 
@@ -1142,7 +1069,8 @@ void ProfilerLauncherDialog::RenderButtonRow()
         }
         else
         {
-            ImGui::TextColored(ImVec4(1.0f, 0.78f, 0.25f, 1.0f), "%s", readiness.c_str());
+            ImVec4 warn = ImGui::ColorConvertU32ToFloat4(settings.GetColor(Colors::kTextWarning));
+            ImGui::TextColored(warn, "%s", readiness.c_str());
         }
     }
 }

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -992,9 +992,14 @@ void ProfilerLauncherDialog::RenderRemotePopups()
     // was torn down); waiting for a final "downloaded == size" snapshot would hang
     // the popup open on fast transfers. Rendering is shared with the remote trace
     // opener via RenderRemoteDownloadPopup.
-    RenderRemoteDownloadPopup("Remote Trace Download", "##profiler_dl",
-                              m_remote_last_progress, "Starting...", !downloading,
-                              m_remote_show_progress_popup);
+    if (!RenderRemoteDownloadPopup("Remote Trace Download", "##profiler_dl",
+                                   m_remote_last_progress, "Starting...", !downloading,
+                                   m_remote_show_progress_popup))
+    {
+        // Popup not actually open (e.g. dismissed); clear our flag so it can be
+        // reopened on the next download.
+        m_remote_show_progress_popup = false;
+    }
 }
 #endif  // ROCPROFVIS_ENABLE_REMOTE
 

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
@@ -4,6 +4,7 @@
 #include "rocprofvis_rocprof_sys_backend.h"
 #include "rocprofvis_launch_shared_tabs.h"
 #include "rocprofvis_gui_helpers.h"
+#include "rocprofvis_settings_manager.h"
 #include "rocprofvis_json_utils.h"
 #include "imgui.h"
 #include <sstream>
@@ -128,46 +129,39 @@ namespace
 // ImGui helpers
 // ==================================================================================
 
-void HelpMarker(char const* env_var, char const* desc)
+// Each advanced-tab control documents the env var it maps to, shown above the
+// description. Thin adapter over the shared HelpMarker (which takes the
+// description first) so the call sites can keep reading env-var-first.
+void EnvTooltip(char const* env_var, char const* desc)
 {
-    ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
-    if (ImGui::BeginItemTooltip())
-    {
-        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 25.0f);
-        ImGui::TextUnformatted(env_var);
-        ImGui::Separator();
-        ImGui::TextUnformatted(desc);
-        ImGui::PopTextWrapPos();
-        ImGui::EndTooltip();
-    }
+    HelpMarker(desc, env_var);
 }
 
 // Shared control widths so combos/inputs across the advanced tabs are neither
 // full-window-wide nor ragged.
-constexpr float kFieldLabelW = 150.0f;  // label column width (aligns all inputs)
-constexpr float kNumW        = 130.0f;  // numeric inputs
-constexpr float kComboW      = 200.0f;  // dropdowns
-constexpr float kTextW       = 260.0f;  // single-value text
-constexpr float kListW       = 340.0f;  // comma-separated list text
+constexpr float FIELD_LABEL_WIDTH = 150.0f;  // label column width (aligns all inputs)
+constexpr float NUM_WIDTH        = 130.0f;  // numeric inputs
+constexpr float COMBO_WIDTH      = 200.0f;  // dropdowns
+constexpr float TEXT_WIDTH       = 260.0f;  // single-value text
+constexpr float LIST_WIDTH       = 340.0f;  // comma-separated list text
 
 // Checkbox lists lay out as a responsive grid clamped to this many columns.
-constexpr float kCheckboxColWidth = 190.0f;
-constexpr int   kCheckboxMaxCols  = 4;
+constexpr float CHECKBOX_COL_WIDTH = 190.0f;
+constexpr int   CHECKBOX_MAX_COLS  = 4;
 
 // General tab: the preset row and the side-by-side OUTPUT FORMAT / TRACE WINDOW
 // split (output takes a narrow fixed column so the trace window keeps Delay and
 // Duration on one line).
-constexpr float kPresetLabelW    = 110.0f;
-constexpr float kPresetComboW    = 240.0f;
-constexpr float kOutputColW      = 160.0f;
-constexpr float kTraceInlineNumW = 85.0f;   // Delay / Duration inputs (share a row)
-constexpr float kTraceFieldGapX  = 16.0f;   // gap between Delay and Duration
-constexpr float kTraceRegionTrail = 26.0f;  // width reserved for the Region (?)
+constexpr float PRESET_LABEL_WIDTH    = 110.0f;
+constexpr float PRESET_COMBO_WIDTH    = 240.0f;
+constexpr float OUTPUT_COL_WIDTH      = 160.0f;
+constexpr float TRACE_INLINE_NUM_WIDTH = 85.0f;   // Delay / Duration inputs (share a row)
+constexpr float TRACE_FIELD_GAP_X  = 16.0f;   // gap between Delay and Duration
+constexpr float TRACE_REGION_TRAIL = 26.0f;  // width reserved for the Region (?)
 
 // Renders a label in a fixed-width column and sizes the next item so a whole
 // column of controls lines up regardless of label length.
-void FieldLabel(const char* label, float item_w, float label_w = kFieldLabelW)
+void FieldLabel(const char* label, float item_w, float label_w = FIELD_LABEL_WIDTH)
 {
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted(label);
@@ -182,8 +176,8 @@ void RenderCheckboxMap(
     char const* id_prefix)
 {
     // Long checkbox lists read better as a responsive grid than one tall column.
-    int cols = static_cast<int>(ImGui::GetContentRegionAvail().x / kCheckboxColWidth);
-    cols     = std::clamp(cols, 1, kCheckboxMaxCols);
+    int cols = static_cast<int>(ImGui::GetContentRegionAvail().x / CHECKBOX_COL_WIDTH);
+    cols     = std::clamp(cols, 1, CHECKBOX_MAX_COLS);
     if (count > 0 && static_cast<size_t>(cols) > count)
     {
         cols = static_cast<int>(count);
@@ -223,8 +217,6 @@ bool AnyEnabled(std::map<std::string, bool> const& m)
     return false;
 }
 
-const ImVec4 kPresetLockColor(1.0f, 0.8f, 0.0f, 1.0f);  // amber "locked by preset"
-
 // Advanced tabs are read-only while a built-in preset is active. Draws the
 // "controlled by preset" banner (when one is set) and opens a BeginDisabled()
 // scope that the caller closes with ImGui::EndDisabled().
@@ -233,7 +225,10 @@ void BeginPresetLockedSection(std::string const& preset)
     const bool has_preset = !preset.empty();
     if (has_preset)
     {
-        ImGui::TextColored(kPresetLockColor,
+        // Amber "locked by preset" banner, tinted from the theme.
+        const ImVec4 lock_color = ImGui::ColorConvertU32ToFloat4(
+            SettingsManager::Get().GetColor(Colors::kTextWarning));
+        ImGui::TextColored(lock_color,
                            "Preset \"%s\" controls these settings.", preset.c_str());
         ImGui::TextDisabled("Clear the preset or use Raw Env Vars to override.");
         ImGui::Spacing();
@@ -1087,23 +1082,23 @@ void RocprofSysBackend::RenderGeneralTraceOptions()
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Delay (s)");
     ImGui::SameLine();
-    ImGui::SetNextItemWidth(kTraceInlineNumW);
+    ImGui::SetNextItemWidth(TRACE_INLINE_NUM_WIDTH);
     ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
 
-    ImGui::SameLine(0.0f, kTraceFieldGapX);
+    ImGui::SameLine(0.0f, TRACE_FIELD_GAP_X);
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Duration (s)");
     ImGui::SameLine();
-    ImGui::SetNextItemWidth(kTraceInlineNumW);
+    ImGui::SetNextItemWidth(TRACE_INLINE_NUM_WIDTH);
     ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0, 0.0, "%.2f");
 
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Region");
     ImGui::SameLine();
-    ImGui::SetNextItemWidth(-kTraceRegionTrail);
+    ImGui::SetNextItemWidth(-TRACE_REGION_TRAIL);
     InputTextStringWithHint("##TraceRegion", "ROCTX regions (comma-separated)",
                             m_settings.trace_region);
-    HelpMarker("ROCPROFSYS_TRACE_REGION",
+    EnvTooltip("ROCPROFSYS_TRACE_REGION",
                "Comma-separated ROCTX region names for selective tracing");
 }
 
@@ -1112,12 +1107,12 @@ void RocprofSysBackend::RenderBackendsTab()
     // Headline choice: the built-in rocprof-sys preset.
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Preset");
-    ImGui::SameLine(kPresetLabelW);
+    ImGui::SameLine(PRESET_LABEL_WIDTH);
 
     const char* preset_label =
         m_settings.rocprof_preset.empty() ? "Custom" : m_settings.rocprof_preset.c_str();
 
-    ImGui::SetNextItemWidth(kPresetComboW);
+    ImGui::SetNextItemWidth(PRESET_COMBO_WIDTH);
     if (ImGui::BeginCombo("##RocprofPresetCombo", preset_label))
     {
         if (ImGui::Selectable("Custom", m_settings.rocprof_preset.empty()))
@@ -1138,7 +1133,7 @@ void RocprofSysBackend::RenderBackendsTab()
         }
         ImGui::EndCombo();
     }
-    HelpMarker("Profiling preset",
+    EnvTooltip("Profiling preset",
                "Pick a built-in rocprof-sys preset to configure collection defaults. "
                "When a preset is active, detailed settings are locked to preset values. "
                "Choose Custom to unlock every control.");
@@ -1166,15 +1161,15 @@ void RocprofSysBackend::RenderBackendsTab()
     // Output format and the trace window sit side by side.
     if (ImGui::BeginTable("general_split", 2, ImGuiTableFlags_None))
     {
-        ImGui::TableSetupColumn("##out", ImGuiTableColumnFlags_WidthFixed, kOutputColW);
+        ImGui::TableSetupColumn("##out", ImGuiTableColumnFlags_WidthFixed, OUTPUT_COL_WIDTH);
         ImGui::TableSetupColumn("##trace", ImGuiTableColumnFlags_WidthStretch);
 
         ImGui::TableNextColumn();
         LaunchSubHeader("OUTPUT FORMAT");
         ToggleSwitch("Perfetto trace", &m_settings.trace_backend);
-        HelpMarker("ROCPROFSYS_TRACE", "Enable the Perfetto trace backend");
+        EnvTooltip("ROCPROFSYS_TRACE", "Enable the Perfetto trace backend");
         ToggleSwitch("ROCpd database", &m_settings.use_rocpd);
-        HelpMarker("ROCPROFSYS_USE_ROCPD", "Enable ROCpd SQLite output");
+        EnvTooltip("ROCPROFSYS_USE_ROCPD", "Enable ROCpd SQLite output");
 
         ImGui::TableNextColumn();
         ImGui::BeginDisabled(has_preset);
@@ -1200,62 +1195,62 @@ void RocprofSysBackend::RenderSamplingTab()
 
     LaunchSubHeader("ENABLE");
     ToggleSwitch("Call-stack sampling", &m_settings.use_sampling);
-    HelpMarker("ROCPROFSYS_USE_SAMPLING", "Enable call-stack sampling");
+    EnvTooltip("ROCPROFSYS_USE_SAMPLING", "Enable call-stack sampling");
     ToggleSwitch("Process / system sampling", &m_settings.use_process_sampling);
-    HelpMarker("ROCPROFSYS_USE_PROCESS_SAMPLING",
+    EnvTooltip("ROCPROFSYS_USE_PROCESS_SAMPLING",
                "Background process/system metrics (CPU freq, memory, GPU via SMI)");
 
     ImGui::Spacing();
     ImGui::Separator();
 
-    FieldLabel("Frequency (Hz)", kNumW);
+    FieldLabel("Frequency (Hz)", NUM_WIDTH);
     ImGui::InputDouble("##SampFreq", &m_settings.sampling_freq, 10.0, 100.0, "%.0f");
-    HelpMarker("ROCPROFSYS_SAMPLING_FREQ", "Software interrupts per second");
+    EnvTooltip("ROCPROFSYS_SAMPLING_FREQ", "Software interrupts per second");
 
     ImGui::Separator();
     ImGui::Text("Timer Sources:");
 
     ImGui::Checkbox("CPU Time", &m_settings.sampling_cputime);
-    HelpMarker("ROCPROFSYS_SAMPLING_CPUTIME",
+    EnvTooltip("ROCPROFSYS_SAMPLING_CPUTIME",
                "Sample on CPU-time timer (ITIMER_PROF)");
 
     ImGui::Checkbox("Real Time", &m_settings.sampling_realtime);
-    HelpMarker("ROCPROFSYS_SAMPLING_REALTIME",
+    EnvTooltip("ROCPROFSYS_SAMPLING_REALTIME",
                "Sample on real-time timer (ITIMER_REAL)");
 
     ImGui::Checkbox("Hardware Overflow", &m_settings.sampling_overflow);
-    HelpMarker("ROCPROFSYS_SAMPLING_OVERFLOW",
+    EnvTooltip("ROCPROFSYS_SAMPLING_OVERFLOW",
                "Sample on hardware counter overflow");
 
     ImGui::Separator();
 
-    FieldLabel("Duration (s)", kNumW);
+    FieldLabel("Duration (s)", NUM_WIDTH);
     ImGui::InputDouble("##SampDur", &m_settings.sampling_duration, 0.0, 0.0, "%.2f");
-    HelpMarker("ROCPROFSYS_SAMPLING_DURATION",
+    EnvTooltip("ROCPROFSYS_SAMPLING_DURATION",
                "Stop sampling after N seconds (0 = unlimited)");
 
     int alloc_sz = m_settings.sampling_allocator_size;
-    FieldLabel("Allocator Size", kNumW);
+    FieldLabel("Allocator Size", NUM_WIDTH);
     if (ImGui::InputInt("##AllocSz", &alloc_sz))
     {
         m_settings.sampling_allocator_size = alloc_sz;
     }
-    HelpMarker("ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE",
+    EnvTooltip("ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE",
                "Threads per background allocator");
 
-    FieldLabel("Overflow Event", kTextW);
+    FieldLabel("Overflow Event", TEXT_WIDTH);
     InputTextString("##OverflowEvt", m_settings.sampling_overflow_event);
-    HelpMarker("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
+    EnvTooltip("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
                "Linux perf metric name for overflow sampling");
 
     ImGui::Separator();
 
     ImGui::Checkbox("Keep Internal Frames", &m_settings.sampling_keep_internal);
-    HelpMarker("ROCPROFSYS_SAMPLING_KEEP_INTERNAL",
+    EnvTooltip("ROCPROFSYS_SAMPLING_KEEP_INTERNAL",
                "Show rocprof-sys frames in call stacks");
 
     ImGui::Checkbox("Include Inline Entries", &m_settings.sampling_include_inlines);
-    HelpMarker("ROCPROFSYS_SAMPLING_INCLUDE_INLINES",
+    EnvTooltip("ROCPROFSYS_SAMPLING_INCLUDE_INLINES",
                "Include inline function entries in stacks");
 
     ImGui::EndDisabled();
@@ -1266,27 +1261,27 @@ void RocprofSysBackend::RenderRocmTab()
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
     ImGui::Text("ROCm Domains:");
-    HelpMarker("ROCPROFSYS_ROCM_DOMAINS",
+    EnvTooltip("ROCPROFSYS_ROCM_DOMAINS",
                "ROCm SDK domains to trace (checked = enabled)");
 
     RenderCheckboxMap(m_settings.rocm_domains,
                       kRocmDomains, kRocmDomainsCount, "rd_");
 
     ImGui::Spacing();
-    FieldLabel("Custom Domains", kListW);
+    FieldLabel("Custom Domains", LIST_WIDTH);
     InputTextString("##RocmDomainsCustom", m_settings.rocm_domains_custom);
-    HelpMarker("ROCPROFSYS_ROCM_DOMAINS",
+    EnvTooltip("ROCPROFSYS_ROCM_DOMAINS",
                "Additional comma-separated domain names not in the list above");
 
     ImGui::Separator();
 
-    FieldLabel("Hardware Counters", kListW);
+    FieldLabel("Hardware Counters", LIST_WIDTH);
     InputTextString("##RocmEvents", m_settings.rocm_events);
-    HelpMarker("ROCPROFSYS_ROCM_EVENTS",
+    EnvTooltip("ROCPROFSYS_ROCM_EVENTS",
                "HW counters (use :device=N syntax for specific GPU)");
 
     ImGui::Checkbox("Group by Queue", &m_settings.rocm_group_by_queue);
-    HelpMarker("ROCPROFSYS_ROCM_GROUP_BY_QUEUE",
+    EnvTooltip("ROCPROFSYS_ROCM_GROUP_BY_QUEUE",
                "Group by HSA queue instead of HIP stream");
 
     ImGui::EndDisabled();
@@ -1306,47 +1301,47 @@ void RocprofSysBackend::RenderPerfettoTab()
             break;
         }
     }
-    FieldLabel("Backend", kComboW);
+    FieldLabel("Backend", COMBO_WIDTH);
     if (ImGui::Combo("##PerfBackend", &backend_idx, backends, IM_ARRAYSIZE(backends)))
     {
         m_settings.perfetto_backend = backends[backend_idx];
     }
-    HelpMarker("ROCPROFSYS_PERFETTO_BACKEND", "Perfetto tracing backend mode");
+    EnvTooltip("ROCPROFSYS_PERFETTO_BACKEND", "Perfetto tracing backend mode");
 
     int buf_kb = m_settings.perfetto_buffer_size_kb;
-    FieldLabel("Buffer Size (KB)", kNumW);
+    FieldLabel("Buffer Size (KB)", NUM_WIDTH);
     if (ImGui::InputInt("##BufKB", &buf_kb, 1024, 10240))
     {
         m_settings.perfetto_buffer_size_kb = buf_kb;
     }
-    HelpMarker("ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB",
+    EnvTooltip("ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB",
                "Perfetto shared memory buffer size");
 
     int flush_ms = m_settings.perfetto_flush_period_ms;
-    FieldLabel("Flush Period (ms)", kNumW);
+    FieldLabel("Flush Period (ms)", NUM_WIDTH);
     if (ImGui::InputInt("##FlushMs", &flush_ms, 1000, 5000))
     {
         m_settings.perfetto_flush_period_ms = flush_ms;
     }
-    HelpMarker("ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS",
+    EnvTooltip("ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS",
                "Flush interval in milliseconds");
 
     const char* policies[] = {"discard", "fill"};
     int policy_idx = (m_settings.perfetto_fill_policy == "fill") ? 1 : 0;
-    FieldLabel("Fill Policy", kComboW);
+    FieldLabel("Fill Policy", COMBO_WIDTH);
     if (ImGui::Combo("##FillPolicy", &policy_idx, policies, IM_ARRAYSIZE(policies)))
     {
         m_settings.perfetto_fill_policy = policies[policy_idx];
     }
-    HelpMarker("ROCPROFSYS_PERFETTO_FILL_POLICY",
+    EnvTooltip("ROCPROFSYS_PERFETTO_FILL_POLICY",
                "Buffer fill policy: discard old or stop writing");
 
     ImGui::Checkbox("Annotations", &m_settings.perfetto_annotations);
-    HelpMarker("ROCPROFSYS_PERFETTO_ANNOTATIONS",
+    EnvTooltip("ROCPROFSYS_PERFETTO_ANNOTATIONS",
                "Function argument annotations (larger traces)");
 
     ImGui::Checkbox("Combine Traces", &m_settings.perfetto_combine_traces);
-    HelpMarker("ROCPROFSYS_PERFETTO_COMBINE_TRACES",
+    EnvTooltip("ROCPROFSYS_PERFETTO_COMBINE_TRACES",
                "Combine per-process traces into one file");
 
     ImGui::Separator();
@@ -1356,7 +1351,7 @@ void RocprofSysBackend::RenderPerfettoTab()
     bool has_disable = AnyEnabled(m_settings.disable_categories);
 
     ImGui::Text("Enable Categories (allowlist):");
-    HelpMarker("ROCPROFSYS_ENABLE_CATEGORIES",
+    EnvTooltip("ROCPROFSYS_ENABLE_CATEGORIES",
                "Perfetto categories to enable (mutually exclusive with disable list)");
     if (has_disable)
     {
@@ -1371,7 +1366,7 @@ void RocprofSysBackend::RenderPerfettoTab()
     ImGui::Spacing();
 
     ImGui::Text("Disable Categories (denylist):");
-    HelpMarker("ROCPROFSYS_DISABLE_CATEGORIES",
+    EnvTooltip("ROCPROFSYS_DISABLE_CATEGORIES",
                "Perfetto categories to disable (mutually exclusive with enable list)");
     if (has_enable)
     {
@@ -1385,9 +1380,9 @@ void RocprofSysBackend::RenderPerfettoTab()
 
     ImGui::Separator();
 
-    FieldLabel("Output File", kTextW);
+    FieldLabel("Output File", TEXT_WIDTH);
     InputTextString("##PerfFile", m_settings.perfetto_file);
-    HelpMarker("ROCPROFSYS_PERFETTO_FILE", "Output filename for perfetto trace");
+    EnvTooltip("ROCPROFSYS_PERFETTO_FILE", "Output filename for perfetto trace");
 
     ImGui::EndDisabled();
 }
@@ -1398,45 +1393,45 @@ void RocprofSysBackend::RenderProcessSamplingTab()
 
     LaunchSubHeader("ENABLE");
     ToggleSwitch("AMD SMI GPU metrics", &m_settings.use_amd_smi);
-    HelpMarker("ROCPROFSYS_USE_AMD_SMI", "GPU metrics via AMD SMI");
+    EnvTooltip("ROCPROFSYS_USE_AMD_SMI", "GPU metrics via AMD SMI");
 
     ImGui::Spacing();
     ImGui::Separator();
 
     ImGui::Checkbox("CPU Frequency / Mem / Context Switches",
                     &m_settings.cpu_freq_enabled);
-    HelpMarker("ROCPROFSYS_CPU_FREQ_ENABLED",
+    EnvTooltip("ROCPROFSYS_CPU_FREQ_ENABLED",
                "Enable CPU frequency, memory, and context switch sampling");
 
     ImGui::Separator();
 
     ImGui::Text("AMD SMI Metrics:");
-    HelpMarker("ROCPROFSYS_AMD_SMI_METRICS",
+    EnvTooltip("ROCPROFSYS_AMD_SMI_METRICS",
                "GPU metrics to collect (checked = enabled)");
 
     RenderCheckboxMap(m_settings.amd_smi_metrics,
                       kAmdSmiMetrics, kAmdSmiMetricsCount, "smi_");
 
     ImGui::Spacing();
-    FieldLabel("Custom Metrics", kListW);
+    FieldLabel("Custom Metrics", LIST_WIDTH);
     InputTextString("##SmiMetricsCustom", m_settings.amd_smi_metrics_custom);
-    HelpMarker("ROCPROFSYS_AMD_SMI_METRICS",
+    EnvTooltip("ROCPROFSYS_AMD_SMI_METRICS",
                "Additional comma-separated metric names not in the list above");
 
     ImGui::Separator();
 
-    FieldLabel("CPUs", kTextW);
+    FieldLabel("CPUs", TEXT_WIDTH);
     InputTextString("##SampCPUs", m_settings.sampling_cpus);
-    HelpMarker("ROCPROFSYS_SAMPLING_CPUS",
+    EnvTooltip("ROCPROFSYS_SAMPLING_CPUS",
                "CPU list for frequency sampling ('none', 'all', or index list)");
 
-    FieldLabel("GPUs", kTextW);
+    FieldLabel("GPUs", TEXT_WIDTH);
     InputTextString("##SampGPUs", m_settings.sampling_gpus);
-    HelpMarker("ROCPROFSYS_SAMPLING_GPUS",
+    EnvTooltip("ROCPROFSYS_SAMPLING_GPUS",
                "AMD SMI device indices for GPU sampling");
 
     ImGui::Checkbox("AI NIC Metrics", &m_settings.use_ainic);
-    HelpMarker("ROCPROFSYS_USE_AINIC", "Enable AI NIC metrics collection");
+    EnvTooltip("ROCPROFSYS_USE_AINIC", "Enable AI NIC metrics collection");
 
     ImGui::EndDisabled();
 }
@@ -1450,7 +1445,7 @@ void RocprofSysBackend::RenderParallelismTab()
     {
         ImGui::TableNextColumn();
         ToggleSwitch(label, &val);
-        HelpMarker(env, help);
+        EnvTooltip(env, help);
     };
 
     if (ImGui::BeginTable("parallelism_grid", 2, ImGuiTableFlags_None))
@@ -1480,24 +1475,24 @@ void RocprofSysBackend::RenderInstrumentTab()
     ImGui::Text("Binary Instrumentation Options");
     ImGui::Separator();
 
-    FieldLabel("Include Regex", kListW);
+    FieldLabel("Include Regex", LIST_WIDTH);
     InputTextString("##InstrInclude", m_settings.instr_include);
-    HelpMarker("-I / --function-include",
+    EnvTooltip("-I / --function-include",
                "Regex for functions to include in instrumentation");
 
-    FieldLabel("Exclude Regex", kListW);
+    FieldLabel("Exclude Regex", LIST_WIDTH);
     InputTextString("##InstrExclude", m_settings.instr_exclude);
-    HelpMarker("-E / --function-exclude",
+    EnvTooltip("-E / --function-exclude",
                "Regex for functions to exclude from instrumentation");
 
     int min_instr = m_settings.min_instructions;
-    FieldLabel("Min Instructions", kNumW);
+    FieldLabel("Min Instructions", NUM_WIDTH);
     if (ImGui::InputInt("##MinInstr", &min_instr))
     {
         if (min_instr < 0) min_instr = 0;
         m_settings.min_instructions = min_instr;
     }
-    HelpMarker("--min-instructions",
+    EnvTooltip("--min-instructions",
                "Minimum instruction count for a function to be instrumented");
 
     ImGui::EndDisabled();
@@ -1530,15 +1525,15 @@ void RocprofSysBackend::RenderAdvancedTab()
         m_settings.flat_profile = true;
     }
     ImGui::SameLine();
-    HelpMarker("ROCPROFSYS_PROFILE / ROCPROFSYS_FLAT_PROFILE",
+    EnvTooltip("ROCPROFSYS_PROFILE / ROCPROFSYS_FLAT_PROFILE",
                "Timemory summary profile mode (hierarchical or flat call stacks)");
 
     ImGui::Spacing();
     ImGui::Separator();
 
-    FieldLabel("Config File", kListW);
+    FieldLabel("Config File", LIST_WIDTH);
     InputTextString("##CfgFile", m_settings.config_file);
-    HelpMarker("ROCPROFSYS_CONFIG_FILE",
+    EnvTooltip("ROCPROFSYS_CONFIG_FILE",
                "Path to rocprof-sys configuration file (overrides individual settings)");
     ImGui::TextDisabled("For full Perfetto control, point to a config file.");
 
@@ -1554,21 +1549,21 @@ void RocprofSysBackend::RenderAdvancedTab()
             break;
         }
     }
-    FieldLabel("Log Level", kComboW);
+    FieldLabel("Log Level", COMBO_WIDTH);
     if (ImGui::Combo("##LogLevel", &level_idx, levels, IM_ARRAYSIZE(levels)))
     {
         m_settings.log_level = levels[level_idx];
     }
-    HelpMarker("ROCPROFSYS_LOG_LEVEL", "Logging verbosity level");
+    EnvTooltip("ROCPROFSYS_LOG_LEVEL", "Logging verbosity level");
 
-    FieldLabel("Log File", kTextW);
+    FieldLabel("Log File", TEXT_WIDTH);
     InputTextString("##LogFile", m_settings.log_file);
-    HelpMarker("ROCPROFSYS_LOG_FILE",
+    EnvTooltip("ROCPROFSYS_LOG_FILE",
                "Log file name (empty disables file logging)");
 
-    FieldLabel("Temp Directory", kTextW);
+    FieldLabel("Temp Directory", TEXT_WIDTH);
     InputTextString("##TmpDir", m_settings.tmpdir);
-    HelpMarker("ROCPROFSYS_TMPDIR",
+    EnvTooltip("ROCPROFSYS_TMPDIR",
                "Base directory for temporary/spill files");
 
     // MPI profiling (MPIP) forces PID suffixing off. Show the toggle off and
@@ -1583,7 +1578,7 @@ void RocprofSysBackend::RenderAdvancedTab()
         m_settings.use_pid = pid_display;
     }
     ImGui::EndDisabled();
-    HelpMarker("ROCPROFSYS_USE_PID", "Suffix output filenames with the process ID");
+    EnvTooltip("ROCPROFSYS_USE_PID", "Suffix output filenames with the process ID");
     if (pid_locked_by_mpi)
     {
         ImGui::SameLine();

--- a/src/view/src/remote/rocprofvis_remote_download_popup.cpp
+++ b/src/view/src/remote/rocprofvis_remote_download_popup.cpp
@@ -29,18 +29,19 @@ constexpr float PROGRESS_POPUP_WIDTH = 440.0f;
 constexpr uint64_t BYTES_PER_KIB = 1024;
 }  // namespace
 
-void
+bool
 RenderRemoteDownloadPopup(const char* popup_id, const char* id_prefix,
                           const FileStat::Snapshot& progress, const char* idle_label,
                           bool finished, bool& open)
 {
     if(!open)
     {
-        return;
+        return false;
     }
 
     SettingsManager&  settings = SettingsManager::GetInstance();
     const ImGuiStyle& style    = ImGui::GetStyle();
+    bool              rendered = false;
 
     PopUpStyle popup_style;
     popup_style.PushPopupStyles();
@@ -57,6 +58,8 @@ RenderRemoteDownloadPopup(const char* popup_id, const char* id_prefix,
                                   ImGuiWindowFlags_NoTitleBar |
                                   ImGuiWindowFlags_NoScrollbar))
     {
+        rendered = true;
+
         // Tighten the gap between the stacked cards so they read as one surface.
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
                             ImVec2(style.ItemSpacing.x, PANEL_CARD_STACK_SPACING_Y));
@@ -89,6 +92,10 @@ RenderRemoteDownloadPopup(const char* popup_id, const char* id_prefix,
             {
                 float fraction = static_cast<float>(progress.downloaded) /
                                  static_cast<float>(progress.size);
+                if(fraction > 1.0f)
+                {
+                    fraction = 1.0f;
+                }
                 const std::string label =
                     std::to_string(progress.downloaded / BYTES_PER_KIB) + " / " +
                     std::to_string(progress.size / BYTES_PER_KIB) + " KiB";
@@ -110,15 +117,10 @@ RenderRemoteDownloadPopup(const char* popup_id, const char* id_prefix,
         ImGui::PopStyleVar();  // ItemSpacing
         ImGui::EndPopup();
     }
-    else
-    {
-        // The popup is no longer on the stack (dismissed, or never opened this
-        // frame), so clear the flag to let the next transfer reopen it.
-        open = false;
-    }
 
     ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
     popup_style.PopStyles();
+    return rendered;
 }
 
 }  // namespace View

--- a/src/view/src/remote/rocprofvis_remote_download_popup.cpp
+++ b/src/view/src/remote/rocprofvis_remote_download_popup.cpp
@@ -1,0 +1,125 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_remote_download_popup.h"
+
+#include <cfloat>
+#include <string>
+
+#include "imgui.h"
+
+#include "icons/rocprovfis_icon_defines.h"
+#include "rocprofvis_font_manager.h"
+#include "rocprofvis_settings_manager.h"
+#include "widgets/rocprofvis_gui_helpers.h"
+#include "widgets/rocprofvis_widget.h"
+
+namespace RocProfVis
+{
+namespace View
+{
+
+namespace
+{
+// Fixed width for the transient download popup; height auto-fits its content.
+constexpr float PROGRESS_POPUP_WIDTH = 440.0f;
+
+// Bytes shown as whole KiB in the progress label (matches the transfer's
+// reporting granularity).
+constexpr uint64_t BYTES_PER_KIB = 1024;
+}  // namespace
+
+void
+RenderRemoteDownloadPopup(const char* popup_id, const char* id_prefix,
+                          const FileStat::Snapshot& progress, const char* idle_label,
+                          bool finished, bool& open)
+{
+    if(!open)
+    {
+        return;
+    }
+
+    SettingsManager&  settings = SettingsManager::GetInstance();
+    const ImGuiStyle& style    = ImGui::GetStyle();
+
+    PopUpStyle popup_style;
+    popup_style.PushPopupStyles();
+    popup_style.PushTitlebarColors();
+    popup_style.CenterPopup();
+    // Borderless: the cards paint their own bands edge to edge, so the window
+    // carries no padding of its own but keeps the app's themed rounding.
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, settings.GetDefaultStyle().WindowRounding);
+    ImGui::SetNextWindowSize(ImVec2(PROGRESS_POPUP_WIDTH, 0.0f));
+
+    if(ImGui::BeginPopupModal(popup_id, nullptr,
+                              ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove |
+                                  ImGuiWindowFlags_NoTitleBar |
+                                  ImGuiWindowFlags_NoScrollbar))
+    {
+        // Tighten the gap between the stacked cards so they read as one surface.
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                            ImVec2(style.ItemSpacing.x, PANEL_CARD_STACK_SPACING_Y));
+
+        const std::string header_id = std::string(id_prefix) + "_header";
+        BeginPanelCard(header_id.c_str(), PanelCardTone::kFrame, PANEL_HEADER_PADDING, true,
+                       &settings);
+        {
+            PanelIcon(ICON_ARROW_DOWN, Colors::kAccent, &settings);
+            ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+            ImGui::BeginGroup();
+            ImGui::PushFont(nullptr,
+                            settings.GetFontManager().GetFontSize(FontSize::kMedLarge));
+            ImGui::TextUnformatted("Remote Download");
+            ImGui::PopFont();
+            ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
+            ImGui::TextUnformatted("Fetching the trace over SSH.");
+            ImGui::PopStyleColor();
+            ImGui::EndGroup();
+        }
+        EndPanelCard();
+
+        const std::string body_id = std::string(id_prefix) + "_body";
+        BeginPanelCard(body_id.c_str(), PanelCardTone::kPanel, PANEL_BODY_PADDING, true,
+                       &settings);
+        {
+            ImGui::TextWrapped("%s", progress.name.c_str());
+            ImGui::Spacing();
+            if(progress.size > 0)
+            {
+                float fraction = static_cast<float>(progress.downloaded) /
+                                 static_cast<float>(progress.size);
+                const std::string label =
+                    std::to_string(progress.downloaded / BYTES_PER_KIB) + " / " +
+                    std::to_string(progress.size / BYTES_PER_KIB) + " KiB";
+                ImGui::ProgressBar(fraction, ImVec2(-FLT_MIN, 0.0f), label.c_str());
+            }
+            else
+            {
+                PanelFieldLabel(idle_label, false, &settings);
+            }
+        }
+        EndPanelCard();
+
+        if(finished)
+        {
+            ImGui::CloseCurrentPopup();
+            open = false;
+        }
+
+        ImGui::PopStyleVar();  // ItemSpacing
+        ImGui::EndPopup();
+    }
+    else
+    {
+        // The popup is no longer on the stack (dismissed, or never opened this
+        // frame), so clear the flag to let the next transfer reopen it.
+        open = false;
+    }
+
+    ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
+    popup_style.PopStyles();
+}
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/remote/rocprofvis_remote_download_popup.h
+++ b/src/view/src/remote/rocprofvis_remote_download_popup.h
@@ -19,8 +19,9 @@ namespace View
 // detect completion differently, so the caller passes its own verdict in
 // finished; when set, the modal closes and open is cleared. id_prefix scopes the
 // internal card ids so two instances never collide, and idle_label is shown
-// until the first byte count arrives.
-void
+// until the first byte count arrives. Returns true while the modal is on the
+// ImGui stack; false means it was never opened or has been dismissed.
+bool
 RenderRemoteDownloadPopup(const char* popup_id, const char* id_prefix,
                           const FileStat::Snapshot& progress, const char* idle_label,
                           bool finished, bool& open);

--- a/src/view/src/remote/rocprofvis_remote_download_popup.h
+++ b/src/view/src/remote/rocprofvis_remote_download_popup.h
@@ -1,0 +1,29 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocprofvis_ssh_fetch.h"
+
+namespace RocProfVis
+{
+namespace View
+{
+
+// Modal progress card for an SSH file download, shared by the remote trace
+// opener and the profiler launcher so a transfer looks the same wherever it was
+// started from.
+//
+// The caller owns the popup's lifetime: it calls ImGui::OpenPopup(popup_id) and
+// keeps open true while the modal should stay on screen. The two workflows
+// detect completion differently, so the caller passes its own verdict in
+// finished; when set, the modal closes and open is cleared. id_prefix scopes the
+// internal card ids so two instances never collide, and idle_label is shown
+// until the first byte count arrives.
+void
+RenderRemoteDownloadPopup(const char* popup_id, const char* id_prefix,
+                          const FileStat::Snapshot& progress, const char* idle_label,
+                          bool finished, bool& open);
+
+}  // namespace View
+}  // namespace RocProfVis

--- a/src/view/src/remote/rocprofvis_remote_file_browser.cpp
+++ b/src/view/src/remote/rocprofvis_remote_file_browser.cpp
@@ -598,7 +598,9 @@ void RemoteFileBrowser::Render()
         }
         else if (!m_browser_error.empty())
         {
-            ImGui::TextColored(ImVec4(1.0f, 0.45f, 0.35f, 1.0f), "%s", m_browser_error.c_str());
+            ImGui::TextColored(
+                ImGui::ColorConvertU32ToFloat4(settings.GetColor(Colors::kTextError)), "%s",
+                m_browser_error.c_str());
         }
         else
         {

--- a/src/view/src/remote/rocprofvis_remote_file_browser.cpp
+++ b/src/view/src/remote/rocprofvis_remote_file_browser.cpp
@@ -388,11 +388,7 @@ void RemoteFileBrowser::Render()
                           ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
         {
             // Title and host chip.
-            ImGui::PushFont(icon_font, ImGui::GetFontSize());
-            ImGui::PushStyleColor(ImGuiCol_Text, accent);
-            ImGui::TextUnformatted(ICON_COMPASS);
-            ImGui::PopStyleColor();
-            ImGui::PopFont();
+            PanelIcon(ICON_COMPASS, accent, &settings);
             ImGui::SameLine();
             ImGui::TextUnformatted(dir_mode ? "Choose Remote Folder" : "Remote File System");
 
@@ -511,12 +507,8 @@ void RemoteFileBrowser::Render()
                         accum += segment;
 
                         ImGui::SameLine(0, 2.0f);
-                        ImGui::PushFont(icon_font, ImGui::GetFontSize());
-                        ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
                         ImGui::AlignTextToFramePadding();
-                        ImGui::TextUnformatted(ICON_CHEVRON_RIGHT);
-                        ImGui::PopStyleColor();
-                        ImGui::PopFont();
+                        PanelIcon(ICON_CHEVRON_RIGHT, text_dim, &settings);
                         ImGui::SameLine(0, 2.0f);
 
                         std::string crumb = segment + "##crumb" + accum;
@@ -712,15 +704,6 @@ void RemoteFileBrowser::Render()
                 }
             }
 
-            auto row_icon = [&](const char* glyph, ImU32 color) {
-                ImGui::PushFont(icon_font, ImGui::GetFontSize());
-                ImGui::PushStyleColor(ImGuiCol_Text, color);
-                ImGui::TextUnformatted(glyph);
-                ImGui::PopStyleColor();
-                ImGui::PopFont();
-                ImGui::SameLine(0, style.ItemInnerSpacing.x);
-            };
-
             // Synthetic ".." parent row (not at the root).
             if (!is_posix_root_path(m_browser_dir))
             {
@@ -736,7 +719,8 @@ void RemoteFileBrowser::Render()
                 }
                 const ImU32 c = parent_selected ? text_on_accent : accent;
                 ImGui::SameLine(0, 0);
-                row_icon(ICON_FOLDER, c);
+                PanelIcon(ICON_FOLDER, c, &settings);
+                ImGui::SameLine(0, style.ItemInnerSpacing.x);
                 ImGui::PushStyleColor(ImGuiCol_Text, c);
                 ImGui::TextUnformatted("..");
                 ImGui::PopStyleColor();
@@ -813,7 +797,8 @@ void RemoteFileBrowser::Render()
                 const ImU32 name_color =
                     row_selected ? text_on_accent : (f.is_dir ? accent : text_main);
                 ImGui::SameLine(0, 0);
-                row_icon(f.is_dir ? ICON_FOLDER : ICON_DOCUMENT, icon_color);
+                PanelIcon(f.is_dir ? ICON_FOLDER : ICON_DOCUMENT, icon_color, &settings);
+                ImGui::SameLine(0, style.ItemInnerSpacing.x);
                 // Directory rows show the name (folders with a trailing slash).
                 // The Name column clips long text; the full path is on hover.
                 const std::string display = f.is_dir ? f.name + "/" : f.name;

--- a/src/view/src/remote/rocprofvis_ssh_auth_modal.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_auth_modal.cpp
@@ -37,7 +37,7 @@ void RenderAuthHeaderCard(const char* id, const char* title, const char* subtitl
     SettingsManager&  settings = SettingsManager::GetInstance();
     const ImGuiStyle& style    = ImGui::GetStyle();
 
-    BeginPanelCard(id, PanelCardTone::kFrame, ImVec2(16.0f, 10.0f), true, &settings);
+    BeginPanelCard(id, PanelCardTone::kFrame, PANEL_HEADER_PADDING, true, &settings);
     PanelIcon(ICON_COMPASS, Colors::kAccent, &settings);
     ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
     ImGui::BeginGroup();
@@ -110,7 +110,7 @@ bool RenderSshAuthModal(SshSession* ssh_session)
             RenderAuthHeaderCard("##ssh_auth_header", "SSH Authentication",
                                  "Enter your credentials to continue.");
 
-            BeginPanelCard("##ssh_auth_body", PanelCardTone::kPanel, ImVec2(14.0f, 10.0f),
+            BeginPanelCard("##ssh_auth_body", PanelCardTone::kPanel, PANEL_BODY_PADDING,
                            true, &settings);
             {
                 if(!req->name.empty())
@@ -137,7 +137,7 @@ bool RenderSshAuthModal(SshSession* ssh_session)
             }
             EndPanelCard();
 
-            BeginPanelCard("##ssh_auth_footer", PanelCardTone::kFrame, ImVec2(14.0f, 8.0f),
+            BeginPanelCard("##ssh_auth_footer", PanelCardTone::kFrame, PANEL_CARD_PADDING,
                            true, &settings);
             {
                 const float total = BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
@@ -210,7 +210,7 @@ bool RenderSshAuthModal(SshSession* ssh_session)
 
             RenderAuthHeaderCard("##ssh_hostkey_header", "SSH Host Key", subtitle);
 
-            BeginPanelCard("##ssh_hostkey_body", PanelCardTone::kPanel, ImVec2(14.0f, 10.0f),
+            BeginPanelCard("##ssh_hostkey_body", PanelCardTone::kPanel, PANEL_BODY_PADDING,
                            true, &settings);
             {
                 if(mismatch)
@@ -266,7 +266,7 @@ bool RenderSshAuthModal(SshSession* ssh_session)
             }
             EndPanelCard();
 
-            BeginPanelCard("##ssh_hostkey_footer", PanelCardTone::kFrame, ImVec2(14.0f, 8.0f),
+            BeginPanelCard("##ssh_hostkey_footer", PanelCardTone::kFrame, PANEL_CARD_PADDING,
                            true, &settings);
             {
                 constexpr float TRUST_WIDTH  = 150.0f;

--- a/src/view/src/remote/rocprofvis_ssh_auth_modal.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_auth_modal.cpp
@@ -87,6 +87,8 @@ bool RenderSshAuthModal(SshSession* ssh_session)
         SettingsManager&  settings = SettingsManager::GetInstance();
         const ImGuiStyle& style    = ImGui::GetStyle();
 
+        constexpr float PROMPT_MODAL_WIDTH = 480.0f;
+
         PopUpStyle popup_style;
         popup_style.PushPopupStyles();
         popup_style.PushTitlebarColors();
@@ -95,17 +97,16 @@ bool RenderSshAuthModal(SshSession* ssh_session)
         // trace dialog) and the header band carries the title instead of the
         // native title bar.
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
-        ImGui::SetNextWindowSize(ImVec2(480, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
+                            settings.GetDefaultStyle().WindowRounding);
+        ImGui::SetNextWindowSize(ImVec2(PROMPT_MODAL_WIDTH, 0));
 
         if(ImGui::BeginPopupModal("SSH Authentication", nullptr,
                                   ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove |
                                       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar))
         {
-            constexpr float BUTTON_WIDTH = 104.0f;
-
             ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                                ImVec2(style.ItemSpacing.x, 4.0f));
+                                ImVec2(style.ItemSpacing.x, PANEL_CARD_STACK_SPACING_Y));
 
             RenderAuthHeaderCard("##ssh_auth_header", "SSH Authentication",
                                  "Enter your credentials to continue.");
@@ -140,13 +141,13 @@ bool RenderSshAuthModal(SshSession* ssh_session)
             BeginPanelCard("##ssh_auth_footer", PanelCardTone::kFrame, PANEL_CARD_PADDING,
                            true, &settings);
             {
-                const float total = BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
+                const float total = DIALOG_BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
                 const float avail = ImGui::GetContentRegionAvail().x;
                 if(avail > total)
                 {
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (avail - total));
                 }
-                if(ImGui::Button("Cancel", ImVec2(BUTTON_WIDTH, 0)))
+                if(ImGui::Button("Cancel", ImVec2(DIALOG_BUTTON_WIDTH, 0)))
                 {
                     ssh_session->CancelRequest();
                     st = {};
@@ -154,7 +155,7 @@ bool RenderSshAuthModal(SshSession* ssh_session)
                     ssh_session->GetPromptRequest()->ClearUpdated();
                 }
                 ImGui::SameLine();
-                if(AccentButton("Submit", ImVec2(BUTTON_WIDTH, 0), &settings))
+                if(AccentButton("Submit", ImVec2(DIALOG_BUTTON_WIDTH, 0), &settings))
                 {
                     std::vector<std::string> resp = st.answers;
 
@@ -189,13 +190,16 @@ bool RenderSshAuthModal(SshSession* ssh_session)
         SettingsManager&  settings = SettingsManager::GetInstance();
         const ImGuiStyle& style    = ImGui::GetStyle();
 
+        constexpr float HOST_KEY_MODAL_WIDTH = 520.0f;
+
         PopUpStyle popup_style;
         popup_style.PushPopupStyles();
         popup_style.PushTitlebarColors();
         popup_style.CenterPopup();
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
-        ImGui::SetNextWindowSize(ImVec2(520, 0));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
+                            settings.GetDefaultStyle().WindowRounding);
+        ImGui::SetNextWindowSize(ImVec2(HOST_KEY_MODAL_WIDTH, 0));
 
         if(ImGui::BeginPopupModal("SSH Host Key", nullptr,
                                   ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove |
@@ -206,7 +210,7 @@ bool RenderSshAuthModal(SshSession* ssh_session)
                                             : "Verify this host before connecting.";
 
             ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                                ImVec2(style.ItemSpacing.x, 4.0f));
+                                ImVec2(style.ItemSpacing.x, PANEL_CARD_STACK_SPACING_Y));
 
             RenderAuthHeaderCard("##ssh_hostkey_header", "SSH Host Key", subtitle);
 
@@ -269,23 +273,22 @@ bool RenderSshAuthModal(SshSession* ssh_session)
             BeginPanelCard("##ssh_hostkey_footer", PanelCardTone::kFrame, PANEL_CARD_PADDING,
                            true, &settings);
             {
-                constexpr float TRUST_WIDTH  = 150.0f;
-                constexpr float BUTTON_WIDTH = 104.0f;
+                constexpr float TRUST_WIDTH = 150.0f;
                 const float     total =
-                    TRUST_WIDTH + BUTTON_WIDTH * 2.0f + style.ItemSpacing.x * 2.0f;
+                    TRUST_WIDTH + DIALOG_BUTTON_WIDTH * 2.0f + style.ItemSpacing.x * 2.0f;
                 const float avail = ImGui::GetContentRegionAvail().x;
                 if(avail > total)
                 {
                     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (avail - total));
                 }
-                if(ImGui::Button("Reject", ImVec2(BUTTON_WIDTH, 0)))
+                if(ImGui::Button("Reject", ImVec2(DIALOG_BUTTON_WIDTH, 0)))
                 {
                     ssh_session->SubmitHostKeyDecision(HostKeyDecision::Reject);
                     ImGui::CloseCurrentPopup();
                     ssh_session->GetHostKeyRequest()->ClearUpdated();
                 }
                 ImGui::SameLine();
-                if(ImGui::Button("Trust once", ImVec2(BUTTON_WIDTH, 0)))
+                if(ImGui::Button("Trust once", ImVec2(DIALOG_BUTTON_WIDTH, 0)))
                 {
                     ssh_session->SubmitHostKeyDecision(HostKeyDecision::TrustOnce);
                     ImGui::CloseCurrentPopup();

--- a/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
@@ -108,11 +108,9 @@ SshSettingsDialog::Render()
                                   ImGuiWindowFlags_NoScrollbar |
                                   ImGuiWindowFlags_NoTitleBar))
     {
-        constexpr float CONTENT_PADDING_X = 14.0f;
-        constexpr float CONTENT_PADDING_Y = 8.0f;
-        constexpr float LABEL_WIDTH       = 104.0f;
-        constexpr float BUTTON_WIDTH      = 104.0f;
-        constexpr float PROFILE_BUTTON_W  = 78.0f;
+        constexpr float LABEL_WIDTH      = 104.0f;
+        constexpr float BUTTON_WIDTH     = 104.0f;
+        constexpr float PROFILE_BUTTON_W = 78.0f;
 
         const ImU32 text_dim  = settings.GetColor(Colors::kTextDim);
         ImFont*     icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
@@ -165,8 +163,7 @@ SshSettingsDialog::Render()
         // Delegate to the shared panel-card helper; restore default item spacing
         // inside the card so the tighter inter-card gap does not cramp fields.
         auto begin_card = [&](const char* id) {
-            BeginPanelCard(id, PanelCardTone::kPanel,
-                           ImVec2(CONTENT_PADDING_X, CONTENT_PADDING_Y), true, &settings);
+            BeginPanelCard(id, PanelCardTone::kPanel, PANEL_CARD_PADDING, true, &settings);
             ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, default_item_spacing);
         };
 
@@ -182,7 +179,7 @@ SshSettingsDialog::Render()
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
                             ImVec2(default_item_spacing.x, 4.0f));
 
-        BeginPanelCard("##ssh_settings_header", PanelCardTone::kFrame, ImVec2(16.0f, 10.0f),
+        BeginPanelCard("##ssh_settings_header", PanelCardTone::kFrame, PANEL_HEADER_PADDING,
                        true, &settings);
         {
             if(ImGui::BeginTable("##ssh_settings_header_table", 2,
@@ -384,7 +381,7 @@ SshSettingsDialog::Render()
         }
         EndPanelCard();
 
-        BeginPanelCard("##ssh_settings_footer", PanelCardTone::kFrame, ImVec2(14.0f, 8.0f),
+        BeginPanelCard("##ssh_settings_footer", PanelCardTone::kFrame, PANEL_CARD_PADDING,
                        true, &settings);
         {
             const float action_width = BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;

--- a/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_settings_dialog.cpp
@@ -19,7 +19,7 @@ namespace RocProfVis
 namespace View
 {
 
-static const char* kSshSettingsPopupName = "SSH Connection Settings";
+constexpr const char* SSH_SETTINGS_POPUP_NAME = "SSH Connection Settings";
 
 SshSettingsDialog::SshSettingsDialog(SshConnectionStore& store, const std::string& initial_id,
                                      std::function<void(const std::string&)> on_commit)
@@ -80,7 +80,7 @@ SshSettingsDialog::Render()
     // Open the modal once on first render.
     if(!m_requested_open)
     {
-        ImGui::OpenPopup(kSshSettingsPopupName);
+        ImGui::OpenPopup(SSH_SETTINGS_POPUP_NAME);
         m_requested_open = true;
     }
 
@@ -93,23 +93,23 @@ SshSettingsDialog::Render()
     const ImGuiStyle& style    = ImGui::GetStyle();
 
     // Fixed width, auto height, so no section clips and no scrollbar is needed.
-    const float dialog_width =
-        GetResponsiveWindowSize(ImVec2(560.0f, 0.0f), ImVec2(480.0f, 0.0f)).x;
+    const float dialog_width = GetResponsiveWindowSize(ImVec2(DIALOG_DEFAULT_WIDTH, 0.0f),
+                                                       ImVec2(DIALOG_MIN_WIDTH, 0.0f))
+                                   .x;
     ImGui::SetNextWindowSizeConstraints(ImVec2(dialog_width, 0.0f),
                                         ImVec2(dialog_width, FLT_MAX));
     // Borderless card-stack: the header band carries the title (and its own
     // close button) instead of the native title bar.
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
+                        settings.GetDefaultStyle().WindowRounding);
 
-    if(ImGui::BeginPopupModal(kSshSettingsPopupName, nullptr,
+    if(ImGui::BeginPopupModal(SSH_SETTINGS_POPUP_NAME, nullptr,
                               ImGuiWindowFlags_AlwaysAutoResize |
                                   ImGuiWindowFlags_NoSavedSettings |
                                   ImGuiWindowFlags_NoScrollbar |
                                   ImGuiWindowFlags_NoTitleBar))
     {
-        constexpr float LABEL_WIDTH      = 104.0f;
-        constexpr float BUTTON_WIDTH     = 104.0f;
         constexpr float PROFILE_BUTTON_W = 78.0f;
 
         const ImU32 text_dim  = settings.GetColor(Colors::kTextDim);
@@ -117,13 +117,6 @@ SshSettingsDialog::Render()
 
         // Restored inside each card so the tighter panel gaps do not cramp fields.
         const ImVec2 default_item_spacing = style.ItemSpacing;
-
-        auto label = [&](const char* text) {
-            ImGui::AlignTextToFramePadding();
-            ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
-            ImGui::TextUnformatted(text);
-            ImGui::PopStyleColor();
-        };
 
         auto section_title = [&](const char* title) {
             ImGui::PushFont(nullptr,
@@ -177,7 +170,7 @@ SshSettingsDialog::Render()
 
         // Tighten the vertical gaps between the stacked panels (header/cards/footer).
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                            ImVec2(default_item_spacing.x, 4.0f));
+                            ImVec2(default_item_spacing.x, PANEL_CARD_STACK_SPACING_Y));
 
         BeginPanelCard("##ssh_settings_header", PanelCardTone::kFrame, PANEL_HEADER_PADDING,
                        true, &settings);
@@ -186,7 +179,8 @@ SshSettingsDialog::Render()
                                   ImGuiTableFlags_SizingStretchProp))
             {
                 ImGui::TableSetupColumn("Title", ImGuiTableColumnFlags_WidthStretch);
-                ImGui::TableSetupColumn("Close", ImGuiTableColumnFlags_WidthFixed, 24.0f);
+                ImGui::TableSetupColumn("Close", ImGuiTableColumnFlags_WidthFixed,
+                                        DIALOG_CLOSE_COLUMN_WIDTH);
                 ImGui::TableNextRow();
 
                 ImGui::TableSetColumnIndex(0);
@@ -213,8 +207,8 @@ SshSettingsDialog::Render()
         }
         EndPanelCard();
 
-        BeginPanelCard("##ssh_settings_body", PanelCardTone::kMain, ImVec2(12.0f, 4.0f),
-                       false, &settings);
+        BeginPanelCard("##ssh_settings_body", PanelCardTone::kMain,
+                       PANEL_BACKDROP_PADDING, false, &settings);
         {
             begin_card("##ssh_profile_card");
             {
@@ -225,14 +219,14 @@ SshSettingsDialog::Render()
                                       ImGuiTableFlags_SizingStretchProp))
                 {
                     ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
-                                            LABEL_WIDTH);
+                                            DIALOG_LABEL_WIDTH);
                     ImGui::TableSetupColumn("Profile", ImGuiTableColumnFlags_WidthStretch);
                     ImGui::TableSetupColumn("Actions", ImGuiTableColumnFlags_WidthFixed,
                                             PROFILE_BUTTON_W * 2.0f + style.ItemSpacing.x);
                     ImGui::TableNextRow();
 
                     ImGui::TableSetColumnIndex(0);
-                    label("Profile");
+                    PanelFieldLabel("Profile", true, &settings);
 
                     ImGui::TableSetColumnIndex(1);
                     ImGui::SetNextItemWidth(-FLT_MIN);
@@ -303,33 +297,33 @@ SshSettingsDialog::Render()
                                       ImGuiTableFlags_SizingStretchProp))
                 {
                     ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
-                                            LABEL_WIDTH);
+                                            DIALOG_LABEL_WIDTH);
                     ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthStretch);
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
-                    label("Name");
+                    PanelFieldLabel("Name", true, &settings);
                     ImGui::TableSetColumnIndex(1);
                     ImGui::SetNextItemWidth(-FLT_MIN);
                     InputTextString("##rname", m_working.display_name);
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
-                    label("Host");
+                    PanelFieldLabel("Host", true, &settings);
                     ImGui::TableSetColumnIndex(1);
                     ImGui::SetNextItemWidth(-FLT_MIN);
                     InputTextString("##rhost", m_working.host);
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
-                    label("Port");
+                    PanelFieldLabel("Port", true, &settings);
                     ImGui::TableSetColumnIndex(1);
                     ImGui::SetNextItemWidth(-FLT_MIN);
                     InputTextString("##rport", m_working.port);
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
-                    label("User");
+                    PanelFieldLabel("User", true, &settings);
                     ImGui::TableSetColumnIndex(1);
                     ImGui::SetNextItemWidth(-FLT_MIN);
                     InputTextString("##ruser", m_working.user);
@@ -348,18 +342,18 @@ SshSettingsDialog::Render()
                                       ImGuiTableFlags_SizingStretchProp))
                 {
                     ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
-                                            LABEL_WIDTH);
+                                            DIALOG_LABEL_WIDTH);
                     ImGui::TableSetupColumn("Field", ImGuiTableColumnFlags_WidthStretch);
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
-                    label("Password");
+                    PanelFieldLabel("Password", true, &settings);
                     ImGui::TableSetColumnIndex(1);
                     reveal_toggle("##rpass", m_working.password, nullptr, m_show_password);
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
-                    label("SSH Key");
+                    PanelFieldLabel("SSH Key", true, &settings);
                     ImGui::TableSetColumnIndex(1);
                     ImGui::SetNextItemWidth(-FLT_MIN);
                     InputTextStringWithHint(
@@ -368,7 +362,7 @@ SshSettingsDialog::Render()
 
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
-                    label("Passphrase");
+                    PanelFieldLabel("Passphrase", true, &settings);
                     ImGui::TableSetColumnIndex(1);
                     reveal_toggle("##rkeypass", m_working.passphrase,
                                   "Leave blank for unencrypted keys or ssh-agent",
@@ -384,7 +378,7 @@ SshSettingsDialog::Render()
         BeginPanelCard("##ssh_settings_footer", PanelCardTone::kFrame, PANEL_CARD_PADDING,
                        true, &settings);
         {
-            const float action_width = BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
+            const float action_width = DIALOG_BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
             if(ImGui::BeginTable("##ssh_settings_footer_table", 2,
                                   ImGuiTableFlags_SizingStretchProp))
             {
@@ -400,12 +394,12 @@ SshSettingsDialog::Render()
                 ImGui::PopStyleColor();
 
                 ImGui::TableSetColumnIndex(1);
-                if(ImGui::Button("Cancel", ImVec2(BUTTON_WIDTH, 0.0f)))
+                if(ImGui::Button("Cancel", ImVec2(DIALOG_BUTTON_WIDTH, 0.0f)))
                 {
                     close_popup = true;
                 }
                 ImGui::SameLine();
-                if(AccentButton("Save", ImVec2(BUTTON_WIDTH, 0.0f), &settings))
+                if(AccentButton("Save", ImVec2(DIALOG_BUTTON_WIDTH, 0.0f), &settings))
                 {
                     accept      = true;
                     close_popup = true;

--- a/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
@@ -84,9 +84,8 @@ SshTestDialog::Render()
 {
     if(m_show_window)
     {
-        SettingsManager&  settings  = SettingsManager::GetInstance();
-        ImFont*           icon_font = settings.GetFontManager().GetFont(FontType::kIcon);
-        const ImGuiStyle& style     = ImGui::GetStyle();
+        SettingsManager&  settings = SettingsManager::GetInstance();
+        const ImGuiStyle& style    = ImGui::GetStyle();
 
         const ImU32 accent         = settings.GetColor(Colors::kAccent);
         const ImU32 accent_hover   = settings.GetColor(Colors::kAccentHover);
@@ -96,7 +95,9 @@ SshTestDialog::Render()
 
         // Fixed width, auto height, so the window hugs its content with no empty band.
         const float dialog_width =
-            GetResponsiveWindowSize(ImVec2(560.0f, 0.0f), ImVec2(480.0f, 0.0f)).x;
+            GetResponsiveWindowSize(ImVec2(DIALOG_DEFAULT_WIDTH, 0.0f),
+                                    ImVec2(DIALOG_MIN_WIDTH, 0.0f))
+                .x;
         if(const ImGuiViewport* viewport = ImGui::GetMainViewport())
         {
             ImGui::SetNextWindowPos(viewport->GetCenter(), ImGuiCond_Appearing,
@@ -105,25 +106,14 @@ SshTestDialog::Render()
         ImGui::SetNextWindowSizeConstraints(ImVec2(dialog_width, 0.0f),
                                             ImVec2(dialog_width, FLT_MAX));
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
+                            settings.GetDefaultStyle().WindowRounding);
         if(ImGui::Begin("Open Remote Trace", &m_show_window,
                ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize |
                    ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoTitleBar))
         {
             const bool running = m_orchestrator && m_orchestrator->IsRunning();
 
-            auto render_icon = [&](const char* glyph, ImU32 color) {
-                ImGui::PushFont(icon_font, ImGui::GetFontSize());
-                ImGui::PushStyleColor(ImGuiCol_Text, color);
-                ImGui::TextUnformatted(glyph);
-                ImGui::PopStyleColor();
-                ImGui::PopFont();
-            };
-            auto field_label = [&](const char* label) {
-                ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
-                ImGui::TextUnformatted(label);
-                ImGui::PopStyleColor();
-            };
             auto open_connection_settings = [&]() {
                 m_settings_dialog = std::make_unique<SshSettingsDialog>(
                     m_connection_store, m_selected_connection_id,
@@ -147,17 +137,15 @@ SshTestDialog::Render()
                 host.empty() ? std::string("Configure")
                              : m_uri->GetConnection().DisplayLabel();
 
-            constexpr float LABEL_WIDTH  = 104.0f;
-            constexpr float BUTTON_WIDTH = 104.0f;
-
             // Tighten the vertical gaps between the stacked panels.
             const ImVec2 default_item_spacing = style.ItemSpacing;
-            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                                ImVec2(default_item_spacing.x, 4.0f));
+            ImGui::PushStyleVar(
+                ImGuiStyleVar_ItemSpacing,
+                ImVec2(default_item_spacing.x, PANEL_CARD_STACK_SPACING_Y));
 
             ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
             ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
-            ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
+            ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, PANEL_CARD_ROUNDING);
             ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, PANEL_HEADER_PADDING);
             ImGui::BeginChild("##remote_trace_header", ImVec2(0.0f, 0.0f),
                               ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
@@ -169,10 +157,11 @@ SshTestDialog::Render()
                     ImGui::TableSetupColumn("Title", ImGuiTableColumnFlags_WidthStretch);
                     ImGui::TableSetupColumn("Connection", ImGuiTableColumnFlags_WidthFixed,
                                             210.0f);
-                    ImGui::TableSetupColumn("Close", ImGuiTableColumnFlags_WidthFixed, 24.0f);
+                    ImGui::TableSetupColumn("Close", ImGuiTableColumnFlags_WidthFixed,
+                                            DIALOG_CLOSE_COLUMN_WIDTH);
                     ImGui::TableNextRow();
                     ImGui::TableSetColumnIndex(0);
-                    render_icon(ICON_COMPASS, accent);
+                    PanelIcon(ICON_COMPASS, accent, &settings);
                     ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
                     ImGui::BeginGroup();
                     ImGui::PushFont(nullptr,
@@ -221,7 +210,7 @@ SshTestDialog::Render()
             ImGui::PopStyleColor(2);
 
             ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgMain));
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(12.0f, 4.0f));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, PANEL_BACKDROP_PADDING);
             ImGui::BeginChild("##remote_trace_body", ImVec2(0.0f, 0.0f),
                               ImGuiChildFlags_AutoResizeY,
                               ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
@@ -229,7 +218,7 @@ SshTestDialog::Render()
                 ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
                 ImGui::PushStyleColor(ImGuiCol_Border,
                                       settings.GetColor(Colors::kPanelBorderSubtle));
-                ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
+                ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, PANEL_CARD_ROUNDING);
                 ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, PANEL_CARD_PADDING);
                 ImGui::BeginChild("##remote_trace_target", ImVec2(0.0f, 0.0f),
                                   ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
@@ -240,14 +229,13 @@ SshTestDialog::Render()
                                           ImGuiTableFlags_SizingStretchProp))
                     {
                         ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed,
-                                                LABEL_WIDTH);
+                                                DIALOG_LABEL_WIDTH);
                         ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
                         ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed,
                                                 94.0f);
                         ImGui::TableNextRow();
                         ImGui::TableSetColumnIndex(0);
-                        ImGui::AlignTextToFramePadding();
-                        field_label("Result database");
+                        PanelFieldLabel("Result database", true, &settings);
 
                         ImGui::TableSetColumnIndex(1);
                         ImGui::SetNextItemWidth(-FLT_MIN);
@@ -292,7 +280,8 @@ SshTestDialog::Render()
                 if(ImGui::BeginTable("##remote_trace_footer_table", 2,
                                       ImGuiTableFlags_SizingStretchProp))
                 {
-                    const float total_width = BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
+                    const float total_width =
+                        DIALOG_BUTTON_WIDTH * 2.0f + style.ItemSpacing.x;
                     ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthStretch);
                     ImGui::TableSetupColumn("Actions", ImGuiTableColumnFlags_WidthFixed,
                                             total_width);
@@ -300,15 +289,12 @@ SshTestDialog::Render()
                     ImGui::TableSetColumnIndex(0);
                     if(status_msg.empty())
                     {
-                        ImGui::AlignTextToFramePadding();
-                        ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
-                        ImGui::TextUnformatted("Ready");
-                        ImGui::PopStyleColor();
+                        PanelFieldLabel("Ready", true, &settings);
                     }
                     else
                     {
-                        render_icon(running ? ICON_ARROWS_CYCLE : ICON_CHAIN,
-                                    running ? accent : text_dim);
+                        PanelIcon(running ? ICON_ARROWS_CYCLE : ICON_CHAIN,
+                                  running ? accent : text_dim, &settings);
                         ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
                         ImGui::PushID("footer_status");
                         ImGui::PushStyleColor(ImGuiCol_Text, running ? accent : text_dim);
@@ -319,7 +305,7 @@ SshTestDialog::Render()
                     }
 
                     ImGui::TableSetColumnIndex(1);
-                    if(ImGui::Button("Close", ImVec2(BUTTON_WIDTH, 0.0f)))
+                    if(ImGui::Button("Close", ImVec2(DIALOG_BUTTON_WIDTH, 0.0f)))
                     {
                         m_show_window = false;
                     }
@@ -334,9 +320,8 @@ SshTestDialog::Render()
                     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, accent_hover);
                     ImGui::PushStyleColor(ImGuiCol_ButtonActive, accent_active);
                     ImGui::PushStyleColor(ImGuiCol_Text, text_on_accent);
-                    open_clicked =
-                        ImGui::Button(running ? "Working..." : "Open",
-                                      ImVec2(BUTTON_WIDTH, 0.0f));
+                    open_clicked = ImGui::Button(running ? "Working..." : "Open",
+                                                 ImVec2(DIALOG_BUTTON_WIDTH, 0.0f));
                     ImGui::PopStyleColor(4);
                     if(open_disabled)
                     {
@@ -446,20 +431,24 @@ SshTestDialog::RenderOutputPopup()
         SettingsManager&  settings = SettingsManager::GetInstance();
         const ImGuiStyle& style    = ImGui::GetStyle();
 
+        constexpr ImVec2 EXEC_POPUP_SIZE      = ImVec2(620.0f, 440.0f);
+        constexpr ImVec2 EXEC_CONSOLE_PADDING = ImVec2(12.0f, 8.0f);
+
         PopUpStyle popup_style;
         popup_style.PushPopupStyles();
         popup_style.PushTitlebarColors();
         popup_style.CenterPopup();
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
-        ImGui::SetNextWindowSize(ImVec2(620, 440));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
+                            settings.GetDefaultStyle().WindowRounding);
+        ImGui::SetNextWindowSize(EXEC_POPUP_SIZE);
         if(ImGui::BeginPopupModal("Remote Execute", nullptr,
                                   ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar))
         {
             const bool finished = m_last_stdout.finished;
 
             ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                                ImVec2(style.ItemSpacing.x, 4.0f));
+                                ImVec2(style.ItemSpacing.x, PANEL_CARD_STACK_SPACING_Y));
 
             BeginPanelCard("##remote_exec_header", PanelCardTone::kFrame, PANEL_HEADER_PADDING,
                            true, &settings);
@@ -479,9 +468,11 @@ SshTestDialog::RenderOutputPopup()
             EndPanelCard();
 
             // Fill the space between the auto-height header and footer with a
-            // scrollable console styled as a kBgMain card.
+            // scrollable console styled as a kBgMain card. The footer keeps the
+            // default gaps above and below it, not the tightened card gap.
+            const float default_spacing_y = settings.GetDefaultStyle().ItemSpacing.y;
             const float footer_reserve =
-                ImGui::GetFrameHeight() + 16.0f + style.ItemSpacing.y;
+                ImGui::GetFrameHeight() + default_spacing_y * 2.0f + style.ItemSpacing.y;
             float body_height =
                 ImGui::GetContentRegionAvail().y - footer_reserve - style.ItemSpacing.y;
             if(body_height < ImGui::GetFrameHeight())
@@ -492,7 +483,7 @@ SshTestDialog::RenderOutputPopup()
             ImGui::PushStyleColor(ImGuiCol_Border,
                                   settings.GetColor(Colors::kPanelBorderSubtle));
             ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, PANEL_CARD_ROUNDING);
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(12.0f, 8.0f));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, EXEC_CONSOLE_PADDING);
             ImGui::BeginChild("##remote_exec_output", ImVec2(0.0f, body_height),
                               ImGuiChildFlags_Borders);
             ImGui::TextUnformatted(m_last_stdout.text.c_str());
@@ -503,24 +494,22 @@ SshTestDialog::RenderOutputPopup()
             BeginPanelCard("##remote_exec_footer", PanelCardTone::kFrame, PANEL_CARD_PADDING,
                            true, &settings);
             {
-                constexpr float BUTTON_WIDTH = 104.0f;
                 PanelIcon(finished ? ICON_CHAIN : ICON_ARROWS_CYCLE,
                           finished ? Colors::kTextDim : Colors::kAccent, &settings);
                 ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
-                ImGui::AlignTextToFramePadding();
-                ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
-                ImGui::TextUnformatted(finished ? "Execution finished." : "Executing...");
-                ImGui::PopStyleColor();
+                PanelFieldLabel(finished ? "Execution finished." : "Executing...", true,
+                                &settings);
 
                 ImGui::SameLine();
                 const float avail = ImGui::GetContentRegionAvail().x;
-                if(avail > BUTTON_WIDTH)
+                if(avail > DIALOG_BUTTON_WIDTH)
                 {
-                    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + (avail - BUTTON_WIDTH));
+                    ImGui::SetCursorPosX(ImGui::GetCursorPosX() +
+                                         (avail - DIALOG_BUTTON_WIDTH));
                 }
                 // Always offer a manual Close so the popup can never wedge open,
                 // even if the terminal snapshot is missed (e.g. connection dropped).
-                if(AccentButton("Close", ImVec2(BUTTON_WIDTH, 0), &settings))
+                if(AccentButton("Close", ImVec2(DIALOG_BUTTON_WIDTH, 0), &settings))
                 {
                     ImGui::CloseCurrentPopup();
                     m_show_stdout_popup = false;

--- a/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_test_dialog.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_ssh_test_dialog.h"
+#include "rocprofvis_remote_download_popup.h"
 #include "rocprofvis_ssh_auth_modal.h"
 #include "rocprofvis_appwindow.h"
 #include "rocprofvis_core_string_utils.h"
@@ -157,7 +158,7 @@ SshTestDialog::Render()
             ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
             ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
             ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(16.0f, 10.0f));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, PANEL_HEADER_PADDING);
             ImGui::BeginChild("##remote_trace_header", ImVec2(0.0f, 0.0f),
                               ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                               ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
@@ -229,7 +230,7 @@ SshTestDialog::Render()
                 ImGui::PushStyleColor(ImGuiCol_Border,
                                       settings.GetColor(Colors::kPanelBorderSubtle));
                 ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, 10.0f);
-                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 8.0f));
+                ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, PANEL_CARD_PADDING);
                 ImGui::BeginChild("##remote_trace_target", ImVec2(0.0f, 0.0f),
                                   ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                                   ImGuiWindowFlags_NoScrollbar |
@@ -283,7 +284,7 @@ SshTestDialog::Render()
             bool open_clicked = false;
             ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgFrame));
             ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(14.0f, 8.0f));
+            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, PANEL_CARD_PADDING);
             ImGui::BeginChild("##remote_trace_footer", ImVec2(0.0f, 0.0f),
                               ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY,
                               ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
@@ -416,85 +417,12 @@ SshTestDialog::RenderProgressPopup()
         }
     }
 
-    if(m_show_progress_popup)
-    {
-        SettingsManager&  settings = SettingsManager::GetInstance();
-        const ImGuiStyle& style    = ImGui::GetStyle();
-
-        PopUpStyle popup_style;
-        popup_style.PushPopupStyles();
-        popup_style.PushTitlebarColors();
-        popup_style.CenterPopup();
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
-        ImGui::SetNextWindowSize(ImVec2(440, 0));
-
-        if(ImGui::BeginPopupModal("Remote Download", nullptr,
-            ImGuiWindowFlags_AlwaysAutoResize |
-            ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoTitleBar |
-            ImGuiWindowFlags_NoScrollbar))
-        {
-            const auto& fetch = m_last_progress;
-
-            uint64_t done  = fetch.downloaded;
-            uint64_t total = fetch.size;
-
-            ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
-                                ImVec2(style.ItemSpacing.x, 4.0f));
-
-            BeginPanelCard("##remote_dl_header", PanelCardTone::kFrame, ImVec2(16.0f, 10.0f),
-                           true, &settings);
-            {
-                PanelIcon(ICON_ARROW_DOWN, Colors::kAccent, &settings);
-                ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
-                ImGui::BeginGroup();
-                ImGui::PushFont(nullptr,
-                                settings.GetFontManager().GetFontSize(FontSize::kMedLarge));
-                ImGui::TextUnformatted("Remote Download");
-                ImGui::PopFont();
-                ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextDim));
-                ImGui::TextUnformatted("Fetching the trace over SSH.");
-                ImGui::PopStyleColor();
-                ImGui::EndGroup();
-            }
-            EndPanelCard();
-
-            BeginPanelCard("##remote_dl_body", PanelCardTone::kPanel, ImVec2(14.0f, 10.0f),
-                           true, &settings);
-            {
-                ImGui::TextWrapped("%s", fetch.name.c_str());
-                ImGui::Spacing();
-                if(total > 0)
-                {
-                    float frac = static_cast<float>(done) / static_cast<float>(total);
-
-                    std::string label =
-                        std::to_string(done / 1024) + " / " +
-                        std::to_string(total / 1024) + " KiB";
-
-                    ImGui::ProgressBar(frac, ImVec2(-FLT_MIN, 0), label.c_str());
-                }
-                else
-                {
-                    PanelFieldLabel("Connecting...", false, &settings);
-                }
-            }
-            EndPanelCard();
-
-            if(total > 0 && done >= total)
-            {
-                ImGui::CloseCurrentPopup();
-                m_show_progress_popup = false;
-            }
-
-            ImGui::PopStyleVar();  // ItemSpacing
-            ImGui::EndPopup();
-        }
-
-        ImGui::PopStyleVar(2);  // WindowPadding, WindowRounding
-        popup_style.PopStyles();
-    }
+    // Close once the transfer reports all bytes received. Rendering is shared
+    // with the profiler launcher via RenderRemoteDownloadPopup.
+    const bool finished =
+        m_last_progress.size > 0 && m_last_progress.downloaded >= m_last_progress.size;
+    RenderRemoteDownloadPopup("Remote Download", "##remote_dl", m_last_progress,
+                              "Connecting...", finished, m_show_progress_popup);
 }
 
 void
@@ -533,7 +461,7 @@ SshTestDialog::RenderOutputPopup()
             ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
                                 ImVec2(style.ItemSpacing.x, 4.0f));
 
-            BeginPanelCard("##remote_exec_header", PanelCardTone::kFrame, ImVec2(16.0f, 10.0f),
+            BeginPanelCard("##remote_exec_header", PanelCardTone::kFrame, PANEL_HEADER_PADDING,
                            true, &settings);
             {
                 PanelIcon(ICON_LIST, Colors::kAccent, &settings);
@@ -572,7 +500,7 @@ SshTestDialog::RenderOutputPopup()
             ImGui::PopStyleVar(2);
             ImGui::PopStyleColor(2);
 
-            BeginPanelCard("##remote_exec_footer", PanelCardTone::kFrame, ImVec2(14.0f, 8.0f),
+            BeginPanelCard("##remote_exec_footer", PanelCardTone::kFrame, PANEL_CARD_PADDING,
                            true, &settings);
             {
                 constexpr float BUTTON_WIDTH = 104.0f;

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -29,6 +29,8 @@ constexpr std::array DARK_THEME_COLORS = {
     IM_COL32(0, 0, 0, 0),          // Colors::kTransparent
     IM_COL32(244, 96, 110, 255),   // Colors::kTextError
     IM_COL32(120, 220, 144, 255),  // Colors::kTextSuccess
+    IM_COL32(235, 195, 90, 255),   // Colors::kTextWarning
+    IM_COL32(120, 176, 255, 255),  // Colors::kTextInfo
     IM_COL32(120, 162, 255, 220),  // Colors::kFlameChartColor
     IM_COL32(120, 130, 150, 32),   // Colors::kGridColor
     IM_COL32(142, 176, 236, 255),  // Colors::kGridRed
@@ -151,6 +153,8 @@ constexpr std::array LIGHT_THEME_COLORS = {
     IM_COL32(0, 0, 0, 0),          // Colors::kTransparent
     IM_COL32(214, 56, 64, 255),    // Colors::kTextError
     IM_COL32(36, 150, 82, 255),    // Colors::kTextSuccess
+    IM_COL32(170, 120, 0, 255),    // Colors::kTextWarning
+    IM_COL32(54, 116, 190, 255),   // Colors::kTextInfo
     IM_COL32(88, 132, 245, 225),   // Colors::kFlameChartColor
     IM_COL32(140, 150, 170, 28),   // Colors::kGridColor
     IM_COL32(120, 162, 220, 255),  // Colors::kGridRed

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -86,6 +86,8 @@ enum class Colors
     kTransparent,
     kTextError,
     kTextSuccess,
+    kTextWarning,
+    kTextInfo,
     kFlameChartColor,
     kGridColor,
     kGridRed,

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -622,7 +622,7 @@ PanelFieldLabel(const char* text, bool align_to_frame, SettingsManager* settings
 }
 
 void
-PanelIcon(const char* glyph, Colors color, SettingsManager* settings)
+PanelIcon(const char* glyph, ImU32 color, SettingsManager* settings)
 {
     if(!settings)
     {
@@ -630,10 +630,39 @@ PanelIcon(const char* glyph, Colors color, SettingsManager* settings)
     }
     ImGui::PushFont(settings->GetFontManager().GetFont(FontType::kIcon),
                     ImGui::GetFontSize());
-    ImGui::PushStyleColor(ImGuiCol_Text, settings->GetColor(color));
+    ImGui::PushStyleColor(ImGuiCol_Text, color);
     ImGui::TextUnformatted(glyph);
     ImGui::PopStyleColor();
     ImGui::PopFont();
+}
+
+void
+PanelIcon(const char* glyph, Colors color, SettingsManager* settings)
+{
+    if(!settings)
+    {
+        settings = &SettingsManager::GetInstance();
+    }
+    PanelIcon(glyph, settings->GetColor(color), settings);
+}
+
+void
+HelpMarker(const char* description, const char* env_var)
+{
+    ImGui::SameLine();
+    ImGui::TextDisabled("(?)");
+    if(ImGui::BeginItemTooltip())
+    {
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * HELP_MARKER_WRAP_EM);
+        if(env_var != nullptr && env_var[0] != '\0')
+        {
+            ImGui::TextUnformatted(env_var);
+            ImGui::Separator();
+        }
+        ImGui::TextUnformatted(description);
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
 }
 
 bool

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -157,13 +157,23 @@ inline constexpr float PANEL_CARD_ROUNDING = 10.0f;
 // dialog uses the same spacing. A standard grouping card is PANEL_CARD_PADDING
 // (also BeginPanelCard's default); header/footer bands are a touch roomier, and
 // cards holding wrapped prose get extra vertical breathing room.
-inline constexpr ImVec2 PANEL_CARD_PADDING   = ImVec2(14.0f, 8.0f);
-inline constexpr ImVec2 PANEL_HEADER_PADDING = ImVec2(16.0f, 10.0f);
-inline constexpr ImVec2 PANEL_BODY_PADDING   = ImVec2(14.0f, 10.0f);
+inline constexpr ImVec2 PANEL_CARD_PADDING     = ImVec2(14.0f, 8.0f);
+inline constexpr ImVec2 PANEL_HEADER_PADDING   = ImVec2(16.0f, 10.0f);
+inline constexpr ImVec2 PANEL_BODY_PADDING     = ImVec2(14.0f, 10.0f);
+inline constexpr ImVec2 PANEL_BACKDROP_PADDING = ImVec2(12.0f, 4.0f);
 
 // Vertical gap between cards in a stack. Deliberately tighter than the default
 // ItemSpacing so a column of panel cards reads as one continuous surface.
 inline constexpr float PANEL_CARD_STACK_SPACING_Y = 4.0f;
+
+// Metrics repeated across the stacked dialogs: the width they open at and the
+// narrowest they shrink to, the width of footer buttons and field-label
+// columns, and the width of a header's close-button column.
+inline constexpr float DIALOG_DEFAULT_WIDTH      = 560.0f;
+inline constexpr float DIALOG_MIN_WIDTH          = 480.0f;
+inline constexpr float DIALOG_BUTTON_WIDTH       = 104.0f;
+inline constexpr float DIALOG_LABEL_WIDTH        = 104.0f;
+inline constexpr float DIALOG_CLOSE_COLUMN_WIDTH = 24.0f;
 
 // Tooltip wrap width for HelpMarker, as a multiple of the current font size.
 inline constexpr float HELP_MARKER_WRAP_EM = 25.0f;

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -153,6 +153,21 @@ VerticalSeparator(SettingsManager* settings = nullptr);
 // Shared corner radius for every stacked design-language panel.
 inline constexpr float PANEL_CARD_ROUNDING = 10.0f;
 
+// Inner padding for the panel-card tiers, shared so every remote/profiler
+// dialog uses the same spacing. A standard grouping card is PANEL_CARD_PADDING
+// (also BeginPanelCard's default); header/footer bands are a touch roomier, and
+// cards holding wrapped prose get extra vertical breathing room.
+inline constexpr ImVec2 PANEL_CARD_PADDING   = ImVec2(14.0f, 8.0f);
+inline constexpr ImVec2 PANEL_HEADER_PADDING = ImVec2(16.0f, 10.0f);
+inline constexpr ImVec2 PANEL_BODY_PADDING   = ImVec2(14.0f, 10.0f);
+
+// Vertical gap between cards in a stack. Deliberately tighter than the default
+// ItemSpacing so a column of panel cards reads as one continuous surface.
+inline constexpr float PANEL_CARD_STACK_SPACING_Y = 4.0f;
+
+// Tooltip wrap width for HelpMarker, as a multiple of the current font size.
+inline constexpr float HELP_MARKER_WRAP_EM = 25.0f;
+
 // Which background tier a panel card paints. Header/footer bands use kFrame,
 // inner grouping cards use kPanel, and the body backdrop uses kMain.
 enum class PanelCardTone
@@ -167,7 +182,7 @@ enum class PanelCardTone
 // Pass a stable id. Always pair with EndPanelCard.
 void
 BeginPanelCard(const char* id, PanelCardTone tone = PanelCardTone::kPanel,
-               ImVec2 padding = ImVec2(14.0f, 8.0f), bool bordered = true,
+               ImVec2 padding = PANEL_CARD_PADDING, bool bordered = true,
                SettingsManager* settings = nullptr);
 
 void
@@ -184,11 +199,22 @@ PanelFieldLabel(const char* text, bool align_to_frame = true,
 void
 PanelIcon(const char* glyph, Colors color, SettingsManager* settings = nullptr);
 
+// As above, for callers that have already resolved a packed color (e.g. table
+// rows that tint per entry type). The Colors overload delegates to this.
+void
+PanelIcon(const char* glyph, ImU32 color, SettingsManager* settings = nullptr);
+
 // Accent-colored primary action button (accent fill + on-accent text). Returns
 // true when clicked.
 bool
 AccentButton(const char* label, ImVec2 size = ImVec2(0.0f, 0.0f),
              SettingsManager* settings = nullptr);
+
+// Dim "(?)" marker on the same line as the preceding item, with a wrapped
+// tooltip on hover. When env_var is non-null it is shown above the description,
+// separated by a rule. Shared by the profiler and rocprof-sys option tabs.
+void
+HelpMarker(const char* description, const char* env_var = nullptr);
 
 float
 TableRowHeight();


### PR DESCRIPTION
Cleanup the remote profiling branch that was previously merged in https://github.com/ROCm/roc-optiq/commit/56da95eb91ad045e54bf7e94308465056443c912. Remove magic numbers and repeated helper functions as well as relying more heavily on existing colors and theming instead of inventing new ones. 