### PR TITLE
Fixed crash when counter pmc_id is 0

### DIFF
--- a/src/model/src/database/rocprofvis_db_rocprof.cpp
+++ b/src/model/src/database/rocprofvis_db_rocprof.cpp
@@ -172,8 +172,7 @@ int RocprofDatabase::ProcessTrack(rocprofvis_dm_track_params_t& track_params, st
             }
             else
             {
-                if(track_params.track_indentifiers.id[TRACK_ID_QUEUE] > 0)
-                    if (CachedTables(db_instance->GuidIndex())->PopulateTrackExtendedDataTemplate(this, db_instance->GuidIndex(), "PMC", track_params.track_indentifiers.id[TRACK_ID_COUNTER]) != kRocProfVisDmResultSuccess) return 1;
+                if (CachedTables(db_instance->GuidIndex())->PopulateTrackExtendedDataTemplate(this, db_instance->GuidIndex(), "PMC", track_params.track_indentifiers.id[TRACK_ID_COUNTER]) != kRocProfVisDmResultSuccess) return 1;
             }
         }
     }


### PR DESCRIPTION
## Motivation

Jira ticket ROCM-29277
Crash when added counter with pmc_id = 0

## Technical Details

We intentionally skipped adding topology properties to track with pmc_id = 0.
Might have been cases before when pmc_id=0 was pointing to invalid data or pmc_id was null.


[ROCM-29277]: https://amd-hub.atlassian.net/browse/ROCM-29277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ