### PR TITLE
View: Add "Z" hotkey to zoom to the current selection

### DIFF
--- a/src/view/src/rocprofvis_hotkey_manager.cpp
+++ b/src/view/src/rocprofvis_hotkey_manager.cpp
@@ -18,6 +18,7 @@ static const HotkeyActionInfo kActionTable[kHotkeyActionCount] = {
     {"Scroll Down",       "Timeline",  "scroll_down",        {ImGuiKey_DownArrow, ImGuiKey_None},       ActionType::kPress, true,  false},
     {"Clear Selection",   "Timeline",  "clear_selection",    {ImGuiKey_Escape,    ImGuiKey_None},       ActionType::kPress, true,  false},
     {"Toggle Mark",       "Timeline",  "toggle_mark",        {ImGuiKey_M,         ImGuiKey_None},       ActionType::kPress, true,  false},
+    {"Zoom to Selection", "Timeline",  "zoom_to_selection",  {ImGuiKey_Z,         ImGuiKey_None},       ActionType::kPress, false, false},
 
     {"Save Bookmark 0",  "Bookmarks", "bookmark_save_0",    {ImGuiKey_0 | ImGuiMod_Ctrl, ImGuiKey_None}, ActionType::kPress, false, false},
     {"Save Bookmark 1",  "Bookmarks", "bookmark_save_1",    {ImGuiKey_1 | ImGuiMod_Ctrl, ImGuiKey_None}, ActionType::kPress, false, false},

--- a/src/view/src/rocprofvis_hotkey_manager.h
+++ b/src/view/src/rocprofvis_hotkey_manager.h
@@ -23,6 +23,7 @@ enum class HotkeyActionId
     kScrollDown,
     kClearSelection,
     kToggleMark,
+    kZoomToSelection,
     kBookmarkSave0,
     kBookmarkSave1,
     kBookmarkSave2,

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -97,6 +97,7 @@ public:
     void ScrollToTrack(const uint64_t& track_id);
     void SetViewableRangeNS(double start_ns, double end_ns);
     void MoveToPosition(double start_ns, double end_ns, double y_position, bool center);
+    void ZoomToTimeRangeSelection();
     void RenderGraphPoints();
     void RenderHistogram();
     void RenderTraceView();
@@ -198,7 +199,6 @@ private:
     void                            CopySelectedEventDetails();
     void                            ZoomToTimeSpan(double start_ns, double end_ns);
     void                            ZoomToMeasurement();
-    void                            ZoomToTimeRangeSelection();
 
     TrackLayout                     BuildTrackLayout();
     EventManager::SubscriptionToken m_scroll_to_track_token;

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -466,33 +466,9 @@ TraceView::HandleHotKeys()
 
     if(hk.WasActionTriggered(HotkeyActionId::kZoomToSelection))
     {
-        if(m_timeline_view && m_timeline_selection)
+        if(m_timeline_view)
         {
-            double start_ns  = 0.0;
-            double end_ns    = 0.0;
-            bool   has_range = false;
-
-            if(m_timeline_selection->HasValidTimeRangeSelection())
-            {
-                has_range =
-                    m_timeline_selection->GetSelectedTimeRange(start_ns, end_ns);
-            }
-            else if(m_timeline_selection->HasSelectedEvents())
-            {
-                has_range =
-                    m_timeline_selection->GetSelectedEventsTimeRange(start_ns, end_ns);
-            }
-
-            if(has_range && end_ns > start_ns)
-            {
-                m_timeline_view->MoveToPosition(
-                    start_ns, end_ns, m_timeline_view->GetViewCoords().y, false);
-            }
-            else
-            {
-                NotificationManager::GetInstance().Show(
-                    "No selection to zoom to.", NotificationLevel::Warning);
-            }
+            m_timeline_view->ZoomToTimeRangeSelection();
         }
     }
 }

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -463,6 +463,38 @@ TraceView::HandleHotKeys()
             }
         }
     }
+
+    if(hk.WasActionTriggered(HotkeyActionId::kZoomToSelection))
+    {
+        if(m_timeline_view && m_timeline_selection)
+        {
+            double start_ns  = 0.0;
+            double end_ns    = 0.0;
+            bool   has_range = false;
+
+            if(m_timeline_selection->HasValidTimeRangeSelection())
+            {
+                has_range =
+                    m_timeline_selection->GetSelectedTimeRange(start_ns, end_ns);
+            }
+            else if(m_timeline_selection->HasSelectedEvents())
+            {
+                has_range =
+                    m_timeline_selection->GetSelectedEventsTimeRange(start_ns, end_ns);
+            }
+
+            if(has_range && end_ns > start_ns)
+            {
+                m_timeline_view->MoveToPosition(
+                    start_ns, end_ns, m_timeline_view->GetViewCoords().y, false);
+            }
+            else
+            {
+                NotificationManager::GetInstance().Show(
+                    "No selection to zoom to.", NotificationLevel::Warning);
+            }
+        }
+    }
 }
 
 bool


### PR DESCRIPTION
## Motivation

Add a keyboard shortcut to zoom the timeline to the current selection, so users
can do it without reaching for the mouse.

## Technical Details

- New rebindable **"Zoom to Selection"** hotkey (default: `Z`) in `HotkeyManager`;
  auto-listed and persisted via Settings > Hotkeys.
- `TraceView::HandleHotKeys()` fits the view to the region/time-range selection
  (falls back to selected events), preserving vertical scroll; warns if nothing
  is selected.