### PR TITLE
[ROCM-29151] - [Optiq-Compute]: Kernel Selection Table: app crashes when a column filter is applied without a comparison operator

### DIFF
--- a/src/model/src/database/rocprofvis_db_compute.cpp
+++ b/src/model/src/database/rocprofvis_db_compute.cpp
@@ -1562,15 +1562,21 @@ void ComputeQueryFactory::ParseMetricParam(std::string metric_str, uint32_t work
 		if (plan.contains("filters"))
 		{
 			auto& obj = plan["filters"].getObject();
-
-			for (auto& s : obj)
+			try
 			{
-				size_t column_index = std::atoll(s.first.c_str());
-				columns[column_index].filter = FilterExpression::Parse(columns[column_index].name + " " + s.second.getString());
-				columns[column_index].has_filter = true;
+				for (auto& s : obj)
+				{
+					size_t column_index = std::atoll(s.first.c_str());
+					columns[column_index].filter = FilterExpression::Parse(columns[column_index].name + " " + s.second.getString());
+					columns[column_index].has_filter = true;
+				}
+			}
+			catch (const std::exception& e)
+			{
+				spdlog::error("Error: {} ", e.what());
+				return kRocProfVisDmResultInvalidParameter;
 			}
 		}
-			
 
 		if (plan.contains("metric_selectors"))
 		{
@@ -1638,16 +1644,25 @@ void ComputeQueryFactory::ParseMetricParam(std::string metric_str, uint32_t work
 				columns[column_index++].eval_value = value;
 			}
 			bool passed_evaluation = true;
-			for (auto column : columns)
-			{
-				if (column.has_filter)
+			try
+            {
+				
+				for (auto column : columns)
 				{
-					if (!column.filter.Evaluate({ {column.name, column.eval_value} }))
+					if (column.has_filter)
 					{
-						passed_evaluation = false;
-						break;
+						if (!column.filter.Evaluate({ {column.name, column.eval_value} }))
+						{
+							passed_evaluation = false;
+							break;
+						}
 					}
-				}
+				}			
+			}
+			catch (const std::exception& e)
+			{
+				spdlog::error("Error: {} ", e.what());
+				return kRocProfVisDmResultInvalidParameter;
 			}
 			if (passed_evaluation)
 			{

--- a/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
+++ b/src/view/src/compute/rocprofvis_compute_kernel_metric_table.cpp
@@ -1008,9 +1008,9 @@ KernelMetricTable::ValidateFilterExpression(const char* expr, bool is_numeric_co
 
     if(is_numeric_column)
     {
-        // Must be: operator + number, or just number
+        // Must be: operator + number
         // Check for operators followed by numbers
-        static const std::vector<std::string> ops = {">=", "<=", "!=", "<>", ">", "<", "="};
+        static const std::vector<std::string> ops = {">=", "<=", "!=", ">", "<", "="};
         for(const auto& op : ops)
         {
             if(trimmed.find(op) == 0)
@@ -1020,15 +1020,14 @@ KernelMetricTable::ValidateFilterExpression(const char* expr, bool is_numeric_co
                 value.erase(0, value.find_first_not_of(" \t\n\r"));
                 value.erase(value.find_last_not_of(" \t\n\r") + 1);
                 // Check if value is numeric
-                if(!value.empty() && (std::isdigit(value[0]) || value[0] == '-' || value[0] == '.'))
+                if(!value.empty() && (std::isdigit(value[0]) || value[0] == '.'))
                 {
                     return true;
                 }
                 return false;
             }
         }
-        // If no operator, check if it's just a number
-        return !trimmed.empty() && (std::isdigit(trimmed[0]) || trimmed[0] == '-' || trimmed[0] == '.');
+        return false;
     }
     else
     {


### PR DESCRIPTION
-Minimal changes to fix crashing pivot table.