### PR TITLE
View: Add sortable timeline tracks (topology/default/custom)

### DIFF
--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -1226,7 +1226,7 @@ AppWindow::RenderViewMenu(Project* project)
                     trace_view_tab->SetSidebarViewVisibility(settings.show_sidebar);
             }
         }
-        if(ImGui::MenuItem("Show Timeline Header", nullptr, &settings.show_histogram))
+        if(ImGui::MenuItem("Show Timeline Overview", nullptr, &settings.show_histogram))
         {
             for(const auto& tab : m_tab_container->GetTabs())
             {

--- a/src/view/src/rocprofvis_appwindow.cpp
+++ b/src/view/src/rocprofvis_appwindow.cpp
@@ -1226,7 +1226,7 @@ AppWindow::RenderViewMenu(Project* project)
                     trace_view_tab->SetSidebarViewVisibility(settings.show_sidebar);
             }
         }
-        if(ImGui::MenuItem("Show Histogram", nullptr, &settings.show_histogram))
+        if(ImGui::MenuItem("Show Timeline Header", nullptr, &settings.show_histogram))
         {
             for(const auto& tab : m_tab_container->GetTabs())
             {

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -286,7 +286,7 @@ DataProvider::SetRequestProgressUpdateCallback(
 }
 
 bool
-DataProvider::SetTrackDisplayOrder(const std::vector<uint64_t>& ordered_track_ids)
+DataProvider::SetTrackIndex(const std::vector<uint64_t>& ordered_track_ids)
 {
     if(m_state != ProviderState::kReady)
     {
@@ -296,10 +296,10 @@ DataProvider::SetTrackDisplayOrder(const std::vector<uint64_t>& ordered_track_id
     TimelineModel&                           tlm      = m_model.GetTimeline();
     std::unordered_map<uint64_t, TrackInfo>& metadata = tlm.GetMutableTrackMetadata();
 
-    // Require a full permutation so no two tracks share a display index.
+    // Require a full permutation so no two tracks share an index.
     if(ordered_track_ids.size() != metadata.size())
     {
-        spdlog::warn("SetTrackDisplayOrder ignored: expected {} track ids, got {}",
+        spdlog::warn("SetTrackIndex ignored: expected {} track ids, got {}",
                      metadata.size(), ordered_track_ids.size());
         return false;
     }
@@ -310,7 +310,7 @@ DataProvider::SetTrackDisplayOrder(const std::vector<uint64_t>& ordered_track_id
         auto it = metadata.find(track_id);
         if(it == metadata.end())
         {
-            spdlog::warn("SetTrackDisplayOrder ignored: unknown track id {}", track_id);
+            spdlog::warn("SetTrackIndex ignored: unknown track id {}", track_id);
             return false;
         }
         it->second.index = index++;

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -304,7 +304,11 @@ DataProvider::SetTrackIndex(const std::vector<uint64_t>& ordered_track_ids)
         return false;
     }
 
-    uint64_t index = 0;
+    // Resolve every id up front so a bad order can't leave the metadata
+    // half-reindexed (some tracks new indexes, the rest stale). We only mutate
+    // once the whole order is confirmed valid.
+    std::vector<TrackInfo*> ordered_metadata;
+    ordered_metadata.reserve(ordered_track_ids.size());
     for(uint64_t track_id : ordered_track_ids)
     {
         auto it = metadata.find(track_id);
@@ -313,7 +317,13 @@ DataProvider::SetTrackIndex(const std::vector<uint64_t>& ordered_track_ids)
             spdlog::warn("SetTrackIndex ignored: unknown track id {}", track_id);
             return false;
         }
-        it->second.index = index++;
+        ordered_metadata.push_back(&it->second);
+    }
+
+    uint64_t index = 0;
+    for(TrackInfo* info : ordered_metadata)
+    {
+        info->index = index++;
     }
 
     if(m_track_metadata_changed_callback)

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -286,47 +286,41 @@ DataProvider::SetRequestProgressUpdateCallback(
 }
 
 bool
-DataProvider::SetGraphIndex(uint64_t track_id, uint64_t index)
+DataProvider::SetTrackDisplayOrder(const std::vector<uint64_t>& ordered_track_ids)
 {
-    rocprofvis_result_t result = kRocProfVisResultUnknownError;
-    TimelineModel& tlm = m_model.GetTimeline();
-    uint64_t num_graphs = tlm.GetTrackCount();
-
-    if(m_state == ProviderState::kReady)
+    if(m_state != ProviderState::kReady)
     {
-        ROCPROFVIS_ASSERT(index < num_graphs);
-        const TrackInfo* metadata = tlm.GetTrack(track_id);
-        ROCPROFVIS_ASSERT(metadata);
-        result = rocprofvis_controller_set_object(m_trace_timeline,
-                                                  kRPVControllerTimelineGraphIndexed,
-                                                  index, metadata->graph_handle);
-        if(result == kRocProfVisResultSuccess)
-        {
-            rocprofvis_handle_t* graph = nullptr;
-            for(int i = 0; i < num_graphs; i++)
-            {
-                result = rocprofvis_controller_get_object(
-                    m_trace_timeline, kRPVControllerTimelineGraphIndexed, i, &graph);
-                if(result == kRocProfVisResultSuccess && graph)
-                {
-                    uint64_t id = 0;
-                    result      = rocprofvis_controller_get_uint64(
-                        graph, kRPVControllerGraphId, 0, &id);
-                    if(result == kRocProfVisResultSuccess)
-                    {
-                        metadata = tlm.GetTrack(id);
-                        ROCPROFVIS_ASSERT(metadata && metadata->graph_handle == graph);
-                        tlm.GetMutableTrackMetadata()[id].index = i;
-                    }
-                }
-            }
-            if(m_track_metadata_changed_callback)
-            {
-                m_track_metadata_changed_callback(m_model.GetTraceFilePath());
-            }
-        }
+        return false;
     }
-    return (result == kRocProfVisResultSuccess);
+
+    TimelineModel&                           tlm      = m_model.GetTimeline();
+    std::unordered_map<uint64_t, TrackInfo>& metadata = tlm.GetMutableTrackMetadata();
+
+    // Require a full permutation so no two tracks share a display index.
+    if(ordered_track_ids.size() != metadata.size())
+    {
+        spdlog::warn("SetTrackDisplayOrder ignored: expected {} track ids, got {}",
+                     metadata.size(), ordered_track_ids.size());
+        return false;
+    }
+
+    uint64_t index = 0;
+    for(uint64_t track_id : ordered_track_ids)
+    {
+        auto it = metadata.find(track_id);
+        if(it == metadata.end())
+        {
+            spdlog::warn("SetTrackDisplayOrder ignored: unknown track id {}", track_id);
+            return false;
+        }
+        it->second.index = index++;
+    }
+
+    if(m_track_metadata_changed_callback)
+    {
+        m_track_metadata_changed_callback(m_model.GetTraceFilePath());
+    }
+    return true;
 }
 
 bool

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -224,10 +224,10 @@ public:
         const std::function<void(const RequestInfo&, uint64_t, const std::string&)>&
             callback);
 
-    // View-only reorder: sets each TrackInfo::index from its position in
-    // ordered_track_ids (a full permutation) and fires the metadata-changed
-    // callback. Does not touch the controller's graph order.
-    bool SetTrackDisplayOrder(const std::vector<uint64_t>& ordered_track_ids);
+    // Sets each track's TrackInfo::index from its position in ordered_track_ids (a
+    // full permutation) and fires the metadata-changed callback. Does not touch the
+    // controller's graph order.
+    bool SetTrackIndex(const std::vector<uint64_t>& ordered_track_ids);
 
     bool SaveTrimmedTrace(const std::string& path, double start_ns, double end_ns);
 

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -224,14 +224,10 @@ public:
         const std::function<void(const RequestInfo&, uint64_t, const std::string&)>&
             callback);
 
-    /*
-     * Moves a graph inside the controller's timeline to a specified index and updates the
-     * indexes of m_track_metadata.
-     * @param track_id: The id of the track to move
-     * @param index: The desired index of the track.
-     * @return: True if operation is successful.
-     */
-    bool SetGraphIndex(uint64_t track_id, uint64_t index);
+    // View-only reorder: sets each TrackInfo::index from its position in
+    // ordered_track_ids (a full permutation) and fires the metadata-changed
+    // callback. Does not touch the controller's graph order.
+    bool SetTrackDisplayOrder(const std::vector<uint64_t>& ordered_track_ids);
 
     bool SaveTrimmedTrace(const std::string& path, double start_ns, double end_ns);
 

--- a/src/view/src/rocprofvis_font_manager.cpp
+++ b/src/view/src/rocprofvis_font_manager.cpp
@@ -27,8 +27,8 @@ constexpr std::array FONT_AVAILABLE_SIZES = { 9.0f,  10.0f, 11.0f, 12.0f, 13.0f,
                                               25.0f, 27.0f, 29.0f, 31.0f, 35.0f };
 
 // Offsets applied to the user-selected base index (kMedium) to produce
-// kSmall/kMedium/kMedLarge/kLarge.
-static constexpr int kSizeOffsets[FontManager::kNumSizes] = { -1, 0, 1, 2 };
+// kXSmall/kSmall/kMedium/kMedLarge/kLarge.
+static constexpr int kSizeOffsets[FontManager::kNumSizes] = { -5, -1, 0, 1, 2 };
 
 FontManager::FontManager() {}
 

--- a/src/view/src/rocprofvis_font_manager.h
+++ b/src/view/src/rocprofvis_font_manager.h
@@ -24,6 +24,7 @@ enum class FontType
 
 enum class FontSize
 {
+    kXSmall,
     kSmall,
     kMedium,
     kMedLarge,

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -153,7 +153,7 @@ constexpr const char* JSON_KEY_TIMELINE_BOOKMARK_Z       = "z";
 
 constexpr const char* JSON_KEY_TIMELINE_TRACK                    = "tracks";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_ORDER              = "order";
-constexpr const char* JSON_KEY_TIMELINE_SORT_MODE               = "sort_mode";
+constexpr const char* JSON_KEY_TIMELINE_SORT_MODE                = "sort_mode";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_DISPLAY            = "display";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_HEIGHT             = "height";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_COMPACT_MODE       = "compact_mode";

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -154,7 +154,6 @@ constexpr const char* JSON_KEY_TIMELINE_BOOKMARK_Z       = "z";
 constexpr const char* JSON_KEY_TIMELINE_TRACK                    = "tracks";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_ORDER              = "order";
 constexpr const char* JSON_KEY_TIMELINE_SORT_MODE               = "sort_mode";
-constexpr const char* JSON_KEY_TIMELINE_CUSTOM_ORDER            = "custom_order";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_DISPLAY            = "display";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_HEIGHT             = "height";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_COMPACT_MODE       = "compact_mode";

--- a/src/view/src/rocprofvis_project.h
+++ b/src/view/src/rocprofvis_project.h
@@ -153,6 +153,8 @@ constexpr const char* JSON_KEY_TIMELINE_BOOKMARK_Z       = "z";
 
 constexpr const char* JSON_KEY_TIMELINE_TRACK                    = "tracks";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_ORDER              = "order";
+constexpr const char* JSON_KEY_TIMELINE_SORT_MODE               = "sort_mode";
+constexpr const char* JSON_KEY_TIMELINE_CUSTOM_ORDER            = "custom_order";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_DISPLAY            = "display";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_HEIGHT             = "height";
 constexpr const char* JSON_KEY_TIMELINE_TRACK_COMPACT_MODE       = "compact_mode";

--- a/src/view/src/rocprofvis_timeline_track_options.cpp
+++ b/src/view/src/rocprofvis_timeline_track_options.cpp
@@ -955,7 +955,7 @@ TimelineTrackOptions::Update()
 }
 
 void
-TimelineTrackOptions::InitContextMenu(const TrackItem& target)
+TimelineTrackOptions::InitTrackOptionsSubmenu(const TrackItem& target)
 {
     m_context_menu_target = nullptr;
     if(target.GetTrackInfo() && target.m_options)
@@ -967,7 +967,7 @@ TimelineTrackOptions::InitContextMenu(const TrackItem& target)
 }
 
 void
-TimelineTrackOptions::RenderContextMenu()
+TimelineTrackOptions::RenderTrackOptionsSubmenu()
 {
     if(m_context_menu_target && m_context_menu_target->m_options)
     {
@@ -1005,7 +1005,7 @@ TimelineTrackOptions::RenderContextMenu()
 }
 
 bool
-TimelineTrackOptions::HasHiddenTracks() const
+TimelineTrackOptions::ShowHiddenTracksSubmenu() const
 {
     for(const auto& entry : m_options_map)
     {
@@ -1015,44 +1015,6 @@ TimelineTrackOptions::HasHiddenTracks() const
         }
     }
     return false;
-}
-
-void
-TimelineTrackOptions::ShowTracks(const std::vector<TrackOptions*>& options)
-{
-    // Sourced from a revealed track rather than the context-menu target, so this
-    // also works when the menu was opened without one (all tracks hidden).
-    const TrackItem* revealed = nullptr;
-    for(TrackOptions* option : options)
-    {
-        if(option && !option->m_display)
-        {
-            option->m_display = true;
-            revealed          = &option->GetTrackItem();
-        }
-    }
-    if(revealed)
-    {
-        // Aggregated context-menu options track visibility too, so refresh them.
-        m_update_aggregates = true;
-        EventManager::GetInstance()->AddEvent(std::make_shared<RocEvent>(
-            static_cast<int>(RocEvents::kTrackVisibilityChanged),
-            revealed->m_data_provider.GetTraceFilePath()));
-    }
-}
-
-void
-TimelineTrackOptions::ShowAllHiddenTracks()
-{
-    std::vector<TrackOptions*> hidden;
-    for(const auto& entry : m_options_map)
-    {
-        if(entry.second && !entry.second->m_display)
-        {
-            hidden.push_back(entry.second);
-        }
-    }
-    ShowTracks(hidden);
 }
 
 void
@@ -1091,10 +1053,9 @@ TimelineTrackOptions::RenderHiddenTracksSubmenu()
             continue;
         }
         const TrackInfo* info = option->GetTrackItem().GetTrackInfo();
-        const char*      label =
-            (info && info->track_type == kRPVControllerTrackTypeSamples)
-                     ? DISPLAY_STRINGS_TOPOLOGY_TRACK_TYPES[TrackInfo::Counter]
-                     : "Event Tracks";
+        const char* label = (info && info->track_type == kRPVControllerTrackTypeSamples)
+                                ? DISPLAY_STRINGS_TOPOLOGY_TRACK_TYPES[TrackInfo::Counter]
+                                : "Event Tracks";
         bucket(label).push_back(option);
     }
 
@@ -1122,9 +1083,8 @@ TimelineTrackOptions::RenderHiddenTracksSubmenu()
             for(TrackOptions* option : category.second)
             {
                 // Hidden ##id suffix keeps ids unique when names repeat.
-                const std::string item =
-                    option->GetTrackItem().GetName() + "##" +
-                    std::to_string(option->GetTrackItem().GetID());
+                const std::string item = option->GetTrackItem().GetName() + "##" +
+                                         std::to_string(option->GetTrackItem().GetID());
                 if(IconMenuItem(nullptr, item.c_str()))
                 {
                     ShowTracks({ option });
@@ -1133,6 +1093,65 @@ TimelineTrackOptions::RenderHiddenTracksSubmenu()
             ImGui::EndMenu();
         }
     }
+}
+
+void
+TimelineTrackOptions::SetTrackSortSubmenu(std::function<void()> renderer)
+{
+    m_render_sort_menu = std::move(renderer);
+}
+
+bool
+TimelineTrackOptions::ShowTrackSortSubmenu() const
+{
+    return static_cast<bool>(m_render_sort_menu);
+}
+
+void
+TimelineTrackOptions::RenderTrackSortSubmenu() const
+{
+    if(m_render_sort_menu)
+    {
+        m_render_sort_menu();
+    }
+}
+
+void
+TimelineTrackOptions::ShowTracks(const std::vector<TrackOptions*>& options)
+{
+    // Sourced from a revealed track rather than the context-menu target, so this
+    // also works when the menu was opened without one (all tracks hidden).
+    const TrackItem* revealed = nullptr;
+    for(TrackOptions* option : options)
+    {
+        if(option && !option->m_display)
+        {
+            option->m_display = true;
+            revealed          = &option->GetTrackItem();
+        }
+    }
+    if(revealed)
+    {
+        // Aggregated context-menu options track visibility too, so refresh them.
+        m_update_aggregates = true;
+        EventManager::GetInstance()->AddEvent(std::make_shared<RocEvent>(
+            static_cast<int>(RocEvents::kTrackVisibilityChanged),
+            revealed->m_data_provider.GetTraceFilePath()));
+    }
+}
+
+void
+TimelineTrackOptions::ShowAllHiddenTracks()
+{
+    std::vector<TrackOptions*> hidden;
+    for(const auto& entry : m_options_map)
+    {
+        if(entry.second && !entry.second->m_display)
+        {
+            hidden.push_back(entry.second);
+        }
+    }
+    ShowTracks(hidden);
 }
 
 std::unique_ptr<TrackOptions>

--- a/src/view/src/rocprofvis_timeline_track_options.h
+++ b/src/view/src/rocprofvis_timeline_track_options.h
@@ -63,7 +63,7 @@ public:
     bool  m_display;
     float m_height;
 #ifdef IMGUI_ENABLE_TEST_ENGINE
-     friend struct FlameTrackItemTestPeer;
+    friend struct FlameTrackItemTestPeer;
 #endif
 protected:
     class TrackProjectSetting : public ProjectSetting
@@ -178,38 +178,34 @@ public:
     std::unique_ptr<TrackOptions> InitTrack(const TrackItem& track);
     void                          Update();
     // Given a target track, snapshot required info and setup aggregated options
-    void InitContextMenu(const TrackItem& target);
-    // Display the options menu for the target track passed in InitContextMenu()
-    void RenderContextMenu();
+    void InitTrackOptionsSubmenu(const TrackItem& target);
+    // Display the options menu for the target track passed in InitTrackOptionsSubmenu()
+    void RenderTrackOptionsSubmenu();
     // Whether any known track is currently hidden.
-    bool HasHiddenTracks() const;
+    bool ShowHiddenTracksSubmenu() const;
     // Render the "Show Hidden Tracks" submenu contents. Call within an open menu
     // or popup.
     void RenderHiddenTracksSubmenu();
 
-    void SetSortMenuRenderer(std::function<void()> renderer)
-    {
-        m_render_sort_menu = std::move(renderer);
-    }
-    bool HasSortMenu() const { return static_cast<bool>(m_render_sort_menu); }
-    void RenderSortMenu() const
-    {
-        if(m_render_sort_menu) m_render_sort_menu();
-    }
+    void SetTrackSortSubmenu(std::function<void()> renderer);
+
+    bool ShowTrackSortSubmenu() const;
+
+    void RenderTrackSortSubmenu() const;
 
 private:
-    // Reveal every track in the list (sets display + fires a single
-    // visibility-changed event). Ignores tracks that are already displayed.
-    void ShowTracks(const std::vector<TrackOptions*>& options);
-    // Reveal every currently hidden track.
-    void ShowAllHiddenTracks();
-
     enum Propagate
     {
         kNone,
         kSelected,  // Apply to selected tracks
         kSiblings,  // Apply to all like tracks
     };
+
+    // Reveal every track in the list (sets display + fires a single
+    // visibility-changed event). Ignores tracks that are already displayed.
+    void ShowTracks(const std::vector<TrackOptions*>& options);
+    // Reveal every currently hidden track.
+    void ShowAllHiddenTracks();
 
     // Construct options that is aggregate representation of compoents
     std::unique_ptr<TrackOptions> CreateAggregate(

--- a/src/view/src/rocprofvis_timeline_track_options.h
+++ b/src/view/src/rocprofvis_timeline_track_options.h
@@ -6,6 +6,7 @@
 #include "rocprofvis_project.h"
 #include <array>
 #include <bitset>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -186,6 +187,16 @@ public:
     // or popup.
     void RenderHiddenTracksSubmenu();
 
+    void SetSortMenuRenderer(std::function<void()> renderer)
+    {
+        m_render_sort_menu = std::move(renderer);
+    }
+    bool HasSortMenu() const { return static_cast<bool>(m_render_sort_menu); }
+    void RenderSortMenu() const
+    {
+        if(m_render_sort_menu) m_render_sort_menu();
+    }
+
 private:
     // Reveal every track in the list (sets display + fires a single
     // visibility-changed event). Ignores tracks that are already displayed.
@@ -229,6 +240,8 @@ private:
 
     const TimelineSelection& m_selection;
     const SettingsManager&   m_settings;
+
+    std::function<void()> m_render_sort_menu;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1211,12 +1211,15 @@ TimelineView::Update()
             m_pending_sort_mode.reset();
         }
 
-        // A topology sort requested before the sidebar tree was ready (e.g. right
-        // after load) is applied here once the order becomes available.
+        // Apply a topology sort deferred until the order was ready; fall back to
+        // Default if the cached order isn't a full permutation of the current tracks.
         if(m_topology_sort_pending && m_sort_mode == TrackSortMode::kTopology &&
            m_topology_order && !m_topology_order->empty())
         {
-            ApplyTrackOrder(*m_topology_order);
+            if(!ApplyTrackOrder(*m_topology_order))
+            {
+                m_sort_mode = TrackSortMode::kDefault;
+            }
             m_topology_sort_pending = false;
         }
 

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -22,6 +22,7 @@
 #include "widgets/rocprofvis_gui_helpers.h"
 #include <algorithm>
 #include <sstream>
+#include <unordered_set>
 
 namespace RocProfVis
 {
@@ -115,6 +116,8 @@ TimelineView::TimelineView(DataProvider&                          dp,
 , m_dragging_measurement_ruler(MeasurementRulerDragTarget::kNone)
 , m_measure_copy_target(MeasurementCopyTarget::kNone)
 , m_loading_timer(DEFAULT_LOADING_TIMER)
+, m_sort_mode(TrackSortMode::kDefault)
+, m_topology_sort_pending(false)
 {
     // Subscribe to events
     auto new_track_data_handler = [this](std::shared_ptr<RocEvent> e) {
@@ -1183,24 +1186,41 @@ TimelineView::Update()
 {
     if(m_meta_map_made)
     {
+        // A topology sort requested before the sidebar tree was ready (e.g. right
+        // after load) is applied here once the provider can satisfy it.
+        if(m_topology_sort_pending && m_sort_mode == TrackSortMode::kTopology &&
+           m_topology_order_provider)
+        {
+            std::vector<uint64_t> order = m_topology_order_provider();
+            if(!order.empty())
+            {
+                ApplyTrackOrder(order);
+                m_topology_sort_pending = false;
+            }
+        }
+
         if(!m_reorder_request.handled)
         {
-            if(m_data_provider.SetGraphIndex(m_reorder_request.track_id,
-                                             m_reorder_request.new_index))
+            // Move the dragged track to its drop index; this becomes the custom order.
+            std::vector<uint64_t> order;
+            order.reserve(m_tracks->size());
+            for(TrackItem* track : *m_tracks)
             {
-                std::vector<TrackItem*> tracks_reordered;
-                TimelineModel&          tlm = m_data_provider.DataModel().GetTimeline();
-                tracks_reordered.resize(tlm.GetTrackCount());
-                for(TrackItem* track : *m_tracks)
+                if(track)
                 {
-                    if(track)
-                    {
-                        const TrackInfo* metadata = tlm.GetTrack(track->GetID());
-                        ROCPROFVIS_ASSERT(metadata);
-                        tracks_reordered[metadata->index] = track;
-                    }
+                    order.push_back(track->GetID());
                 }
-                *m_tracks = std::move(tracks_reordered);
+            }
+            auto it = std::find(order.begin(), order.end(), m_reorder_request.track_id);
+            if(it != order.end())
+            {
+                order.erase(it);
+                int idx = std::clamp(m_reorder_request.new_index, 0,
+                                     static_cast<int>(order.size()));
+                order.insert(order.begin() + idx, m_reorder_request.track_id);
+                ApplyTrackOrder(order);
+                m_sort_mode    = TrackSortMode::kCustom;
+                m_custom_order = order;
             }
         }
         // Rebuild the positioning map.
@@ -2244,25 +2264,15 @@ TimelineView::MakeGraphView()
     uint64_t num_graphs = tlm.GetTrackCount();
     m_tracks->resize(num_graphs);
 
-    std::vector<const TrackInfo*> track_list    = tlm.GetTrackList();
-    bool                          project_valid = m_project_settings.Valid();
+    // Build the track vector in the natural load order. The persisted sort
+    // selection (custom/topology/default) is restored afterwards in
+    // LoadSortSettings() as a view-only reorder.
+    std::vector<const TrackInfo*> track_list = tlm.GetTrackList();
     std::vector<uint64_t>         hidden_tracks;
 
     for(int i = 0; i < track_list.size(); i++)
     {
         const TrackInfo* track_info = track_list[i];
-        bool             display    = true;
-
-        if(project_valid)
-        {
-            uint64_t         track_id_at_index   = m_project_settings.TrackID(i);
-            const TrackInfo* track_at_index_info = tlm.GetTrack(track_id_at_index);
-            if(track_at_index_info && track_at_index_info->index != i)
-            {
-                ROCPROFVIS_ASSERT(m_data_provider.SetGraphIndex(track_id_at_index, i));
-            }
-            track_info = track_at_index_info;
-        }
 
         if(!track_info)
         {
@@ -2311,6 +2321,182 @@ TimelineView::MakeGraphView()
     m_resize_activity = true;
 
     CalculateTrackCounts();
+
+    // Snapshot the natural load order for the "Default" sort, then restore whatever
+    // sort selection the project last used.
+    m_default_order.clear();
+    m_default_order.reserve(m_tracks->size());
+    for(TrackItem* track : *m_tracks)
+    {
+        if(track)
+        {
+            m_default_order.push_back(track->GetID());
+        }
+    }
+    LoadSortSettings();
+}
+
+void
+TimelineView::SetTopologyOrderProvider(std::function<std::vector<uint64_t>()> provider)
+{
+    m_topology_order_provider = std::move(provider);
+}
+
+void
+TimelineView::SortTracksBy(TrackSortMode mode)
+{
+    m_sort_mode = mode;
+    switch(mode)
+    {
+        case TrackSortMode::kTopology:
+        {
+            std::vector<uint64_t> order =
+                m_topology_order_provider ? m_topology_order_provider()
+                                          : std::vector<uint64_t>{};
+            if(!order.empty())
+            {
+                ApplyTrackOrder(order);
+                m_topology_sort_pending = false;
+            }
+            else
+            {
+                // Tree not built yet; Update() applies this once it is available.
+                m_topology_sort_pending = true;
+            }
+            break;
+        }
+        case TrackSortMode::kDefault:
+            if(!m_default_order.empty())
+            {
+                ApplyTrackOrder(m_default_order);
+            }
+            break;
+        case TrackSortMode::kCustom:
+            if(!m_custom_order.empty())
+            {
+                ApplyTrackOrder(m_custom_order);
+            }
+            break;
+    }
+}
+
+void
+TimelineView::ApplyTrackOrder(const std::vector<uint64_t>& order)
+{
+    if(!m_tracks)
+    {
+        return;
+    }
+
+    // Callers pass a full permutation, so this is a straight reindex;
+    // SetTrackDisplayOrder guards against a malformed order.
+    if(!m_data_provider.SetTrackDisplayOrder(order))
+    {
+        return;
+    }
+
+    RebuildTrackVectorFromMetadata();
+    // Force the position map / layout to recompute on the next Update().
+    m_resize_activity = true;
+}
+
+void
+TimelineView::RebuildTrackVectorFromMetadata()
+{
+    TimelineModel&          tlm = m_data_provider.DataModel().GetTimeline();
+    std::vector<TrackItem*> reordered(tlm.GetTrackCount(), nullptr);
+    for(TrackItem* track : *m_tracks)
+    {
+        if(track)
+        {
+            const TrackInfo* metadata = tlm.GetTrack(track->GetID());
+            if(metadata && metadata->index < reordered.size())
+            {
+                reordered[metadata->index] = track;
+            }
+        }
+    }
+    *m_tracks = std::move(reordered);
+}
+
+void
+TimelineView::LoadSortSettings()
+{
+    // Defaults for a trace with no persisted sort selection.
+    m_sort_mode             = TrackSortMode::kDefault;
+    m_custom_order.clear();
+    m_topology_sort_pending = false;
+
+    if(m_project_settings.HasSortSettings())
+    {
+        int mode = m_project_settings.SortMode();
+        if(mode == static_cast<int>(TrackSortMode::kTopology) ||
+           mode == static_cast<int>(TrackSortMode::kCustom))
+        {
+            m_sort_mode = static_cast<TrackSortMode>(mode);
+        }
+        if(m_project_settings.CustomOrderValid())
+        {
+            m_custom_order = m_project_settings.CustomOrder();
+        }
+    }
+    else if(m_project_settings.Valid())
+    {
+        // Legacy projects stored only an explicit track order; treat it as custom.
+        m_custom_order.clear();
+        m_custom_order.reserve(m_tracks->size());
+        for(int i = 0; i < static_cast<int>(m_tracks->size()); i++)
+        {
+            m_custom_order.push_back(m_project_settings.TrackID(i));
+        }
+        m_sort_mode = TrackSortMode::kCustom;
+    }
+
+    switch(m_sort_mode)
+    {
+        case TrackSortMode::kCustom:
+            if(m_custom_order.size() == m_tracks->size())
+            {
+                ApplyTrackOrder(m_custom_order);
+            }
+            else
+            {
+                m_sort_mode = TrackSortMode::kDefault;
+            }
+            break;
+        case TrackSortMode::kTopology:
+            // Applied by Update() once the topology tree is available.
+            m_topology_sort_pending = true;
+            break;
+        case TrackSortMode::kDefault:
+        default:
+            // Tracks are already in natural load order.
+            break;
+    }
+}
+
+void
+TimelineView::RenderTrackSortMenu()
+{
+    // Flat layout: a titled separator header with the options directly beneath it.
+    // A submenu would be pointless here since sorting is the only action.
+    ImGui::SeparatorText("Sort tracks by");
+    if(IconMenuItem(ICON_TREE, "Topology", true,
+                    m_sort_mode == TrackSortMode::kTopology))
+    {
+        SortTracksBy(TrackSortMode::kTopology);
+    }
+    if(IconMenuItem(ICON_LIST, "Default (Track type)", true,
+                    m_sort_mode == TrackSortMode::kDefault))
+    {
+        SortTracksBy(TrackSortMode::kDefault);
+    }
+    // Custom is only selectable once a manual ordering has been established.
+    if(IconMenuItem(ICON_EDIT, "Custom", HasCustomOrder(),
+                    m_sort_mode == TrackSortMode::kCustom))
+    {
+        SortTracksBy(TrackSortMode::kCustom);
+    }
 }
 
 void
@@ -2441,6 +2627,20 @@ TimelineView::RenderTrackStats(float available_width)
     }
 
     ImGui::EndGroup();
+
+    // Pull menu spacing from the base style; the histogram strip's child has zero
+    // padding, which would otherwise leave the popup cramped.
+    const ImGuiStyle& base = m_settings.GetDefaultStyle();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, base.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, base.ItemSpacing);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, base.FramePadding);
+    if(ImGui::BeginPopupContextWindow("##track_sort_ctx",
+                                      ImGuiPopupFlags_MouseButtonRight))
+    {
+        RenderTrackSortMenu();
+        ImGui::EndPopup();
+    }
+    ImGui::PopStyleVar(3);
 
     // Hovering the summary reveals the full per-type breakdown.
     if(BeginItemTooltipStyled())
@@ -3379,6 +3579,16 @@ TimelineViewProjectSettings::ToJson()
         uint64_t id = tracks[i]->GetID();
         m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER][i] = id;
     }
+
+    // Persist the active sort mode and the single remembered custom ordering.
+    m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE] =
+        static_cast<int>(m_timeline_view.m_sort_mode);
+    const std::vector<uint64_t>& custom = m_timeline_view.m_custom_order;
+    for(size_t i = 0; i < custom.size(); i++)
+    {
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_CUSTOM_ORDER][i] =
+            custom[i];
+    }
 }
 
 bool
@@ -3415,6 +3625,72 @@ TimelineViewProjectSettings::TrackID(int index) const
 {
     return m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER][index]
         .getLong();
+}
+
+bool
+TimelineViewProjectSettings::HasSortSettings() const
+{
+    return m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE].isLong();
+}
+
+int
+TimelineViewProjectSettings::SortMode() const
+{
+    return static_cast<int>(
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE].getLong());
+}
+
+std::vector<uint64_t>
+TimelineViewProjectSettings::CustomOrder() const
+{
+    std::vector<uint64_t> order;
+    jt::Json&             node =
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_CUSTOM_ORDER];
+    if(node.isArray())
+    {
+        for(jt::Json& id : node.getArray())
+        {
+            if(id.isLong())
+            {
+                order.push_back(static_cast<uint64_t>(id.getLong()));
+            }
+        }
+    }
+    return order;
+}
+
+bool
+TimelineViewProjectSettings::CustomOrderValid() const
+{
+    jt::Json& node =
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_CUSTOM_ORDER];
+    if(!node.isArray())
+    {
+        return false;
+    }
+    std::vector<jt::Json>& order = node.getArray();
+    if(order.size() != m_timeline_view.m_tracks->size())
+    {
+        return false;
+    }
+    // Require a real permutation (every id known, no duplicates) so the apply path
+    // can trust the stored order without re-checking it.
+    const TimelineModel& tlm =
+        m_timeline_view.m_data_provider.DataModel().GetTimeline();
+    std::unordered_set<uint64_t> seen;
+    for(jt::Json& id : order)
+    {
+        if(!id.isLong())
+        {
+            return false;
+        }
+        const uint64_t track_id = static_cast<uint64_t>(id.getLong());
+        if(!tlm.GetTrack(track_id) || !seen.insert(track_id).second)
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 LoadingTimer::LoadingTimer(uint64_t delay)

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -2648,7 +2648,10 @@ TimelineView::RenderTrackStats(float available_width)
     ImGui::PushFont(fonts.GetFont(FontType::kIcon), fonts.GetFontSize(FontSize::kSmall));
     const float arrow_h = ImGui::GetTextLineHeight();
     ImGui::SetCursorPos(ImVec2(0.0f, ImGui::GetWindowHeight() - arrow_h));
-    if(ImGui::Button(sort_label.c_str(), ImVec2(available_width, arrow_h)))
+    // Open the sort menu from the button itself (left- or right-click), rather than
+    // a right-click anywhere on the stats block.
+    if(ImGui::Button(sort_label.c_str(), ImVec2(available_width, arrow_h)) ||
+       ImGui::IsItemClicked(ImGuiMouseButton_Right))
     {
         ImGui::OpenPopup("##track_sort_ctx");
     }
@@ -2661,15 +2664,14 @@ TimelineView::RenderTrackStats(float available_width)
         EndTooltipStyled();
     }
 
-    // Sort menu, shared by the button above and a right-click anywhere on the
-    // header. Pull spacing from the base style; the histogram strip's child has zero
-    // padding, which would otherwise leave the popup cramped.
+    // Sort menu opened from the button above. Pull spacing from the base style; the
+    // histogram strip's child has zero padding, which would otherwise leave the
+    // popup cramped.
     const ImGuiStyle& base = m_settings.GetDefaultStyle();
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, base.WindowPadding);
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, base.ItemSpacing);
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, base.FramePadding);
-    if(ImGui::BeginPopupContextWindow("##track_sort_ctx",
-                                      ImGuiPopupFlags_MouseButtonRight))
+    if(ImGui::BeginPopup("##track_sort_ctx"))
     {
         RenderTrackSortMenu();
         ImGui::EndPopup();

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -119,6 +119,9 @@ TimelineView::TimelineView(DataProvider&                          dp,
 , m_sort_mode(TrackSortMode::kDefault)
 , m_topology_sort_pending(false)
 {
+    m_track_options_context_menu->SetSortMenuRenderer(
+        [this]() { RenderTrackSortMenu(); });
+
     // Subscribe to events
     auto new_track_data_handler = [this](std::shared_ptr<RocEvent> e) {
         this->HandleNewTrackData(e);
@@ -2673,6 +2676,14 @@ TimelineView::RenderTrackStats(float available_width)
         ImGui::PopStyleColor();
         EndTooltipStyled();
     }
+}
+
+void
+TimelineView::RenderTrackInfo(float available_width)
+{
+    RenderTrackStats(available_width);
+
+    FontManager& fonts = m_settings.GetFontManager();
 
     // Full-width sort affordance pinned to the bottom of the header, so the sort
     // options are discoverable without the right-click menu. The height is clamped
@@ -2720,20 +2731,17 @@ TimelineView::RenderTrackStats(float available_width)
 }
 
 void
-TimelineView::RenderHistogram()
+TimelineView::RenderHeader()
 {
     if(!m_histogram || m_histogram->empty()) return;
 
-    const float kHistogramTotalHeight = ImGui::GetContentRegionAvail().y;
-    const float kHistogramBarHeight   = kHistogramTotalHeight - m_ruler_height;
-    const auto& time_format = m_settings.GetUserSettings().unit_settings.time_format;
+    const float total_height = ImGui::GetContentRegionAvail().y;
 
-    // Sidebar spacer (left side, before histogram)
     ImGui::SetCursorPos(ImVec2(0, 0));
     ImGui::PushStyleColor(ImGuiCol_ChildBg, m_settings.GetColor(Colors::kBgMain));
-    ImGui::BeginChild("HistogramSidebar", ImVec2(m_sidebar_size, kHistogramTotalHeight),
-                      false, ImGuiWindowFlags_NoScrollbar);
-    RenderTrackStats(m_sidebar_size);
+    ImGui::BeginChild("HistogramSidebar", ImVec2(m_sidebar_size, total_height), false,
+                      ImGuiWindowFlags_NoScrollbar);
+    RenderTrackInfo(m_sidebar_size);
     ImGui::EndChild();
     ImGui::PopStyleColor();
     ImGui::SameLine();
@@ -2741,13 +2749,23 @@ TimelineView::RenderHistogram()
     // Vertical splitter
     float splitter_size = 1.0f;
     ImGui::PushStyleColor(ImGuiCol_ChildBg, m_settings.GetColor(Colors::kSplitterColor));
-    ImGui::BeginChild("HistogramSplitter", ImVec2(splitter_size, kHistogramTotalHeight),
-                      false);
+    ImGui::BeginChild("HistogramSplitter", ImVec2(splitter_size, total_height), false);
     ImGui::EndChild();
     ImGui::PopStyleColor();
     ImGui::SameLine();
 
-    float histogram_width = m_tpt->GetGraphSizeX() - splitter_size;
+    RenderHistogram(total_height);
+}
+
+void
+TimelineView::RenderHistogram(float total_height)
+{
+    const float kHistogramTotalHeight = total_height;
+    const float kHistogramBarHeight   = kHistogramTotalHeight - m_ruler_height;
+    const auto& time_format = m_settings.GetUserSettings().unit_settings.time_format;
+
+    constexpr float splitter_size = 1.0f;
+    float           histogram_width = m_tpt->GetGraphSizeX() - splitter_size;
 
     // Outer container
     ImGui::PushStyleColor(ImGuiCol_ChildBg, m_settings.GetColor(Colors::kBgMain));

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1187,16 +1187,12 @@ TimelineView::Update()
     if(m_meta_map_made)
     {
         // A topology sort requested before the sidebar tree was ready (e.g. right
-        // after load) is applied here once the provider can satisfy it.
+        // after load) is applied here once the order becomes available.
         if(m_topology_sort_pending && m_sort_mode == TrackSortMode::kTopology &&
-           m_topology_order_provider)
+           m_topology_order && !m_topology_order->empty())
         {
-            std::vector<uint64_t> order = m_topology_order_provider();
-            if(!order.empty())
-            {
-                ApplyTrackOrder(order);
-                m_topology_sort_pending = false;
-            }
+            ApplyTrackOrder(*m_topology_order);
+            m_topology_sort_pending = false;
         }
 
         if(!m_reorder_request.handled)
@@ -2337,9 +2333,9 @@ TimelineView::MakeGraphView()
 }
 
 void
-TimelineView::SetTopologyOrderProvider(std::function<std::vector<uint64_t>()> provider)
+TimelineView::SetTopologyOrder(const std::vector<uint64_t>* order)
 {
-    m_topology_order_provider = std::move(provider);
+    m_topology_order = order;
 }
 
 void
@@ -2350,12 +2346,9 @@ TimelineView::SortTracksBy(TrackSortMode mode)
     {
         case TrackSortMode::kTopology:
         {
-            std::vector<uint64_t> order =
-                m_topology_order_provider ? m_topology_order_provider()
-                                          : std::vector<uint64_t>{};
-            if(!order.empty())
+            if(m_topology_order && !m_topology_order->empty())
             {
-                ApplyTrackOrder(order);
+                ApplyTrackOrder(*m_topology_order);
                 m_topology_sort_pending = false;
             }
             else
@@ -2389,8 +2382,8 @@ TimelineView::ApplyTrackOrder(const std::vector<uint64_t>& order)
     }
 
     // Callers pass a full permutation, so this is a straight reindex;
-    // SetTrackDisplayOrder guards against a malformed order.
-    if(!m_data_provider.SetTrackDisplayOrder(order))
+    // SetTrackIndex guards against a malformed order.
+    if(!m_data_provider.SetTrackIndex(order))
     {
         return;
     }
@@ -2427,6 +2420,13 @@ TimelineView::LoadSortSettings()
     m_custom_order.clear();
     m_topology_sort_pending = false;
 
+    // The persisted "order" list is the remembered custom order.
+    const bool custom_valid = m_project_settings.Valid();
+    if(custom_valid)
+    {
+        m_custom_order = m_project_settings.CustomOrder();
+    }
+
     if(m_project_settings.HasSortSettings())
     {
         int mode = m_project_settings.SortMode();
@@ -2435,20 +2435,10 @@ TimelineView::LoadSortSettings()
         {
             m_sort_mode = static_cast<TrackSortMode>(mode);
         }
-        if(m_project_settings.CustomOrderValid())
-        {
-            m_custom_order = m_project_settings.CustomOrder();
-        }
     }
-    else if(m_project_settings.Valid())
+    else if(custom_valid)
     {
-        // Legacy projects stored only an explicit track order; treat it as custom.
-        m_custom_order.clear();
-        m_custom_order.reserve(m_tracks->size());
-        for(int i = 0; i < static_cast<int>(m_tracks->size()); i++)
-        {
-            m_custom_order.push_back(m_project_settings.TrackID(i));
-        }
+        // Legacy projects stored only the order; restore it as the custom sort.
         m_sort_mode = TrackSortMode::kCustom;
     }
 
@@ -2628,20 +2618,6 @@ TimelineView::RenderTrackStats(float available_width)
 
     ImGui::EndGroup();
 
-    // Pull menu spacing from the base style; the histogram strip's child has zero
-    // padding, which would otherwise leave the popup cramped.
-    const ImGuiStyle& base = m_settings.GetDefaultStyle();
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, base.WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, base.ItemSpacing);
-    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, base.FramePadding);
-    if(ImGui::BeginPopupContextWindow("##track_sort_ctx",
-                                      ImGuiPopupFlags_MouseButtonRight))
-    {
-        RenderTrackSortMenu();
-        ImGui::EndPopup();
-    }
-    ImGui::PopStyleVar(3);
-
     // Hovering the summary reveals the full per-type breakdown.
     if(BeginItemTooltipStyled())
     {
@@ -2657,6 +2633,48 @@ TimelineView::RenderTrackStats(float available_width)
         ImGui::PopStyleColor();
         EndTooltipStyled();
     }
+
+    // Full-width sort affordance pinned to the bottom of the header, so the sort
+    // options are discoverable without the right-click menu. The height is clamped
+    // to the arrow glyph with no vertical padding.
+    const std::string sort_label = std::string(ICON_CHEVRON_DOWN) + "##sort_tracks_btn";
+    ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kBgFrame));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered,
+                          m_settings.GetColor(Colors::kButtonHovered));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive,
+                          m_settings.GetColor(Colors::kButtonActive));
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 0.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0.0f, 0.0f));
+    ImGui::PushFont(fonts.GetFont(FontType::kIcon), fonts.GetFontSize(FontSize::kSmall));
+    const float arrow_h = ImGui::GetTextLineHeight();
+    ImGui::SetCursorPos(ImVec2(0.0f, ImGui::GetWindowHeight() - arrow_h));
+    if(ImGui::Button(sort_label.c_str(), ImVec2(available_width, arrow_h)))
+    {
+        ImGui::OpenPopup("##track_sort_ctx");
+    }
+    ImGui::PopFont();
+    ImGui::PopStyleVar(2);
+    ImGui::PopStyleColor(3);
+    if(BeginItemTooltipStyled())
+    {
+        ImGui::TextUnformatted("Sort tracks");
+        EndTooltipStyled();
+    }
+
+    // Sort menu, shared by the button above and a right-click anywhere on the
+    // header. Pull spacing from the base style; the histogram strip's child has zero
+    // padding, which would otherwise leave the popup cramped.
+    const ImGuiStyle& base = m_settings.GetDefaultStyle();
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, base.WindowPadding);
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, base.ItemSpacing);
+    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, base.FramePadding);
+    if(ImGui::BeginPopupContextWindow("##track_sort_ctx",
+                                      ImGuiPopupFlags_MouseButtonRight))
+    {
+        RenderTrackSortMenu();
+        ImGui::EndPopup();
+    }
+    ImGui::PopStyleVar(3);
 }
 
 void
@@ -3573,97 +3591,24 @@ TimelineViewProjectSettings::~TimelineViewProjectSettings() {}
 void
 TimelineViewProjectSettings::ToJson()
 {
-    const std::vector<TrackItem*>& tracks = *m_timeline_view.GetTracks();
-    for(int i = 0; i < tracks.size(); i++)
-    {
-        uint64_t id = tracks[i]->GetID();
-        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER][i] = id;
-    }
-
-    // Persist the active sort mode and the single remembered custom ordering.
-    m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE] =
-        static_cast<int>(m_timeline_view.m_sort_mode);
+    // Persist the remembered custom order (reusing the track "order" key) and the
+    // active sort mode. The custom order is the only ordering that can't be derived
+    // at load; default and topology are recomputed.
     const std::vector<uint64_t>& custom = m_timeline_view.m_custom_order;
     for(size_t i = 0; i < custom.size(); i++)
     {
-        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_CUSTOM_ORDER][i] =
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER][i] =
             custom[i];
     }
+    m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE] =
+        static_cast<int>(m_timeline_view.m_sort_mode);
 }
 
 bool
 TimelineViewProjectSettings::Valid() const
 {
-    bool valid = false;
-    if(m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER].isArray())
-    {
-        std::vector<jt::Json>& track_order =
-            m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER]
-                .getArray();
-        if(track_order.size() == m_timeline_view.m_tracks->size())
-        {
-            int valid_count = 0;
-            for(jt::Json& track_id : track_order)
-            {
-                if(track_id.isLong())
-                {
-                    valid_count++;
-                }
-                else
-                {
-                    break;
-                }
-            }
-            valid = (valid_count == track_order.size());
-        }
-    }
-    return valid;
-}
-
-uint64_t
-TimelineViewProjectSettings::TrackID(int index) const
-{
-    return m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER][index]
-        .getLong();
-}
-
-bool
-TimelineViewProjectSettings::HasSortSettings() const
-{
-    return m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE].isLong();
-}
-
-int
-TimelineViewProjectSettings::SortMode() const
-{
-    return static_cast<int>(
-        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE].getLong());
-}
-
-std::vector<uint64_t>
-TimelineViewProjectSettings::CustomOrder() const
-{
-    std::vector<uint64_t> order;
-    jt::Json&             node =
-        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_CUSTOM_ORDER];
-    if(node.isArray())
-    {
-        for(jt::Json& id : node.getArray())
-        {
-            if(id.isLong())
-            {
-                order.push_back(static_cast<uint64_t>(id.getLong()));
-            }
-        }
-    }
-    return order;
-}
-
-bool
-TimelineViewProjectSettings::CustomOrderValid() const
-{
     jt::Json& node =
-        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_CUSTOM_ORDER];
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER];
     if(!node.isArray())
     {
         return false;
@@ -3691,6 +3636,38 @@ TimelineViewProjectSettings::CustomOrderValid() const
         }
     }
     return true;
+}
+
+bool
+TimelineViewProjectSettings::HasSortSettings() const
+{
+    return m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE].isLong();
+}
+
+int
+TimelineViewProjectSettings::SortMode() const
+{
+    return static_cast<int>(
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_SORT_MODE].getLong());
+}
+
+std::vector<uint64_t>
+TimelineViewProjectSettings::CustomOrder() const
+{
+    std::vector<uint64_t> order;
+    jt::Json&             node =
+        m_settings_json[JSON_KEY_GROUP_TIMELINE][JSON_KEY_TIMELINE_TRACK_ORDER];
+    if(node.isArray())
+    {
+        for(jt::Json& id : node.getArray())
+        {
+            if(id.isLong())
+            {
+                order.push_back(static_cast<uint64_t>(id.getLong()));
+            }
+        }
+    }
+    return order;
 }
 
 LoadingTimer::LoadingTimer(uint64_t delay)

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -39,6 +39,7 @@ constexpr uint64_t DEFAULT_LOADING_TIMER         = 150;  // milliseconds
 constexpr float    ARTIFICIAL_SCROLLBAR_HEIGHT   = 18.0f;
 constexpr float    SIDEBAR_SPLITTER_WIDTH        = 5.0f;
 constexpr const char* HIDDEN_TRACKS_MENU_POPUP_NAME = "HiddenTracksMenu";
+constexpr const char* SORT_TRACKS_MENU_POPUP_NAME   = "SortTracksMenu";
 // Build a text block mirroring the on-hover tooltip (name, timing, and id)
 // for the clipboard.
 static std::string
@@ -119,7 +120,7 @@ TimelineView::TimelineView(DataProvider&                          dp,
 , m_sort_mode(TrackSortMode::kDefault)
 , m_topology_sort_pending(false)
 {
-    m_track_options_context_menu->SetSortMenuRenderer(
+    m_track_options_context_menu->SetTrackSortSubmenu(
         [this]() { RenderTrackSortMenu(); });
 
     // Subscribe to events
@@ -2510,9 +2511,6 @@ TimelineView::LoadSortSettings()
 void
 TimelineView::RenderTrackSortMenu()
 {
-    // Flat layout: a titled separator header with the options directly beneath it.
-    // A submenu would be pointless here since sorting is the only action.
-    ImGui::SeparatorText("Sort tracks by");
     // Record only; Update() applies the sort off the render pass.
     if(IconMenuItem(ICON_TREE, "Topology", true,
                     m_sort_mode == TrackSortMode::kTopology))
@@ -2696,38 +2694,48 @@ TimelineView::RenderTrackInfo(float available_width)
                           m_settings.GetColor(Colors::kButtonActive));
     ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 0.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0.0f, 0.0f));
-    ImGui::PushFont(fonts.GetFont(FontType::kIcon), fonts.GetFontSize(FontSize::kSmall));
+    ImGui::PushFont(fonts.GetFont(FontType::kIcon), fonts.GetFontSize(FontSize::kXSmall));
     const float arrow_h = ImGui::GetTextLineHeight();
     ImGui::SetCursorPos(ImVec2(0.0f, ImGui::GetWindowHeight() - arrow_h));
     // Open the sort menu from the button itself (left- or right-click), rather than
     // a right-click anywhere on the stats block.
+    ImGui::PushStyleColor(ImGuiCol_Text, m_settings.GetColor(Colors::kTextDim));
     if(ImGui::Button(sort_label.c_str(), ImVec2(available_width, arrow_h)) ||
        ImGui::IsItemClicked(ImGuiMouseButton_Right))
     {
-        ImGui::OpenPopup("##track_sort_ctx");
+        ImGui::OpenPopup(SORT_TRACKS_MENU_POPUP_NAME);
     }
+    ImGui::PopStyleColor();
     ImGui::PopFont();
     ImGui::PopStyleVar(2);
     ImGui::PopStyleColor(3);
     if(BeginItemTooltipStyled())
     {
-        ImGui::TextUnformatted("Sort tracks");
+        ImGui::TextUnformatted("Sort Tracks");
         EndTooltipStyled();
     }
 
     // Sort menu opened from the button above. Pull spacing from the base style; the
     // histogram strip's child has zero padding, which would otherwise leave the
     // popup cramped.
-    const ImGuiStyle& base = m_settings.GetDefaultStyle();
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, base.WindowPadding);
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, base.ItemSpacing);
-    ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, base.FramePadding);
-    if(ImGui::BeginPopup("##track_sort_ctx"))
+    if(ImGui::IsPopupOpen(SORT_TRACKS_MENU_POPUP_NAME))
     {
-        RenderTrackSortMenu();
-        ImGui::EndPopup();
+        const ImGuiStyle& base = m_settings.GetDefaultStyle();
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, base.WindowPadding);
+        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, base.ItemSpacing);
+        ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, base.FramePadding);
+        ImGui::SetNextWindowPos(
+            ImGui::GetItemRectMin() +
+                ImVec2(0.5f * ImGui::GetItemRectSize().x, ImGui::GetItemRectSize().y),
+            ImGuiCond_Always, ImVec2(0.5f, 0.0f));
+        if(ImGui::BeginPopup(SORT_TRACKS_MENU_POPUP_NAME))
+        {
+            ImGui::SeparatorText("Sort Tracks");
+            RenderTrackSortMenu();
+            ImGui::EndPopup();
+        }
+        ImGui::PopStyleVar(3);
     }
-    ImGui::PopStyleVar(3);
 }
 
 void

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1199,6 +1199,14 @@ TimelineView::Update()
 {
     if(m_meta_map_made)
     {
+        // Apply the menu-requested sort off the render pass. Consumed even on
+        // failure so a rejected order can't retry every frame.
+        if(m_pending_sort_mode)
+        {
+            SortTracksBy(*m_pending_sort_mode);
+            m_pending_sort_mode.reset();
+        }
+
         // A topology sort requested before the sidebar tree was ready (e.g. right
         // after load) is applied here once the order becomes available.
         if(m_topology_sort_pending && m_sort_mode == TrackSortMode::kTopology &&
@@ -2502,21 +2510,22 @@ TimelineView::RenderTrackSortMenu()
     // Flat layout: a titled separator header with the options directly beneath it.
     // A submenu would be pointless here since sorting is the only action.
     ImGui::SeparatorText("Sort tracks by");
+    // Record only; Update() applies the sort off the render pass.
     if(IconMenuItem(ICON_TREE, "Topology", true,
                     m_sort_mode == TrackSortMode::kTopology))
     {
-        SortTracksBy(TrackSortMode::kTopology);
+        m_pending_sort_mode = TrackSortMode::kTopology;
     }
     if(IconMenuItem(ICON_LIST, "Default (Track type)", true,
                     m_sort_mode == TrackSortMode::kDefault))
     {
-        SortTracksBy(TrackSortMode::kDefault);
+        m_pending_sort_mode = TrackSortMode::kDefault;
     }
     // Custom is only selectable once a manual ordering has been established.
     if(IconMenuItem(ICON_EDIT, "Custom", HasCustomOrder(),
                     m_sort_mode == TrackSortMode::kCustom))
     {
-        SortTracksBy(TrackSortMode::kCustom);
+        m_pending_sort_mode = TrackSortMode::kCustom;
     }
 }
 

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -2398,6 +2398,8 @@ TimelineView::ApplyTrackOrder(const std::vector<uint64_t>& order)
     return true;
 }
 
+// Replaces m_tracks; only call from Update(), never mid-render, since the render
+// loops iterate this list.
 void
 TimelineView::RebuildTrackVectorFromMetadata()
 {

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1214,9 +1214,11 @@ TimelineView::Update()
                 int idx = std::clamp(m_reorder_request.new_index, 0,
                                      static_cast<int>(order.size()));
                 order.insert(order.begin() + idx, m_reorder_request.track_id);
-                ApplyTrackOrder(order);
-                m_sort_mode    = TrackSortMode::kCustom;
-                m_custom_order = order;
+                if(ApplyTrackOrder(order))
+                {
+                    m_sort_mode    = TrackSortMode::kCustom;
+                    m_custom_order = order;
+                }
             }
         }
         // Rebuild the positioning map.
@@ -2264,7 +2266,6 @@ TimelineView::MakeGraphView()
     // selection (custom/topology/default) is restored afterwards in
     // LoadSortSettings() as a view-only reorder.
     std::vector<const TrackInfo*> track_list = tlm.GetTrackList();
-    std::vector<uint64_t>         hidden_tracks;
 
     for(int i = 0; i < track_list.size(); i++)
     {
@@ -2341,14 +2342,16 @@ TimelineView::SetTopologyOrder(const std::vector<uint64_t>* order)
 void
 TimelineView::SortTracksBy(TrackSortMode mode)
 {
-    m_sort_mode = mode;
     switch(mode)
     {
         case TrackSortMode::kTopology:
         {
             if(m_topology_order && !m_topology_order->empty())
             {
-                ApplyTrackOrder(*m_topology_order);
+                if(!ApplyTrackOrder(*m_topology_order))
+                {
+                    return;
+                }
                 m_topology_sort_pending = false;
             }
             else
@@ -2359,38 +2362,40 @@ TimelineView::SortTracksBy(TrackSortMode mode)
             break;
         }
         case TrackSortMode::kDefault:
-            if(!m_default_order.empty())
+            if(!m_default_order.empty() && !ApplyTrackOrder(m_default_order))
             {
-                ApplyTrackOrder(m_default_order);
+                return;
             }
             break;
         case TrackSortMode::kCustom:
-            if(!m_custom_order.empty())
+            if(!m_custom_order.empty() && !ApplyTrackOrder(m_custom_order))
             {
-                ApplyTrackOrder(m_custom_order);
+                return;
             }
             break;
     }
+    m_sort_mode = mode;
 }
 
-void
+bool
 TimelineView::ApplyTrackOrder(const std::vector<uint64_t>& order)
 {
     if(!m_tracks)
     {
-        return;
+        return false;
     }
 
     // Callers pass a full permutation, so this is a straight reindex;
     // SetTrackIndex guards against a malformed order.
     if(!m_data_provider.SetTrackIndex(order))
     {
-        return;
+        return false;
     }
 
     RebuildTrackVectorFromMetadata();
     // Force the position map / layout to recompute on the next Update().
     m_resize_activity = true;
+    return true;
 }
 
 void

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -89,15 +89,6 @@ class TimelineView : public RocWidget
     friend TimelineViewProjectSettings;
 
 public:
-    // How the timeline track order is derived. Persisted as an int, so keep the
-    // explicit values stable.
-    enum class TrackSortMode
-    {
-        kTopology = 0,  // Match the sidebar topology tree order.
-        kDefault  = 1,  // Natural load order captured when the trace opened.
-        kCustom   = 2,  // The user's manual (drag-reordered) order; one remembered slot.
-    };
-
     TimelineView(DataProvider& dp, std::shared_ptr<TimelineSelection> timeline_selection,
                  std::shared_ptr<MeasurementController> measurement,
                  std::shared_ptr<AnnotationsManager>   annotations);
@@ -143,17 +134,27 @@ public:
     void           RenderTimelineViewOptionsMenu(ImVec2 window_position);
     TimelineArrow& GetArrowLayer();
 
+    // Points at the sidebar-tree (topology) order owned by TrackTopology. Wired by
+    // the owning TraceView; the pointee stays valid for the view's lifetime.
+    void          SetTopologyOrder(const std::vector<uint64_t>* order);
+
+private:
+    // How the timeline track order is derived. Persisted as an int, so keep the
+    // explicit values stable.
+    enum class TrackSortMode
+    {
+        kTopology = 0,  // Match the sidebar topology tree order.
+        kDefault  = 1,  // Natural load order captured when the trace opened.
+        kCustom   = 2,  // The user's manual (drag-reordered) order; one remembered slot.
+    };
+
     // Reorder the tracks according to the given sort mode. If topology order isn't
     // available yet (the tree is still building at load), the sort is deferred and
     // applied once SetTopologyOrder() provides it.
     void          SortTracksBy(TrackSortMode mode);
     TrackSortMode GetSortMode() const { return m_sort_mode; }
     bool          HasCustomOrder() const { return !m_custom_order.empty(); }
-    // Points at the sidebar-tree (topology) order owned by TrackTopology. Wired by
-    // the owning TraceView; the pointee stays valid for the view's lifetime.
-    void          SetTopologyOrder(const std::vector<uint64_t>* order);
 
-private:
     // Reindexes each TrackInfo and rebuilds m_tracks to match order, which must be
     // a full permutation of the current track ids. View-only: never syncs the
     // controller graph order.

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -16,6 +16,7 @@
 #include "widgets/rocprofvis_widget.h"
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -318,6 +319,8 @@ private:
     std::vector<uint64_t>        m_custom_order;
     bool                         m_topology_sort_pending;
     const std::vector<uint64_t>* m_topology_order = nullptr;
+    // Menu-requested sort, applied in Update() (not mid-render). Empty if none.
+    std::optional<TrackSortMode> m_pending_sort_mode;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -152,13 +152,13 @@ private:
     // available yet (the tree is still building at load), the sort is deferred and
     // applied once SetTopologyOrder() provides it.
     void          SortTracksBy(TrackSortMode mode);
-    TrackSortMode GetSortMode() const { return m_sort_mode; }
     bool          HasCustomOrder() const { return !m_custom_order.empty(); }
 
     // Reindexes each TrackInfo and rebuilds m_tracks to match order, which must be
     // a full permutation of the current track ids. View-only: never syncs the
-    // controller graph order.
-    void ApplyTrackOrder(const std::vector<uint64_t>& order);
+    // controller graph order. Returns false (and leaves state untouched) if the
+    // order is rejected downstream.
+    bool ApplyTrackOrder(const std::vector<uint64_t>& order);
     // Rebuilds the m_tracks pointer vector from the current TrackInfo::index values.
     void RebuildTrackVectorFromMetadata();
     // Restores the persisted sort selection (and remembered custom order) after a

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 #include <chrono>
-#include <functional>
  
 namespace RocProfVis
 {
@@ -71,16 +70,14 @@ public:
                                 TimelineView&      timeline_view);
     ~TimelineViewProjectSettings() override;
     void ToJson() override;
+    // True when the persisted "order" list is a valid full permutation of the
+    // current tracks (the remembered custom order).
     bool Valid() const override;
 
-    uint64_t TrackID(int index) const;
-
-    // Sort-selection persistence. HasSortSettings() reports whether the newer
-    // sort_mode key exists; older projects only stored an explicit "order" array
-    // (see Valid()/TrackID()) which is treated as the custom order on load.
+    // The stored sort mode, if present; older projects only stored the "order"
+    // list, which is treated as the custom order on load.
     bool                  HasSortSettings() const;
     int                   SortMode() const;
-    bool                  CustomOrderValid() const;
     std::vector<uint64_t> CustomOrder() const;
 
 private:
@@ -146,16 +143,15 @@ public:
     void           RenderTimelineViewOptionsMenu(ImVec2 window_position);
     TimelineArrow& GetArrowLayer();
 
-    // Reorder the tracks according to the given sort mode. Topology order is
-    // resolved lazily through the provider set by SetTopologyOrderProvider(); if
-    // it is not available yet (e.g. the topology tree is still building at load),
-    // the sort is deferred and applied once the provider yields an order.
+    // Reorder the tracks according to the given sort mode. If topology order isn't
+    // available yet (the tree is still building at load), the sort is deferred and
+    // applied once SetTopologyOrder() provides it.
     void          SortTracksBy(TrackSortMode mode);
     TrackSortMode GetSortMode() const { return m_sort_mode; }
     bool          HasCustomOrder() const { return !m_custom_order.empty(); }
-    // Supplies the sidebar-tree (topology) order. Wired by the owning TraceView,
-    // which owns the TrackTopology that builds the tree.
-    void          SetTopologyOrderProvider(std::function<std::vector<uint64_t>()> provider);
+    // Points at the sidebar-tree (topology) order owned by TrackTopology. Wired by
+    // the owning TraceView; the pointee stays valid for the view's lifetime.
+    void          SetTopologyOrder(const std::vector<uint64_t>* order);
 
 private:
     // Reindexes each TrackInfo and rebuilds m_tracks to match order, which must be
@@ -313,14 +309,14 @@ private:
     TrackTypeCounts             m_track_counts;
 
     // Track sort state. m_default_order is captured once when the trace loads;
-    // m_custom_order is the single remembered manual ordering. Topology order is
-    // fetched on demand from m_topology_order_provider; m_topology_sort_pending is
-    // set when a topology sort is requested before that provider can satisfy it.
-    TrackSortMode                          m_sort_mode;
-    std::vector<uint64_t>                  m_default_order;
-    std::vector<uint64_t>                  m_custom_order;
-    bool                                   m_topology_sort_pending;
-    std::function<std::vector<uint64_t>()> m_topology_order_provider;
+    // m_custom_order is the single remembered manual ordering. m_topology_order
+    // points at TrackTopology's cached order; m_topology_sort_pending is set when a
+    // topology sort is requested before that order is available.
+    TrackSortMode                m_sort_mode;
+    std::vector<uint64_t>        m_default_order;
+    std::vector<uint64_t>        m_custom_order;
+    bool                         m_topology_sort_pending;
+    const std::vector<uint64_t>* m_topology_order = nullptr;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 #include <chrono>
+#include <functional>
  
 namespace RocProfVis
 {
@@ -74,6 +75,14 @@ public:
 
     uint64_t TrackID(int index) const;
 
+    // Sort-selection persistence. HasSortSettings() reports whether the newer
+    // sort_mode key exists; older projects only stored an explicit "order" array
+    // (see Valid()/TrackID()) which is treated as the custom order on load.
+    bool                  HasSortSettings() const;
+    int                   SortMode() const;
+    bool                  CustomOrderValid() const;
+    std::vector<uint64_t> CustomOrder() const;
+
 private:
     TimelineView& m_timeline_view;
 };
@@ -83,6 +92,15 @@ class TimelineView : public RocWidget
     friend TimelineViewProjectSettings;
 
 public:
+    // How the timeline track order is derived. Persisted as an int, so keep the
+    // explicit values stable.
+    enum class TrackSortMode
+    {
+        kTopology = 0,  // Match the sidebar topology tree order.
+        kDefault  = 1,  // Natural load order captured when the trace opened.
+        kCustom   = 2,  // The user's manual (drag-reordered) order; one remembered slot.
+    };
+
     TimelineView(DataProvider& dp, std::shared_ptr<TimelineSelection> timeline_selection,
                  std::shared_ptr<MeasurementController> measurement,
                  std::shared_ptr<AnnotationsManager>   annotations);
@@ -128,7 +146,29 @@ public:
     void           RenderTimelineViewOptionsMenu(ImVec2 window_position);
     TimelineArrow& GetArrowLayer();
 
+    // Reorder the tracks according to the given sort mode. Topology order is
+    // resolved lazily through the provider set by SetTopologyOrderProvider(); if
+    // it is not available yet (e.g. the topology tree is still building at load),
+    // the sort is deferred and applied once the provider yields an order.
+    void          SortTracksBy(TrackSortMode mode);
+    TrackSortMode GetSortMode() const { return m_sort_mode; }
+    bool          HasCustomOrder() const { return !m_custom_order.empty(); }
+    // Supplies the sidebar-tree (topology) order. Wired by the owning TraceView,
+    // which owns the TrackTopology that builds the tree.
+    void          SetTopologyOrderProvider(std::function<std::vector<uint64_t>()> provider);
+
 private:
+    // Reindexes each TrackInfo and rebuilds m_tracks to match order, which must be
+    // a full permutation of the current track ids. View-only: never syncs the
+    // controller graph order.
+    void ApplyTrackOrder(const std::vector<uint64_t>& order);
+    // Rebuilds the m_tracks pointer vector from the current TrackInfo::index values.
+    void RebuildTrackVectorFromMetadata();
+    // Restores the persisted sort selection (and remembered custom order) after a
+    // trace loads.
+    void LoadSortSettings();
+    // Renders the "Sort tracks by" options inside an open popup.
+    void RenderTrackSortMenu();
     enum class MeasurementRulerDragTarget
     {
         kNone,
@@ -271,6 +311,16 @@ private:
     TimelineViewProjectSettings m_project_settings;
     LoadingTimer                m_loading_timer;
     TrackTypeCounts             m_track_counts;
+
+    // Track sort state. m_default_order is captured once when the trace loads;
+    // m_custom_order is the single remembered manual ordering. Topology order is
+    // fetched on demand from m_topology_order_provider; m_topology_sort_pending is
+    // set when a topology sort is requested before that provider can satisfy it.
+    TrackSortMode                          m_sort_mode;
+    std::vector<uint64_t>                  m_default_order;
+    std::vector<uint64_t>                  m_custom_order;
+    bool                                   m_topology_sort_pending;
+    std::function<std::vector<uint64_t>()> m_topology_order_provider;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -106,7 +106,8 @@ public:
     void MoveToPosition(double start_ns, double end_ns, double y_position, bool center);
     void ZoomToTimeRangeSelection();
     void RenderGraphPoints();
-    void RenderHistogram();
+    void RenderHeader();
+    void RenderHistogram(float total_height);
     void RenderTraceView();
 
     void           RenderGrid();
@@ -214,6 +215,7 @@ private:
 
     void CalculateTrackCounts();
     void BuildTrackCountLabels();
+    void RenderTrackInfo(float available_width);
     void RenderTrackStats(float available_width);
 
     void UpdateMaxMetaAreaSize(bool update_tracks = false);

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -285,6 +285,11 @@ TraceView::CreateView()
     m_timeline_view         = std::make_shared<TimelineView>(m_data_provider,
                                                              m_timeline_selection,
                                                              m_measurement, m_annotations);
+    m_timeline_view->SetTopologyOrderProvider(
+        [this]() -> std::vector<uint64_t> {
+            return m_track_topology ? m_track_topology->GetTrackIdsInTreeOrder()
+                                    : std::vector<uint64_t>{};
+        });
     m_summary_view = std::make_shared<SummaryView>(m_data_provider, m_timeline_selection);
     m_event_search = std::make_shared<EventSearch>(m_data_provider, m_timeline_selection);
     m_minimap               = std::make_shared<Minimap>(m_data_provider, m_timeline_view.get());

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -285,11 +285,7 @@ TraceView::CreateView()
     m_timeline_view         = std::make_shared<TimelineView>(m_data_provider,
                                                              m_timeline_selection,
                                                              m_measurement, m_annotations);
-    m_timeline_view->SetTopologyOrderProvider(
-        [this]() -> std::vector<uint64_t> {
-            return m_track_topology ? m_track_topology->GetTrackIdsInTreeOrder()
-                                    : std::vector<uint64_t>{};
-        });
+    m_timeline_view->SetTopologyOrder(&m_track_topology->GetTrackIdsInTreeOrder());
     m_summary_view = std::make_shared<SummaryView>(m_data_provider, m_timeline_selection);
     m_event_search = std::make_shared<EventSearch>(m_data_provider, m_timeline_selection);
     m_minimap               = std::make_shared<Minimap>(m_data_provider, m_timeline_view.get());

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -290,7 +290,7 @@ TraceView::CreateView()
     m_event_search = std::make_shared<EventSearch>(m_data_provider, m_timeline_selection);
     m_minimap               = std::make_shared<Minimap>(m_data_provider, m_timeline_view.get());
     auto m_histogram_widget = std::make_shared<RocCustomWidget>(
-        [this]() { m_timeline_view->RenderHistogram(); });
+        [this]() { m_timeline_view->RenderHeader(); });
 
     auto sidebar =
         std::make_shared<SideBar>(m_track_topology, m_timeline_selection,

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -558,6 +558,15 @@ TrackItem::RenderMetaArea()
             m_timeline_track_options.RenderContextMenu();
             ImGui::EndMenu();
         }
+        // Also expose sorting here so it stays reachable when the header is hidden.
+        if(m_timeline_track_options.HasSortMenu())
+        {
+            if(IconBeginMenu(ICON_LIST, "Sort tracks"))
+            {
+                m_timeline_track_options.RenderSortMenu();
+                ImGui::EndMenu();
+            }
+        }
         // Restore hidden tracks without needing the topology side bar. The entry
         // is only shown when something is actually hidden.
         if(m_timeline_track_options.HasHiddenTracks())

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -525,7 +525,7 @@ TrackItem::RenderMetaArea()
 
     if(meta_area_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
     {
-        m_timeline_track_options.InitContextMenu(*this);
+        m_timeline_track_options.InitTrackOptionsSubmenu(*this);
         ImGui::OpenPopup(TRACK_COPY_MENU_POPUP_NAME);
     }
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, style.WindowPadding);
@@ -555,21 +555,22 @@ TrackItem::RenderMetaArea()
         ImGui::Separator();
         if(IconBeginMenu(ICON_GEAR, "Track Options"))
         {
-            m_timeline_track_options.RenderContextMenu();
+            m_timeline_track_options.RenderTrackOptionsSubmenu();
             ImGui::EndMenu();
         }
+        ImGui::Separator();
         // Also expose sorting here so it stays reachable when the header is hidden.
-        if(m_timeline_track_options.HasSortMenu())
+        if(m_timeline_track_options.ShowTrackSortSubmenu())
         {
-            if(IconBeginMenu(ICON_LIST, "Sort tracks"))
+            if(IconBeginMenu(ICON_LIST, "Sort Tracks"))
             {
-                m_timeline_track_options.RenderSortMenu();
+                m_timeline_track_options.RenderTrackSortSubmenu();
                 ImGui::EndMenu();
             }
         }
         // Restore hidden tracks without needing the topology side bar. The entry
         // is only shown when something is actually hidden.
-        if(m_timeline_track_options.HasHiddenTracks())
+        if(m_timeline_track_options.ShowHiddenTracksSubmenu())
         {
             if(IconBeginMenu(ICON_EYE, "Show Hidden Tracks"))
             {

--- a/src/view/src/rocprofvis_track_topology.cpp
+++ b/src/view/src/rocprofvis_track_topology.cpp
@@ -7,6 +7,8 @@
 #include "rocprofvis_utils.h"
 #include "rocprofvis_settings_manager.h"
 
+#include <unordered_set>
+
 namespace RocProfVis
 {
 namespace View
@@ -146,6 +148,30 @@ BuildProcessTree(TreeNode* parent, const ProcessModel& process,
                   process.sampled_threads, track_list);
 }
 
+// Flattens leaf track ids in tree order, deduping repeats (a track can appear more
+// than once, e.g. a device's queues under both the processor list and a stream).
+void
+CollectLeafTrackIds(const TreeNode* node, std::vector<uint64_t>& out,
+                    std::unordered_set<uint64_t>& seen)
+{
+    if(!node)
+    {
+        return;
+    }
+    if(node->IsLeaf())
+    {
+        const uint64_t track_id = static_cast<const LeafNode*>(node)->track_id;
+        if(seen.insert(track_id).second)
+        {
+            out.push_back(track_id);
+        }
+    }
+    for(const auto& child : node->children)
+    {
+        CollectLeafTrackIds(child.get(), out, seen);
+    }
+}
+
 }  // namespace
 
 TrackTopology::TrackTopology(DataProvider& dp)
@@ -211,6 +237,12 @@ const SidebarTree&
 TrackTopology::GetSidebarTree() const
 {
     return m_sidebar_tree;
+}
+
+const std::vector<uint64_t>&
+TrackTopology::GetTrackIdsInTreeOrder() const
+{
+    return m_track_order;
 }
 
 void
@@ -823,6 +855,12 @@ TrackTopology::BuildSidebarTree()
     }
 
     m_sidebar_tree.root = std::move(root);
+
+    // Cache the flattened, deduped leaf order so "Sort by topology" is an O(1)
+    // lookup of a clean permutation rather than a fresh tree walk each time.
+    m_track_order.clear();
+    std::unordered_set<uint64_t> seen;
+    CollectLeafTrackIds(m_sidebar_tree.root.get(), m_track_order, seen);
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_track_topology.h
+++ b/src/view/src/rocprofvis_track_topology.h
@@ -106,6 +106,7 @@ public:
     bool                 Dirty();
     const TopologyModel& GetTopology() const;
     const SidebarTree&   GetSidebarTree() const;
+    const std::vector<uint64_t>& GetTrackIdsInTreeOrder() const;
     void FormatCells();
 
 private:
@@ -133,8 +134,9 @@ private:
     EventManager::SubscriptionToken m_metadata_changed_event_token;
     EventManager::SubscriptionToken m_format_changed_token;
 
-    TopologyModel m_topology;
-    SidebarTree   m_sidebar_tree;
+    TopologyModel         m_topology;
+    SidebarTree           m_sidebar_tree;
+    std::vector<uint64_t> m_track_order;
 };
 
 }  // namespace View

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -851,13 +851,13 @@ DrawMenuItemIcon(ImDrawList* draw_list, const char* icon, const ImVec2& row_star
 }
 
 bool
-IconMenuItem(const char* icon, const char* label, bool enabled)
+IconMenuItem(const char* icon, const char* label, bool enabled, bool selected)
 {
     ImDrawList*  draw_list    = ImGui::GetWindowDrawList();
     const ImVec2 row_start    = ImGui::GetCursorScreenPos();
     std::string  padded_label = MenuLabelWithIconPadding(label);
 
-    bool clicked = ImGui::MenuItem(padded_label.c_str(), nullptr, false, enabled);
+    bool clicked = ImGui::MenuItem(padded_label.c_str(), nullptr, selected, enabled);
     DrawMenuItemIcon(draw_list, icon, row_start, enabled);
 
     if(clicked)

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -219,8 +219,10 @@ CopyableTextUnformatted(
 
 // Renders a selectable menu item with an icon (from the icon font) followed by a text label.
 // Returns true when clicked. Intended for use inside BeginPopup/BeginPopupContextItem blocks.
+// Pass selected = true to show a trailing check mark (e.g. radio-style option groups).
 bool
-IconMenuItem(const char* icon, const char* label, bool enabled = true);
+IconMenuItem(const char* icon, const char* label, bool enabled = true,
+             bool selected = false);
 
 // Opens a submenu entry with a leading icon (from the icon font) before the label.
 // Returns true when the submenu is open; call ImGui::EndMenu() only when it returns true.


### PR DESCRIPTION
## Motivation

Give users a quick way to organize timeline tracks instead of only manual
drag-reorder. Also decouples reordering from the controller — its graph order
is presentation-only (fetch is keyed by track id), so the round-trip was
unnecessary.

## Technical Details

- Right-click the track-list header → *Sort tracks by*: **Topology** (sidebar
  order), **Default** (load order), **Custom** (remembered manual order; drag
  auto-switches to it).
- Reordering is now view-only: updates `TrackInfo::index` + fires
  `kTrackMetadataChanged`; removed the controller `SetGraphIndex` sync.
- Topology order cached/deduped in `TrackTopology` (computed once per tree build).
- Persists `sort_mode` + `custom_order` per project (validated before applying).
- Menu matches the other context menus (`IconMenuItem` + base-style padding).