### PR TITLE
View: Fix flame event labels hidden on high-DPI displays

### DIFF
--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -870,7 +870,9 @@ SettingsManager::DeserializeUnitSettings(jt::Json& json)
 const float
 SettingsManager::GetEventLevelHeight() const
 {
-    const float font_size = m_font_manager.GetFontSize(FontSize::kDefault);
+    const ImGuiStyle& style     = ImGui::GetStyle();
+    const float       base_size = m_font_manager.GetFontSize(FontSize::kDefault);
+    const float       font_size = base_size * style.FontScaleMain * style.FontScaleDpi;
     return std::ceil(font_size + EVENT_LEVEL_VERTICAL_MARGIN + EVENT_LEVEL_SPACING);
 }
 


### PR DESCRIPTION
GetEventLevelHeight() sized each flame row from the unscaled font-size preference while the label-visibility gate in DrawBox() and the rendered text use the DPI-scaled font, so on scaled displays the row stayed shorter than the text and labels were dropped at every size above the minimum. Scale the base size by ImGui's global font factors (FontScaleMain * FontScaleDpi) so the row tracks the rendered text height on every display.
