### PR TITLE
docs: refactor Optiq install guide to per-OS install-method structure

### DIFF
--- a/docs/install/optiq-install.rst
+++ b/docs/install/optiq-install.rst
@@ -1,66 +1,82 @@
 .. meta::
-  :description: Learn how to install ROCm Optiq on Windows, Linux (Ubuntu, RHEL, CentOS), and macOS, including system requirements and verification steps.
-  :keywords: ROCm Optiq, ROCm, install, profiler
+  :description: Learn how to install ROCm Optiq on Ubuntu, Debian, RHEL, Oracle Linux, Windows, and macOS, including supported versions, install methods, and verification steps.
+  :keywords: ROCm Optiq, ROCm, install, profiler, Ubuntu, Debian, RHEL, Oracle Linux, Windows, macOS
 
 ******************
 Install ROCm Optiq
 ******************
 
-Install ROCm Optiq for Windows or Linux using the installation files in the `https://github.com/ROCm/roc-optiq <https://github.com/ROCm/roc-optiq>`_  GitHub repository.
+Install ROCm Optiq using the installation files on the `ROCm Optiq GitHub Releases <https://github.com/ROCm/roc-optiq/releases>`_ page. Choose your operating system, then follow the matching install method below.
 
 .. _requirements:
 
-System requirements
-===================
+Supported operating systems
+===========================
 
-- You must be running ROCm 7.1.0 or later for ROCm Systems Profiler database file support, and ROCm 7.12.0 or later for ROCm Compute Profiler analysis database file support.
+ROCm Optiq is available for the following operating systems and versions:
 
-  .. tip::
+================  ====================
+Operating system  Supported versions
+================  ====================
+Ubuntu            24, 22
+Debian            13, 12
+RHEL              10, 9, 8
+Oracle Linux      10, 9, 8
+Windows           11
+macOS             26, 15, 14
+================  ====================
 
-   Use this command to check which ROCm version is installed on your machine:
+Each operating system supports one or more install methods:
 
-   .. code-block:: shell
-      
-      cat /opt/rocm/.info/version
+================  =====================
+Operating system  Available methods
+================  =====================
+Ubuntu            apt, Tarball
+Debian            apt, Tarball
+RHEL              dnf, Tarball
+Oracle Linux      dnf, Tarball
+Windows           Windows installer
+macOS             .zip
+================  =====================
 
-- For LDS roofline chart support, ROCm Compute Profiler analysis database schema 1.4.0 is required (ROCm 7.14.0 or later). 
-- Your system must be running one of these operating systems:
+Compare installation methods
+============================
 
-  - Microsoft Windows 11
-  - Ubuntu 22.04 / 24.04 (Debian-based) 
-  - CentOS Stream 9 
-  - macOS 14 or 15 
+Use the following descriptions to choose an installation method for your operating system.
+
+- **apt (Ubuntu / Debian)**: Uses the native ``apt`` package manager. Suits standard installations where the ROCm Optiq package is tracked, updated, and removed through normal system package workflows.
+- **dnf (RHEL / Oracle Linux)**: Uses the native ``dnf`` package manager. Suits standard installations where the ROCm Optiq package is tracked, updated, and removed through normal system package workflows.
+- **Tarball (any supported Linux distribution)**: Provides ROCm Optiq as a self-contained pre-built archive. Suits controlled or restricted environments requiring manual placement, updates, and removal outside the system package manager.
+- **Windows installer**: A guided, wizard-based setup using the ROCm Optiq installer for Windows.
+- **.zip (macOS)**: A compressed folder containing the ROCm Optiq application. No installer or package manager is required.
+
+Prerequisites
+=============
+
+Before installing ROCm Optiq, confirm the following:
+
+- **Memory**: At least 16 GB of RAM is recommended for working with large traces.
 
 .. note::
 
-   Use at least 16 GB of RAM to run large traces in ROCm Optiq.
+   ROCm Optiq only visualizes profiler database files. The machine that runs ROCm Optiq does not need ROCm, ROCm Systems Profiler, or ROCm Compute Profiler installed. The following ROCm versions apply to the profiling host that *generates* the ``.db`` file:
 
+   - ROCm 7.1.0 or later for ROCm Systems Profiler database file support.
+   - ROCm 7.12.0 or later for ROCm Compute Profiler analysis database file support.
+   - ROCm 7.14.0 or later (ROCm Compute Profiler analysis database schema 1.4.0) for LDS roofline chart support.
 
-Install on Windows
-==================
+   .. tip::
 
-1. Download the **ROCm-Optiq-Beta.exe** installer from the `ROCm Optiq GitHub repo <https://github.com/ROCm/roc-optiq/releases/tag/v0.5.0-optiq>`_ and follow the instructions in the install wizard.
-   
-   .. image:: ../images/wizard.png
-      :width: 500
-      :alt: ROCm Optiq installation wizard welcome screen on Windows
+      Use the following command to check which ROCm version is installed on the profiling host:
 
-2. Accept the agreement to install, then follow the installation instructions.
+      .. code-block:: shell
 
-   .. image:: ../images/agreement.png
-      :width: 500
-      :alt: ROCm Optiq installer license agreement screen
+         cat /opt/rocm/.info/version
 
-3. Launch **roc-optiq.exe** from the installation directory.
+Linux: identify your distribution and version
+=============================================
 
-
-Install on Linux
-================
-
-Identify the operating system
-------------------------------
-
-If you're unsure of the Linux distribution and version, the ``/etc/os-release`` and ``/usr/lib/os-release`` files contain this information.
+If you're not sure which distribution or version you're running, the ``/etc/os-release`` and ``/usr/lib/os-release`` files contain this information:
 
 .. code-block:: shell
 
@@ -71,19 +87,40 @@ If you're unsure of the Linux distribution and version, the ``/etc/os-release`` 
    VERSION_CODENAME=noble
    ID=ubuntu
 
-The relevant fields are ``ID`` and the ``VERSION_ID``.
+The relevant fields are ``ID`` and ``VERSION_ID``.
 
-Ubuntu (Debian-based)
----------------------
+Installation
+============
 
-1. Download the ``.deb`` package from the `ROCm Optiq GitHub repo <https://github.com/ROCm/roc-optiq/releases/tag/v0.5.0-optiq>`_.
-2. Install the ``.deb`` package:
+ROCm Optiq is distributed as direct package downloads from GitHub Releases. Package and file names below are examples that follow the naming convention; confirm the exact names for your release on the `ROCm Optiq GitHub Releases <https://github.com/ROCm/roc-optiq/releases>`_ page.
+
+Ubuntu / Debian -- apt
+----------------------
+
+1. Download the ``.zip`` package for your operating system and version from the `ROCm Optiq GitHub Releases <https://github.com/ROCm/roc-optiq/releases>`_ page:
+
+   ============  ========================================
+   OS / version  Example package name
+   ============  ========================================
+   Ubuntu 24     ``roc-optiq_1.0.0.0_amd64_ubuntu24.zip``
+   Ubuntu 22     ``roc-optiq_1.0.0.0_amd64_ubuntu22.zip``
+   Debian 13     ``roc-optiq_1.0.0.0_amd64_debian13.zip``
+   Debian 12     ``roc-optiq_1.0.0.0_amd64_debian12.zip``
+   ============  ========================================
+
+2. Unzip the package to extract the ``.deb`` file:
+
+   .. code-block:: shell
+
+      unzip <file>.zip
+
+3. Install the ``.deb`` package:
 
    .. code-block:: shell
 
       sudo apt install ./<file>.deb
 
-3. Verify the installation:
+4. Verify the installation:
 
    .. code-block:: shell
 
@@ -91,38 +128,158 @@ Ubuntu (Debian-based)
 
 .. tip::
 
-   Download the latest ``.deb`` from the `ROCm Optiq GitHub repo <https://github.com/ROCm/roc-optiq/releases/tag/v0.5.0-optiq>`_ to ensure ROCm Optiq is up-to-date.
+   The ``roc-optiq`` binary is installed to ``/opt/roc-optiq/bin``. To launch ROCm Optiq by name, add that directory to your ``PATH``:
 
-Check the ROCm Optiq version
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   .. code-block:: shell
 
-Use these commands to verify the ROCm Optiq version (when installed on Ubuntu):
+      export PATH=/opt/roc-optiq/bin:$PATH
+
+RHEL / Oracle Linux -- dnf
+--------------------------
+
+1. Download the ``.zip`` package for your operating system and version from the `ROCm Optiq GitHub Releases <https://github.com/ROCm/roc-optiq/releases>`_ page:
+
+   ===============  ==============================================
+   OS / version     Example package name
+   ===============  ==============================================
+   RHEL 10          ``roc-optiq-1.0.0.0.el10.x86_64.zip``
+   RHEL 9           ``roc-optiq-1.0.0.0.el9.x86_64.zip``
+   RHEL 8           ``roc-optiq-1.0.0.0.el8.x86_64.zip``
+   Oracle Linux 10  ``roc-optiq-1.0.0.0.ol10.x86_64.zip``
+   Oracle Linux 9   ``roc-optiq-1.0.0.0.ol9.x86_64.zip``
+   Oracle Linux 8   ``roc-optiq-1.0.0.0.ol8.x86_64.zip``
+   ===============  ==============================================
+
+2. Unzip the package to extract the ``.rpm`` file:
+
+   .. code-block:: shell
+
+      unzip <file>.zip
+
+3. Install the ``.rpm`` package:
+
+   .. code-block:: shell
+
+      sudo dnf install ./<file>.rpm
+
+4. Verify the installation:
+
+   .. code-block:: shell
+
+      rpm -q roc-optiq
+
+.. tip::
+
+   The ``roc-optiq`` binary is installed to ``/opt/roc-optiq/bin``. To launch ROCm Optiq by name, add that directory to your ``PATH``:
+
+   .. code-block:: shell
+
+      export PATH=/opt/roc-optiq/bin:$PATH
+
+Any Linux distribution -- Tarball
+---------------------------------
+
+1. Download the tarball for your architecture from the `ROCm Optiq GitHub Releases <https://github.com/ROCm/roc-optiq/releases>`_ page:
+
+   .. code-block:: shell
+
+      wget https://github.com/ROCm/roc-optiq/releases/download/v1.0.0-optiq/roc-optiq-1.0.0.0-linux-x86_64.tar.gz
+
+2. Extract it to your preferred install location (no root required):
+
+   .. code-block:: shell
+
+      mkdir -p "$HOME/opt/roc-optiq"
+      tar -xzf roc-optiq-1.0.0.0-linux-x86_64.tar.gz -C "$HOME/opt/roc-optiq" --strip-components=1
+
+3. Add ROCm Optiq to your ``PATH``:
+
+   .. code-block:: shell
+
+      export PATH="$HOME/opt/roc-optiq/bin:$PATH"
+
+4. Verify the installation:
+
+   .. code-block:: shell
+
+      roc-optiq -v
+
+Windows -- Installer
+--------------------
+
+1. Download the ``.exe`` installer from the `ROCm Optiq GitHub Releases <https://github.com/ROCm/roc-optiq/releases>`_ page and follow the instructions in the install wizard.
+
+   .. image:: ../images/wizard.png
+      :width: 500
+      :alt: ROCm Optiq installation wizard welcome screen on Windows
+
+2. Accept the agreement to install, then follow the installation instructions.
+
+   .. image:: ../images/agreement.png
+      :width: 500
+      :alt: ROCm Optiq installer license agreement screen
+
+3. Launch **roc-optiq.exe** from the installation directory or the Start menu.
+
+macOS -- .zip
+-------------
+
+1. Download the archive for your macOS version (for example, ``roc-optiq_1.0.0.0_macos.zip``) from the `ROCm Optiq GitHub Releases <https://github.com/ROCm/roc-optiq/releases>`_ page.
+2. Unzip it, then drag ``roc-optiq.app`` from the ``roc-optiq_1.0.0.0_macos`` folder to the ``Applications`` folder.
+3. Launch ROCm Optiq from **Applications**.
+
+Settings, logs, and presets are stored at ``~/Library/Application Support/ROCm-Optiq/``.
+
+Verify your installation
+========================
+
+=========================  ===========================================================
+Method                     Command
+=========================  ===========================================================
+apt (Ubuntu / Debian)      ``dpkg -l | grep roc-optiq``
+dnf (RHEL / Oracle Linux)  ``rpm -q roc-optiq``
+Tarball                    ``roc-optiq -v``
+Windows                    ``roc-optiq.exe -v`` from an install-directory terminal
+macOS                      Open the app; check the version under the About/Help menu
+=========================  ===========================================================
+
+Uninstall
+=========
+
+apt (Ubuntu / Debian)
+---------------------
 
 .. code-block:: shell
 
-   apt show roc-optiq
+   sudo apt remove roc-optiq
+   sudo apt autoremove
 
-Add ROCm binaries to your ``PATH``
-----------------------------------
-
-Once you've installed ROCm Optiq for your operating system, add the ROCm binaries to your ``PATH`` if it isn't automatically configured:
+dnf (RHEL / Oracle Linux)
+-------------------------
 
 .. code-block:: shell
 
-   export PATH=opt/roc-optiq/bin:$PATH
+   sudo dnf remove roc-optiq
 
-Install on CentOS Stream 9
-==========================
+Tarball
+-------
 
-1. Download the appropriate ``.rpm`` package from GitHub Releases. 
-2. Install the package: ``sudo dnf install ./roc-optiq-*.rpm``. 
-3. Verify the installation: ``rpm -q roc-optiq``. 
+.. code-block:: shell
 
-Install on macOS
-================
+   rm -rf "$HOME/opt/roc-optiq"
 
-1. Download ``roc-optiq_0.5.0_macos.zip`` from `GitHub Releases <https://github.com/ROCm/roc-optiq/releases>`_.
-2. Drag and drop ``roc-optiq.app`` from the ``roc-optiq_0.5.0_macos`` folder to the ``Applications`` folder. 
-3. Launch ROCm Optiq from **Applications**. 
+Then remove the ``export PATH=...`` line you added to your shell profile.
 
-Settings, logs, and presets are stored at: ``~/Library/Application Support/ROCm-Optiq/``.
+Windows
+-------
+
+Go to **Control Panel > Programs > Uninstall a program**, select **ROCm Optiq**, and follow the prompts.
+
+macOS
+-----
+
+Drag ``roc-optiq.app`` from ``/Applications`` to the Trash. Optionally remove the settings directory:
+
+.. code-block:: shell
+
+   rm -rf "$HOME/Library/Application Support/ROCm-Optiq"


### PR DESCRIPTION
Refactors the install guide to mirror the ROCm install-doc structure (per-OS support matrix plus per-method steps) and updates content to 1.0.0.

## Changes
- Restructured to match format of Install-ROCm-Optiq-1.0.0.docx
- Changed version numbers of example files to 1.0.0
- Dropped specification of point versions for Ubuntu as per Install-ROCm-Optiq-1.0.0.docx comment
- Added "Add to PATH" tips
- Added note to specify ROCm versions are only needed for profiling host (not Optiq)
