### PR TITLE
View: Add "Show Hidden Tracks" to the track context menu

### DIFF
--- a/src/view/src/rocprofvis_timeline_track_options.cpp
+++ b/src/view/src/rocprofvis_timeline_track_options.cpp
@@ -12,6 +12,7 @@
 #include "rocprofvis_track_item.h"
 #include "widgets/rocprofvis_gui_helpers.h"
 #include <algorithm>
+#include <cstring>
 
 namespace RocProfVis
 {
@@ -22,6 +23,10 @@ constexpr std::array<const char*, TrackInfo::Count>
     DISPLAY_STRINGS_TOPOLOGY_TRACK_TYPES = { "##Unknown",         "Queue Tracks",
                                              "Stream Tracks",     "Thread Tracks",
                                              "Thread (S) Tracks", "Counter Tracks" };
+
+// Fraction of the viewport work area that a "Show Hidden Tracks" category
+// submenu may occupy before it starts scrolling.
+constexpr float HIDDEN_TRACKS_MENU_MAX_HEIGHT_FRACTION = 0.5f;
 constexpr std::array<const char*, 2> DISPLAY_STRINGS_TRACK_DATA_TYPES = {
     "Counter Tracks", "Event Tracks"
 };
@@ -995,6 +1000,139 @@ TimelineTrackOptions::RenderContextMenu()
                 ROCPROFVIS_ASSERT(false);
                 break;
             }
+        }
+    }
+}
+
+bool
+TimelineTrackOptions::HasHiddenTracks() const
+{
+    for(const auto& entry : m_options_map)
+    {
+        if(entry.second && !entry.second->m_display)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void
+TimelineTrackOptions::ShowTracks(const std::vector<TrackOptions*>& options)
+{
+    if(!m_context_menu_target)
+    {
+        return;
+    }
+    bool changed = false;
+    for(TrackOptions* option : options)
+    {
+        if(option && !option->m_display)
+        {
+            option->m_display = true;
+            changed           = true;
+        }
+    }
+    if(changed)
+    {
+        // Aggregated context-menu options track visibility too, so refresh them.
+        m_update_aggregates = true;
+        EventManager::GetInstance()->AddEvent(std::make_shared<RocEvent>(
+            static_cast<int>(RocEvents::kTrackVisibilityChanged),
+            m_context_menu_target->m_data_provider.GetTraceFilePath()));
+    }
+}
+
+void
+TimelineTrackOptions::ShowAllHiddenTracks()
+{
+    std::vector<TrackOptions*> hidden;
+    for(const auto& entry : m_options_map)
+    {
+        if(entry.second && !entry.second->m_display)
+        {
+            hidden.push_back(entry.second);
+        }
+    }
+    ShowTracks(hidden);
+}
+
+void
+TimelineTrackOptions::RenderHiddenTracksSubmenu()
+{
+    // Group hidden tracks by category (topology-type order; unknown-topology
+    // tracks fall back to a data-type label).
+    std::vector<std::pair<const char*, std::vector<TrackOptions*>>> categories;
+    auto bucket = [&categories](const char* label) -> std::vector<TrackOptions*>& {
+        for(auto& category : categories)
+        {
+            if(std::strcmp(category.first, label) == 0)
+            {
+                return category.second;
+            }
+        }
+        categories.emplace_back(label, std::vector<TrackOptions*>{});
+        return categories.back().second;
+    };
+
+    for(size_t type = TrackInfo::Queue; type < static_cast<size_t>(TrackInfo::Count);
+        ++type)
+    {
+        for(TrackOptions* option : m_siblings_by_topology_type[type])
+        {
+            if(option && !option->m_display)
+            {
+                bucket(DISPLAY_STRINGS_TOPOLOGY_TRACK_TYPES[type]).push_back(option);
+            }
+        }
+    }
+    for(TrackOptions* option : m_siblings_by_topology_type[TrackInfo::Unknown])
+    {
+        if(!option || option->m_display)
+        {
+            continue;
+        }
+        const TrackInfo* info = option->GetTrackItem().GetTrackInfo();
+        const char*      label =
+            (info && info->track_type == kRPVControllerTrackTypeSamples)
+                     ? DISPLAY_STRINGS_TOPOLOGY_TRACK_TYPES[TrackInfo::Counter]
+                     : "Event Tracks";
+        bucket(label).push_back(option);
+    }
+
+    // Null icon keeps rows aligned with the icon-bearing parent menu.
+    if(IconMenuItem(nullptr, "Show All Hidden Tracks"))
+    {
+        ShowAllHiddenTracks();
+    }
+    ImGui::Separator();
+
+    // Cap category submenu height so long lists scroll instead of filling the screen.
+    const float max_submenu_height =
+        ImGui::GetMainViewport()->WorkSize.y * HIDDEN_TRACKS_MENU_MAX_HEIGHT_FRACTION;
+    for(auto& category : categories)
+    {
+        ImGui::SetNextWindowSizeConstraints(ImVec2(0.0f, 0.0f),
+                                            ImVec2(FLT_MAX, max_submenu_height));
+        if(IconBeginMenu(nullptr, category.first))
+        {
+            if(IconMenuItem(nullptr, "Show All Hidden"))
+            {
+                ShowTracks(category.second);
+            }
+            ImGui::Separator();
+            for(TrackOptions* option : category.second)
+            {
+                // Hidden ##id suffix keeps ids unique when names repeat.
+                const std::string item =
+                    option->GetTrackItem().GetName() + "##" +
+                    std::to_string(option->GetTrackItem().GetID());
+                if(IconMenuItem(nullptr, item.c_str()))
+                {
+                    ShowTracks({ option });
+                }
+            }
+            ImGui::EndMenu();
         }
     }
 }

--- a/src/view/src/rocprofvis_timeline_track_options.cpp
+++ b/src/view/src/rocprofvis_timeline_track_options.cpp
@@ -1020,26 +1020,24 @@ TimelineTrackOptions::HasHiddenTracks() const
 void
 TimelineTrackOptions::ShowTracks(const std::vector<TrackOptions*>& options)
 {
-    if(!m_context_menu_target)
-    {
-        return;
-    }
-    bool changed = false;
+    // Sourced from a revealed track rather than the context-menu target, so this
+    // also works when the menu was opened without one (all tracks hidden).
+    const TrackItem* revealed = nullptr;
     for(TrackOptions* option : options)
     {
         if(option && !option->m_display)
         {
             option->m_display = true;
-            changed           = true;
+            revealed          = &option->GetTrackItem();
         }
     }
-    if(changed)
+    if(revealed)
     {
         // Aggregated context-menu options track visibility too, so refresh them.
         m_update_aggregates = true;
         EventManager::GetInstance()->AddEvent(std::make_shared<RocEvent>(
             static_cast<int>(RocEvents::kTrackVisibilityChanged),
-            m_context_menu_target->m_data_provider.GetTraceFilePath()));
+            revealed->m_data_provider.GetTraceFilePath()));
     }
 }
 

--- a/src/view/src/rocprofvis_timeline_track_options.h
+++ b/src/view/src/rocprofvis_timeline_track_options.h
@@ -55,6 +55,9 @@ public:
     // Inheritance hierarchy
     const std::bitset<kNumTypes>& TypeMask() const;
 
+    // The track this option set belongs to.
+    const TrackItem& GetTrackItem() const { return m_track_item; }
+
     // Option members...
     bool  m_display;
     float m_height;
@@ -177,8 +180,18 @@ public:
     void InitContextMenu(const TrackItem& target);
     // Display the options menu for the target track passed in InitContextMenu()
     void RenderContextMenu();
+    // Whether any known track is currently hidden.
+    bool HasHiddenTracks() const;
+    // Render the "Show Hidden Tracks" submenu contents. Call within a BeginMenu.
+    void RenderHiddenTracksSubmenu();
 
 private:
+    // Reveal every track in the list (sets display + fires a single
+    // visibility-changed event). Ignores tracks that are already displayed.
+    void ShowTracks(const std::vector<TrackOptions*>& options);
+    // Reveal every currently hidden track.
+    void ShowAllHiddenTracks();
+
     enum Propagate
     {
         kNone,

--- a/src/view/src/rocprofvis_timeline_track_options.h
+++ b/src/view/src/rocprofvis_timeline_track_options.h
@@ -182,7 +182,8 @@ public:
     void RenderContextMenu();
     // Whether any known track is currently hidden.
     bool HasHiddenTracks() const;
-    // Render the "Show Hidden Tracks" submenu contents. Call within a BeginMenu.
+    // Render the "Show Hidden Tracks" submenu contents. Call within an open menu
+    // or popup.
     void RenderHiddenTracksSubmenu();
 
 private:

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -37,6 +37,7 @@ constexpr float    SCROLL_SPEED                  = 100.0f;
 constexpr uint64_t DEFAULT_LOADING_TIMER         = 150;  // milliseconds
 constexpr float    ARTIFICIAL_SCROLLBAR_HEIGHT   = 18.0f;
 constexpr float    SIDEBAR_SPLITTER_WIDTH        = 5.0f;
+constexpr const char* HIDDEN_TRACKS_MENU_POPUP_NAME = "HiddenTracksMenu";
 // Build a text block mirroring the on-hover tooltip (name, timing, and id)
 // for the clipboard.
 static std::string
@@ -1754,6 +1755,8 @@ TimelineView::RenderGraphView()
         RenderTrack(index, request_data, window_flags, container_size);
     }
 
+    RenderEmptyTrackAreaMenu();
+
     TrackItem::SetSidebarSize(m_sidebar_size);
     ImGui::EndChild();
     ImGui::PopStyleColor();
@@ -1803,6 +1806,66 @@ TimelineView::IsRequestDataNeeded()
         request_data                        = true;
     }
     return request_data;
+}
+
+bool
+TimelineView::HasVisibleTracks() const
+{
+    if(!m_tracks) return false;
+
+    for(const TrackItem* track : *m_tracks)
+    {
+        if(track && track->IsDisplayed()) return true;
+    }
+    return false;
+}
+
+void
+TimelineView::RenderEmptyTrackAreaMenu()
+{
+    if(!m_track_options_context_menu || !m_track_options_context_menu->HasHiddenTracks())
+    {
+        return;
+    }
+
+    const ImGuiStyle& style       = m_settings.GetDefaultStyle();
+    const ImVec2      window_pos  = ImGui::GetWindowPos();
+    const ImVec2      window_size = ImGui::GetWindowSize();
+
+    // Starts below the last rendered track, so tracks keep their own context
+    // menu, and stops at the description column, so the graph area keeps
+    // TimelineContextMenu. Called after the track loop, hence the cursor.
+    const ImVec2 area_min = ImVec2(window_pos.x, ImGui::GetCursorScreenPos().y);
+    const ImVec2 area_max =
+        ImVec2(window_pos.x + m_sidebar_size, window_pos.y + window_size.y);
+    if(area_min.y >= area_max.y)
+    {
+        return;
+    }
+
+    // A blank timeline offers no affordance at all, so point at the right-click.
+    if(!HasVisibleTracks())
+    {
+        ImGui::SetCursorPos(style.WindowPadding);
+        ImGui::PushTextWrapPos(std::max(m_sidebar_size - style.WindowPadding.x, 0.0f));
+        ImGui::TextDisabled("All tracks are hidden.\nRight-click here to show them.");
+        ImGui::PopTextWrapPos();
+    }
+
+    if(ImGui::IsMouseClicked(ImGuiMouseButton_Right) && ImGui::IsWindowHovered() &&
+       ImGui::IsMouseHoveringRect(area_min, area_max))
+    {
+        ImGui::OpenPopup(HIDDEN_TRACKS_MENU_POPUP_NAME);
+    }
+
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, style.ItemSpacing);
+    if(ImGui::BeginPopup(HIDDEN_TRACKS_MENU_POPUP_NAME))
+    {
+        m_track_options_context_menu->RenderHiddenTracksSubmenu();
+        ImGui::EndPopup();
+    }
+    ImGui::PopStyleVar(2);
 }
 
 void

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -92,6 +92,7 @@ TimelineView::TimelineView(DataProvider&                          dp,
 , m_last_graph_size(0.0f, 0.0f)
 , m_reorder_request({ true, 0, 0 })
 , m_track_height_sum(0.0f)
+, m_hidden_track_count(0)
 , m_arrow_layer(m_data_provider, timeline_selection)
 , m_stop_user_interaction(false)
 , m_timeline_selection(timeline_selection)
@@ -1206,17 +1207,19 @@ TimelineView::Update()
         if(m_resize_activity || !m_reorder_request.handled)
         {
             m_track_position_y.clear();
-            m_track_height_sum = 0;
+            m_track_height_sum   = 0;
+            m_hidden_track_count = 0;
             for(int i = 0; i < m_tracks->size(); i++)
             {
                 if((*m_tracks)[i])
                 {
+                    const bool displayed = (*m_tracks)[i]->IsDisplayed();
                     m_track_position_y[(*m_tracks)[i]->GetID()] = m_track_height_sum;
                     m_track_height_sum +=
-                        (*m_tracks)[i]->IsDisplayed()
-                            ? (*m_tracks)[i]
-                                  ->GetTrackHeight()  // Get the height of the track.
-                            : 0;
+                        displayed ? (*m_tracks)[i]
+                                        ->GetTrackHeight()  // Get the height of the track.
+                                  : 0;
+                    m_hidden_track_count += displayed ? 0 : 1;
                 }
             }
         }
@@ -1811,7 +1814,7 @@ TimelineView::IsRequestDataNeeded()
 void
 TimelineView::RenderEmptyTrackAreaMenu()
 {
-    if(!m_track_options_context_menu || !m_track_options_context_menu->HasHiddenTracks())
+    if(m_hidden_track_count == 0 || !m_track_options_context_menu)
     {
         return;
     }

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1808,18 +1808,6 @@ TimelineView::IsRequestDataNeeded()
     return request_data;
 }
 
-bool
-TimelineView::HasVisibleTracks() const
-{
-    if(!m_tracks) return false;
-
-    for(const TrackItem* track : *m_tracks)
-    {
-        if(track && track->IsDisplayed()) return true;
-    }
-    return false;
-}
-
 void
 TimelineView::RenderEmptyTrackAreaMenu()
 {
@@ -1844,7 +1832,7 @@ TimelineView::RenderEmptyTrackAreaMenu()
     }
 
     // A blank timeline offers no affordance at all, so point at the right-click.
-    if(!HasVisibleTracks())
+    if(m_track_height_sum <= 0.0f)
     {
         ImGui::SetCursorPos(style.WindowPadding);
         ImGui::PushTextWrapPos(std::max(m_sidebar_size - style.WindowPadding.x, 0.0f));

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -181,6 +181,10 @@ private:
 
     void RenderTrack(int track_index, bool request_data, ImGuiWindowFlags window_flags,
                      ImVec2 container_size);
+    bool HasVisibleTracks() const;
+    // Right-click menu for restoring hidden tracks, from the empty space below
+    // the last track.
+    void RenderEmptyTrackAreaMenu();
     bool IsRequestDataNeeded();
     void RequestDataIfEmpty(TrackItem* track_item, bool request_data);
     void RenderNormalTrack(TrackItem* track_item, int track_index, ImGuiWindowFlags window_flags,

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -181,7 +181,6 @@ private:
 
     void RenderTrack(int track_index, bool request_data, ImGuiWindowFlags window_flags,
                      ImVec2 container_size);
-    bool HasVisibleTracks() const;
     // Right-click menu for restoring hidden tracks, from the empty space below
     // the last track.
     void RenderEmptyTrackAreaMenu();

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -239,6 +239,7 @@ private:
     float                               m_last_zoom;
     std::unordered_map<uint64_t, float> m_track_position_y;  // Track index to height
     float                               m_track_height_sum;
+    size_t                              m_hidden_track_count;
     std::shared_ptr<TimelineSelection>  m_timeline_selection;
     std::shared_ptr<MeasurementController> m_measurement;
     std::shared_ptr<AnnotationsManager> m_annotations;

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -215,7 +215,7 @@ TrackItem::GetTrackHeight() const
 }
 
 const std::string&
-TrackItem::GetName()
+TrackItem::GetName() const
 {
     return m_name;
 }
@@ -556,6 +556,16 @@ TrackItem::RenderMetaArea()
         {
             m_timeline_track_options.RenderContextMenu();
             ImGui::EndMenu();
+        }
+        // Restore hidden tracks without needing the topology side bar. The entry
+        // is only shown when something is actually hidden.
+        if(m_timeline_track_options.HasHiddenTracks())
+        {
+            if(IconBeginMenu(ICON_EYE, "Show Hidden Tracks"))
+            {
+                m_timeline_track_options.RenderHiddenTracksSubmenu();
+                ImGui::EndMenu();
+            }
         }
         ImGui::EndPopup();
     }

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -100,7 +100,7 @@ public:
     virtual float      GetTrackHeight() const;
     virtual void       Render(float width);
     virtual void       Update();
-    const std::string& GetName();
+    const std::string& GetName() const;
     bool               IsInViewVertical() const;
     void               SetInViewVertical(bool in_view);
 

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -724,26 +724,20 @@ DrawInternalBuildBanner(const char* text /*= "Internal Build"*/)
 }
 #endif // ROCPROFVIS_ENABLE_INTERNAL_BANNER
 
-// Menu icon spacing, in multiples of the font size.
-inline constexpr float MENU_ICON_GAP_EM       = 0.7f;
-inline constexpr float MENU_NO_ICON_INDENT_EM = 1.0f;
+inline constexpr float MENU_ICON_COLUMN_EM = 1.0f;
+inline constexpr float MENU_ICON_GAP_EM    = 0.7f;
 
 static float
-MenuIconWidth(const char* icon)
+MenuIconColumnWidth()
 {
-    const float font_size = ImGui::GetFontSize();
-    if(!icon || icon[0] == '\0')
-        return font_size * MENU_NO_ICON_INDENT_EM;
-
-    ImFont* icon_font = SettingsManager::GetInstance().GetFontManager().GetFont(FontType::kIcon);
-    return icon_font->CalcTextSizeA(font_size, FLT_MAX, -1.0f, icon).x;
+    return ImGui::GetFontSize() * MENU_ICON_COLUMN_EM;
 }
 
 // Pads the label with leading spaces to leave room for the left-aligned icon.
 static std::string
-MenuLabelWithIconPadding(const char* icon, const char* label)
+MenuLabelWithIconPadding(const char* label)
 {
-    const float offset  = MenuIconWidth(icon) + ImGui::GetFontSize() * MENU_ICON_GAP_EM;
+    const float offset  = MenuIconColumnWidth() + ImGui::GetFontSize() * MENU_ICON_GAP_EM;
     const float space_w = ImGui::CalcTextSize(" ").x;
     const int   pad     = space_w > 0.0f ? static_cast<int>(std::ceil(offset / space_w)) : 1;
     std::string padded(static_cast<size_t>(std::max(pad, 1)), ' ');
@@ -773,7 +767,7 @@ IconMenuItem(const char* icon, const char* label, bool enabled)
 {
     ImDrawList*  draw_list    = ImGui::GetWindowDrawList();
     const ImVec2 row_start    = ImGui::GetCursorScreenPos();
-    std::string  padded_label = MenuLabelWithIconPadding(icon, label);
+    std::string  padded_label = MenuLabelWithIconPadding(label);
 
     bool clicked = ImGui::MenuItem(padded_label.c_str(), nullptr, false, enabled);
     DrawMenuItemIcon(draw_list, icon, row_start, enabled);
@@ -788,7 +782,7 @@ IconBeginMenu(const char* icon, const char* label)
 {
     ImDrawList*  draw_list    = ImGui::GetWindowDrawList();
     const ImVec2 row_start    = ImGui::GetCursorScreenPos();
-    std::string  padded_label = MenuLabelWithIconPadding(icon, label);
+    std::string  padded_label = MenuLabelWithIconPadding(label);
 
     bool open = ImGui::BeginMenu(padded_label.c_str());
     DrawMenuItemIcon(draw_list, icon, row_start, true);


### PR DESCRIPTION
## Motivation

Hidden timeline tracks could only be restored from the topology side bar. If
that panel is closed, there was no way to bring them back. This adds that
option to a track's right-click menu.

## Technical Details

- New **Show Hidden Tracks** entry in the track context menu, shown only when
  tracks are hidden.
- Lists hidden tracks grouped by category (queues, streams, threads,
  counters), each with **Show All Hidden**, plus a top-level **Show All Hidden
  Tracks**.
- Revealing a track fires `kTrackVisibilityChanged`, the same path the side bar
  uses. Category submenus are height-capped and scroll for long lists.
- Menu fix: the icon column is now a fixed width, so labels align regardless of
  the leading icon's glyph width (e.g. eye vs. gear). Affects all icon menus.