### PR TITLE
Correct missing flame labels, track minimum height

### DIFF
--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -870,8 +870,7 @@ SettingsManager::DeserializeUnitSettings(jt::Json& json)
 const float
 SettingsManager::GetEventLevelHeight() const
 {
-    const float font_size = m_font_manager.GetFontSize(FontSize::kDefault);
-    return std::ceil(font_size + EVENT_LEVEL_VERTICAL_MARGIN + EVENT_LEVEL_SPACING);
+    return std::ceil(ImGui::GetTextLineHeight() + EVENT_LEVEL_VERTICAL_MARGIN + EVENT_LEVEL_SPACING);
 }
 
 const float

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -192,7 +192,7 @@ TrackItem::GetMetaAreaMinHeight() const
 
     if(pill_height > 0.0f)
     {
-        const float title_row_height = fonts.GetFontSize(FontSize::kDefault) +
+        const float title_row_height = ImGui::GetTextLineHeight() +
                                        2.0f * META_FRAME_PADDING_Y + META_ITEM_SPACING_Y;
         min_height = title_row_height + pill_height + chrome;
     }


### PR DESCRIPTION
- Reconcile flame event box and label heights to use text height instead of literal font size.
  - Similarly, update track minimum height. Seems like the intent was to ensure pills always had room to render, but this was not working for the same reason.

Note: It cannot be the reverse (everybody uses literal font size). In that case label would render, but its size may overflow/be too small compared to the event box.