### PR TITLE
Reorder compute tabs and clean up log severity levels

### DIFF
--- a/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
+++ b/src/controller/src/remote/rocprofvis_controller_ssh_client.cpp
@@ -113,7 +113,7 @@ namespace Controller
         void** abstract)
     {
         auto* ctx = static_cast<KbdintCtx*>(*abstract);
-        spdlog::info("[ssh] kbdint callback fired: name_len={} instr_len={} num_prompts={} ctx={}",
+        spdlog::debug("[ssh] kbdint callback fired: name_len={} instr_len={} num_prompts={} ctx={}",
             name_len, instruction_len, num_prompts,
             static_cast<void*>(ctx));
         if(!ctx || !ctx->bridge) return;
@@ -124,7 +124,7 @@ namespace Controller
         // continue without touching the UI.
         if(num_prompts == 0)
         {
-            spdlog::info("[ssh] kbdint callback: zero-prompt round (info/banner), auto-acking");
+            spdlog::debug("[ssh] kbdint callback: zero-prompt round (info/banner), auto-acking");
             return;
         }
 
@@ -141,10 +141,10 @@ namespace Controller
             req.prompts.push_back(std::move(p));
         }
 
-        spdlog::info("[ssh] kbdint callback: posting {} prompt(s) to UI bridge, blocking...",
+        spdlog::debug("[ssh] kbdint callback: posting {} prompt(s) to UI bridge, blocking...",
             num_prompts);
         auto answer = ctx->bridge->AskPrompts(req);
-        spdlog::info("[ssh] kbdint callback: bridge returned (cancelled={})", !answer.has_value());
+        spdlog::debug("[ssh] kbdint callback: bridge returned (cancelled={})", !answer.has_value());
         if(!answer)
         {
             ctx->was_cancelled = true;
@@ -225,7 +225,7 @@ namespace Controller
 
         bool        have_pub = std::filesystem::exists(pub_path);
         std::string pub      = pub_path.string();
-        spdlog::info("[ssh] trying publickey: priv={} pub={} have_passphrase={}",
+        spdlog::debug("[ssh] trying publickey: priv={} pub={} have_passphrase={}",
             priv_path, have_pub ? pub_path.string().c_str() : std::string("(derived from priv)"),
             !passphrase.empty());
         int rc = libssh2_userauth_publickey_fromfile(
@@ -272,12 +272,12 @@ namespace Controller
         LIBSSH2_AGENT* agent = libssh2_agent_init(connection->GetSession());
         if(!agent)
         {
-            spdlog::info("[ssh] agent: init failed (libssh2 built without agent support?)");
+            spdlog::debug("[ssh] agent: init failed (libssh2 built without agent support?)");
             return false;
         }
         if(libssh2_agent_connect(agent) != 0)
         {
-            spdlog::info("[ssh] agent: connect failed (no $SSH_AUTH_SOCK or agent not running)");
+            spdlog::debug("[ssh] agent: connect failed (no $SSH_AUTH_SOCK or agent not running)");
             libssh2_agent_free(agent);
             return false;
         }
@@ -303,7 +303,7 @@ namespace Controller
                 break;
             }
             identity_count++;
-            spdlog::info("[ssh] agent: trying identity '{}'",
+            spdlog::debug("[ssh] agent: trying identity '{}'",
                 identity->comment ? identity->comment : "(no comment)");
 
             rc = libssh2_agent_userauth(agent, user.c_str(), identity);
@@ -325,12 +325,12 @@ namespace Controller
             }
             char* msg = nullptr;
             libssh2_session_last_error(connection->GetSession(), &msg, nullptr, 0);
-            spdlog::info("[ssh] agent: identity rejected: {}", msg ? msg : "(no message)");
+            spdlog::debug("[ssh] agent: identity rejected: {}", msg ? msg : "(no message)");
             prev = identity;
         }
         if(!ok && identity_count == 0)
         {
-            spdlog::info("[ssh] agent: connected but no identities loaded (run 'ssh-add')");
+            spdlog::debug("[ssh] agent: connected but no identities loaded (run 'ssh-add')");
         }
 
         libssh2_agent_disconnect(agent);
@@ -517,7 +517,7 @@ namespace Controller
             return SshClient::Result::SocketError;
         }
 
-        spdlog::info("[ssh] TCP connected");
+        spdlog::debug("[ssh] TCP connected");
 
         connection->SetSession(libssh2_session_init());
         if (!connection->GetSession())
@@ -579,14 +579,14 @@ namespace Controller
         {
             KnownHosts kh(connection->GetSession());
             bool       loaded = kh.Load();
-            spdlog::info("[ssh] known_hosts loaded={} path={} fingerprint={}",
+            spdlog::debug("[ssh] known_hosts loaded={} path={} fingerprint={}",
                 loaded, kh.Path(), FormatHostKeyFingerprint(connection->GetSession()));
             KnownHostMatch m = kh.Check(connection->GetHost(), connection->GetPort());
             const char* mstr = m == KnownHostMatch::Match    ? "Match"
                 : m == KnownHostMatch::Mismatch ? "Mismatch"
                 : m == KnownHostMatch::NotFound ? "NotFound"
                 : "Failure";
-            spdlog::info("[ssh] host key check: {}", mstr);
+            spdlog::debug("[ssh] host key check: {}", mstr);
 
             if(m == KnownHostMatch::NotFound || m == KnownHostMatch::Mismatch)
             {
@@ -643,7 +643,7 @@ namespace Controller
         // ---- auth ----
         char* methods = libssh2_userauth_list(connection->GetSession(), user.c_str(),
             static_cast<unsigned int>(user.size()));
-        spdlog::info("[ssh] server auth methods: {}", methods ? methods : "(none)");
+        spdlog::debug("[ssh] server auth methods: {}", methods ? methods : "(none)");
 
         bool tried_password = false;
         bool tried_kbdint   = false;
@@ -662,18 +662,18 @@ namespace Controller
                 }
             }
             // 1b) ssh-agent - handles encrypted keys without us needing a passphrase.
-            spdlog::info("[ssh] trying ssh-agent");
+            spdlog::debug("[ssh] trying ssh-agent");
             if (TryAgent(connection, user, future))
             {
                 return Result::Success;
             }
             // 1c) default on-disk identity files
-            spdlog::info("[ssh] trying default identity files");
+            spdlog::debug("[ssh] trying default identity files");
             for(const auto& p : DefaultKeyPaths())
             {
                 if(!std::filesystem::exists(p))
                 {
-                    spdlog::info("[ssh]   default key absent: {}", p);
+                    spdlog::debug("[ssh]   default key absent: {}", p);
                     continue;
                 }
                 if (IsCancelRequested(connection, future))
@@ -688,7 +688,7 @@ namespace Controller
         }
         else
         {
-            spdlog::info("[ssh] server does not advertise publickey");
+            spdlog::debug("[ssh] server does not advertise publickey");
         }
         if (IsCancelRequested(connection, future))
         {
@@ -705,7 +705,7 @@ namespace Controller
             std::string effective_password = password;
             if(effective_password.empty())
             {
-                spdlog::info("[ssh] no password supplied; prompting UI for password");
+                spdlog::debug("[ssh] no password supplied; prompting UI for password");
                 PromptRequest req;
                 std::string target = user.empty() ? connection->GetHost()
                                                    : user + "@" + connection->GetHost();
@@ -720,7 +720,7 @@ namespace Controller
                 if(!answer)
                 {
                     err = "password prompt cancelled by user";
-                    spdlog::info("[ssh] {}", err);
+                    spdlog::debug("[ssh] {}", err);
                     connection->GetSshBridge()->SaveError(err);
                     connection->Disconnect();
                     return Result::AuthError;
@@ -733,7 +733,7 @@ namespace Controller
 
             if(!effective_password.empty())
             {
-                spdlog::info("[ssh] trying password auth");
+                spdlog::debug("[ssh] trying password auth");
                 tried_password = true;
                 auth_rc = libssh2_userauth_password(connection->GetSession(), user.c_str(),
                     effective_password.c_str());
@@ -763,7 +763,7 @@ namespace Controller
         }
         else
         {
-            spdlog::info("[ssh] skipping password auth (server does not advertise password)");
+            spdlog::debug("[ssh] skipping password auth (server does not advertise password)");
         }
 
         if (IsCancelRequested(connection, future))
@@ -775,7 +775,7 @@ namespace Controller
         auto kbd_ctx = std::make_shared<KbdintCtx>(KbdintCtx{connection->GetSshBridge(), false});
         if(MethodListed(methods, "keyboard-interactive"))
         {
-            spdlog::info("[ssh] trying keyboard-interactive auth (will route prompts to UI)");
+            spdlog::debug("[ssh] trying keyboard-interactive auth (will route prompts to UI)");
             tried_kbdint = true;
             // libssh2's session abstract slot: stash kbd_ctx so the C callback can find it.
             void** abstract = libssh2_session_abstract(connection->GetSession());
@@ -795,7 +795,7 @@ namespace Controller
             if(kbd_ctx->was_cancelled)
             {
                 err = "kbdint cancelled by user";
-                spdlog::info("[ssh] {}", err);
+                spdlog::debug("[ssh] {}", err);
                 connection->GetSshBridge()->SaveError(err);
                 connection->Disconnect();
                 return Result::AuthError;
@@ -1050,7 +1050,7 @@ namespace Controller
             if(m >> cached_size >> cached_mtime &&
                 cached_size == remote_size && cached_mtime == remote_mtime)
             {
-                spdlog::info("[ssh] already up-to-date: {}", local_path);
+                spdlog::debug("[ssh] already up-to-date: {}", local_path);
 
                 connection->GetSshBridge()->SetFileStat(remote_path, fileinfo.st_size, fileinfo.st_mtime, fileinfo.st_size);
                 libssh2_channel_free(channel);

--- a/src/controller/src/system/rocprofvis_controller_trace_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_trace_system.cpp
@@ -128,7 +128,7 @@ void SystemTrace::DbgPrintTopologyNodeData(rocprofvis_dm_topology_node node, int
         rocprofvis_dm_get_property_as_uint64(
             node, kRPVControllerTopologyNodeNumChildren, 0);
 
-    spdlog::info(line);
+    spdlog::debug(line);
 
     for (int i = 0; i < num_children; i++)
     {

--- a/src/core/src/rocprofvis_core_profile.cpp
+++ b/src/core/src/rocprofvis_core_profile.cpp
@@ -30,7 +30,7 @@ TimeRecorder::TimeRecorder(const char* function, const char* property, uint64_t 
 TimeRecorder::~TimeRecorder() {
     auto t = std::chrono::steady_clock::now();
     std::chrono::duration<double> diff = t - m_start_time;
-    spdlog::info("{0:13.9f} seconds | {1}", diff.count(), m_function.c_str());   
+    spdlog::debug("{0:13.9f} seconds | {1}", diff.count(), m_function.c_str());   
 }
 
 #endif

--- a/src/model/src/database/rocprofvis_db_future.cpp
+++ b/src/model/src/database/rocprofvis_db_future.cpp
@@ -106,7 +106,7 @@ rocprofvis_dm_result_t Future::WaitForCompletion(rocprofvis_db_timeout_ms_t time
     if (status != std::future_status::ready) {
         if(timeout_ms == 0) return result;
         m_interrupt_status = true;
-        spdlog::debug("Timeout expired!");
+        spdlog::warn("Timeout expired!");
     }
     if (m_worker.joinable()) m_worker.join();
     result = m_future.get();

--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -862,7 +862,7 @@ rocprofvis_dm_result_t  RocprofDatabase::ReadTraceMetadata(Future* future)
             {
                 if (version != m_db_version)
                 {
-                    spdlog::debug("Cannot support different version database nodes!");
+                    spdlog::warn("Cannot support different version database nodes!");
                     result = kRocProfVisDmResultNotSupported;
                     break;
                 }

--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -862,7 +862,7 @@ rocprofvis_dm_result_t  RocprofDatabase::ReadTraceMetadata(Future* future)
             {
                 if (version != m_db_version)
                 {
-                    spdlog::warn("Cannot support different version database nodes!");
+                    spdlog::warn("Schema mismatch: all database sources must use the same schema version; the trace cannot be opened.");
                     result = kRocProfVisDmResultNotSupported;
                     break;
                 }

--- a/src/view/src/compute/rocprofvis_compute_view.cpp
+++ b/src/view/src/compute/rocprofvis_compute_view.cpp
@@ -162,13 +162,13 @@ ComputeView::CreateView()
                 std::make_shared<ComputeTableView>(m_data_provider, m_compute_selection),
                 false});
     m_tab_container->AddTab(
-        TabItem{"Workload Details", "compute_workload_view",
-                std::make_shared<ComputeWorkloadView>(m_data_provider, m_compute_selection),
-                false});
-    m_tab_container->AddTab(
         TabItem{"Baseline Comparison", "compute_comparison_view",
                 std::make_shared<ComputeComparisonView>(m_data_provider,
                                                         m_compute_selection),
+                false});
+    m_tab_container->AddTab(
+        TabItem{"Workload Details", "compute_workload_view",
+                std::make_shared<ComputeWorkloadView>(m_data_provider, m_compute_selection),
                 false});
 
 #ifdef ROCPROFVIS_DEVELOPER_MODE

--- a/src/view/src/remote/rocprofvis_ssh_auth_modal.cpp
+++ b/src/view/src/remote/rocprofvis_ssh_auth_modal.cpp
@@ -79,7 +79,7 @@ bool RenderSshAuthModal(SshSession* ssh_session)
         // auto-closes and a fresh request re-opens it (no wedged latch).
         if(!ImGui::IsPopupOpen("SSH Authentication"))
         {
-            spdlog::info("[ssh-ui] kbdint pending: {} prompt(s); calling OpenPopup",
+            spdlog::debug("[ssh-ui] kbdint pending: {} prompt(s); calling OpenPopup",
                          req->prompts.size());
             ImGui::OpenPopup("SSH Authentication");
         }

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -1212,7 +1212,7 @@ DataProvider::HandleLoadTrackMetaData()
         }
     }
 
-    spdlog::info("Track meta data loaded");
+    spdlog::debug("Track meta data loaded");
 }
 
 void
@@ -1257,7 +1257,7 @@ DataProvider::ApplyTrackOrderRanking()
         metadata[ordered[i]->id].index = i;
     }
 
-    spdlog::info("Applied compare track order ranking to {} tracks", ordered.size());
+    spdlog::debug("Applied compare track order ranking to {} tracks", ordered.size());
 }
 
 bool
@@ -2998,7 +2998,7 @@ DataProvider::ProcessSummaryRequest(RequestInfo& req)
         }
         else
         {
-            spdlog::debug("Summary request failed with code {}", req.response_code);
+            spdlog::warn("Summary request failed with code {}", req.response_code);
         }
         rocprofvis_controller_summary_metric_free(metrics_handle);
         req.request_obj_handle = nullptr;
@@ -3021,7 +3021,7 @@ DataProvider::ProcessAnalysisTrackStatisticsRequest(RequestInfo& req)
     }
     else if(req.response_code != kRocProfVisResultSuccess)
     {
-        spdlog::debug("Track statistics request for track {} failed with code {}",
+        spdlog::warn("Track statistics request for track {} failed with code {}",
                       params->m_track_id, req.response_code);
     }
     else
@@ -3520,7 +3520,7 @@ DataProvider::ProcessTableRequest(RequestInfo& req)
     }
     else
     {
-        spdlog::debug("Table request failed with code {}", req.response_code);
+        spdlog::warn("Table request failed with code {}", req.response_code);
     }
 
     // free the array
@@ -3644,7 +3644,7 @@ DataProvider::ProcessGraphRequest(RequestInfo& req)
     }
     else
     {
-        spdlog::debug("Graph request failed with code {}", req.response_code);
+        spdlog::warn("Graph request failed with code {}", req.response_code);
     }
 
     // use the track type to determine what type of data is present in the graph array
@@ -3703,7 +3703,7 @@ DataProvider::CreateRawSampleData(const TrackRequestParams& params,
     {
         // TODO: review the controller return codes to see if anycase should be escalated
         // to a warning
-        spdlog::debug("Sample track data request failed with code {}", req.response_code);
+        spdlog::warn("Sample track data request failed with code {}", req.response_code);
         count = 0;
     }
 
@@ -3810,7 +3810,7 @@ DataProvider::CreateRawEventData(const TrackRequestParams& params, const Request
     {
         // TODO: review the controller return codes to see if anycase should be escalated
         // to a warning
-        spdlog::debug("Event track data request failed with code {}", req.response_code);
+        spdlog::warn("Event track data request failed with code {}", req.response_code);
         count = 0;
     }
 
@@ -5196,7 +5196,7 @@ DataProvider::ProcessMetricsRequest(RequestInfo& req)
         }
         else
         {
-            spdlog::debug("Metrics request failed with code {}", req.response_code);
+            spdlog::warn("Metrics request failed with code {}", req.response_code);
             //call callback
             if(m_metrics_fetch_callback)
             {
@@ -5301,7 +5301,7 @@ DataProvider::ProcessMetricPivotTable(RequestInfo& req)
 
             kernel_pivot_table.table_params = request_params;
 
-            spdlog::info("Processed {} rows from metric pivot table", num_rows);
+            spdlog::debug("Processed {} rows from metric pivot table", num_rows);
         }
         else
         {
@@ -5364,7 +5364,7 @@ DataProvider::ProcessPcSamplingRequest(RequestInfo& req)
     }
     else if(!success)
     {
-        spdlog::debug("PC sampling request failed with code {}", req.response_code);
+        spdlog::warn("PC sampling request failed with code {}", req.response_code);
     }
 
     req.request_obj_handle = nullptr;

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -1208,7 +1208,7 @@ DataProvider::HandleLoadTrackMetaData()
         }
         else
         {
-            spdlog::debug("Error getting track meta data for track at index: {}", i);
+            spdlog::warn("Error getting track meta data for track at index: {}", i);
         }
     }
 
@@ -1426,7 +1426,7 @@ DataProvider::FetchWholeTrack(uint32_t track_id, double start_ts, double end_ts,
             {
                 rocprofvis_controller_array_free(track_array);
                 rocprofvis_controller_future_free(track_future);
-                spdlog::debug("Failed to fetch track graph data {}, result: {}", track_id,
+                spdlog::warn("Failed to fetch track graph data {}, result: {}", track_id,
                               static_cast<int>(result));
             }
         }
@@ -1514,7 +1514,7 @@ DataProvider::FetchTrack(const TrackRequestParams& request_params)
             {
                 rocprofvis_controller_array_free(graph_array);
                 rocprofvis_controller_future_free(graph_future);
-                spdlog::debug("Failed to fetch track graph data {}, result: {}",
+                spdlog::warn("Failed to fetch track graph data {}, result: {}",
                               request_params.m_track_id, static_cast<int>(result));
             }
         }

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -57,7 +57,7 @@ TraceView::TraceView()
         (void)trace_path;                                    
         if(!success)
         {
-            spdlog::debug("Failed to fetch event data for event ID: {}", event_id);
+            spdlog::warn("Failed to fetch event data for event ID: {}", event_id);
             return;
         }
 


### PR DESCRIPTION
## Motivation

Two small, low-risk cleanups: reorder the compute tabs, and fix log levels so
the default log is quiet during normal use while real failures stand out.

## Technical Details

- **UI:** swap compute tab order so "Baseline Comparison" precedes
  "Workload Details".
- **`info` → `debug`:** topology tree dump, scoped profiler timings, granular
  `[ssh]`/`[ssh-ui]` auth traces (auth-OK milestones stay `info`), and a few
  `data_provider` status lines.
- **`debug` → `warn`:** the `"<X> request failed with code {}"` family, plus
  failures with a specific cause or sole report (version mismatch, wait
  timeout, track metadata, track-graph fetch, primary event-data fetch).
- **Left at `debug`:** generic duplicates, soft probes, and redundant echoes
  already logged deeper (avoids double-reporting the same failure).