### PR TITLE
RPD Table & Extdata Update

### DIFF
--- a/src/model/src/database/rocprofvis_db_packed_storage.cpp
+++ b/src/model/src/database/rocprofvis_db_packed_storage.cpp
@@ -198,7 +198,8 @@ namespace DataModel
             return db->CachedTables(node_id)->GetTableCellByIndex("Node", static_cast<uint32_t>(value), "id");
         } else
         if (column_index == Builder::SCHEMA_INDEX_CATEGORY || column_index == Builder::SCHEMA_INDEX_CATEGORY_RPD || 
-            column_index == Builder::SCHEMA_INDEX_EVENT_NAME || column_index == Builder::SCHEMA_INDEX_EVENT_NAME_RPD)
+            column_index == Builder::SCHEMA_INDEX_EVENT_NAME || column_index == Builder::SCHEMA_INDEX_EVENT_NAME_RPD || 
+            column_index == Builder::SCHEMA_INDEX_EVENT_ARGS_RPD)
         {
             if (kRocProfVisDmResultSuccess == db->RemapStringId(value, rocprofvis_db_string_type_t::kRPVStringTypeNameOrCategory, node_id, string_index))
             {

--- a/src/model/src/database/rocprofvis_db_query_builder.h
+++ b/src/model/src/database/rocprofvis_db_query_builder.h
@@ -215,6 +215,7 @@ class Builder
         static constexpr const char* STREAM_PUBLIC_NAME = "stream";
         static constexpr const char* QUEUE_PUBLIC_NAME = "queue";
         static constexpr const char* NAME_PUBLIC_NAME = "name";
+        static constexpr const char* ARGS_PUBLIC_NAME = "arguments";
         static constexpr const char* NODE_PUBLIC_NAME = "node";
         static constexpr const char* SRC_ADDRESS_PUBLIC_NAME = "SrcAddr";
 
@@ -245,6 +246,7 @@ class Builder
         static constexpr const char* CATEGORY_REFERENCE_RPD = "_s_cat_rpd";
         static constexpr const char* EVENT_NAME_REFERENCE = "_s_name";
         static constexpr const char* EVENT_NAME_REFERENCE_RPD = "_s_name_rpd";
+        static constexpr const char* EVENT_ARGS_RPD = "_s_arguments_rpd";
         static constexpr const char* STREAM_NAME_REFERENCE = "_st_name";
         static constexpr const char* QUEUE_NAME_REFERENCE = "_q_name";
         static constexpr const char* SYMBOL_NAME_REFERENCE = "_sy_name";
@@ -327,6 +329,7 @@ class Builder
             SCHEMA_INDEX_EVENT_SYMBOL,
             SCHEMA_INDEX_EVENT_NAME_RPD,
             SCHEMA_INDEX_EVENT_NAME_PERFETTO,
+            SCHEMA_INDEX_EVENT_ARGS_RPD,
             SCHEMA_INDEX_MEM_TYPE,
             SCHEMA_INDEX_STREAM_NAME,
             SCHEMA_INDEX_QUEUE_NAME,
@@ -370,12 +373,13 @@ class Builder
             {DB_ID_PUBLIC_NAME, {DB_ID_PUBLIC_NAME, ColumnType::Qword, SCHEMA_INDEX_EVENT_DB_ID}},
             {ID_PUBLIC_NAME, {ID_PUBLIC_NAME, ColumnType::Qword, SCHEMA_INDEX_EVENT_ID}},
             {CATEGORY_REFERENCE, {CATEGORY_PUBLIC_NAME, ColumnType::Word, SCHEMA_INDEX_CATEGORY}},
-            {CATEGORY_REFERENCE_RPD, {CATEGORY_PUBLIC_NAME, ColumnType::Word, SCHEMA_INDEX_CATEGORY_RPD}},
+            {CATEGORY_REFERENCE_RPD, {CATEGORY_PUBLIC_NAME, ColumnType::Qword, SCHEMA_INDEX_CATEGORY_RPD}},
             {CATEGORY_REFERENCE_PERFETTO, {CATEGORY_PUBLIC_NAME, ColumnType::Word, SCHEMA_INDEX_CATEGORY_PERFETTO}},
             {EVENT_NAME_REFERENCE, {NAME_PUBLIC_NAME, ColumnType::Dword, SCHEMA_INDEX_EVENT_NAME}},
             {SYMBOL_NAME_REFERENCE, {NAME_PUBLIC_NAME, ColumnType::Dword, SCHEMA_INDEX_EVENT_SYMBOL}},
             {EVENT_NAME_REFERENCE_RPD, {NAME_PUBLIC_NAME, ColumnType::Qword, SCHEMA_INDEX_EVENT_NAME_RPD}},
             {EVENT_NAME_REFERENCE_PERFETTO, {NAME_PUBLIC_NAME, ColumnType::Qword, SCHEMA_INDEX_EVENT_NAME_PERFETTO}},
+            {EVENT_ARGS_RPD, {ARGS_PUBLIC_NAME, ColumnType::Qword, SCHEMA_INDEX_EVENT_ARGS_RPD}},
             {M_TYPE_REFERENCE, {NAME_PUBLIC_NAME, ColumnType::Byte, SCHEMA_INDEX_MEM_TYPE}},
             {STREAM_NAME_REFERENCE, {STREAM_PUBLIC_NAME, ColumnType::Word,SCHEMA_INDEX_STREAM_NAME}},
             {QUEUE_NAME_REFERENCE, {QUEUE_PUBLIC_NAME, ColumnType::Byte,SCHEMA_INDEX_QUEUE_NAME}},

--- a/src/model/src/database/rocprofvis_db_rocpd.cpp
+++ b/src/model/src/database/rocprofvis_db_rocpd.cpp
@@ -565,7 +565,7 @@ rocprofvis_dm_result_t RocpdDatabase::BuildTableStringIdFilter(rocprofvis_dm_num
         }
         if(!string.empty())
         {
-            filter[kRocProfVisDmOperationLaunch][0] = std::string(Builder::CATEGORY_REFERENCE_RPD) + " IN (" + string + ") OR " + Builder::EVENT_NAME_REFERENCE_RPD + " IN(" + string;
+            filter[kRocProfVisDmOperationLaunch][0] =  std::string(Builder::EVENT_NAME_REFERENCE_RPD) + " IN(" + string;
             filter[kRocProfVisDmOperationDispatch][0] = std::string(Builder::CATEGORY_REFERENCE_RPD) + " IN (" + string + ") OR " + Builder::EVENT_NAME_REFERENCE_RPD + " IN(" + string;
         }
     }   
@@ -582,8 +582,8 @@ rocprofvis_dm_string_t RocpdDatabase::GetEventOperationQuery(const rocprofvis_dm
                 { { Builder::QParamOperation(kRocProfVisDmOperationLaunch),
                 Builder::QParam("id", Builder::ID_PUBLIC_NAME),
                 Builder::QParam("id", Builder::DB_ID_PUBLIC_NAME),
-                Builder::QParam("apiName_id", Builder::CATEGORY_REFERENCE_RPD),
-                Builder::QParam("args_id", Builder::EVENT_NAME_REFERENCE_RPD), 
+                Builder::QParam("apiName_id", Builder::EVENT_NAME_REFERENCE_RPD),
+                Builder::QParam("args_id", Builder::EVENT_ARGS_RPD), 
                 Builder::QParam("start", Builder::START_SERVICE_NAME),
                 Builder::QParam("end", Builder::END_SERVICE_NAME),
                 Builder::QParam("(end-start)", Builder::DURATION_PUBLIC_NAME),

--- a/src/model/src/database/rocprofvis_db_rocpd.h
+++ b/src/model/src/database/rocprofvis_db_rocpd.h
@@ -181,8 +181,7 @@ private:
                 {
                     kRocProfVisDmOperationLaunch,
                     {
-                        { "apiName", kRocProfVisEventEssentialDataCategory },
-                        { "args", kRocProfVisEventEssentialDataName },
+                        { "apiName", kRocProfVisEventEssentialDataName },
                         { "pid", kRocProfVisEventEssentialDataProcess },
                         { "tid", kRocProfVisEventEssentialDataThread },
                     },


### PR DESCRIPTION
1. Correct naming disagreements between flame chart and tables for Api events:
    - Previous: flame chart name = `apiName`, table name column = `args`, event details name = `args`
    - New: flame chart name = `apiName`, table name column = `apiName`, event details name = `apiName`
2.  Replaced table `category` column for api events with `arguments` column. 
    - op events have a `opType` field that is mapped to category, api events do not have this field. They instead have `args`.
4. Fixed incorrect table `category` values for op events.
    - `CATEGORY_REFERENCE_RPD` should be `qword` instead of `word`.

This addresses api events unexpectedly having blank names, but it is still expected that there are op events with blank names:
<img width="3854" height="2071" alt="image" src="https://github.com/user-attachments/assets/addc97c1-5192-4560-b186-57bd13dd404c" />

