### PR TITLE
Harden profiling backend

### DIFF
--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -1555,9 +1555,11 @@ through this** - never hardcode `IM_COL32(...)` in feature code.
   `GetEventLevelSpacing()` is the gap between stacked event boxes, so
   a box is one row height minus that spacing.
   **Reuse these instead of magic numbers.**
-- `GetProfilerSettings()` / `SaveProfilerSettings()` persist launcher
-  paths, auto-load behavior, recent targets, and last profiler/preset/
-  SSH-connection IDs.
+- `GetProfilerSettings()` / `SaveProfilerSettings()` persist the launcher's
+  output directory, auto-load behavior, recent targets, and last
+  profiler/preset/SSH-connection IDs. Deliberately **not** a path to a
+  profiler binary: that is chosen by a tool enum so a settings file cannot
+  decide what gets executed (D9 in `.agents/PROFILER_PIPELINE.md`).
 
 JSON keys are constants in this header
 (`JSON_KEY_SETTINGS_DISPLAY_DARK_MODE` etc.).
@@ -1762,8 +1764,11 @@ sessions are **not** `Project`s until a produced trace is handed to
 `AppWindow::OpenFile()`.
 
 **Backends (`IProfilerBackend`, `rocprofvis_profiler_backend.h`).** The
-pluggable extension point. Methods: `Id`, `DisplayName`, `GetTools`,
-`GetDefaultBinary`, `GetTabs` (returns `TabDescriptor`s that each carry
+pluggable extension point. Methods: `Id`, `DisplayName`, `GetTools`
+(each `ToolOption` carries a `rocprofvis_profiler_tool_t` directly -
+backends name a tool and never a path, so binary names live only in the
+controller's tool table), `GetTabs` (takes the selected tool; returns
+`TabDescriptor`s that each carry
 an ImGui `render_fn` - the backend supplies renderers, the dialog draws
 the tab bar), `Validate` (empty string = OK), `FlattenToExecution`
 (curated settings -> env + the **complete** argv after `argv[0]`,
@@ -1777,8 +1782,8 @@ structs: `ToolOption`, `TabDescriptor`, `WarningMessage`.
 
 **`RocprofSysBackend`** is the only backend registered today (the
 `ProfilerLauncherDialog` ctor pushes one). `Id()` = `"rocprof-sys"`.
-Tools: `run` (`rocprof-sys-run`), `sample` (`rocprof-sys-sample`),
-`instrument` (`rocprof-sys-instrument`). Tabs: Quick, Sampling, ROCm,
+Tools: `kRPVProfilerToolRocprofSysRun`, `…SysSample`, `…SysInstrument`.
+Tabs: Quick, Sampling, ROCm,
 Process Sampling, Parallelism, Advanced, plus Instrument (only when the
 tool is `instrument`); the dialog appends a shared "Raw Env Vars" tab.
 Perfetto options are nested inside Advanced, not a top-level tab.
@@ -1787,7 +1792,7 @@ sampling, ROCm domains, Perfetto, process sampling, parallelism,
 advanced, instrument) plus 11 built-in rocprof-sys `--preset=` names.
 
 **`LaunchConfig` (`rocprofvis_launch_config.h`)** is the serializable
-payload: `profiler_id`, `tool_id`, `connection` (`ConnectionType
+payload: `profiler_id`, `tool`, `connection` (`ConnectionType
 {kLocal, kSsh}`), `ssh_connection_ref` (an `SshConnectionConfig::id`,
 never inline credentials), `target` (`TargetSpec {executable, arguments,
 working_directory, output_directory, auto_load_trace}`), `extra_env`,
@@ -1797,7 +1802,28 @@ so today it is only reachable through a saved profile. The same header
 provides `SplitArguments`, which word-splits `TargetSpec::arguments` the
 way a shell would (quote-aware, no expansion) - backends must use it
 rather than splitting on whitespace, or a quoted argument containing
-spaces is torn into several.
+spaces is torn into several - plus the tool helpers `GetToolBinaryName`,
+`ToolFromInt`, and `ResolveToolPath` (see 13.2). Note that `LaunchConfig`
+holds no profiler binary path: `tool` is an enum, so a saved profile
+cannot name an executable.
+
+`tool` is persisted as the enum's **integer** value, which makes
+`rocprofvis_profiler_tool_t` append-only - renumbering or reusing a value
+would silently repoint every saved profile at a different tool, and that is
+a launch-the-wrong-thing bug rather than a load error. `FromJson` runs the
+stored integer through `ToolFromInt`, which bounds it with the enum's own
+`__kRPVProfilerToolLast` sentinel (the same `__k...Last` idiom the rest of
+`rocprofvis_controller_enums.h` uses) and yields `kRPVProfilerToolNone`
+otherwise, so a corrupted value or one from a newer build is never cast
+blindly into the enum. The dialog then resolves `None` through
+`SyncToolWithBackend`.
+
+It also holds `tool_directory`, an optional absolute directory to find the
+tools in for a ROCm install in a non-standard location - a directory only,
+since the filename stays the controller's to choose. It lives on the
+profile rather than in app settings because a remote profile needs a
+directory on the *remote* host, which a machine-local setting could not
+express.
 
 **Two independent preset systems - do not conflate:**
 - `LaunchPresetManager` - named Optiq launch profiles in the
@@ -1812,7 +1838,7 @@ spaces is torn into several.
 
 **Shared form helpers (`rocprofvis_launch_shared_tabs.h`)** - reuse
 these instead of re-authoring launcher UI: `RenderTargetSection`,
-`RenderRawEnvVarsTab`, `BuildCommandPreviewString`,
+`RenderToolLocationSection`, `RenderRawEnvVarsTab`, `BuildCommandPreviewString`,
 `RenderCommandPreview`, `RenderOutputConsole` (+ `ConsoleStatusLevel
 {kIdle, kRunning, kSuccess, kError}`), `RenderSavedProfileBar`. The
 connection-mode selector and SSH UI live in the dialog
@@ -1825,6 +1851,17 @@ preview, rebuilt on a dirty flag). `AppWindow::ShowProfilerLauncher()`
 lazily creates it; the only entry point is `File > Launch Profiler...`
 (`#ifdef ROCPROFVIS_ENABLE_PROFILER`).
 
+There is deliberately **no** selected-tool index beside `m_config.tool` -
+the enum is the only copy. An earlier version kept an `m_tool_index` in
+step by searching `GetTools()` for the config's tool id after each profile
+load, which silently did nothing when the profile named a tool the backend
+did not offer: the combo then showed the stale index's tool while the
+launch ran the fallback. `SyncToolWithBackend()` replaces both copies of
+that search - it forces `m_config.tool` to something the current backend
+offers, warns when it has to substitute, and is called after a backend
+switch and after every profile load. Anything that changes either the
+backend or the config must call it.
+
 **`ProfilerSessionBase`** owns the controller `config`/`profiler`/
 `future` handles and the `AppMonitor` op id. `GetState`, `GetOutput`,
 `GetExitCode`, `Cancel`, `Close`, and `GetOperationId` forward to the
@@ -1834,14 +1871,42 @@ handles teardown (see 13.4). Subclasses set `m_extra_teardown` for
 resources that must outlive the profiler worker.
 
 `Launch` and `BuildConfig` take a **`ProfilerLaunchSpec`** (same header):
-`profiler_type`, `profiler_path` (`argv[0]`), `profiler_argv` (the
-complete argument list from `FlattenToExecution`, one entry per argv
-entry - the controller never re-splits it), `env_vars`,
-`working_directory` (applied to the child process only), and
-`target_executable` / `output_directory` as metadata that deliberately do
-**not** reach the command line. A struct rather than a parameter list
-because a transposed pair of the string fields would compile cleanly and
-launch the wrong command.
+`tool` (a `rocprofvis_profiler_tool_t` - the controller resolves it to
+`argv[0]`; the View never supplies a path), `tool_directory` (where to look
+for it, see below), `profiler_argv` (the complete argument
+list from `FlattenToExecution`, one entry per argv entry - the controller
+never re-splits it), `env_vars`, `working_directory` (applied to the child
+process only), and `target_executable` / `output_directory` as metadata
+that deliberately do **not** reach the command line. A struct rather than
+a parameter list because a transposed pair of the string fields would
+compile cleanly and launch the wrong command.
+
+**Tool selection never involves a path from the UI.** The combo hands back
+a `rocprofvis_profiler_tool_t` straight from `GetTools`, and the launcher
+calls `View::ResolveToolPath`
+(`rocprofvis_launch_config.h`, wrapping
+`rocprofvis_profiler_tool_resolve_path`) purely to show the resolved
+absolute path in the command preview and to report a missing tool before
+Launch is pressed; the launch passes the enum and the controller resolves
+again. **`ResolveToolPath` answers a question about the local machine
+only**, so `RefreshExecutionCache` skips it entirely in SSH mode and
+previews what the remote will run - `<tool_directory>/<name>` or the bare
+name for the remote `$PATH`, joined with `'/'` because the remote is
+addressed as POSIX. Resolving locally for a remote run would report the
+wrong machine's install and print a path that is not what executes.
+
+`LaunchConfig::tool_directory` is edited in the Advanced window via the
+shared `RenderToolLocationSection`, placed above the backend tabs because
+it belongs to the profile rather than to any one backend; in local mode the
+field also shows the absolute path the selection currently resolves to. A
+set directory is repeated above the command preview by
+`RenderToolResolutionNotice`, so a profile imported from elsewhere cannot
+silently run a different build. If the tool is not in the configured
+directory the launch fails rather than falling back to `$ROCM_PATH` or
+`$PATH`. Nothing about the profiler binary is persisted in
+`ProfilerSettings` - see D9 in `.agents/PROFILER_PIPELINE.md` for why, and
+for why a *directory* on the profile is a different proposition from the
+`profiler_path` it replaced.
 
 ### 13.3 Local vs remote profiling workflows
 
@@ -2517,7 +2582,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `profiler/rocprofvis_profiler_backend.h`.
 - `RocprofSysBackend`, `RocprofSysSettings` ->
   `profiler/rocprofvis_rocprof_sys_backend.h`.
-- `LaunchConfig`, `TargetSpec`, `ConnectionType`, `SplitArguments` ->
+- `LaunchConfig`, `TargetSpec`, `ConnectionType`, `SplitArguments`,
+  `GetToolBinaryName`, `ToolFromInt`, `ResolveToolPath` ->
   `profiler/rocprofvis_launch_config.h`.
 - `LaunchPresetManager`, `PresetInfo` ->
   `profiler/rocprofvis_launch_preset_manager.h`.

--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -1558,8 +1558,9 @@ through this** - never hardcode `IM_COL32(...)` in feature code.
 - `GetProfilerSettings()` / `SaveProfilerSettings()` persist the launcher's
   output directory, auto-load behavior, recent targets, and last
   profiler/preset/SSH-connection IDs. Deliberately **not** a path to a
-  profiler binary: that is chosen by a tool enum so a settings file cannot
-  decide what gets executed (D9 in `.agents/PROFILER_PIPELINE.md`).
+  profiler binary: which binary runs is chosen by a tool enum, so a settings
+  file that is edited, corrupted, or copied from another machine cannot
+  decide what gets executed. Do not add one back as a convenience.
 
 JSON keys are constants in this header
 (`JSON_KEY_SETTINGS_DISPLAY_DARK_MODE` etc.).
@@ -1903,10 +1904,16 @@ set directory is repeated above the command preview by
 `RenderToolResolutionNotice`, so a profile imported from elsewhere cannot
 silently run a different build. If the tool is not in the configured
 directory the launch fails rather than falling back to `$ROCM_PATH` or
-`$PATH`. Nothing about the profiler binary is persisted in
-`ProfilerSettings` - see D9 in `.agents/PROFILER_PIPELINE.md` for why, and
-for why a *directory* on the profile is a different proposition from the
-`profiler_path` it replaced.
+`$PATH`.
+
+No path to a profiler binary is persisted anywhere. An earlier development
+build kept one in `ProfilerSettings`, which meant an edited or shared
+settings file became the `argv[0]` of the next launch; it was deleted rather
+than sanitized. A directory on the profile is a different proposition
+because the filename still comes from the controller's tool table, so the
+worst a bad value can do is name a directory that lacks the tool - and the
+launcher shows an active directory before Launch, so an imported profile
+cannot redirect a run unnoticed.
 
 ### 13.3 Local vs remote profiling workflows
 

--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -1877,10 +1877,18 @@ resources that must outlive the profiler worker.
 for it, see below), `profiler_argv` (the complete argument
 list from `FlattenToExecution`, one entry per argv entry - the controller
 never re-splits it), `env_vars`, `working_directory` (applied to the child
-process only), and `target_executable` / `output_directory` as metadata
-that deliberately do **not** reach the command line. A struct rather than
-a parameter list because a transposed pair of the string fields would
-compile cleanly and launch the wrong command.
+process only), and `output_directory`, which deliberately does **not**
+reach the command line and currently has no reader in the controller at
+all - the backend emits the output flag itself, because profilers spell it
+differently and some take none. A struct rather than a parameter list
+because a transposed pair of the string fields would compile cleanly and
+launch the wrong command.
+
+There is deliberately **no `target_executable`** on the spec. It used to be
+carried as metadata and was read by nothing; the target reaches the child
+only as argv entries the backend emits, so the View is the single owner of
+it. Do not re-add it to give the controller "context" - that recreates a
+second source of truth for a value the command line already carries.
 
 **Tool selection never involves a path from the UI.** The combo hands back
 a `rocprofvis_profiler_tool_t` straight from `GetTools`, and the launcher

--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -1766,7 +1766,9 @@ pluggable extension point. Methods: `Id`, `DisplayName`, `GetTools`,
 `GetDefaultBinary`, `GetTabs` (returns `TabDescriptor`s that each carry
 an ImGui `render_fn` - the backend supplies renderers, the dialog draws
 the tab bar), `Validate` (empty string = OK), `FlattenToExecution`
-(curated settings -> env + argv; caller then merges `extra_env`),
+(curated settings -> env + the **complete** argv after `argv[0]`,
+including `extra_argv`, the output flag in this profiler's spelling, and
+the target plus its arguments; caller then merges `extra_env`),
 `LoadSettings`/`SaveSettings` (the JSON `backend_payload`), `ExportCfg`
 (native config text), and the default-implemented `GetWarnings`
 (`WarningMessage { Level {kInfo,kWarning,kError}, text }`) and
@@ -1790,6 +1792,12 @@ payload: `profiler_id`, `tool_id`, `connection` (`ConnectionType
 never inline credentials), `target` (`TargetSpec {executable, arguments,
 working_directory, output_directory, auto_load_trace}`), `extra_env`,
 `extra_argv`, and `backend_payload` (the backend's JSON).
+`TargetSpec::working_directory` is honored at launch but has no UI field,
+so today it is only reachable through a saved profile. The same header
+provides `SplitArguments`, which word-splits `TargetSpec::arguments` the
+way a shell would (quote-aware, no expansion) - backends must use it
+rather than splitting on whitespace, or a quoted argument containing
+spaces is torn into several.
 
 **Two independent preset systems - do not conflate:**
 - `LaunchPresetManager` - named Optiq launch profiles in the
@@ -1824,6 +1832,16 @@ lazily creates it; the only entry point is `File > Launch Profiler...`
 `MonitorOperationType::ProfilerSession` op; `FreeProfilerObjects()`
 handles teardown (see 13.4). Subclasses set `m_extra_teardown` for
 resources that must outlive the profiler worker.
+
+`Launch` and `BuildConfig` take a **`ProfilerLaunchSpec`** (same header):
+`profiler_type`, `profiler_path` (`argv[0]`), `profiler_argv` (the
+complete argument list from `FlattenToExecution`, one entry per argv
+entry - the controller never re-splits it), `env_vars`,
+`working_directory` (applied to the child process only), and
+`target_executable` / `output_directory` as metadata that deliberately do
+**not** reach the command line. A struct rather than a parameter list
+because a transposed pair of the string fields would compile cleanly and
+launch the wrong command.
 
 ### 13.3 Local vs remote profiling workflows
 
@@ -2499,13 +2517,13 @@ For fast lookup. Each entry: class -> file -> one-line role.
   `profiler/rocprofvis_profiler_backend.h`.
 - `RocprofSysBackend`, `RocprofSysSettings` ->
   `profiler/rocprofvis_rocprof_sys_backend.h`.
-- `LaunchConfig`, `TargetSpec`, `ConnectionType` ->
+- `LaunchConfig`, `TargetSpec`, `ConnectionType`, `SplitArguments` ->
   `profiler/rocprofvis_launch_config.h`.
 - `LaunchPresetManager`, `PresetInfo` ->
   `profiler/rocprofvis_launch_preset_manager.h`.
-- `ProfilerSessionBase`, `ProfilerSession` -> matching `profiler/`
-  headers. `RemoteProfilerSession` additionally requires
-  `ROCPROFVIS_ENABLE_REMOTE`.
+- `ProfilerLaunchSpec`, `ProfilerSessionBase`, `ProfilerSession` ->
+  matching `profiler/` headers. `RemoteProfilerSession` additionally
+  requires `ROCPROFVIS_ENABLE_REMOTE`.
 - `ProfilerLaunchOrchestrator` ->
   `profiler/rocprofvis_profiler_launch_orchestrator.h`.
 - `ProfilerLauncherDialog` ->

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -56,6 +56,7 @@ if(ROCPROFVIS_ENABLE_PROFILER)
 list(APPEND rocprofvis_controller_source_files
     src/profiler/rocprofvis_controller_profiler_process.cpp
     src/profiler/rocprofvis_controller_profiler_cmdline.cpp
+    src/profiler/rocprofvis_controller_profiler_tool.cpp
     src/profiler/rocprofvis_profiler.cpp
 )
 endif(ROCPROFVIS_ENABLE_PROFILER)

--- a/src/controller/CMakeLists.txt
+++ b/src/controller/CMakeLists.txt
@@ -140,4 +140,15 @@ if(BUILD_TESTING)
     add_test(NAME ${COMPUTE_TEST_NAME} COMMAND ${COMPUTE_TEST_NAME} --input_file "${CMAKE_SOURCE_DIR}/sample/rocprof_compute_23ed6f36.db")
     set_tests_properties(${COMPUTE_TEST_NAME} PROPERTIES RUN_SERIAL ON)
     set_tests_properties(${COMPUTE_TEST_NAME} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
+    # TEMPORARY (profiler launch): remove this guard when the profiler feature
+    # graduates.
+    if(ROCPROFVIS_ENABLE_PROFILER)
+        set(PROFILER_TEST_NAME ${PROJECT_NAME}-profiler-tests)
+        add_executable(${PROFILER_TEST_NAME} tests/rocprofvis_controller_profiler_tests.cpp)
+        target_link_libraries(${PROFILER_TEST_NAME} PRIVATE ${PROJECT_NAME})
+        target_link_libraries(${PROFILER_TEST_NAME} PRIVATE Catch2::Catch2WithMain)
+        add_test(NAME ${PROFILER_TEST_NAME} COMMAND ${PROFILER_TEST_NAME})
+        set_tests_properties(${PROFILER_TEST_NAME} PROPERTIES WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+    endif(ROCPROFVIS_ENABLE_PROFILER)
 endif()

--- a/src/controller/inc/rocprofvis_controller_enums.h
+++ b/src/controller/inc/rocprofvis_controller_enums.h
@@ -40,6 +40,8 @@ typedef enum rocprofvis_result_t
     kRocProfVisResultDuplicate = 13,
     // SSH authentication failed
     kRocProfVisResultFailedSshCommunication = 14,
+    // A requested profiler tool could not be found on this system
+    kRocProfVisResultToolNotFound = 15,
 } rocprofvis_result_t;
 
 /*
@@ -1228,19 +1230,30 @@ typedef enum rocprofvis_controller_roofline_kernel_intensity_type_t : uint32_t
 } rocprofvis_controller_roofline_kernel_intensity_type_t;
 
 /*
- * Profiler types supported by the profiler launcher
+ * Profiler tools the launcher knows how to find and execute.
+ *
+ * A launch names its tool with this enum rather than a path, and the controller
+ * owns both the enum-to-binary-name mapping and the resolution of that name to
+ * a validated absolute path. 
  */
-typedef enum rocprofvis_profiler_type_t
+typedef enum rocprofvis_profiler_tool_t : uint32_t
 {
-    // ROCm Systems Profiler - sampling mode (single-stage)
-    kRPVProfilerTypeRocprofSysRun = 0,
-    // ROCm Systems Profiler - instrumentation mode (two-stage: instrument + run)
-    kRPVProfilerTypeRocprofSysInstrument = 1,
-    // ROCm Compute Profiler v2 (rocprof)
-    kRPVProfilerTypeRocprofCompute = 2,
-    // ROCm Compute Profiler v3 (rocprofv3)
-    kRPVProfilerTypeRocprofV3 = 3,
-} rocprofvis_profiler_type_t;
+    // No tool selected. Never resolvable.
+    kRPVProfilerToolNone = 0,
+    // ROCm Systems Profiler, LD_PRELOAD mode
+    kRPVProfilerToolRocprofSysRun = 1,
+    // ROCm Systems Profiler, sampling mode
+    kRPVProfilerToolRocprofSysSample = 2,
+    // ROCm Systems Profiler, Dyninst instrumentation
+    kRPVProfilerToolRocprofSysInstrument = 3,
+    // ROCm Systems Profiler capability query, used for probing
+    kRPVProfilerToolRocprofSysAvail = 4,
+    // ROCm Compute Profiler (both its profile and analyze modes)
+    kRPVProfilerToolRocprofCompute = 5,
+    // rocprofv3
+    kRPVProfilerToolRocprofV3 = 6,
+    __kRPVProfilerToolLast
+} rocprofvis_profiler_tool_t;
 
 /*
  * Profiler execution state

--- a/src/controller/inc/rocprofvis_profiler.h
+++ b/src/controller/inc/rocprofvis_profiler.h
@@ -12,6 +12,44 @@ extern "C"
 #endif
 
 /*
+* Gets the executable name for a profiler tool, without directory or platform
+* suffix (e.g. "rocprof-sys-run").
+* This is the single source of truth for what each tool is called on disk;
+* callers should query it rather than hard-coding names.
+* String getter convention: pass buffer = nullptr to query the required size in
+* *length, then call again with a buffer of at least that many bytes. *length is
+* a byte count and does not include a null terminator, so a caller wanting a
+* C string should allocate *length + 1 and terminate it itself.
+* @param tool The profiler tool.
+* @param buffer Destination buffer, or nullptr to query the length.
+* @param length In/out byte count (must not be null).
+* @returns kRocProfVisResultSuccess, or kRocProfVisResultInvalidEnum for an
+*          unrecognized tool or kRPVProfilerToolNone.
+*/
+rocprofvis_result_t rocprofvis_profiler_tool_get_binary_name(rocprofvis_profiler_tool_t tool, char* buffer, uint32_t* length);
+
+/*
+* Finds the absolute path of a profiler tool on this machine, in the same way and
+* the same order a launch would: inside tool_directory alone if one is given,
+* otherwise $ROCM_PATH/bin (defaulting to /opt/rocm off Windows) then each $PATH
+* entry.
+* Exposed separately from any session so a caller can show what will actually run
+* in a command preview, or check a tool is installed before committing to a run.
+* Answers a question about the LOCAL machine only - a remote launch resolves its
+* tool on the remote host, so a caller must not apply this to one.
+* Same string getter convention as rocprofvis_profiler_tool_get_binary_name.
+* @param tool The profiler tool.
+* @param tool_directory Absolute directory to search, or null/empty for the
+*        default search.
+* @param buffer Destination buffer, or nullptr to query the length.
+* @param length In/out byte count (must not be null).
+* @returns kRocProfVisResultSuccess, kRocProfVisResultToolNotFound if the tool is
+*          not present, or kRocProfVisResultInvalidArgument for an unknown tool
+*          or a relative directory.
+*/
+rocprofvis_result_t rocprofvis_profiler_tool_resolve_path(rocprofvis_profiler_tool_t tool, char const* tool_directory, char* buffer, uint32_t* length);
+
+/*
 * Allocates a profiler configuration object.
 * @returns A valid profiler config object, or nullptr on error.
 */
@@ -24,20 +62,36 @@ rocprofvis_profiler_config_t* rocprofvis_profiler_config_alloc(void);
 void rocprofvis_profiler_config_free(rocprofvis_profiler_config_t* config);
 
 /*
-* Sets the profiler type in the configuration.
+* Selects which profiler binary to run.
+* The tool is named, not pathed: the controller owns the mapping to a binary
+* name and the search for it (see rocprofvis_profiler_tool_resolve_path), so no
+* caller-supplied string becomes argv[0]. The search happens at launch, and a
+* tool that cannot be found fails the launch with kRocProfVisResultToolNotFound
+* instead of the child exiting 127.
 * @param config The profiler config object.
-* @param profiler_type The type of profiler to launch.
-* @returns kRocProfVisResultSuccess or an error code.
+* @param tool The profiler binary to run. kRPVProfilerToolNone is rejected.
+* @returns kRocProfVisResultSuccess, or kRocProfVisResultInvalidEnum for an
+*          unrecognized tool.
 */
-rocprofvis_result_t rocprofvis_profiler_config_set_type(rocprofvis_profiler_config_t* config, rocprofvis_profiler_type_t profiler_type);
+rocprofvis_result_t rocprofvis_profiler_config_set_tool(rocprofvis_profiler_config_t* config, rocprofvis_profiler_tool_t tool);
 
 /*
-* Sets the profiler executable path in the configuration.
+* Restricts where the configured tool is looked for, for a ROCm install in a
+* non-standard location.
+* This is a directory, never a path to an executable: the filename still comes
+* from the tool table, so this cannot name a different program to run. It is a
+* separate call from rocprofvis_profiler_config_set_tool so that a path can never
+* be supplied where a tool was expected.
+* Must be absolute - for a remote launch, an absolute path on the remote host.
+* When set, the tool must be in this directory: resolution does not fall back to
+* $ROCM_PATH or $PATH, so a directory that lacks the tool fails loudly rather
+* than silently running a different build of it. Logged prominently at launch.
 * @param config The profiler config object.
-* @param profiler_path Path to the profiler executable.
+* @param tool_directory Absolute directory holding the profiler tools. Empty
+*        restores the default search.
 * @returns kRocProfVisResultSuccess or an error code.
 */
-rocprofvis_result_t rocprofvis_profiler_config_set_profiler_path(rocprofvis_profiler_config_t* config, char const* profiler_path);
+rocprofvis_result_t rocprofvis_profiler_config_set_tool_directory(rocprofvis_profiler_config_t* config, char const* tool_directory);
 
 /*
 * Sets the target executable path in the configuration.
@@ -88,7 +142,7 @@ rocprofvis_result_t rocprofvis_profiler_config_add_env_var(rocprofvis_profiler_c
 /*
 * Appends a single argument to the profiler command line.
 * This is the only way arguments reach the process. The full command line is
-* argv[0] = profiler_path followed by these arguments in the order added, so
+* argv[0] = the resolved tool path followed by these arguments in the order added, so
 * the caller composes the entire command - including any output flag, "--"
 * separator, target executable, and target arguments.
 * Each call adds exactly one argv entry, which is passed to the process

--- a/src/controller/inc/rocprofvis_profiler.h
+++ b/src/controller/inc/rocprofvis_profiler.h
@@ -41,6 +41,10 @@ rocprofvis_result_t rocprofvis_profiler_config_set_profiler_path(rocprofvis_prof
 
 /*
 * Sets the target executable path in the configuration.
+* Descriptive metadata only (logging, diagnostics); it does not add anything to
+* the command line. Pass the target on the command line explicitly with
+* rocprofvis_profiler_config_add_profiler_arg, since where it belongs (and
+* whether it needs a "--" separator) is profiler-specific.
 * @param config The profiler config object.
 * @param target_executable Path to the target application to profile.
 * @returns kRocProfVisResultSuccess or an error code.
@@ -48,28 +52,28 @@ rocprofvis_result_t rocprofvis_profiler_config_set_profiler_path(rocprofvis_prof
 rocprofvis_result_t rocprofvis_profiler_config_set_target_executable(rocprofvis_profiler_config_t* config, char const* target_executable);
 
 /*
-* Sets the target application arguments in the configuration.
-* @param config The profiler config object.
-* @param target_args Arguments to pass to the target application.
-* @returns kRocProfVisResultSuccess or an error code.
-*/
-rocprofvis_result_t rocprofvis_profiler_config_set_target_args(rocprofvis_profiler_config_t* config, char const* target_args);
-
-/*
-* Sets the profiler arguments in the configuration.
-* @param config The profiler config object.
-* @param profiler_args Arguments to pass to the profiler.
-* @returns kRocProfVisResultSuccess or an error code.
-*/
-rocprofvis_result_t rocprofvis_profiler_config_set_profiler_args(rocprofvis_profiler_config_t* config, char const* profiler_args);
-
-/*
 * Sets the output directory in the configuration.
+* Descriptive metadata only (logging, artifact resolution); it does not add
+* anything to the command line. Profilers spell their output flag differently,
+* so pass it explicitly with rocprofvis_profiler_config_add_profiler_arg.
 * @param config The profiler config object.
-* @param output_directory Directory where profiler output should be saved.
+* @param output_directory Directory where profiler output is expected.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_config_set_output_directory(rocprofvis_profiler_config_t* config, char const* output_directory);
+
+/*
+* Sets the working directory of the profiler process.
+* The directory is applied to the child process only (chdir after fork on
+* POSIX, lpCurrentDirectory on Windows, a "cd" prefix for remote launches);
+* the calling process's working directory is never changed. Required by tools
+* that write output relative to their own working directory rather than to a
+* path given on the command line.
+* @param config The profiler config object.
+* @param working_directory Directory to run the profiler process in. Must exist.
+* @returns kRocProfVisResultSuccess or an error code.
+*/
+rocprofvis_result_t rocprofvis_profiler_config_set_working_directory(rocprofvis_profiler_config_t* config, char const* working_directory);
 
 /*
 * Adds an environment variable to the profiler configuration.
@@ -82,8 +86,14 @@ rocprofvis_result_t rocprofvis_profiler_config_set_output_directory(rocprofvis_p
 rocprofvis_result_t rocprofvis_profiler_config_add_env_var(rocprofvis_profiler_config_t* config, char const* name, char const* value);
 
 /*
-* Adds a single argument to the profiler argument list.
-* Arguments added this way are passed before --output and -- target.
+* Appends a single argument to the profiler command line.
+* This is the only way arguments reach the process. The full command line is
+* argv[0] = profiler_path followed by these arguments in the order added, so
+* the caller composes the entire command - including any output flag, "--"
+* separator, target executable, and target arguments.
+* Each call adds exactly one argv entry, which is passed to the process
+* verbatim: no splitting on whitespace and no shell interpretation, so
+* arguments containing spaces or quotes arrive intact.
 * @param config The profiler config object.
 * @param arg The argument string (must not be null).
 * @returns kRocProfVisResultSuccess or an error code.
@@ -166,9 +176,14 @@ rocprofvis_result_t rocprofvis_profiler_get_state(rocprofvis_profiler_t* profile
 
 /*
 * Gets the profiler output (stdout/stderr).
+* Call with a null buffer (or *length of 0) to query the length in bytes, then
+* again with a buffer to receive the bytes. No null terminator is written, and
+* *length is a byte count rather than a capacity, so the queried length can be
+* passed straight back in; allocate length + 1 bytes and terminate the string
+* yourself. On the second call *length is updated to the number of bytes copied.
 * @param profiler The profiler session handle.
 * @param buffer Buffer to write the output to, or null to query the length.
-* @param length Pointer to integer containing buffer size, or to write required size.
+* @param length In: bytes to copy. Out: bytes available, or bytes copied.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_get_output(rocprofvis_profiler_t* profiler, char* buffer, uint32_t* length);

--- a/src/controller/inc/rocprofvis_profiler.h
+++ b/src/controller/inc/rocprofvis_profiler.h
@@ -12,16 +12,12 @@ extern "C"
 #endif
 
 /*
-* Gets the executable name for a profiler tool, without directory or platform
-* suffix (e.g. "rocprof-sys-run").
-* This is the single source of truth for what each tool is called on disk;
-* callers should query it rather than hard-coding names.
-* String getter convention: pass buffer = nullptr to query the required size in
-* *length, then call again with a buffer of at least that many bytes. *length is
-* a byte count and does not include a null terminator, so a caller wanting a
-* C string should allocate *length + 1 and terminate it itself.
+* Canonical on-disk name for `tool` (e.g. "rocprof-sys-run"), no directory or
+* platform suffix. Query rather than hard-coding.
+* String getters: pass buffer = nullptr to query *length (byte count, no
+* terminator). Allocate *length + 1 and terminate the C string yourself.
 * @param tool The profiler tool.
-* @param buffer Destination buffer, or nullptr to query the length.
+* @param buffer Destination, or nullptr to query length.
 * @param length In/out byte count (must not be null).
 * @returns kRocProfVisResultSuccess, or kRocProfVisResultInvalidEnum for an
 *          unrecognized tool or kRPVProfilerToolNone.
@@ -29,29 +25,22 @@ extern "C"
 rocprofvis_result_t rocprofvis_profiler_tool_get_binary_name(rocprofvis_profiler_tool_t tool, char* buffer, uint32_t* length);
 
 /*
-* Finds the absolute path of a profiler tool on this machine, in the same way and
-* the same order a launch would: inside tool_directory alone if one is given,
-* otherwise $ROCM_PATH/bin (defaulting to /opt/rocm off Windows) then each $PATH
-* entry.
-* Exposed separately from any session so a caller can show what will actually run
-* in a command preview, or check a tool is installed before committing to a run.
-* Answers a question about the LOCAL machine only - a remote launch resolves its
-* tool on the remote host, so a caller must not apply this to one.
-* Same string getter convention as rocprofvis_profiler_tool_get_binary_name.
+* Absolute path of `tool` on this machine, same order as a local launch:
+* tool_directory alone if set, else $ROCM_PATH/bin (default /opt/rocm off
+* Windows), then $PATH. Local only — do not use for a remote launch.
+* Same string-getter convention as rocprofvis_profiler_tool_get_binary_name.
 * @param tool The profiler tool.
-* @param tool_directory Absolute directory to search, or null/empty for the
-*        default search.
-* @param buffer Destination buffer, or nullptr to query the length.
+* @param tool_directory Absolute search dir, or null/empty for the default.
+* @param buffer Destination, or nullptr to query length.
 * @param length In/out byte count (must not be null).
-* @returns kRocProfVisResultSuccess, kRocProfVisResultToolNotFound if the tool is
-*          not present, or kRocProfVisResultInvalidArgument for an unknown tool
-*          or a relative directory.
+* @returns kRocProfVisResultSuccess, kRocProfVisResultToolNotFound, or
+*          kRocProfVisResultInvalidArgument (unknown tool or relative directory).
 */
 rocprofvis_result_t rocprofvis_profiler_tool_resolve_path(rocprofvis_profiler_tool_t tool, char const* tool_directory, char* buffer, uint32_t* length);
 
 /*
 * Allocates a profiler configuration object.
-* @returns A valid profiler config object, or nullptr on error.
+* @returns A valid config, or nullptr on error.
 */
 rocprofvis_profiler_config_t* rocprofvis_profiler_config_alloc(void);
 
@@ -62,48 +51,29 @@ rocprofvis_profiler_config_t* rocprofvis_profiler_config_alloc(void);
 void rocprofvis_profiler_config_free(rocprofvis_profiler_config_t* config);
 
 /*
-* Selects which profiler binary to run.
-* The tool is named, not pathed: the controller owns the mapping to a binary
-* name and the search for it (see rocprofvis_profiler_tool_resolve_path), so no
-* caller-supplied string becomes argv[0]. The search happens at launch, and a
-* tool that cannot be found fails the launch with kRocProfVisResultToolNotFound
-* instead of the child exiting 127.
+* Names the binary to run (not a path). The controller maps the enum and
+* searches at launch; a missing tool is kRocProfVisResultToolNotFound, not
+* child exit 127. No caller-supplied string becomes argv[0].
 * @param config The profiler config object.
-* @param tool The profiler binary to run. kRPVProfilerToolNone is rejected.
-* @returns kRocProfVisResultSuccess, or kRocProfVisResultInvalidEnum for an
-*          unrecognized tool.
+* @param tool Rejects kRPVProfilerToolNone.
+* @returns kRocProfVisResultSuccess, or kRocProfVisResultInvalidEnum.
 */
 rocprofvis_result_t rocprofvis_profiler_config_set_tool(rocprofvis_profiler_config_t* config, rocprofvis_profiler_tool_t tool);
 
 /*
-* Restricts where the configured tool is looked for, for a ROCm install in a
-* non-standard location.
-* This is a directory, never a path to an executable: the filename still comes
-* from the tool table, so this cannot name a different program to run. It is a
-* separate call from rocprofvis_profiler_config_set_tool so that a path can never
-* be supplied where a tool was expected.
-* Must be absolute - for a remote launch, an absolute path on the remote host.
-* When set, the tool must be in this directory: resolution does not fall back to
-* $ROCM_PATH or $PATH, so a directory that lacks the tool fails loudly rather
-* than silently running a different build of it. Logged prominently at launch.
+* Directory to search for the tool (non-standard ROCm install). Filename still
+* comes from the tool table. Must be absolute (remote: on the remote host).
+* When set, no fallback to $ROCM_PATH or $PATH. Empty restores the default.
 * @param config The profiler config object.
-* @param tool_directory Absolute directory holding the profiler tools. Empty
-*        restores the default search.
+* @param tool_directory Absolute directory, or empty for the default search.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_config_set_tool_directory(rocprofvis_profiler_config_t* config, char const* tool_directory);
 
 /*
-* Records where the profiler is expected to write its output.
-* This does not put anything on the command line: profilers spell their output
-* flag differently, and some take none at all, so pass it explicitly with
-* rocprofvis_profiler_config_add_profiler_arg.
-* Nothing reads this value yet. It is kept because a staged pipeline will need
-* a destination the controller acts on - moving a produced artifact there for
-* tools that can only write to their own working directory - at which point it
-* becomes a per-stage setting rather than a per-config one. Until then, do not
-* add readers that would make it a second source of truth for a path the
-* command line already carries.
+* Expected output location. Not on argv — add the profiler's own flag via
+* rocprofvis_profiler_config_add_profiler_arg. Unread for now; kept for a later
+* per-stage artifact destination. Do not add readers.
 * @param config The profiler config object.
 * @param output_directory Directory where profiler output is expected.
 * @returns kRocProfVisResultSuccess or an error code.
@@ -111,103 +81,85 @@ rocprofvis_result_t rocprofvis_profiler_config_set_tool_directory(rocprofvis_pro
 rocprofvis_result_t rocprofvis_profiler_config_set_output_directory(rocprofvis_profiler_config_t* config, char const* output_directory);
 
 /*
-* Sets the working directory of the profiler process.
-* The directory is applied to the child process only (chdir after fork on
-* POSIX, lpCurrentDirectory on Windows, a "cd" prefix for remote launches);
-* the calling process's working directory is never changed. Required by tools
-* that write output relative to their own working directory rather than to a
-* path given on the command line.
+* Child cwd only (chdir after fork, lpCurrentDirectory, remote "cd"). Never
+* changes the caller's cwd. Must exist.
 * @param config The profiler config object.
-* @param working_directory Directory to run the profiler process in. Must exist.
+* @param working_directory Directory to run the profiler in.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_config_set_working_directory(rocprofvis_profiler_config_t* config, char const* working_directory);
 
 /*
-* Adds an environment variable to the profiler configuration.
-* These are set in the child process environment before exec.
+* Adds an environment variable set in the child before exec.
 * @param config The profiler config object.
-* @param name Environment variable name (must not be null).
-* @param value Environment variable value (must not be null).
+* @param name Variable name (must not be null).
+* @param value Variable value (must not be null).
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_config_add_env_var(rocprofvis_profiler_config_t* config, char const* name, char const* value);
 
 /*
-* Appends a single argument to the profiler command line.
-* This is the only way arguments reach the process. The full command line is
-* argv[0] = the resolved tool path followed by these arguments in the order added, so
-* the caller composes the entire command - including any output flag, "--"
-* separator, target executable, and target arguments.
-* Each call adds exactly one argv entry, which is passed to the process
-* verbatim: no splitting on whitespace and no shell interpretation, so
-* arguments containing spaces or quotes arrive intact.
+* Appends one argv entry after argv[0] (the resolved tool). Caller composes
+* the rest (output flag, "--", target). No whitespace split, no shell.
 * @param config The profiler config object.
-* @param arg The argument string (must not be null).
+* @param arg The argument (must not be null).
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_config_add_profiler_arg(rocprofvis_profiler_config_t* config, char const* arg);
 
 /*
-* Sets the connection type to local execution (default).
+* Sets local execution (default).
 * @param config The profiler config object.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_config_set_connection_local(rocprofvis_profiler_config_t* config);
 
 /*
-* Sets the connection type to SSH (not yet implemented, will return kRocProfVisResultNotSupported at launch).
+* Sets SSH execution. Launch still returns kRocProfVisResultNotSupported
+* unless using rocprofvis_profiler_launch_remote_async.
 * @param config The profiler config object.
 * @param host Remote hostname (must not be null).
 * @param user Remote username (must not be null).
-* @param port SSH port number.
-* @param identity_file Path to SSH identity file (may be null for default).
-* @param remote_stage_dir Remote directory for staging output (may be null).
+* @param port SSH port.
+* @param identity_file Identity file, or null for default.
+* @param remote_stage_dir Remote staging directory, or null.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_config_set_connection_ssh(rocprofvis_profiler_config_t* config,
     char const* host, char const* user, int port, char const* identity_file, char const* remote_stage_dir);
 
 /*
-* Allocates a profiler session handle. The session owns the in-process
-* profiler controller state (process handle, captured output, trace path,
-* exit code). Status queries take this handle rather than the future, so the
-* caller can free the future independently once it completes.
-* @returns A valid profiler session handle, or nullptr on error.
+* Allocates a session (process, captured output, exit code). Status queries
+* use this handle, not the future, so the future can be freed independently.
+* @returns A valid session, or nullptr on error.
 */
 rocprofvis_profiler_t* rocprofvis_profiler_alloc(void);
 
 /*
-* Frees a profiler session handle. Cancels any in-flight profiler process.
-* The bound future is NOT freed; callers must free it separately via
-* rocprofvis_controller_future_free.
+* Frees a session and cancels any in-flight process. Does not free the bound
+* future; call rocprofvis_controller_future_free separately.
 * @param profiler The profiler session to free.
 */
 void rocprofvis_profiler_free(rocprofvis_profiler_t* profiler);
 
 /*
-* Launches a profiler process asynchronously and binds it to the given future.
-* @param profiler The profiler session handle (owns the controller state).
+* Launches asynchronously and binds `future`. A missing tool returns
+* kRocProfVisResultToolNotFound and leaves the session Failed.
+* @param profiler The profiler session.
 * @param config The profiler configuration.
-* @param future The future object used to track job completion / cancellation.
+* @param future Job completion / cancellation.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_launch_async(rocprofvis_profiler_t* profiler, rocprofvis_profiler_config_t* config, rocprofvis_controller_future_t* future);
 
 /*
-* TEMPORARY (remote/SSH): remote profiler launch C ABI. Remove this guard when
-* the remote feature graduates.
-*
-* Launches a profiler process on a remote host over an existing SSH connection.
-* The connection must already be connected and authenticated (e.g. by the View's
-* SshSession) and must be idle (no other SSH operation in flight) for the
-* duration of the remote profiler run. The connection is borrowed; the caller
-* retains ownership and must keep it alive until the profiler reaches a terminal
-* state. Downloading the produced trace back is the caller's responsibility.
-* @param profiler The profiler session handle (owns the controller state).
-* @param config The profiler configuration (should have SSH connection set).
-* @param connection The connected/authenticated SSH connection handle.
-* @param future The future object used to track job completion / cancellation.
+* TEMPORARY (remote/SSH): remove this guard when remote graduates.
+* Runs on a borrowed, idle, already-authenticated connection. Caller keeps it
+* alive until a terminal state. Trace download is the caller's job.
+* @param profiler The profiler session.
+* @param config The profiler configuration.
+* @param connection Connected SSH handle.
+* @param future Job completion / cancellation.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 #ifdef ROCPROFVIS_ENABLE_REMOTE
@@ -215,48 +167,41 @@ rocprofvis_result_t rocprofvis_profiler_launch_remote_async(rocprofvis_profiler_
 #endif
 
 /*
-* Gets the current state of the profiler execution.
-* @param profiler The profiler session handle.
-* @param state Output parameter for the profiler state.
+* Current profiler state.
+* @param profiler The profiler session.
+* @param state Output state.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_get_state(rocprofvis_profiler_t* profiler, rocprofvis_profiler_state_t* state);
 
 /*
-* Gets the profiler output (stdout/stderr).
-* Call with a null buffer (or *length of 0) to query the length in bytes, then
-* again with a buffer to receive the bytes. No null terminator is written, and
-* *length is a byte count rather than a capacity, so the queried length can be
-* passed straight back in; allocate length + 1 bytes and terminate the string
-* yourself. On the second call *length is updated to the number of bytes copied.
-* @param profiler The profiler session handle.
-* @param buffer Buffer to write the output to, or null to query the length.
+* Captured stdout/stderr. Same string-getter convention as
+* rocprofvis_profiler_tool_get_binary_name (no terminator written).
+* @param profiler The profiler session.
+* @param buffer Destination, or null to query length.
 * @param length In: bytes to copy. Out: bytes available, or bytes copied.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_get_output(rocprofvis_profiler_t* profiler, char* buffer, uint32_t* length);
 
 /*
-* Clears the accumulated profiler output buffer.
-* After calling this, rocprofvis_profiler_get_output will only return output
-* produced after the clear.
-* @param profiler The profiler session handle.
+* Drops captured output so later get_output calls only return new data.
+* @param profiler The profiler session.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_clear_output(rocprofvis_profiler_t* profiler);
 
 /*
-* Gets the exit code of a completed profiler process.
-* @param profiler The profiler session handle.
-* @param exit_code Output parameter for the process exit code.
+* Exit code of a completed process.
+* @param profiler The profiler session.
+* @param exit_code Output exit code.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_get_exit_code(rocprofvis_profiler_t* profiler, int32_t* exit_code);
 
 /*
-* Cancels a running profiler process. Forwards cancellation to the bound
-* future as well so any job waiting on it unblocks.
-* @param profiler The profiler session handle.
+* Cancels a running process and the bound future.
+* @param profiler The profiler session.
 * @returns kRocProfVisResultSuccess or an error code.
 */
 rocprofvis_result_t rocprofvis_profiler_cancel(rocprofvis_profiler_t* profiler);

--- a/src/controller/inc/rocprofvis_profiler.h
+++ b/src/controller/inc/rocprofvis_profiler.h
@@ -94,22 +94,16 @@ rocprofvis_result_t rocprofvis_profiler_config_set_tool(rocprofvis_profiler_conf
 rocprofvis_result_t rocprofvis_profiler_config_set_tool_directory(rocprofvis_profiler_config_t* config, char const* tool_directory);
 
 /*
-* Sets the target executable path in the configuration.
-* Descriptive metadata only (logging, diagnostics); it does not add anything to
-* the command line. Pass the target on the command line explicitly with
-* rocprofvis_profiler_config_add_profiler_arg, since where it belongs (and
-* whether it needs a "--" separator) is profiler-specific.
-* @param config The profiler config object.
-* @param target_executable Path to the target application to profile.
-* @returns kRocProfVisResultSuccess or an error code.
-*/
-rocprofvis_result_t rocprofvis_profiler_config_set_target_executable(rocprofvis_profiler_config_t* config, char const* target_executable);
-
-/*
-* Sets the output directory in the configuration.
-* Descriptive metadata only (logging, artifact resolution); it does not add
-* anything to the command line. Profilers spell their output flag differently,
-* so pass it explicitly with rocprofvis_profiler_config_add_profiler_arg.
+* Records where the profiler is expected to write its output.
+* This does not put anything on the command line: profilers spell their output
+* flag differently, and some take none at all, so pass it explicitly with
+* rocprofvis_profiler_config_add_profiler_arg.
+* Nothing reads this value yet. It is kept because a staged pipeline will need
+* a destination the controller acts on - moving a produced artifact there for
+* tools that can only write to their own working directory - at which point it
+* becomes a per-stage setting rather than a per-config one. Until then, do not
+* add readers that would make it a second source of truth for a path the
+* command line already carries.
 * @param config The profiler config object.
 * @param output_directory Directory where profiler output is expected.
 * @returns kRocProfVisResultSuccess or an error code.

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.cpp
@@ -38,12 +38,8 @@ std::string posix_shell_quote(std::string const& tok)
     return out;
 }
 
-// Windows CRT (CommandLineToArgvW reverse) quoting for a single token.
-// Algorithm follows Microsoft's documented rules:
-//   - Tokens with no whitespace or quotes are passed through unchanged.
-//   - Otherwise wrap in double quotes and double-up backslash runs that
-//     immediately precede a quote, escaping the quote itself with one more
-//     backslash.
+// CommandLineToArgvW reverse quoting: quote if whitespace/quotes; double
+// backslashes that run up to a quote (and the quote itself).
 std::string windows_quote(std::string const& tok)
 {
     if (!tok.empty() && tok.find_first_of(" \t\n\v\"") == std::string::npos)
@@ -145,10 +141,7 @@ std::string ToPosixShellCommand(
 
     for (auto const& kv : env)
     {
-        // Defense-in-depth: the name is emitted unquoted (it must be a literal
-        // shell identifier), so never serialize a malformed name into the shell
-        // command. Invalid names are rejected at ProfilerConfig::AddEnvVar, but
-        // guard here too since this is the actual injection boundary.
+        // Name is emitted unquoted; skip invalid ones (AddEnvVar already rejects).
         if (!IsValidEnvName(kv.first))
         {
             continue;

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.cpp
@@ -94,7 +94,7 @@ std::vector<std::string> BuildArgv(ProfilerConfig const& config)
     std::vector<std::string> argv;
     argv.reserve(config.GetProfilerArgv().size() + 1);
 
-    argv.push_back(config.GetProfilerPath());
+    argv.push_back(config.GetResolvedToolPath());
 
     for (auto const& arg : config.GetProfilerArgv())
     {

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.cpp
@@ -17,20 +17,6 @@ namespace Cmdline
 namespace
 {
 
-void append_whitespace_split(std::vector<std::string>& out, std::string const& s)
-{
-    if (s.empty())
-    {
-        return;
-    }
-    std::istringstream iss(s);
-    std::string        token;
-    while (iss >> token)
-    {
-        out.push_back(token);
-    }
-}
-
 // POSIX shell single-quote a single token. Embedded ' becomes '\''.
 std::string posix_shell_quote(std::string const& tok)
 {
@@ -106,6 +92,7 @@ std::string windows_quote(std::string const& tok)
 std::vector<std::string> BuildArgv(ProfilerConfig const& config)
 {
     std::vector<std::string> argv;
+    argv.reserve(config.GetProfilerArgv().size() + 1);
 
     argv.push_back(config.GetProfilerPath());
 
@@ -113,22 +100,6 @@ std::vector<std::string> BuildArgv(ProfilerConfig const& config)
     {
         argv.push_back(arg);
     }
-
-    append_whitespace_split(argv, config.GetProfilerArgs());
-
-    if (!config.GetOutputDirectory().empty())
-    {
-        argv.emplace_back("--output");
-        argv.push_back(config.GetOutputDirectory());
-    }
-
-    if (!config.GetTargetExecutable().empty())
-    {
-        argv.emplace_back("--");
-        argv.push_back(config.GetTargetExecutable());
-    }
-
-    append_whitespace_split(argv, config.GetTargetArgs());
 
     return argv;
 }
@@ -160,10 +131,17 @@ bool IsValidEnvName(std::string const& name)
 
 std::string ToPosixShellCommand(
     std::vector<std::string> const&                         argv,
-    std::vector<std::pair<std::string, std::string>> const& env)
+    std::vector<std::pair<std::string, std::string>> const& env,
+    std::string const&                                      working_dir)
 {
     std::ostringstream oss;
     bool               first = true;
+
+    if (!working_dir.empty())
+    {
+        oss << "cd " << posix_shell_quote(working_dir) << " &&";
+        first = false;
+    }
 
     for (auto const& kv : env)
     {

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.h
@@ -18,67 +18,40 @@ namespace Cmdline
 {
 
 /*
- * Shared command-line composition helpers for profiler launches.
- *
- * The argv schema (order and conventions) is defined once here so that every
- * sink - POSIX execvp, Windows CreateProcessA, and the future SSH executor -
- * produces the same logical command from a given ProfilerConfig.
- *
- * Typical usage:
+ * Shared argv/env composition for every launch sink (execvp, CreateProcessA,
+ * SSH). Typical use:
  *
  *   auto argv = BuildArgv(config);
  *   auto env  = BuildEnv(config);
- *
- *   // POSIX local:  pass argv to execvp / posix_spawnp directly.
- *   // Windows:      auto cmd = ToWindowsCommandLine(argv);
- *   // SSH remote:   auto cmd = ToPosixShellCommand(argv, env);
- *   // Logging/UI:   auto s   = ToDisplayString(argv, env);
+ *   // POSIX:  execvp / posix_spawnp
+ *   // Windows: ToWindowsCommandLine(argv)
+ *   // SSH:     ToPosixShellCommand(argv, env, working_dir)
+ *   // Log/UI:  ToDisplayString(argv, env)
  */
 
 /*
- * Build the canonical argv from a ProfilerConfig: argv[0] is the profiler
- * executable path, argv[1..] are the config's explicit argv entries
- * (AddProfilerArg) in the order they were added.
- *
- * This is deliberately a pass-through - no flag is synthesized here. Each
- * profiler has its own CLI shape (where the output path goes, whether a "--"
- * separator precedes the target, whether the target is an argument at all), so
- * composing argv is the caller's job and every token arrives as a discrete
- * entry. Nothing is split on whitespace, so paths and arguments containing
- * spaces survive to execvp / CreateProcess intact.
- *
- * The config's output_directory does NOT contribute to argv; a caller that
- * wants it on the command line must add it explicitly. Profilers spell their
- * output flag differently, and some write only to their working directory.
+ * argv[0] = resolved tool path, argv[1..] = AddProfilerArg entries in order.
+ * Pass-through: no flags are synthesized (output path, "--", target), and
+ * nothing is split on whitespace. output_directory is not on argv; add it
+ * explicitly if the profiler needs it.
  */
 std::vector<std::string> BuildArgv(ProfilerConfig const& config);
 
 /*
- * Return the env vars from the config as a vector of (name, value) pairs.
- * Currently a pass-through; exists as a seam for future per-executor tweaks.
+ * Env vars from the config. Pass-through; a seam for per-executor tweaks.
  */
 std::vector<std::pair<std::string, std::string>> BuildEnv(ProfilerConfig const& config);
 
 /*
- * True if `name` is a valid POSIX environment variable name
- * ([A-Za-z_][A-Za-z0-9_]*). Malformed names must be kept out of the remote
- * shell command (ToPosixShellCommand) because the name is emitted unquoted and
- * would otherwise allow shell-syntax injection.
+ * True if `name` is [A-Za-z_][A-Za-z0-9_]*. Invalid names are rejected because
+ * ToPosixShellCommand emits the name unquoted.
  */
 bool IsValidEnvName(std::string const& name);
 
 /*
- * Serialize argv (and optional env) into a single string suitable for a POSIX
- * /bin/sh interpreter - i.e. ssh user@host "<this>" or sh -c "<this>". Each
- * token is single-quoted; embedded single quotes are emitted as '\''. Env
- * pairs are prepended as KEY='VALUE'.
- *
- * When working_dir is non-empty the command is prefixed with
- * "cd '<working_dir>' && ", which is the remote equivalent of the child-side
- * chdir / lpCurrentDirectory used for local launches. "&&" is deliberate: if
- * the directory does not exist the profiler must not run at all, since a tool
- * that writes output relative to its cwd would otherwise silently produce it
- * in the wrong place.
+ * POSIX /bin/sh command: each token single-quoted (embedded ' as '\''),
+ * env as KEY='VALUE'. Non-empty working_dir prefixes "cd '<dir>' && " so a
+ * missing directory fails the launch instead of running in the wrong cwd.
  */
 std::string ToPosixShellCommand(
     std::vector<std::string> const&                         argv,
@@ -86,19 +59,13 @@ std::string ToPosixShellCommand(
     std::string const&                                      working_dir = std::string());
 
 /*
- * Serialize argv into a single string suitable for the lpCommandLine
- * parameter of Windows CreateProcessA/W. Tokens are quoted following the
- * MSVC CommandLineToArgvW reverse rules: backslash-doubling before quotes,
- * double-quote-wrapping for tokens containing whitespace/quotes.
- *
- * Does not include env vars (Windows passes env via a separate block).
+ * CreateProcessA lpCommandLine string (CommandLineToArgvW reverse quoting).
+ * Env is a separate block on Windows, not included here.
  */
 std::string ToWindowsCommandLine(std::vector<std::string> const& argv);
 
 /*
- * Format argv + env as a human-readable single string for logging and the
- * launcher dialog's preamble. Not safe to feed back to a real shell - use
- * the platform-specific serializers above for that.
+ * Human-readable argv+env for logs and the launcher preamble. Not shell-safe.
  */
 std::string ToDisplayString(
     std::vector<std::string> const&                         argv,

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.h
@@ -36,17 +36,20 @@ namespace Cmdline
  */
 
 /*
- * Build the canonical argv from a ProfilerConfig. argv[0] is the profiler
- * executable path; argv[1..] are the arguments in the order:
- *   1. Explicit profiler argv entries (config.GetProfilerArgv()).
- *   2. Legacy whitespace-split profiler_args (config.GetProfilerArgs()).
- *   3. "--output <output_directory>" if set.
- *   4. "--" "<target_executable>" if set.
- *   5. Whitespace-split target args (config.GetTargetArgs()).
+ * Build the canonical argv from a ProfilerConfig: argv[0] is the profiler
+ * executable path, argv[1..] are the config's explicit argv entries
+ * (AddProfilerArg) in the order they were added.
  *
- * The whitespace-split behavior for legacy profiler_args / target_args is
- * preserved for backwards compatibility with existing callers; new callers
- * should prefer AddProfilerArg() so tokens containing spaces survive.
+ * This is deliberately a pass-through - no flag is synthesized here. Each
+ * profiler has its own CLI shape (where the output path goes, whether a "--"
+ * separator precedes the target, whether the target is an argument at all), so
+ * composing argv is the caller's job and every token arrives as a discrete
+ * entry. Nothing is split on whitespace, so paths and arguments containing
+ * spaces survive to execvp / CreateProcess intact.
+ *
+ * The config's target_executable and output_directory are descriptive metadata
+ * (logging, artifact resolution) and do NOT contribute to argv; a caller that
+ * wants them on the command line must add them explicitly.
  */
 std::vector<std::string> BuildArgv(ProfilerConfig const& config);
 
@@ -69,10 +72,18 @@ bool IsValidEnvName(std::string const& name);
  * /bin/sh interpreter - i.e. ssh user@host "<this>" or sh -c "<this>". Each
  * token is single-quoted; embedded single quotes are emitted as '\''. Env
  * pairs are prepended as KEY='VALUE'.
+ *
+ * When working_dir is non-empty the command is prefixed with
+ * "cd '<working_dir>' && ", which is the remote equivalent of the child-side
+ * chdir / lpCurrentDirectory used for local launches. "&&" is deliberate: if
+ * the directory does not exist the profiler must not run at all, since a tool
+ * that writes output relative to its cwd would otherwise silently produce it
+ * in the wrong place.
  */
 std::string ToPosixShellCommand(
     std::vector<std::string> const&                         argv,
-    std::vector<std::pair<std::string, std::string>> const& env = {});
+    std::vector<std::pair<std::string, std::string>> const& env = {},
+    std::string const&                                      working_dir = std::string());
 
 /*
  * Serialize argv into a single string suitable for the lpCommandLine

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_cmdline.h
@@ -47,9 +47,9 @@ namespace Cmdline
  * entry. Nothing is split on whitespace, so paths and arguments containing
  * spaces survive to execvp / CreateProcess intact.
  *
- * The config's target_executable and output_directory are descriptive metadata
- * (logging, artifact resolution) and do NOT contribute to argv; a caller that
- * wants them on the command line must add them explicitly.
+ * The config's output_directory does NOT contribute to argv; a caller that
+ * wants it on the command line must add it explicitly. Profilers spell their
+ * output flag differently, and some write only to their working directory.
  */
 std::vector<std::string> BuildArgv(ProfilerConfig const& config);
 

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
@@ -95,7 +95,8 @@ rocprofvis_result_t ProfilerConfig::ResolveToolPathRemote()
     {
         // A remote path, so "absolute" means starting with '/' - std::filesystem
         // would apply this host's rules, and on Windows would reject a perfectly
-        // good remote path (and join it with a backslash below).
+        // good remote path (and join it with a backslash below). This is one of
+        // the places that assume a POSIX remote.
         if (m_tool_directory.front() != '/')
         {
             spdlog::error("Remote profiler tool directory must be an absolute POSIX path, "

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
@@ -12,6 +12,8 @@
 #include "rocprofvis_controller_job_system.h"
 #include "spdlog/spdlog.h"
 #include <chrono>
+#include <filesystem>
+#include <system_error>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -21,7 +23,6 @@
 #include <signal.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <cstring>
 #endif
 
 namespace RocProfVis
@@ -137,6 +138,28 @@ rocprofvis_result_t ProfilerConfig::SetWorkingDirectory(char const* path)
         return kRocProfVisResultInvalidArgument;
     }
     m_working_directory = path;
+    return kRocProfVisResultSuccess;
+}
+
+rocprofvis_result_t ProfilerConfig::ValidateWorkingDirectory() const
+{
+    // Empty means "inherit this process's cwd", which is always valid.
+    if (m_working_directory.empty())
+    {
+        return kRocProfVisResultSuccess;
+    }
+
+    // The std::error_code overload, as everywhere else in this codebase: the
+    // throwing overloads are not an option, and a path too long for the OS
+    // reports through `ec` rather than by overflowing anything here.
+    std::error_code ec;
+    if (!std::filesystem::is_directory(m_working_directory, ec) || ec)
+    {
+        spdlog::error("Profiler working directory '{}' is not an existing directory",
+                      m_working_directory);
+        return kRocProfVisResultInvalidArgument;
+    }
+
     return kRocProfVisResultSuccess;
 }
 
@@ -478,8 +501,9 @@ static constexpr int SIGTERM_GRACE_MS = 100;
 // profiler itself ever ran. The values follow the POSIX shell convention (see
 // POSIX.1 "Shell Command Language", Exit Status), which reserves 126, 127 and
 // 128+n precisely so they cannot be mistaken for a status the profiled command
-// returned. Callers distinguish the two pre-exec cases by these codes alone -
-// the accompanying stderr message carries the human-readable detail.
+// returned. Callers distinguish the two pre-exec cases by these codes; the
+// accompanying line on the captured stderr pipe is the human-readable detail
+// shown in the launcher output console.
 static constexpr int EXIT_CODE_CANNOT_EXECUTE    = 126;  // found, but setup failed
 static constexpr int EXIT_CODE_COMMAND_NOT_FOUND = 127;  // execvp() could not find it
 static constexpr int EXIT_CODE_SIGNAL_BASE       = 128;  // + signal number
@@ -599,16 +623,17 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         {
             if (chdir(config.GetWorkingDirectory().c_str()) != 0)
             {
-                int chdir_errno = errno;
-                char err_buf[512];
-                int n = snprintf(err_buf, sizeof(err_buf),
-                                 "chdir failed for working directory '%s': %s (errno %d)\n",
-                                 config.GetWorkingDirectory().c_str(),
-                                 strerror(chdir_errno), chdir_errno);
-                if (n > 0)
-                {
-                    (void)write(STDERR_FILENO, err_buf, static_cast<size_t>(n));
-                }
+                int const chdir_errno = errno;
+                // STDERR_FILENO is the capture pipe (dup2 above), not the
+                // parent's real stderr. size() is the actual byte count, unlike
+                // snprintf's untruncated length. This allocates, same class of
+                // post-fork risk as setenv below; posix_spawn is the real fix.
+                std::string msg = "chdir failed for working directory '";
+                msg += config.GetWorkingDirectory();
+                msg += "': errno ";
+                msg += std::to_string(chdir_errno);
+                msg += '\n';
+                (void)write(STDERR_FILENO, msg.c_str(), msg.size());
                 _exit(EXIT_CODE_CANNOT_EXECUTE);
             }
         }
@@ -623,15 +648,13 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
 
         execvp(argv_cstr[0], argv_cstr.data());
 
-        int exec_errno = errno;
-        char err_buf[256];
-        int n = snprintf(err_buf, sizeof(err_buf),
-                         "execvp failed for '%s': %s (errno %d)\n",
-                         config.GetResolvedToolPath().c_str(), strerror(exec_errno), exec_errno);
-        if (n > 0)
-        {
-            (void)write(STDERR_FILENO, err_buf, static_cast<size_t>(n));
-        }
+        int const exec_errno = errno;
+        std::string msg = "execvp failed for '";
+        msg += config.GetResolvedToolPath();
+        msg += "': errno ";
+        msg += std::to_string(exec_errno);
+        msg += '\n';
+        (void)write(STDERR_FILENO, msg.c_str(), msg.size());
         _exit(EXIT_CODE_COMMAND_NOT_FOUND);
     }
 
@@ -831,6 +854,19 @@ rocprofvis_result_t ProfilerProcessController::LaunchAsync(ProfilerConfig const*
     {
         m_state = kRPVProfilerStateFailed;
         return resolved;
+    }
+
+    // Same rationale, applied to the working directory: checking it here turns
+    // the common failure into a proper result code with a logged reason, rather
+    // than a chdir failure inside the forked child whose only channels back are
+    // an exit code and a line on the captured stderr. What remains for the child
+    // to report is the narrow race where the directory disappears between this
+    // check and the fork.
+    rocprofvis_result_t working_directory_valid = m_config->ValidateWorkingDirectory();
+    if (working_directory_valid != kRocProfVisResultSuccess)
+    {
+        m_state = kRPVProfilerStateFailed;
+        return working_directory_valid;
     }
 
     m_executor = std::make_unique<LocalProfilerExecutor>();

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
@@ -3,6 +3,7 @@
 
 #include "rocprofvis_controller_profiler_process.h"
 #include "rocprofvis_controller_profiler_cmdline.h"
+#include "rocprofvis_controller_profiler_tool.h"
 // TEMPORARY (remote/SSH): remove guard when remote graduates.
 #ifdef ROCPROFVIS_ENABLE_REMOTE
 #include "rocprofvis_controller_ssh_profiler_executor.h"
@@ -34,8 +35,9 @@ namespace Controller
 
 ProfilerConfig::ProfilerConfig()
     : Handle(0, 0)
-    , m_profiler_type(kRPVProfilerTypeRocprofSysRun)
-    , m_profiler_path()
+    , m_tool(kRPVProfilerToolNone)
+    , m_tool_directory()
+    , m_resolved_tool_path()
     , m_target_executable()
     , m_output_directory()
     , m_working_directory()
@@ -55,19 +57,66 @@ rocprofvis_controller_object_type_t ProfilerConfig::GetType(void)
     return kRPVProfilerConfig;
 }
 
-rocprofvis_result_t ProfilerConfig::SetProfilerType(rocprofvis_profiler_type_t type)
+rocprofvis_result_t ProfilerConfig::SetTool(rocprofvis_profiler_tool_t tool)
 {
-    m_profiler_type = type;
+    if (ProfilerTool::GetBinaryName(tool) == nullptr)
+    {
+        return kRocProfVisResultInvalidEnum;
+    }
+    m_tool = tool;
     return kRocProfVisResultSuccess;
 }
 
-rocprofvis_result_t ProfilerConfig::SetProfilerPath(char const* path)
+rocprofvis_result_t ProfilerConfig::SetToolDirectory(char const* directory)
 {
-    if (path == nullptr)
+    if (directory == nullptr)
     {
         return kRocProfVisResultInvalidArgument;
     }
-    m_profiler_path = path;
+    m_tool_directory = directory;
+    return kRocProfVisResultSuccess;
+}
+
+rocprofvis_result_t ProfilerConfig::ResolveToolPath()
+{
+    return ProfilerTool::ResolvePath(m_tool, m_tool_directory, m_resolved_tool_path);
+}
+
+rocprofvis_result_t ProfilerConfig::ResolveToolPathRemote()
+{
+    char const* binary_name = ProfilerTool::GetBinaryName(m_tool);
+    if (binary_name == nullptr)
+    {
+        spdlog::error("ProfilerConfig::ResolveToolPathRemote: no tool selected");
+        return kRocProfVisResultInvalidArgument;
+    }
+
+    if (!m_tool_directory.empty())
+    {
+        // A remote path, so "absolute" means starting with '/' - std::filesystem
+        // would apply this host's rules, and on Windows would reject a perfectly
+        // good remote path (and join it with a backslash below).
+        if (m_tool_directory.front() != '/')
+        {
+            spdlog::error("Remote profiler tool directory must be an absolute POSIX path, "
+                          "got '{}'", m_tool_directory);
+            return kRocProfVisResultInvalidArgument;
+        }
+
+        std::string directory = m_tool_directory;
+        while (directory.size() > 1 && directory.back() == '/')
+        {
+            directory.pop_back();
+        }
+        m_resolved_tool_path =
+            (directory == "/") ? ("/" + std::string(binary_name))
+                               : (directory + "/" + binary_name);
+        spdlog::warn("Using configured remote tool directory for '{}': '{}'", binary_name,
+                     m_tool_directory);
+        return kRocProfVisResultSuccess;
+    }
+
+    m_resolved_tool_path = binary_name;
     return kRocProfVisResultSuccess;
 }
 
@@ -588,7 +637,7 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         char err_buf[256];
         int n = snprintf(err_buf, sizeof(err_buf),
                          "execvp failed for '%s': %s (errno %d)\n",
-                         config.GetProfilerPath().c_str(), strerror(exec_errno), exec_errno);
+                         config.GetResolvedToolPath().c_str(), strerror(exec_errno), exec_errno);
         if (n > 0)
         {
             (void)write(STDERR_FILENO, err_buf, static_cast<size_t>(n));
@@ -784,26 +833,36 @@ rocprofvis_result_t ProfilerProcessController::LaunchAsync(ProfilerConfig const*
         return kRocProfVisResultNotSupported;
     }
 
+    // Turn the tool enum into the absolute path that becomes argv[0]. Done on
+    // our own copy of the config, before anything is spawned, so a missing tool
+    // is reported as such instead of surfacing as the child's exit code 127.
+    rocprofvis_result_t resolved = m_config->ResolveToolPath();
+    if (resolved != kRocProfVisResultSuccess)
+    {
+        m_state = kRPVProfilerStateFailed;
+        return resolved;
+    }
+
     m_executor = std::make_unique<LocalProfilerExecutor>();
 
-    for (auto const& kv : config->GetEnvVars())
+    for (auto const& kv : m_config->GetEnvVars())
     {
         spdlog::info("Profiler env: {}={}", kv.first, kv.second);
     }
 
-    if (!config->GetWorkingDirectory().empty())
+    if (!m_config->GetWorkingDirectory().empty())
     {
-        spdlog::info("Profiler working directory: {}", config->GetWorkingDirectory());
+        spdlog::info("Profiler working directory: {}", m_config->GetWorkingDirectory());
     }
 
-    spdlog::info("Profiler launch: {}", Cmdline::ToDisplayString(Cmdline::BuildArgv(*config)));
+    spdlog::info("Profiler launch: {}", Cmdline::ToDisplayString(Cmdline::BuildArgv(*m_config)));
 
-    bool launched = m_executor->Start(*config);
+    bool launched = m_executor->Start(*m_config);
 
     if (!launched)
     {
         spdlog::error("ProfilerProcessController::LaunchAsync: failed to start process "
-                      "(executable='{}')", config->GetProfilerPath());
+                      "(executable='{}')", m_config->GetResolvedToolPath());
         m_state = kRPVProfilerStateFailed;
         m_executor.reset();
         return kRocProfVisResultUnknownError;
@@ -835,6 +894,13 @@ rocprofvis_result_t ProfilerProcessController::LaunchAsyncRemote(ProfilerConfig 
     }
 
     m_config = std::make_unique<ProfilerConfig>(*config);
+
+    rocprofvis_result_t resolved = m_config->ResolveToolPathRemote();
+    if (resolved != kRocProfVisResultSuccess)
+    {
+        m_state = kRPVProfilerStateFailed;
+        return resolved;
+    }
 
     // The executor reads the future lazily inside its worker thread (started in
     // Start) to observe cancellation; the ABI sets the future's job right after

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
@@ -93,10 +93,8 @@ rocprofvis_result_t ProfilerConfig::ResolveToolPathRemote()
 
     if (!m_tool_directory.empty())
     {
-        // A remote path, so "absolute" means starting with '/' - std::filesystem
-        // would apply this host's rules, and on Windows would reject a perfectly
-        // good remote path (and join it with a backslash below). This is one of
-        // the places that assume a POSIX remote.
+        // POSIX-absolute: std::filesystem would apply this host's rules (and
+        // join with '\\' on Windows). Remote is always POSIX.
         if (m_tool_directory.front() != '/')
         {
             spdlog::error("Remote profiler tool directory must be an absolute POSIX path, "
@@ -143,15 +141,12 @@ rocprofvis_result_t ProfilerConfig::SetWorkingDirectory(char const* path)
 
 rocprofvis_result_t ProfilerConfig::ValidateWorkingDirectory() const
 {
-    // Empty means "inherit this process's cwd", which is always valid.
+    // Empty inherits this process's cwd.
     if (m_working_directory.empty())
     {
         return kRocProfVisResultSuccess;
     }
 
-    // The std::error_code overload, as everywhere else in this codebase: the
-    // throwing overloads are not an option, and a path too long for the OS
-    // reports through `ec` rather than by overflowing anything here.
     std::error_code ec;
     if (!std::filesystem::is_directory(m_working_directory, ec) || ec)
     {
@@ -169,9 +164,7 @@ rocprofvis_result_t ProfilerConfig::AddEnvVar(char const* name, char const* valu
     {
         return kRocProfVisResultInvalidArgument;
     }
-    // Reject names that are not valid POSIX identifiers. Besides being invalid
-    // env assignments, a non-identifier name would inject shell syntax when the
-    // config is serialized for a remote /bin/sh launch (see ToPosixShellCommand).
+    // POSIX identifier only: the name is emitted unquoted in ToPosixShellCommand.
     if (!Cmdline::IsValidEnvName(name))
     {
         spdlog::warn("Ignoring environment variable with invalid name '{}'", name);
@@ -278,12 +271,8 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         return false;
     }
 
-    // Build command line via the shared helper. Tokens are quoted following
-    // the Windows CRT / CommandLineToArgvW reverse rules, so paths or
-    // arguments containing whitespace or quotes are preserved correctly.
     std::string cmd_line_str = Cmdline::ToWindowsCommandLine(Cmdline::BuildArgv(config));
 
-    // Create pipes for stdout and stderr
     SECURITY_ATTRIBUTES sa;
     sa.nLength = sizeof(SECURITY_ATTRIBUTES);
     sa.bInheritHandle = TRUE;
@@ -302,11 +291,10 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
     }
     SetHandleInformation(m_stderr_read_handle, HANDLE_FLAG_INHERIT, 0);
 
-    // Build environment block if we have custom env vars
     std::string env_block;
     if (!config.GetEnvVars().empty())
     {
-        // Inherit current environment and add our vars
+        // Inherit the current environment, then append ours.
         char* current_env = GetEnvironmentStrings();
         if (current_env)
         {
@@ -340,10 +328,7 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
 
     LPVOID env_ptr = env_block.empty() ? nullptr : env_block.data();
 
-    // Working directory for the child only; this process's cwd is untouched.
-    // A non-existent directory makes CreateProcessA fail, which is the desired
-    // behavior: tools that write output relative to their cwd must not silently
-    // run somewhere else.
+    // Child cwd only. CreateProcessA fails if the directory does not exist.
     LPCSTR working_dir_ptr =
         config.GetWorkingDirectory().empty() ? nullptr : config.GetWorkingDirectory().c_str();
 
@@ -468,49 +453,21 @@ std::string LocalProfilerExecutor::ReadOutput()
 #else
 
 // ==================================================================================
-// LocalProfilerExecutor Implementation - POSIX (Linux, and macOS if ROCm gains
-// macOS support in the future).
+// LocalProfilerExecutor - POSIX (Linux today).
 //
-// This implementation uses fork() + execvp() with pipes for stdout/stderr capture.
-// The pattern is correct and portable POSIX, but if/when macOS support is added
-// for the ROCm Systems Profiler, this code should be refactored to use
-// posix_spawnp() with posix_spawn_file_actions_* for the fd plumbing. Reasons:
-//
-//   - On macOS, the window between fork() and execvp() is unsafe with respect
-//     to most Apple frameworks (Cocoa, Core Foundation, libdispatch/GCD, Metal,
-//     Mach ports). Roc-optiq links these transitively via MoltenVK / GLFW /
-//     native file dialog, so the Objective-C runtime can abort the forked
-//     child before exec runs (look for OBJC_DISABLE_INITIALIZE_FORK_SAFETY).
-//   - The setenv() and std::string allocations in the child branch below are
-//     not async-signal-safe; they can deadlock on macOS if another roc-optiq
-//     thread held the malloc lock at fork time.
-//   - posix_spawn skips the address-space duplication entirely, which matters
-//     for a GUI/Vulkan process with many Mach VM regions.
-//   - posix_spawn with POSIX_SPAWN_CLOEXEC_DEFAULT / POSIX_SPAWN_SETSIGDEF
-//     gives cleaner fd and signal-handler hygiene than fork+exec.
-//
-// macOS does not provide execvpe(3), so any env-passing refactor on Linux
-// (e.g. switching from per-child setenv to passing envp directly) should
-// target posix_spawnp instead of execvpe for portability.
+// fork()+execvp() is not safe on macOS (Obj-C runtime, non-async-signal-safe
+// setenv/alloc in the child, Mach VM duplication). Refactor to posix_spawnp()
+// before enabling the profiler there. Linux is the only POSIX target today.
 // ==================================================================================
 
 // Grace period after SIGTERM before escalating to SIGKILL during Cancel().
 static constexpr int SIGTERM_GRACE_MS = 100;
 
-// Statuses the forked child uses to report a failure that happened before the
-// profiler itself ever ran. The values follow the POSIX shell convention (see
-// POSIX.1 "Shell Command Language", Exit Status), which reserves 126, 127 and
-// 128+n precisely so they cannot be mistaken for a status the profiled command
-// returned. Callers distinguish the two pre-exec cases by these codes; the
-// accompanying line on the captured stderr pipe is the human-readable detail
-// shown in the launcher output console.
+// Pre-exec child statuses (POSIX shell convention): not a profiled-command code.
 static constexpr int EXIT_CODE_CANNOT_EXECUTE    = 126;  // found, but setup failed
-static constexpr int EXIT_CODE_COMMAND_NOT_FOUND = 127;  // execvp() could not find it
+static constexpr int EXIT_CODE_COMMAND_NOT_FOUND = 127;  // execvp could not find it
 static constexpr int EXIT_CODE_SIGNAL_BASE       = 128;  // + signal number
 
-// Decodes a waitpid() status into the executor's exit-code convention (matches
-// the mapping used by IsRunning): normal exit -> exit status; killed by a
-// signal -> EXIT_CODE_SIGNAL_BASE + signal number.
 static void set_exit_code_from_status(int status, int& exit_code)
 {
     if (WIFEXITED(status))
@@ -563,9 +520,7 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         return false;
     }
 
-    // Build argv tokens BEFORE fork() so we don't allocate in the child between
-    // fork and execvp. The string data is copy-on-written into the child by
-    // fork, and the c_str() pointers we capture in argv_cstr remain valid there.
+    // Build argv before fork so the child does not allocate between fork and exec.
     std::vector<std::string> argv_tokens = Cmdline::BuildArgv(config);
 
     std::vector<char*> argv_cstr;
@@ -584,12 +539,7 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         return false;
     }
 
-    // NOTE (macOS): this fork()+execvp() path is NOT safe on macOS - the child
-    // runs non-async-signal-safe code (setenv/allocations) between fork and exec
-    // while the parent is multithreaded (GLFW/MoltenVK/Obj-C runtime). It works
-    // on Linux, which is the only POSIX target today. Before enabling the
-    // profiler on macOS this must be reworked to posix_spawnp() (deferred; see
-    // the section banner above).
+    // Linux-only today; posix_spawnp before enabling on macOS (section banner).
     m_process_id = fork();
 
     if (m_process_id == -1)
@@ -603,7 +553,6 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
 
     if (m_process_id == 0)
     {
-        // Child process
         close(stdout_pipe[0]);
         close(stderr_pipe[0]);
 
@@ -613,21 +562,14 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         close(stdout_pipe[1]);
         close(stderr_pipe[1]);
 
-        // Enter the requested working directory before exec. Only the child's
-        // cwd changes; the parent's is untouched. chdir() is async-signal-safe,
-        // so it is safe in this post-fork context. Bail out rather than exec on
-        // failure: some tools write their output relative to the cwd, so running
-        // in the wrong directory would silently produce output in the wrong place
-        // instead of reporting an error.
+        // Child cwd only. Fail rather than exec in the wrong directory.
         if (!config.GetWorkingDirectory().empty())
         {
             if (chdir(config.GetWorkingDirectory().c_str()) != 0)
             {
                 int const chdir_errno = errno;
-                // STDERR_FILENO is the capture pipe (dup2 above), not the
-                // parent's real stderr. size() is the actual byte count, unlike
-                // snprintf's untruncated length. This allocates, same class of
-                // post-fork risk as setenv below; posix_spawn is the real fix.
+                // Writes to the capture pipe (dup2 above). Allocates; same
+                // post-fork risk as setenv. posix_spawn is the real fix.
                 std::string msg = "chdir failed for working directory '";
                 msg += config.GetWorkingDirectory();
                 msg += "': errno ";
@@ -638,9 +580,7 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
             }
         }
 
-        // Set environment variables. setenv() takes the libc env lock, which
-        // is not async-signal-safe; see the section banner above for the
-        // posix_spawn-based refactor that will eliminate this risk.
+        // setenv is not async-signal-safe; see the POSIX section banner.
         for (auto const& kv : config.GetEnvVars())
         {
             setenv(kv.first.c_str(), kv.second.c_str(), 1);
@@ -658,7 +598,6 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         _exit(EXIT_CODE_COMMAND_NOT_FOUND);
     }
 
-    // Parent process
     close(stdout_pipe[1]);
     close(stderr_pipe[1]);
 
@@ -685,9 +624,7 @@ bool LocalProfilerExecutor::IsRunning()
     if (result == m_process_id)
     {
         set_exit_code_from_status(status, m_exit_code);
-        // Reaped: clear the pid so we never wait on / signal it again (and so a
-        // recycled PID can't be mistaken for our child).
-        m_process_id = -1;
+        m_process_id = -1;  // reaped; do not wait/kill a recycled pid
         m_is_running = false;
         return false;
     }
@@ -704,22 +641,18 @@ bool LocalProfilerExecutor::Cancel()
 
     if (kill(m_process_id, SIGTERM) != 0)
     {
-        // The pid is gone (already exited, or reaped elsewhere). Nothing to do.
-        m_process_id = -1;
+        m_process_id = -1;  // gone already
         m_is_running = false;
         return false;
     }
 
-    // Give the child a brief chance to exit on SIGTERM, then escalate. Either
-    // way we MUST reap it (blocking waitpid) so it does not linger as a zombie
-    // for the lifetime of the app.
+    // SIGTERM grace, then SIGKILL. Always reap so the child is not a zombie.
     std::this_thread::sleep_for(std::chrono::milliseconds(SIGTERM_GRACE_MS));
 
     int   status = 0;
     pid_t result = waitpid(m_process_id, &status, WNOHANG);
     if (result == 0)
     {
-        // Still alive after the grace period: force-kill and block until reaped.
         kill(m_process_id, SIGKILL);
         result = waitpid(m_process_id, &status, 0);
     }
@@ -730,8 +663,7 @@ bool LocalProfilerExecutor::Cancel()
     }
     else
     {
-        // Could not obtain a status (e.g. ECHILD); best-effort failure code.
-        m_exit_code = 1;
+        m_exit_code = 1;  // e.g. ECHILD
     }
 
     m_process_id = -1;
@@ -792,16 +724,8 @@ ProfilerProcessController::ProfilerProcessController()
 
 ProfilerProcessController::~ProfilerProcessController()
 {
-    // The monitor job (ExecuteJob) holds a raw pointer to this controller and its
-    // executor. Signal cancellation, then block until the Job object that owns
-    // that pointer is gone before our members are destroyed. The block is
-    // released by EndMonitorJob(), which is driven by a shared_ptr scope-guard
-    // captured in the job lambda (see rocprofvis_profiler.cpp): it fires when the
-    // Job is destroyed - in ~Future at future_free - regardless of whether the
-    // job ever ran, so a job cancelled before it was dequeued still releases us.
-    // Contract: the caller must free the bound future before (or concurrently
-    // with, on another thread) freeing the profiler. The view teardown frees the
-    // future first, so this wait returns without blocking.
+    // Cancel, then wait until the monitor Job (raw `this`) is destroyed.
+    // Caller must free the bound future first or concurrently; the View does.
     Cancel();
     std::unique_lock<std::mutex> lock(m_job_mutex);
     m_job_cv.wait(lock, [this] { return !m_job_active; });
@@ -846,9 +770,7 @@ rocprofvis_result_t ProfilerProcessController::LaunchAsync(ProfilerConfig const*
         return kRocProfVisResultNotSupported;
     }
 
-    // Turn the tool enum into the absolute path that becomes argv[0]. Done on
-    // our own copy of the config, before anything is spawned, so a missing tool
-    // is reported as such instead of surfacing as the child's exit code 127.
+    // Resolve before spawn so a missing tool is ToolNotFound, not child exit 127.
     rocprofvis_result_t resolved = m_config->ResolveToolPath();
     if (resolved != kRocProfVisResultSuccess)
     {
@@ -856,12 +778,7 @@ rocprofvis_result_t ProfilerProcessController::LaunchAsync(ProfilerConfig const*
         return resolved;
     }
 
-    // Same rationale, applied to the working directory: checking it here turns
-    // the common failure into a proper result code with a logged reason, rather
-    // than a chdir failure inside the forked child whose only channels back are
-    // an exit code and a line on the captured stderr. What remains for the child
-    // to report is the narrow race where the directory disappears between this
-    // check and the fork.
+    // Same for cwd: fail here rather than as child exit 126 after chdir.
     rocprofvis_result_t working_directory_valid = m_config->ValidateWorkingDirectory();
     if (working_directory_valid != kRocProfVisResultSuccess)
     {
@@ -928,9 +845,7 @@ rocprofvis_result_t ProfilerProcessController::LaunchAsyncRemote(ProfilerConfig 
         return resolved;
     }
 
-    // The executor reads the future lazily inside its worker thread (started in
-    // Start) to observe cancellation; the ABI sets the future's job right after
-    // this returns, which is fine.
+    // Worker reads `future` after Start; ABI binds the job immediately after this.
     m_executor = std::make_unique<SshProfilerExecutor>(connection, future);
 
     bool launched = m_executor->Start(*m_config);
@@ -1045,11 +960,8 @@ rocprofvis_result_t ProfilerProcessController::ExecuteJob(ProfilerProcessControl
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    // The bound future resolves when this job returns. It must not resolve until
-    // the executor's worker has actually stopped: callers key resource teardown
-    // (freeing the profiler - which joins the worker - and the borrowed SSH
-    // connection) on the future. Cancel() only signals the worker; wait here for
-    // it to unwind so "future resolved" implies "worker done".
+    // Do not resolve the future until the executor worker has stopped. Cancel()
+    // only signals it; teardown keys on the future.
     while (controller->m_executor && controller->m_executor->IsRunning())
     {
         controller->GetOutput();
@@ -1084,10 +996,7 @@ ProfilerSession::ProfilerSession()
 
 ProfilerSession::~ProfilerSession()
 {
-    // The member ProfilerProcessController's destructor cancels the run and joins
-    // its monitor job before it (and its executor) are destroyed, so freeing the
-    // session is safe even with a job in flight. The bound Future is owned by the
-    // caller and is not touched here.
+    // Controller dtor joins the monitor job. The bound Future is caller-owned.
 }
 
 rocprofvis_controller_object_type_t ProfilerSession::GetType(void)

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
@@ -38,7 +38,6 @@ ProfilerConfig::ProfilerConfig()
     , m_tool(kRPVProfilerToolNone)
     , m_tool_directory()
     , m_resolved_tool_path()
-    , m_target_executable()
     , m_output_directory()
     , m_working_directory()
     , m_env_vars()
@@ -118,16 +117,6 @@ rocprofvis_result_t ProfilerConfig::ResolveToolPathRemote()
     }
 
     m_resolved_tool_path = binary_name;
-    return kRocProfVisResultSuccess;
-}
-
-rocprofvis_result_t ProfilerConfig::SetTargetExecutable(char const* path)
-{
-    if (path == nullptr)
-    {
-        return kRocProfVisResultInvalidArgument;
-    }
-    m_target_executable = path;
     return kRocProfVisResultSuccess;
 }
 

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
@@ -37,9 +37,8 @@ ProfilerConfig::ProfilerConfig()
     , m_profiler_type(kRPVProfilerTypeRocprofSysRun)
     , m_profiler_path()
     , m_target_executable()
-    , m_target_args()
-    , m_profiler_args()
     , m_output_directory()
+    , m_working_directory()
     , m_env_vars()
     , m_profiler_argv()
     , m_connection_type(ConnectionType::kLocal)
@@ -82,26 +81,6 @@ rocprofvis_result_t ProfilerConfig::SetTargetExecutable(char const* path)
     return kRocProfVisResultSuccess;
 }
 
-rocprofvis_result_t ProfilerConfig::SetTargetArgs(char const* args)
-{
-    if (args == nullptr)
-    {
-        return kRocProfVisResultInvalidArgument;
-    }
-    m_target_args = args;
-    return kRocProfVisResultSuccess;
-}
-
-rocprofvis_result_t ProfilerConfig::SetProfilerArgs(char const* args)
-{
-    if (args == nullptr)
-    {
-        return kRocProfVisResultInvalidArgument;
-    }
-    m_profiler_args = args;
-    return kRocProfVisResultSuccess;
-}
-
 rocprofvis_result_t ProfilerConfig::SetOutputDirectory(char const* path)
 {
     if (path == nullptr)
@@ -109,6 +88,16 @@ rocprofvis_result_t ProfilerConfig::SetOutputDirectory(char const* path)
         return kRocProfVisResultInvalidArgument;
     }
     m_output_directory = path;
+    return kRocProfVisResultSuccess;
+}
+
+rocprofvis_result_t ProfilerConfig::SetWorkingDirectory(char const* path)
+{
+    if (path == nullptr)
+    {
+        return kRocProfVisResultInvalidArgument;
+    }
+    m_working_directory = path;
     return kRocProfVisResultSuccess;
 }
 
@@ -289,6 +278,13 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
 
     LPVOID env_ptr = env_block.empty() ? nullptr : env_block.data();
 
+    // Working directory for the child only; this process's cwd is untouched.
+    // A non-existent directory makes CreateProcessA fail, which is the desired
+    // behavior: tools that write output relative to their cwd must not silently
+    // run somewhere else.
+    LPCSTR working_dir_ptr =
+        config.GetWorkingDirectory().empty() ? nullptr : config.GetWorkingDirectory().c_str();
+
     BOOL success = CreateProcessA(
         nullptr,
         cmd_line_buffer.data(),
@@ -297,7 +293,7 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         TRUE,
         0,
         env_ptr,
-        nullptr,
+        working_dir_ptr,
         &si,
         &pi);
 
@@ -439,9 +435,19 @@ std::string LocalProfilerExecutor::ReadOutput()
 // Grace period after SIGTERM before escalating to SIGKILL during Cancel().
 static constexpr int SIGTERM_GRACE_MS = 100;
 
+// Statuses the forked child uses to report a failure that happened before the
+// profiler itself ever ran. The values follow the POSIX shell convention (see
+// POSIX.1 "Shell Command Language", Exit Status), which reserves 126, 127 and
+// 128+n precisely so they cannot be mistaken for a status the profiled command
+// returned. Callers distinguish the two pre-exec cases by these codes alone -
+// the accompanying stderr message carries the human-readable detail.
+static constexpr int EXIT_CODE_CANNOT_EXECUTE    = 126;  // found, but setup failed
+static constexpr int EXIT_CODE_COMMAND_NOT_FOUND = 127;  // execvp() could not find it
+static constexpr int EXIT_CODE_SIGNAL_BASE       = 128;  // + signal number
+
 // Decodes a waitpid() status into the executor's exit-code convention (matches
 // the mapping used by IsRunning): normal exit -> exit status; killed by a
-// signal -> 128 + signal number.
+// signal -> EXIT_CODE_SIGNAL_BASE + signal number.
 static void set_exit_code_from_status(int status, int& exit_code)
 {
     if (WIFEXITED(status))
@@ -450,7 +456,7 @@ static void set_exit_code_from_status(int status, int& exit_code)
     }
     else if (WIFSIGNALED(status))
     {
-        exit_code = 128 + WTERMSIG(status);
+        exit_code = EXIT_CODE_SIGNAL_BASE + WTERMSIG(status);
     }
 }
 
@@ -544,6 +550,30 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         close(stdout_pipe[1]);
         close(stderr_pipe[1]);
 
+        // Enter the requested working directory before exec. Only the child's
+        // cwd changes; the parent's is untouched. chdir() is async-signal-safe,
+        // so it is safe in this post-fork context. Bail out rather than exec on
+        // failure: some tools write their output relative to the cwd, so running
+        // in the wrong directory would silently produce output in the wrong place
+        // instead of reporting an error.
+        if (!config.GetWorkingDirectory().empty())
+        {
+            if (chdir(config.GetWorkingDirectory().c_str()) != 0)
+            {
+                int chdir_errno = errno;
+                char err_buf[512];
+                int n = snprintf(err_buf, sizeof(err_buf),
+                                 "chdir failed for working directory '%s': %s (errno %d)\n",
+                                 config.GetWorkingDirectory().c_str(),
+                                 strerror(chdir_errno), chdir_errno);
+                if (n > 0)
+                {
+                    (void)write(STDERR_FILENO, err_buf, static_cast<size_t>(n));
+                }
+                _exit(EXIT_CODE_CANNOT_EXECUTE);
+            }
+        }
+
         // Set environment variables. setenv() takes the libc env lock, which
         // is not async-signal-safe; see the section banner above for the
         // posix_spawn-based refactor that will eliminate this risk.
@@ -563,7 +593,7 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
         {
             (void)write(STDERR_FILENO, err_buf, static_cast<size_t>(n));
         }
-        _exit(127);
+        _exit(EXIT_CODE_COMMAND_NOT_FOUND);
     }
 
     // Parent process
@@ -759,6 +789,11 @@ rocprofvis_result_t ProfilerProcessController::LaunchAsync(ProfilerConfig const*
     for (auto const& kv : config->GetEnvVars())
     {
         spdlog::info("Profiler env: {}={}", kv.first, kv.second);
+    }
+
+    if (!config->GetWorkingDirectory().empty())
+    {
+        spdlog::info("Profiler working directory: {}", config->GetWorkingDirectory());
     }
 
     spdlog::info("Profiler launch: {}", Cmdline::ToDisplayString(Cmdline::BuildArgv(*config)));

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.cpp
@@ -575,7 +575,7 @@ bool LocalProfilerExecutor::Start(const ProfilerConfig& config)
     // while the parent is multithreaded (GLFW/MoltenVK/Obj-C runtime). It works
     // on Linux, which is the only POSIX target today. Before enabling the
     // profiler on macOS this must be reworked to posix_spawnp() (deferred; see
-    // the section banner above and review item H6).
+    // the section banner above).
     m_process_id = fork();
 
     if (m_process_id == -1)

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
@@ -64,7 +64,6 @@ public:
 
     rocprofvis_result_t SetTool(rocprofvis_profiler_tool_t tool);
     rocprofvis_result_t SetToolDirectory(char const* directory);
-    rocprofvis_result_t SetTargetExecutable(char const* path);
     rocprofvis_result_t SetOutputDirectory(char const* path);
     rocprofvis_result_t SetWorkingDirectory(char const* path);
     rocprofvis_result_t AddEnvVar(char const* name, char const* value);
@@ -96,7 +95,6 @@ public:
     // hence "resolved" in the name, since reading it earlier yields nothing.
     std::string const& GetResolvedToolPath() const { return m_resolved_tool_path; }
 
-    std::string const& GetTargetExecutable() const { return m_target_executable; }
     std::string const& GetOutputDirectory() const { return m_output_directory; }
     std::string const& GetWorkingDirectory() const { return m_working_directory; }
 
@@ -115,10 +113,10 @@ private:
     rocprofvis_profiler_tool_t m_tool;
     std::string m_tool_directory;
     std::string m_resolved_tool_path;
-    // Descriptive only: the profiled program and where its output is expected.
-    // Neither contributes to argv (see Cmdline::BuildArgv) - callers that want
-    // them on the command line add them as explicit argv entries.
-    std::string m_target_executable;
+    // Where output is expected. Does not contribute to argv (see
+    // Cmdline::BuildArgv) - a caller that wants it on the command line adds it
+    // as an explicit argv entry - and has no reader yet; see
+    // rocprofvis_profiler_config_set_output_directory for why it is kept.
     std::string m_output_directory;
     // Directory the child process runs in. Applied in the child only (chdir
     // after fork / lpCurrentDirectory / a remote "cd" prefix) - never by

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
@@ -62,8 +62,8 @@ public:
 
     rocprofvis_controller_object_type_t GetType(void) final;
 
-    rocprofvis_result_t SetProfilerType(rocprofvis_profiler_type_t type);
-    rocprofvis_result_t SetProfilerPath(char const* path);
+    rocprofvis_result_t SetTool(rocprofvis_profiler_tool_t tool);
+    rocprofvis_result_t SetToolDirectory(char const* directory);
     rocprofvis_result_t SetTargetExecutable(char const* path);
     rocprofvis_result_t SetOutputDirectory(char const* path);
     rocprofvis_result_t SetWorkingDirectory(char const* path);
@@ -74,8 +74,28 @@ public:
                                          int port, char const* identity_file,
                                          char const* remote_stage_dir);
 
-    rocprofvis_profiler_type_t GetProfilerType() const { return m_profiler_type; }
-    std::string const& GetProfilerPath() const { return m_profiler_path; }
+    rocprofvis_profiler_tool_t GetTool() const { return m_tool; }
+    std::string const& GetToolDirectory() const { return m_tool_directory; }
+
+    // Resolves m_tool (in m_tool_directory if set) to an absolute executable path
+    // on this machine and caches it for GetResolvedToolPath. Must succeed before a
+    // launch: argv[0] comes from the cached result, so an unresolved tool must
+    // never reach exec.
+    rocprofvis_result_t ResolveToolPath();
+
+    // Remote equivalent. The tool lives on the remote host, so its filesystem
+    // cannot be searched from here without an extra round trip. argv[0] becomes
+    // <m_tool_directory>/<name> when a directory is configured (joined with '/',
+    // since the remote is addressed as POSIX regardless of what this host is), and
+    // otherwise the bare name for the remote $PATH to resolve. Consequently a
+    // missing remote tool still surfaces as the remote shell's "command not
+    // found" rather than kRocProfVisResultToolNotFound.
+    rocprofvis_result_t ResolveToolPathRemote();
+
+    // argv[0]. Empty until one of the two resolve calls above has succeeded -
+    // hence "resolved" in the name, since reading it earlier yields nothing.
+    std::string const& GetResolvedToolPath() const { return m_resolved_tool_path; }
+
     std::string const& GetTargetExecutable() const { return m_target_executable; }
     std::string const& GetOutputDirectory() const { return m_output_directory; }
     std::string const& GetWorkingDirectory() const { return m_working_directory; }
@@ -87,8 +107,14 @@ public:
     SshConnectionInfo const& GetSshInfo() const { return m_ssh_info; }
 
 private:
-    rocprofvis_profiler_type_t m_profiler_type;
-    std::string m_profiler_path;
+    // Which binary to run, named rather than pathed so that no caller-supplied
+    // string becomes argv[0]. m_tool_directory narrows *where* to look for it
+    // (for a ROCm install in a non-standard location) and is set through its own
+    // setter, never as a side effect of naming a tool; the filename still comes
+    // from the tool table, so a directory cannot name a different program.
+    rocprofvis_profiler_tool_t m_tool;
+    std::string m_tool_directory;
+    std::string m_resolved_tool_path;
     // Descriptive only: the profiled program and where its output is expected.
     // Neither contributes to argv (see Cmdline::BuildArgv) - callers that want
     // them on the command line add them as explicit argv entries.

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
@@ -65,9 +65,8 @@ public:
     rocprofvis_result_t SetProfilerType(rocprofvis_profiler_type_t type);
     rocprofvis_result_t SetProfilerPath(char const* path);
     rocprofvis_result_t SetTargetExecutable(char const* path);
-    rocprofvis_result_t SetTargetArgs(char const* args);
-    rocprofvis_result_t SetProfilerArgs(char const* args);
     rocprofvis_result_t SetOutputDirectory(char const* path);
+    rocprofvis_result_t SetWorkingDirectory(char const* path);
     rocprofvis_result_t AddEnvVar(char const* name, char const* value);
     rocprofvis_result_t AddProfilerArg(char const* arg);
     rocprofvis_result_t SetConnectionLocal();
@@ -78,9 +77,8 @@ public:
     rocprofvis_profiler_type_t GetProfilerType() const { return m_profiler_type; }
     std::string const& GetProfilerPath() const { return m_profiler_path; }
     std::string const& GetTargetExecutable() const { return m_target_executable; }
-    std::string const& GetTargetArgs() const { return m_target_args; }
-    std::string const& GetProfilerArgs() const { return m_profiler_args; }
     std::string const& GetOutputDirectory() const { return m_output_directory; }
+    std::string const& GetWorkingDirectory() const { return m_working_directory; }
 
     std::vector<std::pair<std::string, std::string>> const& GetEnvVars() const { return m_env_vars; }
     std::vector<std::string> const& GetProfilerArgv() const { return m_profiler_argv; }
@@ -91,10 +89,15 @@ public:
 private:
     rocprofvis_profiler_type_t m_profiler_type;
     std::string m_profiler_path;
+    // Descriptive only: the profiled program and where its output is expected.
+    // Neither contributes to argv (see Cmdline::BuildArgv) - callers that want
+    // them on the command line add them as explicit argv entries.
     std::string m_target_executable;
-    std::string m_target_args;
-    std::string m_profiler_args;
     std::string m_output_directory;
+    // Directory the child process runs in. Applied in the child only (chdir
+    // after fork / lpCurrentDirectory / a remote "cd" prefix) - never by
+    // chdir()ing this process, whose cwd is global shared state.
+    std::string m_working_directory;
 
     std::vector<std::pair<std::string, std::string>> m_env_vars;
     std::vector<std::string> m_profiler_argv;

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
@@ -91,6 +91,13 @@ public:
     // found" rather than kRocProfVisResultToolNotFound.
     rocprofvis_result_t ResolveToolPathRemote();
 
+    // Confirms a configured working directory exists locally, so a bad value is
+    // reported by the launching call instead of surfacing as the child's exit
+    // code 126 after a failed chdir - the same reasoning as ResolveToolPath.
+    // Only meaningful for local launches; a remote working directory lives on
+    // the far side of the connection and cannot be checked from here.
+    rocprofvis_result_t ValidateWorkingDirectory() const;
+
     // argv[0]. Empty until one of the two resolve calls above has succeeded -
     // hence "resolved" in the name, since reading it earlier yields nothing.
     std::string const& GetResolvedToolPath() const { return m_resolved_tool_path; }

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_process.h
@@ -51,8 +51,7 @@ struct SshConnectionInfo
 };
 
 /*
- * ProfilerConfig - Configuration for launching a profiler
- * Derives from Handle so it participates in the Reference<> validation pattern.
+ * Launch config. Handle so it participates in Reference<> validation.
  */
 class ProfilerConfig : public Handle
 {
@@ -76,30 +75,18 @@ public:
     rocprofvis_profiler_tool_t GetTool() const { return m_tool; }
     std::string const& GetToolDirectory() const { return m_tool_directory; }
 
-    // Resolves m_tool (in m_tool_directory if set) to an absolute executable path
-    // on this machine and caches it for GetResolvedToolPath. Must succeed before a
-    // launch: argv[0] comes from the cached result, so an unresolved tool must
-    // never reach exec.
+    // Local absolute path for argv[0]. Must succeed before exec.
     rocprofvis_result_t ResolveToolPath();
 
-    // Remote equivalent. The tool lives on the remote host, so its filesystem
-    // cannot be searched from here without an extra round trip. argv[0] becomes
-    // <m_tool_directory>/<name> when a directory is configured (joined with '/',
-    // since the remote is addressed as POSIX regardless of what this host is), and
-    // otherwise the bare name for the remote $PATH to resolve. Consequently a
-    // missing remote tool still surfaces as the remote shell's "command not
-    // found" rather than kRocProfVisResultToolNotFound.
+    // Remote argv[0]: "<tool_directory>/<name>" (POSIX join) or the bare name.
+    // A missing remote tool is still the shell's "command not found".
     rocprofvis_result_t ResolveToolPathRemote();
 
-    // Confirms a configured working directory exists locally, so a bad value is
-    // reported by the launching call instead of surfacing as the child's exit
-    // code 126 after a failed chdir - the same reasoning as ResolveToolPath.
-    // Only meaningful for local launches; a remote working directory lives on
-    // the far side of the connection and cannot be checked from here.
+    // Local-only: the directory exists, so a bad cwd is a launch error, not
+    // child exit 126. Remote cwd cannot be checked from here.
     rocprofvis_result_t ValidateWorkingDirectory() const;
 
-    // argv[0]. Empty until one of the two resolve calls above has succeeded -
-    // hence "resolved" in the name, since reading it earlier yields nothing.
+    // argv[0]; empty until ResolveToolPath or ResolveToolPathRemote succeeds.
     std::string const& GetResolvedToolPath() const { return m_resolved_tool_path; }
 
     std::string const& GetOutputDirectory() const { return m_output_directory; }
@@ -112,22 +99,14 @@ public:
     SshConnectionInfo const& GetSshInfo() const { return m_ssh_info; }
 
 private:
-    // Which binary to run, named rather than pathed so that no caller-supplied
-    // string becomes argv[0]. m_tool_directory narrows *where* to look for it
-    // (for a ROCm install in a non-standard location) and is set through its own
-    // setter, never as a side effect of naming a tool; the filename still comes
-    // from the tool table, so a directory cannot name a different program.
+    // Named tool; filename comes from the tool table, never from a caller path.
     rocprofvis_profiler_tool_t m_tool;
-    std::string m_tool_directory;
-    std::string m_resolved_tool_path;
-    // Where output is expected. Does not contribute to argv (see
-    // Cmdline::BuildArgv) - a caller that wants it on the command line adds it
-    // as an explicit argv entry - and has no reader yet; see
-    // rocprofvis_profiler_config_set_output_directory for why it is kept.
+    std::string m_tool_directory;      // search dir only; empty = default search
+    std::string m_resolved_tool_path;  // argv[0] after resolve
+    // Not on argv (see BuildArgv). Unread for now; kept for a later per-stage
+    // artifact destination. See rocprofvis_profiler_config_set_output_directory.
     std::string m_output_directory;
-    // Directory the child process runs in. Applied in the child only (chdir
-    // after fork / lpCurrentDirectory / a remote "cd" prefix) - never by
-    // chdir()ing this process, whose cwd is global shared state.
+    // Child cwd only (chdir after fork / lpCurrentDirectory / remote "cd").
     std::string m_working_directory;
 
     std::vector<std::pair<std::string, std::string>> m_env_vars;
@@ -137,10 +116,6 @@ private:
     SshConnectionInfo m_ssh_info;
 };
 
-/*
- * LocalProfilerExecutor - Platform-specific local process execution
- * Implements IProfilerExecutor for launching profiler processes on the local machine.
- */
 class LocalProfilerExecutor : public IProfilerExecutor
 {
 public:
@@ -174,9 +149,6 @@ private:
     std::string m_output_buffer;
 };
 
-/*
- * ProfilerProcessController - Manages profiler execution lifecycle
- */
 class ProfilerProcessController
 {
 public:
@@ -186,12 +158,8 @@ public:
     rocprofvis_result_t LaunchAsync(ProfilerConfig const* config);
 
 #ifdef ROCPROFVIS_ENABLE_REMOTE
-    // TEMPORARY (remote/SSH): remote variant runs the profiler over the supplied
-    // (already connected and authenticated) SSH connection via an
-    // SshProfilerExecutor. The connection is borrowed; the caller
-    // (View/SshSession) owns its lifetime. `future` is the bound profiler
-    // future, observed by the remote exec loop for cancellation; it is borrowed
-    // and may be null.
+    // TEMPORARY (remote/SSH): borrowed connected SshConnection; `future` is
+    // observed for cancel and may be null. Caller owns both lifetimes.
     rocprofvis_result_t LaunchAsyncRemote(ProfilerConfig const* config,
                                           SshConnection*        connection,
                                           Future*               future);
@@ -207,15 +175,10 @@ public:
 
     rocprofvis_result_t Cancel();
 
-    // Called by the C ABI immediately BEFORE the monitor job is issued, so the
-    // destructor knows a JobSystem job holding a raw pointer to this controller
-    // (and its executor) is in flight.
+    // C ABI calls this just before issuing the monitor job (raw `this` in flight).
     void BeginMonitorJob();
-    // Called via a shared_ptr scope-guard captured in the job lambda, when the
-    // Job object is destroyed (in ~Future at future_free). This fires whether or
-    // not ExecuteJob ever ran - a job cancelled before it is dequeued never runs
-    // its function - so it reliably releases a destructor blocked below. Safe to
-    // call more than once (idempotent).
+    // Fired when the Job is destroyed (~Future), even if ExecuteJob never ran.
+    // Unblocks the destructor. Idempotent.
     void EndMonitorJob();
 
     static rocprofvis_result_t ExecuteJob(ProfilerProcessController* controller, Future* future);
@@ -231,26 +194,17 @@ private:
     int m_exit_code;
     std::mutex m_mutex;
 
-    // Guards the "a monitor job references this controller" flag. The destructor
-    // cancels the run and blocks on m_job_cv until the owning Job object is
-    // destroyed (at future_free), so the controller/executor are never destroyed
-    // out from under ExecuteJob. Contract: the bound future must be freed before
-    // (or concurrently with) the profiler; the view teardown frees the future
-    // first, so the wait returns without blocking.
+    // Destructor waits on m_job_cv until the monitor Job is destroyed. Free the
+    // bound future before (or with) the profiler; the View already does.
     std::mutex              m_job_mutex;
     std::condition_variable m_job_cv;
     bool                    m_job_active = false;
 };
 
 /*
- * ProfilerSession - C-ABI handle that owns one ProfilerProcessController plus
- * a weak reference to the Future bound at launch time.
- *
- * The session is what rocprofvis_profiler_t maps to. It exists for the
- * lifetime the caller wants to query profiler state, independent of the
- * Future lifetime: status queries (get_state/output/trace_path/exit_code)
- * are routed through the session, not the future. Cancelling the session
- * forwards to both the controller and the bound future.
+ * C-ABI handle (rocprofvis_profiler_t): owns the controller and a non-owning
+ * pointer to the Future bound at launch. Status queries go through the session;
+ * Cancel forwards to both controller and future.
  */
 class ProfilerSession : public Handle
 {
@@ -263,8 +217,7 @@ public:
     ProfilerProcessController& GetController() { return m_controller; }
     ProfilerProcessController const& GetController() const { return m_controller; }
 
-    // Bound at launch_async; non-owning. The caller frees the future via
-    // rocprofvis_controller_future_free independent of this session.
+    // Non-owning; caller frees via rocprofvis_controller_future_free.
     void SetBoundFuture(Future* future) { m_bound_future = future; }
     Future* GetBoundFuture() const { return m_bound_future; }
 

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_tool.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_tool.cpp
@@ -1,0 +1,189 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocprofvis_controller_profiler_tool.h"
+
+#include "spdlog/spdlog.h"
+
+#include <cstdlib>
+#include <filesystem>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+namespace RocProfVis
+{
+namespace Controller
+{
+namespace ProfilerTool
+{
+
+namespace
+{
+
+#ifdef _WIN32
+constexpr char kPathListSeparator = ';';
+constexpr char const* kExecutableSuffix = ".exe";
+#else
+constexpr char kPathListSeparator = ':';
+constexpr char const* kExecutableSuffix = "";
+// Where a ROCm install lives when $ROCM_PATH says nothing. There is no
+// equivalent convention on Windows, so that platform relies on $ROCM_PATH and
+// $PATH alone.
+constexpr char const* kDefaultRocmPath = "/opt/rocm";
+#endif
+
+// Reads an environment variable, returning empty when unset. std::getenv is used
+// rather than the _dupenv_s family to keep one implementation across platforms;
+// the value is copied immediately, so the returned pointer is not retained.
+std::string get_env(char const* name)
+{
+    char const* value = std::getenv(name);
+    return (value != nullptr) ? std::string(value) : std::string();
+}
+
+// True if `path` names an existing file this process may execute. The
+// std::error_code overloads are used throughout because the throwing
+// std::filesystem overloads are not an option in this codebase.
+bool is_executable_file(std::filesystem::path const& path)
+{
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(path, ec) || ec)
+    {
+        // Follow symlinks: is_regular_file already does, but a broken link
+        // lands here and is correctly rejected.
+        return false;
+    }
+
+#ifdef _WIN32
+    // Windows has no execute permission bit that is meaningful here; presence
+    // of the file (with its .exe suffix already applied) is the test.
+    return true;
+#else
+    return ::access(path.c_str(), X_OK) == 0;
+#endif
+}
+
+// Appends the platform's executable suffix to a bare tool name.
+std::string with_suffix(char const* binary_name)
+{
+    return std::string(binary_name) + kExecutableSuffix;
+}
+
+} // namespace
+
+char const* GetBinaryName(rocprofvis_profiler_tool_t tool)
+{
+    switch (tool)
+    {
+        case kRPVProfilerToolRocprofSysRun:
+            return "rocprof-sys-run";
+        case kRPVProfilerToolRocprofSysSample:
+            return "rocprof-sys-sample";
+        case kRPVProfilerToolRocprofSysInstrument:
+            return "rocprof-sys-instrument";
+        case kRPVProfilerToolRocprofSysAvail:
+            return "rocprof-sys-avail";
+        case kRPVProfilerToolRocprofCompute:
+            return "rocprof-compute";
+        case kRPVProfilerToolRocprofV3:
+            return "rocprofv3";
+        case kRPVProfilerToolNone:
+        default:
+            return nullptr;
+    }
+}
+
+rocprofvis_result_t ResolvePath(rocprofvis_profiler_tool_t tool,
+                                std::string const&         tool_directory,
+                                std::string&               out_path)
+{
+    char const* binary_name = GetBinaryName(tool);
+    if (binary_name == nullptr)
+    {
+        spdlog::error("ProfilerTool::ResolvePath: unknown tool {}", static_cast<int>(tool));
+        return kRocProfVisResultInvalidArgument;
+    }
+
+    std::string const file_name = with_suffix(binary_name);
+
+    if (!tool_directory.empty())
+    {
+        if (!std::filesystem::path(tool_directory).is_absolute())
+        {
+            spdlog::error("Profiler tool directory must be an absolute path, got '{}'",
+                          tool_directory);
+            return kRocProfVisResultInvalidArgument;
+        }
+
+        std::filesystem::path candidate = std::filesystem::path(tool_directory) / file_name;
+        if (!is_executable_file(candidate))
+        {
+            spdlog::error("'{}' was not found in the configured tool directory '{}'", file_name,
+                          tool_directory);
+            return kRocProfVisResultToolNotFound;
+        }
+        // Deliberately no fallback to the default search: a configured directory
+        // that lacks the tool is reported, not quietly replaced by whatever else
+        // is installed - which would be a different build of the same tool.
+        spdlog::warn("Using configured tool directory for '{}': '{}'", file_name, tool_directory);
+        out_path = candidate.lexically_normal().string();
+        return kRocProfVisResultSuccess;
+    }
+
+    std::string rocm_path = get_env("ROCM_PATH");
+#ifndef _WIN32
+    if (rocm_path.empty())
+    {
+        rocm_path = kDefaultRocmPath;
+    }
+#endif
+    if (!rocm_path.empty())
+    {
+        std::filesystem::path candidate =
+            std::filesystem::path(rocm_path) / "bin" / file_name;
+        if (is_executable_file(candidate))
+        {
+            out_path = candidate.lexically_normal().string();
+            return kRocProfVisResultSuccess;
+        }
+    }
+
+    std::string const search_path = get_env("PATH");
+    size_t            start       = 0;
+    while (start <= search_path.size())
+    {
+        size_t end = search_path.find(kPathListSeparator, start);
+        if (end == std::string::npos)
+        {
+            end = search_path.size();
+        }
+
+        std::string entry = search_path.substr(start, end - start);
+        start             = end + 1;
+
+        if (entry.empty())
+        {
+            continue;
+        }
+
+        std::filesystem::path candidate = std::filesystem::path(entry) / file_name;
+        if (is_executable_file(candidate))
+        {
+            // Absolute so that what was found is what runs, even if this
+            // process's working directory differs from the child's.
+            std::error_code ec;
+            std::filesystem::path absolute = std::filesystem::absolute(candidate, ec);
+            out_path = (ec ? candidate : absolute).lexically_normal().string();
+            return kRocProfVisResultSuccess;
+        }
+    }
+
+    spdlog::error("Profiler tool '{}' was not found in $ROCM_PATH/bin or on $PATH", file_name);
+    return kRocProfVisResultToolNotFound;
+}
+
+} // namespace ProfilerTool
+} // namespace Controller
+} // namespace RocProfVis

--- a/src/controller/src/profiler/rocprofvis_controller_profiler_tool.h
+++ b/src/controller/src/profiler/rocprofvis_controller_profiler_tool.h
@@ -1,0 +1,66 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocprofvis_controller_enums.h"
+
+#include <string>
+
+namespace RocProfVis
+{
+namespace Controller
+{
+namespace ProfilerTool
+{
+
+/*
+ * Identity and discovery for the profiler binaries the launcher can run.
+ *
+ * A launch names its tool with rocprofvis_profiler_tool_t; this is the only
+ * place that knows what that enum is called on disk and where to look for it.
+ * Callers never supply the name of an executable. The one thing a caller may
+ * say is which *directory* to look in, for a ROCm install in a non-standard
+ * location - and because the filename still comes from the table below, no
+ * configuration file can name an arbitrary program to run.
+ *
+ * These are free functions rather than methods so the UI can resolve a tool for
+ * a command preview or a pre-flight check without allocating a session.
+ */
+
+/*
+ * The executable name for `tool`, without any directory and without a platform
+ * suffix (ResolvePath adds ".exe" on Windows). Returns nullptr for
+ * kRPVProfilerToolNone and for any value outside the enum.
+ */
+char const* GetBinaryName(rocprofvis_profiler_tool_t tool);
+
+/*
+ * Resolves `tool` to an absolute path to an existing executable.
+ *
+ * If `tool_directory` is non-empty it is the only place searched: the tool must
+ * be at <tool_directory>/<name>, and if it is not, resolution fails rather than
+ * falling through to the default search. That strictness is the point - someone
+ * configures a directory precisely because they have more than one ROCm install,
+ * so quietly running the other one is the confusion they were trying to end.
+ * The directory must be absolute; a relative one would mean different things to
+ * this process and to a child given its own working directory.
+ *
+ * With no directory configured, the default search is
+ * $ROCM_PATH/bin/<name> (defaulting to /opt/rocm on non-Windows), then each
+ * $PATH entry in order. Resolving to a full path here, rather than leaving a
+ * bare name for execvp, means what runs is decided (and can be shown to the
+ * user) before the process is created, and a "not found" is reported as such
+ * instead of surfacing later as exit code 127.
+ *
+ * Returns kRocProfVisResultToolNotFound if no candidate exists,
+ * kRocProfVisResultInvalidArgument for an unknown tool or a relative directory,
+ * and writes the resolved path to out_path on success.
+ */
+rocprofvis_result_t ResolvePath(rocprofvis_profiler_tool_t tool,
+                                std::string const&         tool_directory,
+                                std::string&               out_path);
+
+} // namespace ProfilerTool
+} // namespace Controller
+} // namespace RocProfVis

--- a/src/controller/src/profiler/rocprofvis_controller_ssh_profiler_executor.cpp
+++ b/src/controller/src/profiler/rocprofvis_controller_ssh_profiler_executor.cpp
@@ -61,7 +61,13 @@ bool SshProfilerExecutor::Start(const ProfilerConfig& config)
     // for a POSIX shell (the remote host).
     std::vector<std::string> argv = Cmdline::BuildArgv(config);
     std::vector<std::pair<std::string, std::string>> env = Cmdline::BuildEnv(config);
-    std::string remote_cmd = Cmdline::ToPosixShellCommand(argv, env);
+    std::string remote_cmd =
+        Cmdline::ToPosixShellCommand(argv, env, config.GetWorkingDirectory());
+
+    if (!config.GetWorkingDirectory().empty())
+    {
+        spdlog::info("SSH profiler working directory: {}", config.GetWorkingDirectory());
+    }
 
     spdlog::info("SSH profiler launch: {}", Cmdline::ToDisplayString(argv, env));
 

--- a/src/controller/src/profiler/rocprofvis_controller_ssh_profiler_executor.h
+++ b/src/controller/src/profiler/rocprofvis_controller_ssh_profiler_executor.h
@@ -30,6 +30,17 @@ class Future;
  *
  * This class lives in its own translation unit so the libssh2 / winsock headers
  * pulled in by the SSH client stay isolated from the profiler process code.
+ *
+ * NOTE (remote OS): the remote host is assumed to be POSIX, which holds today
+ * because the ROCm profilers ship on Linux only. If they gain Windows support,
+ * driving a Windows remote takes more than selecting a different tool: the
+ * command is serialized by Cmdline::ToPosixShellCommand, which single-quotes
+ * every token and prefixes "cd '<dir>' &&" for /bin/sh, and cmd.exe or
+ * PowerShell would not treat those quotes as quoting at all.
+ * ProfilerConfig::ResolveToolPathRemote requires a leading '/' and joins with
+ * '/', and the launcher's remote command preview reproduces that same
+ * composition, so those three have to be reworked together or the preview and
+ * the executed command stop matching.
  */
 class SshProfilerExecutor : public IProfilerExecutor
 {

--- a/src/controller/src/profiler/rocprofvis_profiler.cpp
+++ b/src/controller/src/profiler/rocprofvis_profiler.cpp
@@ -23,6 +23,7 @@
 #include "remote/rocprofvis_controller_ssh_client.h"
 #endif
 #include "rocprofvis_controller_profiler_process.h"
+#include "rocprofvis_controller_profiler_tool.h"
 #include "rocprofvis_controller_reference.h"
 #include "rocprofvis_controller_future.h"
 #include "rocprofvis_controller_job_system.h"
@@ -95,18 +96,31 @@ void rocprofvis_profiler_config_free(rocprofvis_profiler_config_t* config)
     }
 }
 
-rocprofvis_result_t rocprofvis_profiler_config_set_type(rocprofvis_profiler_config_t* config, rocprofvis_profiler_type_t profiler_type)
+rocprofvis_result_t rocprofvis_profiler_tool_get_binary_name(rocprofvis_profiler_tool_t tool, char* buffer, uint32_t* length)
 {
-    RocProfVis::Controller::ProfilerConfigRef config_ref(config);
-    if (!config_ref.IsValid())
+    char const* name = RocProfVis::Controller::ProfilerTool::GetBinaryName(tool);
+    if (name == nullptr)
     {
-        return kRocProfVisResultInvalidArgument;
+        return kRocProfVisResultInvalidEnum;
     }
 
-    return config_ref->SetProfilerType(profiler_type);
+    return RocProfVis::Controller::copy_string_to_buffer(name, buffer, length);
 }
 
-rocprofvis_result_t rocprofvis_profiler_config_set_profiler_path(rocprofvis_profiler_config_t* config, char const* profiler_path)
+rocprofvis_result_t rocprofvis_profiler_tool_resolve_path(rocprofvis_profiler_tool_t tool, char const* tool_directory, char* buffer, uint32_t* length)
+{
+    std::string         resolved;
+    rocprofvis_result_t result = RocProfVis::Controller::ProfilerTool::ResolvePath(
+        tool, tool_directory != nullptr ? tool_directory : "", resolved);
+    if (result != kRocProfVisResultSuccess)
+    {
+        return result;
+    }
+
+    return RocProfVis::Controller::copy_string_to_buffer(resolved, buffer, length);
+}
+
+rocprofvis_result_t rocprofvis_profiler_config_set_tool(rocprofvis_profiler_config_t* config, rocprofvis_profiler_tool_t tool)
 {
     RocProfVis::Controller::ProfilerConfigRef config_ref(config);
     if (!config_ref.IsValid())
@@ -114,7 +128,18 @@ rocprofvis_result_t rocprofvis_profiler_config_set_profiler_path(rocprofvis_prof
         return kRocProfVisResultInvalidArgument;
     }
 
-    return config_ref->SetProfilerPath(profiler_path);
+    return config_ref->SetTool(tool);
+}
+
+rocprofvis_result_t rocprofvis_profiler_config_set_tool_directory(rocprofvis_profiler_config_t* config, char const* tool_directory)
+{
+    RocProfVis::Controller::ProfilerConfigRef config_ref(config);
+    if (!config_ref.IsValid())
+    {
+        return kRocProfVisResultInvalidArgument;
+    }
+
+    return config_ref->SetToolDirectory(tool_directory);
 }
 
 rocprofvis_result_t rocprofvis_profiler_config_set_target_executable(rocprofvis_profiler_config_t* config, char const* target_executable)

--- a/src/controller/src/profiler/rocprofvis_profiler.cpp
+++ b/src/controller/src/profiler/rocprofvis_profiler.cpp
@@ -44,11 +44,16 @@ typedef Reference<rocprofvis_controller_connection_t, SshConnection, kRPVControl
 
 // Copies a std::string into the caller's buffer using the standard
 // "pass null buffer to query length" idiom shared by every string getter
-// in the profiler C API.
-//   - If buffer is null or *length is 0: writes the required size (excluding
-//     the null terminator) into *length and returns success.
-//   - Otherwise copies up to *length bytes (including a null terminator when
-//     it fits) and returns success.
+// in the controller C API (see Handle::GetStringImpl, which this matches):
+//   - If buffer is null or *length is 0: writes the string length, excluding
+//     any null terminator, into *length and returns success.
+//   - Otherwise copies up to *length bytes and returns success.
+//
+// No null terminator is written, so *length is a plain byte count rather than
+// a capacity that has to reserve room for one. That is what lets a caller feed
+// the queried length straight back in without losing the final character. The
+// terminator is the caller's job, and every caller already allocates
+// length + 1 zero-filled bytes for it.
 static rocprofvis_result_t copy_string_to_buffer(std::string const& src, char* buffer, uint32_t* length)
 {
     if (length == nullptr)
@@ -62,13 +67,10 @@ static rocprofvis_result_t copy_string_to_buffer(std::string const& src, char* b
         return kRocProfVisResultSuccess;
     }
 
-    // Copy what fits and always leave room for the null terminator. The
-    // *length == 0 case is handled above, so *length >= 1 here. std::memcpy is
-    // used instead of std::strncpy to avoid the MSVC C4996 deprecation and to
-    // guarantee termination even on truncation.
-    uint32_t copy_len = std::min(*length - 1, static_cast<uint32_t>(src.size()));
+    // std::memcpy rather than std::strncpy to avoid the MSVC C4996 deprecation.
+    uint32_t copy_len = std::min(*length, static_cast<uint32_t>(src.size()));
     std::memcpy(buffer, src.c_str(), copy_len);
-    buffer[copy_len] = '\0';
+    *length = copy_len;
     return kRocProfVisResultSuccess;
 }
 
@@ -126,28 +128,6 @@ rocprofvis_result_t rocprofvis_profiler_config_set_target_executable(rocprofvis_
     return config_ref->SetTargetExecutable(target_executable);
 }
 
-rocprofvis_result_t rocprofvis_profiler_config_set_target_args(rocprofvis_profiler_config_t* config, char const* target_args)
-{
-    RocProfVis::Controller::ProfilerConfigRef config_ref(config);
-    if (!config_ref.IsValid())
-    {
-        return kRocProfVisResultInvalidArgument;
-    }
-
-    return config_ref->SetTargetArgs(target_args);
-}
-
-rocprofvis_result_t rocprofvis_profiler_config_set_profiler_args(rocprofvis_profiler_config_t* config, char const* profiler_args)
-{
-    RocProfVis::Controller::ProfilerConfigRef config_ref(config);
-    if (!config_ref.IsValid())
-    {
-        return kRocProfVisResultInvalidArgument;
-    }
-
-    return config_ref->SetProfilerArgs(profiler_args);
-}
-
 rocprofvis_result_t rocprofvis_profiler_config_set_output_directory(rocprofvis_profiler_config_t* config, char const* output_directory)
 {
     RocProfVis::Controller::ProfilerConfigRef config_ref(config);
@@ -157,6 +137,17 @@ rocprofvis_result_t rocprofvis_profiler_config_set_output_directory(rocprofvis_p
     }
 
     return config_ref->SetOutputDirectory(output_directory);
+}
+
+rocprofvis_result_t rocprofvis_profiler_config_set_working_directory(rocprofvis_profiler_config_t* config, char const* working_directory)
+{
+    RocProfVis::Controller::ProfilerConfigRef config_ref(config);
+    if (!config_ref.IsValid())
+    {
+        return kRocProfVisResultInvalidArgument;
+    }
+
+    return config_ref->SetWorkingDirectory(working_directory);
 }
 
 rocprofvis_result_t rocprofvis_profiler_config_add_env_var(rocprofvis_profiler_config_t* config, char const* name, char const* value)

--- a/src/controller/src/profiler/rocprofvis_profiler.cpp
+++ b/src/controller/src/profiler/rocprofvis_profiler.cpp
@@ -142,17 +142,6 @@ rocprofvis_result_t rocprofvis_profiler_config_set_tool_directory(rocprofvis_pro
     return config_ref->SetToolDirectory(tool_directory);
 }
 
-rocprofvis_result_t rocprofvis_profiler_config_set_target_executable(rocprofvis_profiler_config_t* config, char const* target_executable)
-{
-    RocProfVis::Controller::ProfilerConfigRef config_ref(config);
-    if (!config_ref.IsValid())
-    {
-        return kRocProfVisResultInvalidArgument;
-    }
-
-    return config_ref->SetTargetExecutable(target_executable);
-}
-
 rocprofvis_result_t rocprofvis_profiler_config_set_output_directory(rocprofvis_profiler_config_t* config, char const* output_directory)
 {
     RocProfVis::Controller::ProfilerConfigRef config_ref(config);

--- a/src/controller/tests/rocprofvis_controller_profiler_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_profiler_tests.cpp
@@ -141,14 +141,13 @@ TEST_CASE("BuildArgv passes explicit arguments through verbatim", "[profiler][cm
 
 TEST_CASE("BuildArgv synthesizes no flags of its own", "[profiler][cmdline]")
 {
-    // target_executable and output_directory are descriptive metadata. Each
-    // profiler spells its output flag differently and disagrees about whether a
-    // "--" separator precedes the target, so the command line must contain only
-    // what the caller put there.
+    // Each profiler spells its output flag differently, and some take none at
+    // all, so neither the output directory nor a "--" separator may be
+    // synthesized here - the command line must contain only what the caller put
+    // there.
     ScratchToolDir tool_dir;
     ProfilerConfig config;
     use_tool_in(config, tool_dir);
-    config.SetTargetExecutable("/home/me/app");
     config.SetOutputDirectory("/tmp/out");
     config.SetWorkingDirectory("/tmp");
 
@@ -587,9 +586,8 @@ TEST_CASE("Arguments reach the child process unsplit and uninterpreted", "[profi
     rocprofvis_profiler_config_add_profiler_arg(config, "meta;|&$(echo hi)*?");
     rocprofvis_profiler_config_add_profiler_arg(config, "/path/with space/trace.db");
 
-    // Metadata that must not leak onto the command line.
-    rocprofvis_profiler_config_set_target_executable(config, "/should/not/appear");
-    rocprofvis_profiler_config_set_output_directory(config, "/should/not/appear/either");
+    // Must not leak onto the command line.
+    rocprofvis_profiler_config_set_output_directory(config, "/should/not/appear");
 
     rocprofvis_profiler_state_t state     = kRPVProfilerStateIdle;
     int32_t                     exit_code = -1;

--- a/src/controller/tests/rocprofvis_controller_profiler_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_profiler_tests.cpp
@@ -17,25 +17,92 @@
 #include "rocprofvis_profiler.h"
 #include "profiler/rocprofvis_controller_profiler_cmdline.h"
 #include "profiler/rocprofvis_controller_profiler_process.h"
+#include "profiler/rocprofvis_controller_profiler_tool.h"
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <cfloat>
 #include <filesystem>
+#include <fstream>
 #include <string>
 #include <vector>
+
+#ifndef _WIN32
+#include <cstdlib>
+#include <sys/stat.h>
+#endif
 
 // Tests for how a ProfilerConfig becomes a real command line and a real
 // process. The command line is the security- and correctness-sensitive part of
 // the profiler launch: every argument must reach the child exactly as composed,
-// with no re-splitting on whitespace and no shell interpretation, and the child
-// must run in the requested directory or not run at all.
+// with no re-splitting on whitespace and no shell interpretation, the tool that
+// runs must be the one the tool table resolved rather than any caller-supplied
+// string, and the child must run in the requested directory or not run at all.
 
 using RocProfVis::Controller::ProfilerConfig;
-namespace Cmdline = RocProfVis::Controller::Cmdline;
+namespace Cmdline     = RocProfVis::Controller::Cmdline;
+namespace ProfilerTool = RocProfVis::Controller::ProfilerTool;
 
 namespace
 {
+
+// An executable that certainly exists, used as a stand-in for a ROCm tool so
+// these tests need no ROCm install.
+#ifdef _WIN32
+constexpr char const* kRealExecutable = "C:\\Windows\\System32\\cmd.exe";
+#else
+constexpr char const* kRealExecutable = "/bin/sh";
+#endif
+
+// The file name the tool table expects for kRPVProfilerToolRocprofSysRun.
+#ifdef _WIN32
+constexpr char const* kToolFileName = "rocprof-sys-run.exe";
+#else
+constexpr char const* kToolFileName = "rocprof-sys-run";
+#endif
+
+// A scratch directory containing a stand-in for a ROCm tool.
+//
+// A tool is named, never pathed, so making a launch run some other program means
+// installing that program under the tool's own name and pointing the tool
+// directory at it - the same mechanism a user with a ROCm install in a
+// non-standard location would use. There is deliberately no API that sets argv[0]
+// to an arbitrary string, so this is how these tests get a runnable tool, and
+// exercising it here keeps that the only route.
+class ScratchToolDir
+{
+public:
+    explicit ScratchToolDir(char const* binary = kRealExecutable)
+        : m_dir(std::filesystem::temp_directory_path() /
+                ("roc-optiq tool dir " + std::filesystem::path(binary).filename().string()))
+    {
+        std::filesystem::remove_all(m_dir);
+        std::filesystem::create_directories(m_dir);
+        // A copy rather than a link so this works the same on every platform;
+        // copy_file carries the executable bit across on POSIX.
+        std::filesystem::copy_file(binary, m_dir / kToolFileName);
+    }
+
+    ~ScratchToolDir() { std::filesystem::remove_all(m_dir); }
+
+    ScratchToolDir(ScratchToolDir const&)            = delete;
+    ScratchToolDir& operator=(ScratchToolDir const&) = delete;
+
+    std::string Path() const { return m_dir.string(); }
+    std::string ToolPath() const { return (m_dir / kToolFileName).string(); }
+
+private:
+    std::filesystem::path m_dir;
+};
+
+// Points a config at a stand-in tool and resolves it, leaving GetResolvedToolPath
+// populated the way a launch would.
+void use_tool_in(ProfilerConfig& config, ScratchToolDir const& dir)
+{
+    REQUIRE(config.SetTool(kRPVProfilerToolRocprofSysRun) == kRocProfVisResultSuccess);
+    REQUIRE(config.SetToolDirectory(dir.Path().c_str()) == kRocProfVisResultSuccess);
+    REQUIRE(config.ResolveToolPath() == kRocProfVisResultSuccess);
+}
 
 // ==================================================================================
 // Command-line composition (platform independent)
@@ -43,8 +110,9 @@ namespace
 
 TEST_CASE("BuildArgv passes explicit arguments through verbatim", "[profiler][cmdline]")
 {
+    ScratchToolDir tool_dir;
     ProfilerConfig config;
-    config.SetProfilerPath("/opt/rocm/bin/rocprof-sys-run");
+    use_tool_in(config, tool_dir);
     config.AddProfilerArg("--preset=balanced");
     config.AddProfilerArg("-I");
     // A single argument containing spaces must survive as ONE argument. This is
@@ -54,7 +122,7 @@ TEST_CASE("BuildArgv passes explicit arguments through verbatim", "[profiler][cm
 
     std::vector<std::string> argv = Cmdline::BuildArgv(config);
 
-    REQUIRE(argv == std::vector<std::string>{"/opt/rocm/bin/rocprof-sys-run",
+    REQUIRE(argv == std::vector<std::string>{tool_dir.ToolPath(),
                                              "--preset=balanced",
                                              "-I",
                                              "my func(int, float)",
@@ -67,15 +135,16 @@ TEST_CASE("BuildArgv synthesizes no flags of its own", "[profiler][cmdline]")
     // profiler spells its output flag differently and disagrees about whether a
     // "--" separator precedes the target, so the command line must contain only
     // what the caller put there.
+    ScratchToolDir tool_dir;
     ProfilerConfig config;
-    config.SetProfilerPath("/usr/bin/tool");
+    use_tool_in(config, tool_dir);
     config.SetTargetExecutable("/home/me/app");
     config.SetOutputDirectory("/tmp/out");
     config.SetWorkingDirectory("/tmp");
 
     std::vector<std::string> argv = Cmdline::BuildArgv(config);
 
-    REQUIRE(argv == std::vector<std::string>{"/usr/bin/tool"});
+    REQUIRE(argv == std::vector<std::string>{tool_dir.ToolPath()});
 }
 
 TEST_CASE("ToPosixShellCommand quotes every token", "[profiler][cmdline]")
@@ -127,14 +196,329 @@ TEST_CASE("Env vars with names that are not identifiers are rejected", "[profile
 }
 
 // ==================================================================================
+// Tool identity and resolution
+// ==================================================================================
+
+TEST_CASE("Every tool maps to its binary name", "[profiler][tool]")
+{
+    CHECK(std::string(ProfilerTool::GetBinaryName(kRPVProfilerToolRocprofSysRun)) ==
+          "rocprof-sys-run");
+    CHECK(std::string(ProfilerTool::GetBinaryName(kRPVProfilerToolRocprofSysSample)) ==
+          "rocprof-sys-sample");
+    CHECK(std::string(ProfilerTool::GetBinaryName(kRPVProfilerToolRocprofSysInstrument)) ==
+          "rocprof-sys-instrument");
+    CHECK(std::string(ProfilerTool::GetBinaryName(kRPVProfilerToolRocprofSysAvail)) ==
+          "rocprof-sys-avail");
+    CHECK(std::string(ProfilerTool::GetBinaryName(kRPVProfilerToolRocprofCompute)) ==
+          "rocprof-compute");
+    CHECK(std::string(ProfilerTool::GetBinaryName(kRPVProfilerToolRocprofV3)) == "rocprofv3");
+
+    // Nothing to run, and nothing outside the enum is guessed at.
+    CHECK(ProfilerTool::GetBinaryName(kRPVProfilerToolNone) == nullptr);
+    CHECK(ProfilerTool::GetBinaryName(static_cast<rocprofvis_profiler_tool_t>(999)) == nullptr);
+}
+
+TEST_CASE("A config refuses a tool it cannot name", "[profiler][tool]")
+{
+    ProfilerConfig config;
+    CHECK(config.SetTool(kRPVProfilerToolNone) == kRocProfVisResultInvalidEnum);
+    CHECK(config.SetTool(static_cast<rocprofvis_profiler_tool_t>(999)) ==
+          kRocProfVisResultInvalidEnum);
+    CHECK(config.SetTool(kRPVProfilerToolRocprofCompute) == kRocProfVisResultSuccess);
+    CHECK(config.GetTool() == kRPVProfilerToolRocprofCompute);
+}
+
+TEST_CASE("A configured tool directory decides where the tool is looked for",
+          "[profiler][tool]")
+{
+    ScratchToolDir tool_dir;
+    std::string    resolved;
+
+    SECTION("the tool is found under its own name in the configured directory")
+    {
+        REQUIRE(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, tool_dir.Path(),
+                                          resolved) == kRocProfVisResultSuccess);
+        CHECK(resolved == tool_dir.ToolPath());
+    }
+
+    SECTION("a relative directory is refused rather than resolved against the cwd")
+    {
+        // The child may be given a working directory of its own, so a relative
+        // directory would not mean the same thing to it as to us.
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, "build/bin", resolved) ==
+              kRocProfVisResultInvalidArgument);
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, "./bin", resolved) ==
+              kRocProfVisResultInvalidArgument);
+    }
+
+    SECTION("a directory that does not hold the tool is a failure, not a different tool")
+    {
+        // The directory has rocprof-sys-run in it but not rocprofv3.
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofV3, tool_dir.Path(), resolved) ==
+              kRocProfVisResultToolNotFound);
+    }
+
+    SECTION("a directory that does not exist is a failure")
+    {
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun,
+                                        "/nonexistent-roc-optiq-tool-directory",
+                                        resolved) == kRocProfVisResultToolNotFound);
+    }
+
+    SECTION("a directory cannot name the executable")
+    {
+        // Pointing at the executable itself finds <exe>/rocprof-sys-run, which is
+        // not a thing. The filename is the tool table's to choose, and this is
+        // what stops a directory from being a path to an arbitrary program.
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, kRealExecutable,
+                                        resolved) == kRocProfVisResultToolNotFound);
+    }
+
+    SECTION("an unknown tool cannot be conjured out of a directory")
+    {
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolNone, tool_dir.Path(), resolved) ==
+              kRocProfVisResultInvalidArgument);
+    }
+}
+
+// Resolution reads $ROCM_PATH and $PATH, so the remaining cases install a fake
+// tool in a scratch directory and point those at it. Environment manipulation and
+// the executable bit are POSIX-specific here; the ordering logic they cover is
+// shared with Windows.
+#ifndef _WIN32
+
+// Sets an environment variable for the duration of a scope and restores whatever
+// was there before, so one test cannot leak a $PATH into the next.
+class ScopedEnv
+{
+public:
+    ScopedEnv(char const* name, std::string const& value)
+        : m_name(name)
+        , m_had_value(false)
+    {
+        char const* previous = std::getenv(name);
+        if(previous != nullptr)
+        {
+            m_previous  = previous;
+            m_had_value = true;
+        }
+        ::setenv(name, value.c_str(), 1);
+    }
+
+    ~ScopedEnv()
+    {
+        if(m_had_value)
+        {
+            ::setenv(m_name.c_str(), m_previous.c_str(), 1);
+        }
+        else
+        {
+            ::unsetenv(m_name.c_str());
+        }
+    }
+
+    ScopedEnv(ScopedEnv const&)            = delete;
+    ScopedEnv& operator=(ScopedEnv const&) = delete;
+
+private:
+    std::string m_name;
+    std::string m_previous;
+    bool        m_had_value;
+};
+
+// Writes an executable no-op script named `name` into `dir` and returns its path.
+std::filesystem::path install_fake_tool(std::filesystem::path const& dir,
+                                        std::string const&           name)
+{
+    std::filesystem::create_directories(dir);
+    std::filesystem::path path = dir / name;
+    {
+        std::ofstream out(path);
+        out << "#!/bin/sh\nexit 0\n";
+    }
+    ::chmod(path.c_str(), 0755);
+    return path;
+}
+
+TEST_CASE("Resolution prefers ROCM_PATH, then PATH, then fails", "[profiler][tool]")
+{
+    std::filesystem::path scratch =
+        std::filesystem::temp_directory_path() / "roc-optiq tool resolution";
+    std::filesystem::remove_all(scratch);
+
+    std::filesystem::path rocm_bin = scratch / "rocm" / "bin";
+    std::filesystem::path path_dir = scratch / "elsewhere";
+    std::string const     tool_name = "rocprof-sys-run";
+    std::string           resolved;
+
+    SECTION("$ROCM_PATH/bin wins over a copy earlier in $PATH")
+    {
+        std::filesystem::path in_rocm = install_fake_tool(rocm_bin, tool_name);
+        install_fake_tool(path_dir, tool_name);
+
+        ScopedEnv rocm("ROCM_PATH", (scratch / "rocm").string());
+        ScopedEnv path("PATH", path_dir.string());
+
+        REQUIRE(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, "", resolved) ==
+                kRocProfVisResultSuccess);
+        CHECK(resolved == in_rocm.string());
+    }
+
+    SECTION("$PATH is searched when the ROCm install has no such tool")
+    {
+        install_fake_tool(rocm_bin, "rocprof-compute");
+        std::filesystem::path in_path = install_fake_tool(path_dir, tool_name);
+
+        ScopedEnv rocm("ROCM_PATH", (scratch / "rocm").string());
+        // A leading empty entry and a directory that does not exist: both are
+        // skipped rather than ending the search.
+        ScopedEnv path("PATH", ":" + (scratch / "missing").string() + ":" + path_dir.string());
+
+        REQUIRE(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, "", resolved) ==
+                kRocProfVisResultSuccess);
+        CHECK(resolved == in_path.string());
+    }
+
+    SECTION("a non-executable file of the right name is not a match")
+    {
+        std::filesystem::create_directories(path_dir);
+        std::ofstream(path_dir / tool_name) << "not executable\n";
+        ::chmod((path_dir / tool_name).c_str(), 0644);
+
+        ScopedEnv rocm("ROCM_PATH", (scratch / "rocm").string());
+        ScopedEnv path("PATH", path_dir.string());
+
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, "", resolved) ==
+              kRocProfVisResultToolNotFound);
+    }
+
+    SECTION("an uninstalled tool is reported as not found, not left for execvp")
+    {
+        ScopedEnv rocm("ROCM_PATH", (scratch / "rocm").string());
+        ScopedEnv path("PATH", path_dir.string());
+
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofV3, "", resolved) ==
+              kRocProfVisResultToolNotFound);
+    }
+
+    SECTION("a relative $PATH entry still resolves to an absolute path")
+    {
+        // argv[0] has to be absolute: the child may be given a different working
+        // directory, which would change what a relative path means.
+        install_fake_tool(path_dir, tool_name);
+        std::filesystem::path saved_cwd = std::filesystem::current_path();
+        std::filesystem::current_path(scratch);
+
+        {
+            ScopedEnv rocm("ROCM_PATH", (scratch / "rocm").string());
+            ScopedEnv path("PATH", "elsewhere");
+
+            REQUIRE(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, "", resolved) ==
+                    kRocProfVisResultSuccess);
+            CHECK(std::filesystem::path(resolved).is_absolute());
+        }
+
+        std::filesystem::current_path(saved_cwd);
+    }
+
+    SECTION("a configured directory suppresses the default search entirely")
+    {
+        // The tool is installed in both $ROCM_PATH/bin and $PATH, and the
+        // configured directory has it too - resolution must take that one.
+        install_fake_tool(rocm_bin, tool_name);
+        install_fake_tool(path_dir, tool_name);
+        std::filesystem::path chosen_dir = scratch / "chosen";
+        std::filesystem::path in_chosen  = install_fake_tool(chosen_dir, tool_name);
+
+        ScopedEnv rocm("ROCM_PATH", (scratch / "rocm").string());
+        ScopedEnv path("PATH", path_dir.string());
+
+        REQUIRE(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, chosen_dir.string(),
+                                          resolved) == kRocProfVisResultSuccess);
+        CHECK(resolved == in_chosen.string());
+
+        // And when the configured directory lacks the tool, an installed copy
+        // elsewhere must not stand in for it: someone configures a directory
+        // precisely because they have more than one build, so quietly running the
+        // other one is the confusion they were trying to end.
+        std::filesystem::remove(in_chosen);
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, chosen_dir.string(),
+                                        resolved) == kRocProfVisResultToolNotFound);
+    }
+
+    std::filesystem::remove_all(scratch);
+}
+
+#endif  // !_WIN32
+
+TEST_CASE("The C ABI reports tool names with the shared string convention", "[profiler][tool]")
+{
+    // *length is a byte count without a terminator, so a caller can feed the
+    // queried length straight back in; see copy_string_to_buffer.
+    uint32_t length = 0;
+    REQUIRE(rocprofvis_profiler_tool_get_binary_name(kRPVProfilerToolRocprofCompute, nullptr,
+                                                     &length) == kRocProfVisResultSuccess);
+    REQUIRE(length == std::string("rocprof-compute").size());
+
+    std::vector<char> buffer(length + 1, '\0');
+    REQUIRE(rocprofvis_profiler_tool_get_binary_name(kRPVProfilerToolRocprofCompute,
+                                                     buffer.data(),
+                                                     &length) == kRocProfVisResultSuccess);
+    CHECK(std::string(buffer.data()) == "rocprof-compute");
+
+    length = 0;
+    CHECK(rocprofvis_profiler_tool_get_binary_name(kRPVProfilerToolNone, nullptr, &length) ==
+          kRocProfVisResultInvalidEnum);
+    CHECK(rocprofvis_profiler_tool_resolve_path(kRPVProfilerToolNone, nullptr, nullptr, &length) ==
+          kRocProfVisResultInvalidArgument);
+}
+
+TEST_CASE("The C ABI resolves a tool inside a configured directory", "[profiler][tool]")
+{
+    ScratchToolDir tool_dir;
+
+    uint32_t length = 0;
+    REQUIRE(rocprofvis_profiler_tool_resolve_path(kRPVProfilerToolRocprofSysRun,
+                                                  tool_dir.Path().c_str(), nullptr,
+                                                  &length) == kRocProfVisResultSuccess);
+    REQUIRE(length == tool_dir.ToolPath().size());
+
+    std::vector<char> buffer(length + 1, '\0');
+    REQUIRE(rocprofvis_profiler_tool_resolve_path(kRPVProfilerToolRocprofSysRun,
+                                                  tool_dir.Path().c_str(), buffer.data(),
+                                                  &length) == kRocProfVisResultSuccess);
+    CHECK(std::string(buffer.data()) == tool_dir.ToolPath());
+
+    // A directory without the tool reports that, rather than reaching past it.
+    length = 0;
+    CHECK(rocprofvis_profiler_tool_resolve_path(kRPVProfilerToolRocprofV3,
+                                                tool_dir.Path().c_str(), nullptr,
+                                                &length) == kRocProfVisResultToolNotFound);
+}
+
+// ==================================================================================
 // Process launch
 // ==================================================================================
 //
 // These run a real child process, so they use POSIX system utilities and are
 // skipped on Windows. /usr/bin/printf repeats its format once per remaining
 // argument, which makes each argv entry individually visible in the output.
+//
+// A ScratchToolDir installs the utility under the tool's own name, since naming a
+// tool is the only way to select a binary and nothing here is a ROCm tool. The
+// utilities used do not inspect argv[0], so running under another name is
+// indistinguishable to them.
 
 #ifndef _WIN32
+
+// Runs whatever `dir` holds as the named tool.
+void use_tool_in(rocprofvis_profiler_config_t* config, ScratchToolDir const& dir)
+{
+    REQUIRE(rocprofvis_profiler_config_set_tool(config, kRPVProfilerToolRocprofSysRun) ==
+            kRocProfVisResultSuccess);
+    REQUIRE(rocprofvis_profiler_config_set_tool_directory(config, dir.Path().c_str()) ==
+            kRocProfVisResultSuccess);
+}
 
 // Runs a config to completion and returns the child's captured output.
 // out_exit_code receives the child's exit code.
@@ -184,7 +568,8 @@ TEST_CASE("Arguments reach the child process unsplit and uninterpreted", "[profi
     rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
     REQUIRE(config != nullptr);
 
-    rocprofvis_profiler_config_set_profiler_path(config, "/usr/bin/printf");
+    ScratchToolDir tool_dir("/usr/bin/printf");
+    use_tool_in(config, tool_dir);
     rocprofvis_profiler_config_add_profiler_arg(config, "[%s]\n");
     rocprofvis_profiler_config_add_profiler_arg(config, "--simple");
     rocprofvis_profiler_config_add_profiler_arg(config, "with spaces  and   runs");
@@ -221,7 +606,8 @@ TEST_CASE("Environment variables are set in the child", "[profiler][process]")
     rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
     REQUIRE(config != nullptr);
 
-    rocprofvis_profiler_config_set_profiler_path(config, "/bin/sh");
+    ScratchToolDir tool_dir;
+    use_tool_in(config, tool_dir);
     rocprofvis_profiler_config_add_profiler_arg(config, "-c");
     rocprofvis_profiler_config_add_profiler_arg(config, "printf '%s' \"$ROCPROFVIS_TEST_VAR\"");
     rocprofvis_profiler_config_add_env_var(config, "ROCPROFVIS_TEST_VAR", "a value");
@@ -247,7 +633,8 @@ TEST_CASE("The child runs in the configured working directory", "[profiler][proc
     rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
     REQUIRE(config != nullptr);
 
-    rocprofvis_profiler_config_set_profiler_path(config, "/bin/sh");
+    ScratchToolDir tool_dir;
+    use_tool_in(config, tool_dir);
     rocprofvis_profiler_config_add_profiler_arg(config, "-c");
     rocprofvis_profiler_config_add_profiler_arg(config, "printf '%s' \"$PWD\"");
     rocprofvis_profiler_config_set_working_directory(config, scratch.string().c_str());
@@ -273,7 +660,8 @@ TEST_CASE("An empty working directory inherits Optiq's", "[profiler][process]")
     rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
     REQUIRE(config != nullptr);
 
-    rocprofvis_profiler_config_set_profiler_path(config, "/bin/sh");
+    ScratchToolDir tool_dir;
+    use_tool_in(config, tool_dir);
     rocprofvis_profiler_config_add_profiler_arg(config, "-c");
     rocprofvis_profiler_config_add_profiler_arg(config, "printf '%s' \"$PWD\"");
 
@@ -287,6 +675,37 @@ TEST_CASE("An empty working directory inherits Optiq's", "[profiler][process]")
     rocprofvis_profiler_config_free(config);
 }
 
+TEST_CASE("A tool that cannot be resolved fails the launch without spawning anything",
+          "[profiler][process][tool]")
+{
+    // The launch must not get as far as exec: reporting "not found" here is the
+    // whole reason resolution happens up front rather than being left to execvp,
+    // which would surface only as exit code 127 after a process had been created.
+    rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
+    REQUIRE(config != nullptr);
+
+    REQUIRE(rocprofvis_profiler_config_set_tool(config, kRPVProfilerToolRocprofSysRun) ==
+            kRocProfVisResultSuccess);
+    REQUIRE(rocprofvis_profiler_config_set_tool_directory(
+                config, "/nonexistent-roc-optiq-tool-directory") == kRocProfVisResultSuccess);
+
+    rocprofvis_profiler_t*          profiler = rocprofvis_profiler_alloc();
+    rocprofvis_controller_future_t* future   = rocprofvis_controller_future_alloc();
+    REQUIRE(profiler != nullptr);
+    REQUIRE(future != nullptr);
+
+    CHECK(rocprofvis_profiler_launch_async(profiler, config, future) ==
+          kRocProfVisResultToolNotFound);
+
+    rocprofvis_profiler_state_t state = kRPVProfilerStateIdle;
+    rocprofvis_profiler_get_state(profiler, &state);
+    CHECK(state == kRPVProfilerStateFailed);
+
+    rocprofvis_controller_future_free(future);
+    rocprofvis_profiler_free(profiler);
+    rocprofvis_profiler_config_free(config);
+}
+
 TEST_CASE("A missing working directory fails the run instead of running elsewhere",
           "[profiler][process]")
 {
@@ -296,7 +715,8 @@ TEST_CASE("A missing working directory fails the run instead of running elsewher
     rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
     REQUIRE(config != nullptr);
 
-    rocprofvis_profiler_config_set_profiler_path(config, "/bin/sh");
+    ScratchToolDir tool_dir;
+    use_tool_in(config, tool_dir);
     rocprofvis_profiler_config_add_profiler_arg(config, "-c");
     rocprofvis_profiler_config_add_profiler_arg(config, "printf 'SHOULD NOT RUN'");
     rocprofvis_profiler_config_set_working_directory(

--- a/src/controller/tests/rocprofvis_controller_profiler_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_profiler_tests.cpp
@@ -1,0 +1,320 @@
+// Copyright Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Windows: ensure NOMINMAX is defined before any header drags in windows.h,
+// so std::min/std::max are not shadowed by the min/max macros.
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#endif
+
+#include "rocprofvis_controller.h"
+#include "rocprofvis_core.h"
+#include "rocprofvis_profiler.h"
+#include "profiler/rocprofvis_controller_profiler_cmdline.h"
+#include "profiler/rocprofvis_controller_profiler_process.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cfloat>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+// Tests for how a ProfilerConfig becomes a real command line and a real
+// process. The command line is the security- and correctness-sensitive part of
+// the profiler launch: every argument must reach the child exactly as composed,
+// with no re-splitting on whitespace and no shell interpretation, and the child
+// must run in the requested directory or not run at all.
+
+using RocProfVis::Controller::ProfilerConfig;
+namespace Cmdline = RocProfVis::Controller::Cmdline;
+
+namespace
+{
+
+// ==================================================================================
+// Command-line composition (platform independent)
+// ==================================================================================
+
+TEST_CASE("BuildArgv passes explicit arguments through verbatim", "[profiler][cmdline]")
+{
+    ProfilerConfig config;
+    config.SetProfilerPath("/opt/rocm/bin/rocprof-sys-run");
+    config.AddProfilerArg("--preset=balanced");
+    config.AddProfilerArg("-I");
+    // A single argument containing spaces must survive as ONE argument. This is
+    // what the old join-then-split round-trip destroyed.
+    config.AddProfilerArg("my func(int, float)");
+    config.AddProfilerArg("");
+
+    std::vector<std::string> argv = Cmdline::BuildArgv(config);
+
+    REQUIRE(argv == std::vector<std::string>{"/opt/rocm/bin/rocprof-sys-run",
+                                             "--preset=balanced",
+                                             "-I",
+                                             "my func(int, float)",
+                                             ""});
+}
+
+TEST_CASE("BuildArgv synthesizes no flags of its own", "[profiler][cmdline]")
+{
+    // target_executable and output_directory are descriptive metadata. Each
+    // profiler spells its output flag differently and disagrees about whether a
+    // "--" separator precedes the target, so the command line must contain only
+    // what the caller put there.
+    ProfilerConfig config;
+    config.SetProfilerPath("/usr/bin/tool");
+    config.SetTargetExecutable("/home/me/app");
+    config.SetOutputDirectory("/tmp/out");
+    config.SetWorkingDirectory("/tmp");
+
+    std::vector<std::string> argv = Cmdline::BuildArgv(config);
+
+    REQUIRE(argv == std::vector<std::string>{"/usr/bin/tool"});
+}
+
+TEST_CASE("ToPosixShellCommand quotes every token", "[profiler][cmdline]")
+{
+    std::vector<std::string> argv{"/usr/bin/tool", "--filter", "a b", "it's", "x;rm -rf /"};
+
+    std::string cmd = Cmdline::ToPosixShellCommand(argv);
+
+    // Metacharacters must be inside quotes so the remote shell treats them as
+    // data. The ' in "it's" is closed, escaped, and reopened.
+    REQUIRE(cmd == "'/usr/bin/tool' '--filter' 'a b' 'it'\\''s' 'x;rm -rf /'");
+}
+
+TEST_CASE("ToPosixShellCommand prefixes the working directory with &&", "[profiler][cmdline]")
+{
+    std::vector<std::string> argv{"/usr/bin/tool"};
+
+    SECTION("empty working directory adds no prefix")
+    {
+        REQUIRE(Cmdline::ToPosixShellCommand(argv, {}, "") == "'/usr/bin/tool'");
+    }
+
+    SECTION("cd is quoted and joined with && so a missing directory aborts the run")
+    {
+        REQUIRE(Cmdline::ToPosixShellCommand(argv, {}, "/tmp/my results") ==
+                "cd '/tmp/my results' && '/usr/bin/tool'");
+    }
+
+    SECTION("cd precedes the environment assignments")
+    {
+        REQUIRE(Cmdline::ToPosixShellCommand(argv, {{"ROCPROFSYS_USE_PID", "false"}}, "/tmp") ==
+                "cd '/tmp' && ROCPROFSYS_USE_PID='false' '/usr/bin/tool'");
+    }
+}
+
+TEST_CASE("Env vars with names that are not identifiers are rejected", "[profiler][cmdline]")
+{
+    // The name is emitted unquoted in the remote command, so a malformed name
+    // would be a shell injection point.
+    ProfilerConfig config;
+    REQUIRE(config.AddEnvVar("PATH_OK", "1") == kRocProfVisResultSuccess);
+    REQUIRE(config.AddEnvVar("BAD NAME", "1") == kRocProfVisResultInvalidArgument);
+    REQUIRE(config.AddEnvVar("X; rm -rf /", "1") == kRocProfVisResultInvalidArgument);
+    REQUIRE(config.AddEnvVar("2LEADING_DIGIT", "1") == kRocProfVisResultInvalidArgument);
+
+    REQUIRE(config.GetEnvVars().size() == 1);
+    REQUIRE(Cmdline::ToPosixShellCommand({"/usr/bin/tool"}, config.GetEnvVars()) ==
+            "PATH_OK='1' '/usr/bin/tool'");
+}
+
+// ==================================================================================
+// Process launch
+// ==================================================================================
+//
+// These run a real child process, so they use POSIX system utilities and are
+// skipped on Windows. /usr/bin/printf repeats its format once per remaining
+// argument, which makes each argv entry individually visible in the output.
+
+#ifndef _WIN32
+
+// Runs a config to completion and returns the child's captured output.
+// out_exit_code receives the child's exit code.
+std::string run_to_completion(rocprofvis_profiler_config_t* config,
+                              rocprofvis_profiler_state_t*  out_state,
+                              int32_t*                      out_exit_code)
+{
+    rocprofvis_profiler_t*          profiler = rocprofvis_profiler_alloc();
+    rocprofvis_controller_future_t* future   = rocprofvis_controller_future_alloc();
+    REQUIRE(profiler != nullptr);
+    REQUIRE(future != nullptr);
+
+    rocprofvis_result_t launched = rocprofvis_profiler_launch_async(profiler, config, future);
+    std::string         output;
+
+    if(launched == kRocProfVisResultSuccess)
+    {
+        // Seconds. Generous: these children are trivial, so anything close to
+        // this means something is wedged rather than slow.
+        REQUIRE(rocprofvis_controller_future_wait(future, 30.0f) == kRocProfVisResultSuccess);
+
+        uint32_t length = 0;
+        rocprofvis_profiler_get_output(profiler, nullptr, &length);
+        if(length > 0)
+        {
+            std::vector<char> buffer(length + 1, '\0');
+            rocprofvis_profiler_get_output(profiler, buffer.data(), &length);
+            output.assign(buffer.data());
+        }
+    }
+
+    *out_state = kRPVProfilerStateIdle;
+    rocprofvis_profiler_get_state(profiler, out_state);
+    *out_exit_code = -1;
+    rocprofvis_profiler_get_exit_code(profiler, out_exit_code);
+
+    // The future must be freed first: ~ProfilerProcessController blocks until the
+    // monitor job's Job object is destroyed, and that happens in ~Future. Freeing
+    // the profiler first deadlocks.
+    rocprofvis_controller_future_free(future);
+    rocprofvis_profiler_free(profiler);
+    return output;
+}
+
+TEST_CASE("Arguments reach the child process unsplit and uninterpreted", "[profiler][process]")
+{
+    rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
+    REQUIRE(config != nullptr);
+
+    rocprofvis_profiler_config_set_profiler_path(config, "/usr/bin/printf");
+    rocprofvis_profiler_config_add_profiler_arg(config, "[%s]\n");
+    rocprofvis_profiler_config_add_profiler_arg(config, "--simple");
+    rocprofvis_profiler_config_add_profiler_arg(config, "with spaces  and   runs");
+    rocprofvis_profiler_config_add_profiler_arg(config, "quo\"te's");
+    // No shell is involved, so these are ordinary characters.
+    rocprofvis_profiler_config_add_profiler_arg(config, "meta;|&$(echo hi)*?");
+    rocprofvis_profiler_config_add_profiler_arg(config, "/path/with space/trace.db");
+
+    // Metadata that must not leak onto the command line.
+    rocprofvis_profiler_config_set_target_executable(config, "/should/not/appear");
+    rocprofvis_profiler_config_set_output_directory(config, "/should/not/appear/either");
+
+    rocprofvis_profiler_state_t state     = kRPVProfilerStateIdle;
+    int32_t                     exit_code = -1;
+    std::string output = run_to_completion(config, &state, &exit_code);
+
+    CHECK(state == kRPVProfilerStateCompleted);
+    CHECK(exit_code == 0);
+
+    // One bracketed line per argument: nothing was split, merged, expanded, or
+    // added.
+    REQUIRE(output ==
+            "[--simple]\n"
+            "[with spaces  and   runs]\n"
+            "[quo\"te's]\n"
+            "[meta;|&$(echo hi)*?]\n"
+            "[/path/with space/trace.db]\n");
+
+    rocprofvis_profiler_config_free(config);
+}
+
+TEST_CASE("Environment variables are set in the child", "[profiler][process]")
+{
+    rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
+    REQUIRE(config != nullptr);
+
+    rocprofvis_profiler_config_set_profiler_path(config, "/bin/sh");
+    rocprofvis_profiler_config_add_profiler_arg(config, "-c");
+    rocprofvis_profiler_config_add_profiler_arg(config, "printf '%s' \"$ROCPROFVIS_TEST_VAR\"");
+    rocprofvis_profiler_config_add_env_var(config, "ROCPROFVIS_TEST_VAR", "a value");
+
+    rocprofvis_profiler_state_t state     = kRPVProfilerStateIdle;
+    int32_t                     exit_code = -1;
+    std::string output = run_to_completion(config, &state, &exit_code);
+
+    CHECK(state == kRPVProfilerStateCompleted);
+    REQUIRE(output == "a value");
+
+    rocprofvis_profiler_config_free(config);
+}
+
+TEST_CASE("The child runs in the configured working directory", "[profiler][process]")
+{
+    // A directory with a space in it, since the working directory reaches the
+    // child without passing through any quoting layer.
+    std::filesystem::path scratch =
+        std::filesystem::temp_directory_path() / "roc-optiq profiler wd test";
+    std::filesystem::create_directories(scratch);
+
+    rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
+    REQUIRE(config != nullptr);
+
+    rocprofvis_profiler_config_set_profiler_path(config, "/bin/sh");
+    rocprofvis_profiler_config_add_profiler_arg(config, "-c");
+    rocprofvis_profiler_config_add_profiler_arg(config, "printf '%s' \"$PWD\"");
+    rocprofvis_profiler_config_set_working_directory(config, scratch.string().c_str());
+
+    std::filesystem::path before = std::filesystem::current_path();
+
+    rocprofvis_profiler_state_t state     = kRPVProfilerStateIdle;
+    int32_t                     exit_code = -1;
+    std::string output = run_to_completion(config, &state, &exit_code);
+
+    CHECK(state == kRPVProfilerStateCompleted);
+    CHECK(output == scratch.string());
+    // Only the child moved. Optiq's own working directory is global state shared
+    // by every open trace and relative path in the process.
+    CHECK(std::filesystem::current_path() == before);
+
+    rocprofvis_profiler_config_free(config);
+    std::filesystem::remove_all(scratch);
+}
+
+TEST_CASE("An empty working directory inherits Optiq's", "[profiler][process]")
+{
+    rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
+    REQUIRE(config != nullptr);
+
+    rocprofvis_profiler_config_set_profiler_path(config, "/bin/sh");
+    rocprofvis_profiler_config_add_profiler_arg(config, "-c");
+    rocprofvis_profiler_config_add_profiler_arg(config, "printf '%s' \"$PWD\"");
+
+    rocprofvis_profiler_state_t state     = kRPVProfilerStateIdle;
+    int32_t                     exit_code = -1;
+    std::string output = run_to_completion(config, &state, &exit_code);
+
+    CHECK(state == kRPVProfilerStateCompleted);
+    CHECK(output == std::filesystem::current_path().string());
+
+    rocprofvis_profiler_config_free(config);
+}
+
+TEST_CASE("A missing working directory fails the run instead of running elsewhere",
+          "[profiler][process]")
+{
+    // Silently falling back to the inherited directory would let a tool that
+    // writes output relative to its own cwd scatter results somewhere the user
+    // never asked for, and report success while doing it.
+    rocprofvis_profiler_config_t* config = rocprofvis_profiler_config_alloc();
+    REQUIRE(config != nullptr);
+
+    rocprofvis_profiler_config_set_profiler_path(config, "/bin/sh");
+    rocprofvis_profiler_config_add_profiler_arg(config, "-c");
+    rocprofvis_profiler_config_add_profiler_arg(config, "printf 'SHOULD NOT RUN'");
+    rocprofvis_profiler_config_set_working_directory(
+        config, "/nonexistent-roc-optiq-working-directory");
+
+    rocprofvis_profiler_state_t state     = kRPVProfilerStateIdle;
+    int32_t                     exit_code = -1;
+    std::string output = run_to_completion(config, &state, &exit_code);
+
+    CHECK(state == kRPVProfilerStateFailed);
+    CHECK(exit_code == 126);
+    CHECK(output.find("SHOULD NOT RUN") == std::string::npos);
+    // The reason is reported to the console the user is looking at.
+    CHECK(output.find("chdir failed") != std::string::npos);
+
+    rocprofvis_profiler_config_free(config);
+}
+
+#endif  // !_WIN32
+
+}  // namespace

--- a/src/controller/tests/rocprofvis_controller_profiler_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_profiler_tests.cpp
@@ -61,6 +61,16 @@ constexpr char const* kToolFileName = "rocprof-sys-run.exe";
 constexpr char const* kToolFileName = "rocprof-sys-run";
 #endif
 
+// An absolute directory that does not exist. It has to be absolute per this
+// platform's rules, or resolution rejects it as relative before it ever looks
+// at the filesystem - and on Windows "absolute" means a drive letter, so a
+// leading '/' alone is not enough.
+#ifdef _WIN32
+constexpr char const* kMissingToolDirectory = "C:\\nonexistent-roc-optiq-tool-directory";
+#else
+constexpr char const* kMissingToolDirectory = "/nonexistent-roc-optiq-tool-directory";
+#endif
+
 // A scratch directory containing a stand-in for a ROCm tool.
 //
 // A tool is named, never pathed, so making a launch run some other program means
@@ -260,8 +270,7 @@ TEST_CASE("A configured tool directory decides where the tool is looked for",
 
     SECTION("a directory that does not exist is a failure")
     {
-        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun,
-                                        "/nonexistent-roc-optiq-tool-directory",
+        CHECK(ProfilerTool::ResolvePath(kRPVProfilerToolRocprofSysRun, kMissingToolDirectory,
                                         resolved) == kRocProfVisResultToolNotFound);
     }
 
@@ -686,8 +695,8 @@ TEST_CASE("A tool that cannot be resolved fails the launch without spawning anyt
 
     REQUIRE(rocprofvis_profiler_config_set_tool(config, kRPVProfilerToolRocprofSysRun) ==
             kRocProfVisResultSuccess);
-    REQUIRE(rocprofvis_profiler_config_set_tool_directory(
-                config, "/nonexistent-roc-optiq-tool-directory") == kRocProfVisResultSuccess);
+    REQUIRE(rocprofvis_profiler_config_set_tool_directory(config, kMissingToolDirectory) ==
+            kRocProfVisResultSuccess);
 
     rocprofvis_profiler_t*          profiler = rocprofvis_profiler_alloc();
     rocprofvis_controller_future_t* future   = rocprofvis_controller_future_alloc();

--- a/src/view/src/profiler/rocprofvis_launch_config.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_config.cpp
@@ -107,5 +107,72 @@ LaunchConfig LaunchConfig::FromJson(jt::Json const& json)
     return cfg;
 }
 
+std::vector<std::string> SplitArguments(std::string const& arguments)
+{
+    std::vector<std::string> argv;
+    std::string              current;
+    // Tracks whether `current` holds a token at all, so that an explicitly
+    // empty argument ("" on the command line) survives as an empty entry
+    // instead of being dropped as if it were whitespace.
+    bool                     have_token = false;
+
+    for (size_t i = 0; i < arguments.size(); i++)
+    {
+        char c = arguments[i];
+
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f')
+        {
+            if (have_token)
+            {
+                argv.push_back(current);
+                current.clear();
+                have_token = false;
+            }
+            continue;
+        }
+
+        have_token = true;
+
+        if (c == '\'')
+        {
+            // Single quotes are fully literal: everything up to the closing
+            // quote, backslashes included.
+            for (i++; i < arguments.size() && arguments[i] != '\''; i++)
+            {
+                current.push_back(arguments[i]);
+            }
+        }
+        else if (c == '"')
+        {
+            for (i++; i < arguments.size() && arguments[i] != '"'; i++)
+            {
+                bool is_escape = arguments[i] == '\\' && (i + 1) < arguments.size() &&
+                                 (arguments[i + 1] == '"' || arguments[i + 1] == '\\');
+                if (is_escape)
+                {
+                    i++;
+                }
+                current.push_back(arguments[i]);
+            }
+        }
+        else if (c == '\\' && (i + 1) < arguments.size())
+        {
+            i++;
+            current.push_back(arguments[i]);
+        }
+        else
+        {
+            current.push_back(c);
+        }
+    }
+
+    if (have_token)
+    {
+        argv.push_back(current);
+    }
+
+    return argv;
+}
+
 } // namespace View
 } // namespace RocProfVis

--- a/src/view/src/profiler/rocprofvis_launch_config.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_config.cpp
@@ -3,6 +3,8 @@
 
 #include "rocprofvis_launch_config.h"
 #include "rocprofvis_json_utils.h"
+#include "rocprofvis_profiler.h"
+#include "spdlog/spdlog.h"
 
 namespace RocProfVis
 {
@@ -11,7 +13,6 @@ namespace View
 
 LaunchConfig::LaunchConfig()
     : profiler_id("rocprof-sys")
-    , tool_id("run")
     , connection(ConnectionType::kLocal)
     , target()
     , extra_env()
@@ -24,7 +25,8 @@ jt::Json LaunchConfig::ToJson() const
 {
     jt::Json json;
     json["profiler_id"] = profiler_id;
-    json["tool_id"] = tool_id;
+    json["tool"] = static_cast<int32_t>(tool);
+    json["tool_directory"] = tool_directory;
 
     jt::Json& conn = json["connection"];
     conn["type"] = (connection == ConnectionType::kLocal) ? "local" : "ssh";
@@ -59,8 +61,9 @@ LaunchConfig LaunchConfig::FromJson(jt::Json const& json)
     LaunchConfig cfg;
     jt::Json& j = const_cast<jt::Json&>(json);
 
-    cfg.profiler_id = JsonUtils::GetString(j, "profiler_id", cfg.profiler_id);
-    cfg.tool_id     = JsonUtils::GetString(j, "tool_id", cfg.tool_id);
+    cfg.profiler_id    = JsonUtils::GetString(j, "profiler_id", cfg.profiler_id);
+    cfg.tool_directory = JsonUtils::GetString(j, "tool_directory", cfg.tool_directory);
+    cfg.tool           = ToolFromInt(JsonUtils::GetInt(j, "tool", kRPVProfilerToolNone));
 
     if (j.contains("connection"))
     {
@@ -172,6 +175,95 @@ std::vector<std::string> SplitArguments(std::string const& arguments)
     }
 
     return argv;
+}
+
+std::string GetToolBinaryName(rocprofvis_profiler_tool_t tool)
+{
+    uint32_t length = 0;
+    rocprofvis_profiler_tool_get_binary_name(tool, nullptr, &length);
+    if (length == 0)
+    {
+        return std::string();
+    }
+
+    std::vector<char>   buffer(length + 1, '\0');
+    rocprofvis_result_t result =
+        rocprofvis_profiler_tool_get_binary_name(tool, buffer.data(), &length);
+    if (result != kRocProfVisResultSuccess)
+    {
+        return std::string();
+    }
+
+    buffer[length] = '\0';
+    return std::string(buffer.data());
+}
+
+rocprofvis_profiler_tool_t ToolFromInt(int32_t value)
+{
+    // The signed test comes first and stands alone: comparing a negative int32
+    // against the enum's unsigned values would convert it to a huge positive one.
+    bool const is_tool =
+        (value > 0) && (static_cast<uint32_t>(value) < __kRPVProfilerToolLast);
+    if (!is_tool)
+    {
+        // 0 is kRPVProfilerToolNone, which is how an absent key arrives - not
+        // worth a warning. Anything else is a value this build has no tool for.
+        if (value != 0)
+        {
+            spdlog::warn("Ignoring unknown profiler tool {} in a saved launch profile", value);
+        }
+        return kRPVProfilerToolNone;
+    }
+    return static_cast<rocprofvis_profiler_tool_t>(value);
+}
+
+std::string ResolveToolPath(rocprofvis_profiler_tool_t tool,
+                            std::string const&         tool_directory,
+                            std::string&               out_error)
+{
+    out_error.clear();
+
+    char const* directory = tool_directory.empty() ? nullptr : tool_directory.c_str();
+
+    // The search runs on the length query, so that first call is the one that
+    // reports why a tool could not be resolved.
+    uint32_t            length = 0;
+    rocprofvis_result_t result =
+        rocprofvis_profiler_tool_resolve_path(tool, directory, nullptr, &length);
+    if (result == kRocProfVisResultSuccess && length > 0)
+    {
+        std::vector<char> buffer(length + 1, '\0');
+        result = rocprofvis_profiler_tool_resolve_path(tool, directory, buffer.data(), &length);
+        if (result == kRocProfVisResultSuccess)
+        {
+            buffer[length] = '\0';
+            return std::string(buffer.data());
+        }
+    }
+
+    std::string const name = GetToolBinaryName(tool);
+    switch (result)
+    {
+        case kRocProfVisResultToolNotFound:
+            // Naming the configured directory matters: the reason this fails
+            // rather than falling back is that the user asked for that directory
+            // specifically, so the fix is to correct it or clear it.
+            out_error = !tool_directory.empty()
+                            ? (name + " was not found in " + tool_directory)
+                            : (name + " was not found. Check that ROCm is installed and that "
+                                      "$ROCM_PATH or $PATH points at it.");
+            break;
+        case kRocProfVisResultInvalidArgument:
+            out_error = tool_directory.empty()
+                            ? std::string("No profiler tool selected")
+                            : ("The tool directory must be an absolute path: " + tool_directory);
+            break;
+        default:
+            out_error = "Could not determine which " +
+                        (name.empty() ? std::string("profiler") : name) + " binary to run";
+            break;
+    }
+    return std::string();
 }
 
 } // namespace View

--- a/src/view/src/profiler/rocprofvis_launch_config.h
+++ b/src/view/src/profiler/rocprofvis_launch_config.h
@@ -51,5 +51,23 @@ struct LaunchConfig
     static LaunchConfig FromJson(jt::Json const& json);
 };
 
+/**
+ * Splits a user-typed argument string (TargetSpec::arguments) into individual
+ * argv entries the way a POSIX shell would word-split it, so that a quoted
+ * argument stays a single entry: --msg "hello world" yields two entries, not
+ * three. Whitespace separates entries; single quotes are literal; double quotes
+ * honor \" and \\; a backslash outside quotes escapes the next character.
+ *
+ * Only word-splitting and quote removal are performed. Nothing here is
+ * expanded - no globbing, variables, command substitution, or operators - and
+ * the resulting entries are passed to the process directly rather than through
+ * a shell, so shell metacharacters have no special meaning.
+ *
+ * An unterminated quote is not an error: the remainder of the string becomes
+ * the final entry, which keeps a half-typed command line previewing sensibly
+ * while the user is still editing it.
+ */
+std::vector<std::string> SplitArguments(std::string const& arguments);
+
 } // namespace View
 } // namespace RocProfVis

--- a/src/view/src/profiler/rocprofvis_launch_config.h
+++ b/src/view/src/profiler/rocprofvis_launch_config.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "json.h"
+#include "rocprofvis_controller_enums.h"
 #include <string>
 #include <vector>
 #include <map>
@@ -35,7 +36,19 @@ struct TargetSpec
 struct LaunchConfig
 {
     std::string              profiler_id;
-    std::string              tool_id;
+    // Which tool of that profiler to run. kRPVProfilerToolNone means "not chosen
+    // yet" - the launcher replaces it with the backend's first tool, so a launch
+    // never sees it. Persisted as the enum's integer value, hence the append-only
+    // rule on rocprofvis_profiler_tool_t.
+    rocprofvis_profiler_tool_t tool = kRPVProfilerToolNone;
+    // Directory holding the profiler tools, for a ROCm install in a non-standard
+    // location. Empty (the default) searches $ROCM_PATH/bin then $PATH. A
+    // directory rather than a path to an executable: the filename comes from the
+    // controller's tool table, so a profile cannot name a program to run. It
+    // lives on the profile rather than in app settings because a remote profile
+    // needs a path on the *remote* host, which a machine-local setting could
+    // never express.
+    std::string              tool_directory;
     ConnectionType           connection = ConnectionType::kLocal;
     // Id of the SSH connection profile (SshConnectionConfig::id) used when
     // connection == kSsh. Empty for local launches or when unset.
@@ -68,6 +81,42 @@ struct LaunchConfig
  * while the user is still editing it.
  */
 std::vector<std::string> SplitArguments(std::string const& arguments);
+
+/**
+ * The executable name of a profiler tool ("rocprof-sys-run"), as the controller
+ * spells it. Empty for kRPVProfilerToolNone. Use for labels and for a command
+ * preview when the tool could not be resolved to a real path.
+ */
+std::string GetToolBinaryName(rocprofvis_profiler_tool_t tool);
+
+/**
+ * Validates an integer read from a saved profile and returns the tool it names,
+ * or kRPVProfilerToolNone if this build has no such tool - which covers both a
+ * corrupted value and a profile written by a newer build that knows more tools.
+ * Bounded by the enum's own __kRPVProfilerToolLast, so there is no second list of
+ * valid values to keep in step with it.
+ */
+rocprofvis_profiler_tool_t ToolFromInt(int32_t value);
+
+/**
+ * Finds the absolute path a profiler tool would be launched from, searching
+ * tool_directory alone if it is set and the default locations otherwise, so the
+ * UI can show what will actually run and can tell the user a tool is missing
+ * before they commit to a run. Returns empty on failure, with a message written
+ * to out_error suitable for display.
+ *
+ * Applies to LOCAL launches only. A remote launch resolves its tool on the
+ * remote host, so calling this for one would report the wrong machine.
+ *
+ * This does not decide what gets launched: the launch passes the tool enum and
+ * the controller resolves it again at that point. Resolving twice is deliberate
+ * - it keeps the path out of the launch input entirely - and the small window
+ * where the answer could change between preview and launch is not worth a
+ * cached path that could be stale for other reasons.
+ */
+std::string ResolveToolPath(rocprofvis_profiler_tool_t tool,
+                            std::string const&         tool_directory,
+                            std::string&               out_error);
 
 } // namespace View
 } // namespace RocProfVis

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -467,7 +467,6 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
 }
 
 std::string BuildCommandPreviewString(
-    LaunchConfig const& config,
     std::string const& profiler_path,
     std::vector<std::pair<std::string, std::string>> const& env_vars,
     std::vector<std::string> const& argv)
@@ -482,29 +481,14 @@ std::string BuildCommandPreviewString(
         }
     }
 
+    // argv is already the complete argument list (see
+    // IProfilerBackend::FlattenToExecution), so the preview renders it as-is
+    // rather than re-deriving any part of the command. Anything appended here
+    // would be shown but not run.
     preview << profiler_path;
     for (auto const& arg : argv)
     {
         preview << " " << arg;
-    }
-
-    // Add extra_argv
-    for (auto const& arg : config.extra_argv)
-    {
-        preview << " " << arg;
-    }
-
-    if (!config.target.output_directory.empty())
-    {
-        preview << " --output " << config.target.output_directory;
-    }
-    if (!config.target.executable.empty())
-    {
-        preview << " -- " << config.target.executable;
-    }
-    if (!config.target.arguments.empty())
-    {
-        preview << " " << config.target.arguments;
     }
 
     return preview.str();

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -466,8 +466,74 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
     return modified;
 }
 
+bool RenderToolLocationSection(std::string& tool_directory, ConnectionType connection,
+                               AppWindow* app_window, std::string const& resolved_hint,
+                               const std::function<void()>& on_remote_browse_directory)
+{
+    bool modified = false;
+
+    const bool is_remote     = (connection == ConnectionType::kSsh);
+    const bool remote_browse = is_remote && static_cast<bool>(on_remote_browse_directory);
+
+    const float label_w  = 105.0f;
+    const float browse_w = 84.0f;
+    const float spacing  = ImGui::GetStyle().ItemSpacing.x;
+
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Tools folder");
+    ImGui::SameLine(label_w);
+    ImGui::SetNextItemWidth(-(browse_w + spacing));
+    if (InputTextStringWithHint(
+            "##ToolDir",
+            is_remote ? "leave empty to use the remote $ROCM_PATH or $PATH"
+                      : "leave empty to use $ROCM_PATH or $PATH",
+            tool_directory))
+    {
+        modified = true;
+    }
+    if (ImGui::IsItemHovered())
+    {
+        ImGui::SetTooltip("Folder containing the profiler executables, for a ROCm install in a\n"
+                          "non-standard location. The executable name is chosen by Optiq, so\n"
+                          "the tool must be present in this folder for the run to start.");
+    }
+
+    ImGui::SameLine();
+    const bool browse_disabled = is_remote && !remote_browse;
+    if (browse_disabled)
+    {
+        ImGui::BeginDisabled();
+    }
+    if (ImGui::Button("Browse##ToolDir", ImVec2(browse_w, 0)))
+    {
+        if (remote_browse)
+        {
+            on_remote_browse_directory();
+        }
+        else if (!is_remote && app_window)
+        {
+            app_window->ShowPathPickerDialog(
+                "Choose Profiler Tools Directory", "",
+                [&tool_directory](std::string const& path) { tool_directory = path; });
+        }
+    }
+    if (browse_disabled)
+    {
+        ImGui::EndDisabled();
+    }
+
+    if (!resolved_hint.empty())
+    {
+        ImGui::Dummy(ImVec2(label_w - ImGui::GetStyle().ItemSpacing.x, 0.0f));
+        ImGui::SameLine();
+        ImGui::TextDisabled("%s", resolved_hint.c_str());
+    }
+
+    return modified;
+}
+
 std::string BuildCommandPreviewString(
-    std::string const& profiler_path,
+    std::string const& tool_path,
     std::vector<std::pair<std::string, std::string>> const& env_vars,
     std::vector<std::string> const& argv)
 {
@@ -485,7 +551,7 @@ std::string BuildCommandPreviewString(
     // IProfilerBackend::FlattenToExecution), so the preview renders it as-is
     // rather than re-deriving any part of the command. Anything appended here
     // would be shown but not run.
-    preview << profiler_path;
+    preview << tool_path;
     for (auto const& arg : argv)
     {
         preview << " " << arg;

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
@@ -71,7 +71,9 @@ void RenderConfigChips(const char* lead_label, std::vector<std::string> const& t
 void StatusPill(const char* label, ImU32 bg_color);
 
 /**
- * Renders the Target section: executable, arguments, working dir, output dir.
+ * Renders the Target section: executable, arguments, output dir. TargetSpec::
+ * working_directory is deliberately not exposed here - it is honored at launch
+ * but currently only settable through a saved profile.
  * The connection-mode selector lives in the launcher dialog (ProfilerLauncher
  * Dialog::RenderRemoteSection), next to the dialog-owned SSH options; the mode
  * is passed in here so labels read "Remote ...".
@@ -87,10 +89,12 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
                          const std::function<void()>& on_remote_browse_output  = {});
 
 /**
- * Builds the displayed command line from cached execution inputs.
+ * Renders the command that will actually run, from the same inputs handed to
+ * the launch: the resolved binary, the merged env block, and the complete argv
+ * produced by IProfilerBackend::FlattenToExecution. For display only - tokens
+ * are not shell-quoted.
  */
 std::string BuildCommandPreviewString(
-    LaunchConfig const& config,
     std::string const& profiler_path,
     std::vector<std::pair<std::string, std::string>> const& env_vars,
     std::vector<std::string> const& argv);

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
@@ -89,13 +89,31 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
                          const std::function<void()>& on_remote_browse_output  = {});
 
 /**
+ * Renders the "where are the profiler tools" row: an optional directory that
+ * replaces the default $ROCM_PATH/bin then $PATH search, for a ROCm install in a
+ * non-standard location.
+ *
+ * Note this is a *directory*, never a path to an executable - the filename comes
+ * from the controller's tool table, so nothing the user types here can name a
+ * different program to run. In remote mode it is a directory on the remote host,
+ * so the local path picker does not apply and Browse is driven by the supplied
+ * callback (disabled when none is given), matching RenderTargetSection.
+ * `resolved_hint`, when non-empty, is shown beneath the field as the absolute
+ * path this selection currently resolves to.
+ * Returns true if the field was modified.
+ */
+bool RenderToolLocationSection(std::string& tool_directory, ConnectionType connection,
+                               AppWindow* app_window, std::string const& resolved_hint,
+                               const std::function<void()>& on_remote_browse_directory = {});
+
+/**
  * Renders the command that will actually run, from the same inputs handed to
  * the launch: the resolved binary, the merged env block, and the complete argv
  * produced by IProfilerBackend::FlattenToExecution. For display only - tokens
  * are not shell-quoted.
  */
 std::string BuildCommandPreviewString(
-    std::string const& profiler_path,
+    std::string const& tool_path,
     std::vector<std::pair<std::string, std::string>> const& env_vars,
     std::vector<std::string> const& argv);
 

--- a/src/view/src/profiler/rocprofvis_profiler_backend.h
+++ b/src/view/src/profiler/rocprofvis_profiler_backend.h
@@ -62,8 +62,23 @@ public:
     virtual std::string Validate(LaunchConfig const& config) const = 0;
 
     /**
-     * Convert the curated settings into env vars and argv for the
-     * profiler process. The caller merges extra_env on top afterwards.
+     * Convert the curated settings into the env vars and the complete argument
+     * list for the profiler process.
+     *
+     * argv_out receives every argument after argv[0] (the profiler binary), in
+     * the exact order and form the process will see it: the backend's own flags,
+     * config.extra_argv, the output path in whatever spelling this profiler
+     * uses, and the target executable plus its arguments (word-split with
+     * SplitArguments) wherever this profiler expects them. Command-line shape
+     * varies enough between profilers that no part of it is synthesized for the
+     * backend downstream - what is emitted here is what runs, and it is also
+     * what the command preview renders, so the two cannot drift apart.
+     *
+     * Each entry becomes one argv entry verbatim; nothing is re-split on
+     * whitespace or interpreted by a shell, so paths and arguments containing
+     * spaces must be emitted as single entries rather than pre-quoted.
+     *
+     * The caller merges config.extra_env on top of env_out afterwards.
      */
     virtual void FlattenToExecution(
         LaunchConfig const& config,

--- a/src/view/src/profiler/rocprofvis_profiler_backend.h
+++ b/src/view/src/profiler/rocprofvis_profiler_backend.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "rocprofvis_launch_config.h"
+#include "rocprofvis_controller_enums.h"
 #include "json.h"
 #include <string>
 #include <vector>
@@ -15,10 +16,14 @@ namespace RocProfVis
 namespace View
 {
 
+// One entry in the launcher's tool combo. The tool is identified by the
+// controller's enum rather than a backend-local string id, so there is a single
+// spelling of "which tool" from the combo through to argv[0] - and no per-backend
+// id table to keep in step with it.
 struct ToolOption
 {
-    std::string id;
-    std::string display_name;
+    rocprofvis_profiler_tool_t tool = kRPVProfilerToolNone;
+    std::string                display_name;
 };
 
 struct TabDescriptor
@@ -50,10 +55,19 @@ public:
     virtual const char* Id() const = 0;
     virtual const char* DisplayName() const = 0;
 
+    /**
+     * The tools this backend offers, in combo order. The first is the default
+     * for a fresh config and the fallback when a loaded profile names a tool this
+     * backend does not offer.
+     */
     virtual std::vector<ToolOption> GetTools() const = 0;
-    virtual std::string GetDefaultBinary(std::string const& tool_id) const = 0;
 
-    virtual std::vector<TabDescriptor> GetTabs(std::string const& tool_id) const = 0;
+    /**
+     * Tabs for the given tool, which is always one of GetTools() - the launcher
+     * keeps LaunchConfig::tool in step with the selected backend, so this does
+     * not need to handle a foreign or unset value.
+     */
+    virtual std::vector<TabDescriptor> GetTabs(rocprofvis_profiler_tool_t tool) const = 0;
 
     /**
      * Validate the config before launch. Returns empty string on success,

--- a/src/view/src/profiler/rocprofvis_profiler_launch_orchestrator.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launch_orchestrator.cpp
@@ -105,14 +105,7 @@ bool ProfilerLaunchOrchestrator::Launch(const LaunchRequest& request)
 
 bool ProfilerLaunchOrchestrator::LaunchLocal(const LaunchRequest& request)
 {
-    bool success = m_profiler_session.Launch(
-        request.profiler_type,
-        request.profiler_path,
-        request.target_executable,
-        request.target_args,
-        request.output_directory,
-        request.profiler_args,
-        request.env_vars);
+    bool success = m_profiler_session.Launch(request.spec);
 
     if(!success)
     {
@@ -157,14 +150,7 @@ bool ProfilerLaunchOrchestrator::LaunchRemote(const LaunchRequest& request)
             return parse_trace ? parse_trace(profiler_stdout) : std::string();
         });
 
-    bool success = m_remote_session->Launch(
-        request.profiler_type,
-        request.profiler_path,
-        request.target_executable,
-        request.target_args,
-        request.output_directory,
-        request.profiler_args,
-        request.env_vars);
+    bool success = m_remote_session->Launch(request.spec);
 
     if(!success)
     {

--- a/src/view/src/profiler/rocprofvis_profiler_launch_orchestrator.h
+++ b/src/view/src/profiler/rocprofvis_profiler_launch_orchestrator.h
@@ -49,13 +49,9 @@ public:
     // (the dialog) assembles this from its LaunchConfig + execution cache.
     struct LaunchRequest
     {
-        rocprofvis_profiler_type_t profiler_type = kRPVProfilerTypeRocprofSysRun;
-        std::string                profiler_path;
-        std::string                target_executable;
-        std::string                target_args;
-        std::string                output_directory;
-        std::string                profiler_args;
-        std::vector<std::pair<std::string, std::string>> env_vars;
+        // What to run: binary, argv, env, working directory. Handed to the
+        // session as-is.
+        ProfilerLaunchSpec         spec;
 
         bool                       is_remote       = false;
         bool                       auto_load_trace = true;

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -1237,15 +1237,15 @@ void ProfilerLauncherDialog::OnLaunchClicked()
     // to the orchestrator. The backend scraper resolves the produced trace path
     // from the profiler's stdout (local and remote).
     ProfilerLaunchOrchestrator::LaunchRequest request;
-    request.profiler_type     = ResolveProfilerType();
-    request.profiler_path     = m_execution_cache.profiler_path;
-    request.target_executable = m_config.target.executable;
-    request.target_args       = m_config.target.arguments;
-    request.output_directory  = m_config.target.output_directory;
-    request.profiler_args     = m_execution_cache.profiler_args;
-    request.env_vars          = m_execution_cache.env_vars;
-    request.is_remote         = is_remote;
-    request.auto_load_trace   = m_config.target.auto_load_trace;
+    request.spec.profiler_type     = ResolveProfilerType();
+    request.spec.profiler_path     = m_execution_cache.profiler_path;
+    request.spec.target_executable = m_config.target.executable;
+    request.spec.output_directory  = m_config.target.output_directory;
+    request.spec.working_directory = m_config.target.working_directory;
+    request.spec.profiler_argv     = m_execution_cache.argv;
+    request.spec.env_vars          = m_execution_cache.env_vars;
+    request.is_remote              = is_remote;
+    request.auto_load_trace        = m_config.target.auto_load_trace;
 #ifdef ROCPROFVIS_ENABLE_REMOTE
     request.remote_uri        = is_remote ? m_remote_uri : nullptr;
 #endif
@@ -1444,26 +1444,8 @@ void ProfilerLauncherDialog::RefreshExecutionCache()
         cache.env_vars.emplace_back(kv.first, kv.second);
     }
 
-    for (size_t i = 0; i < cache.argv.size(); i++)
-    {
-        if (i > 0)
-        {
-            cache.profiler_args += " ";
-        }
-        cache.profiler_args += cache.argv[i];
-    }
-
-    for (auto const& arg : m_config.extra_argv)
-    {
-        if (!cache.profiler_args.empty())
-        {
-            cache.profiler_args += " ";
-        }
-        cache.profiler_args += arg;
-    }
-
-    cache.command_preview = BuildCommandPreviewString(
-        m_config, cache.profiler_path, cache.env_vars, cache.argv);
+    cache.command_preview =
+        BuildCommandPreviewString(cache.profiler_path, cache.env_vars, cache.argv);
 
     m_execution_cache = std::move(cache);
 }

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -61,9 +61,7 @@ ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
     , m_run_end_time(0.0)
     , m_last_seen_state(kRPVProfilerStateIdle)
     , m_backend_index(0)
-    , m_tool_index(0)
     , m_config()
-    , m_profiler_path_override()
     , m_execution_cache()
     , m_preset_manager()
     , m_current_preset_name()
@@ -74,7 +72,7 @@ ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
     m_backends.push_back(std::make_unique<RocprofSysBackend>());
 
     m_config.profiler_id = m_backends[0]->Id();
-    m_config.tool_id = m_backends[0]->GetTools()[0].id;
+    SyncToolWithBackend();
     m_backends[0]->LoadSettings(jt::Json());
     m_config.backend_payload = m_backends[0]->SaveSettings();
 
@@ -210,10 +208,10 @@ void ProfilerLauncherDialog::RenderConfigureView()
 #else
         tags.push_back("Local");
 #endif
-        auto tools = backend->GetTools();
-        if (m_tool_index >= 0 && m_tool_index < static_cast<int>(tools.size()))
+        std::string const tool_name = CurrentToolDisplayName();
+        if (!tool_name.empty())
         {
-            tags.push_back(tools[m_tool_index].display_name);
+            tags.push_back(tool_name);
         }
         std::vector<std::string> backend_tags = backend->GetSummaryTags(m_config);
         tags.insert(tags.end(), backend_tags.begin(), backend_tags.end());
@@ -358,10 +356,10 @@ std::string ProfilerLauncherDialog::BuildRunSummary() const
     if (m_backend_index >= 0 && m_backend_index < static_cast<int>(m_backends.size()))
     {
         ss << m_backends[m_backend_index]->DisplayName();
-        auto tools = m_backends[m_backend_index]->GetTools();
-        if (m_tool_index >= 0 && m_tool_index < static_cast<int>(tools.size()))
+        std::string const tool_name = CurrentToolDisplayName();
+        if (!tool_name.empty())
         {
-            ss << " (" << tools[m_tool_index].display_name << ")";
+            ss << " (" << tool_name << ")";
         }
     }
 
@@ -430,16 +428,14 @@ void ProfilerLauncherDialog::RenderToolbar()
     ImGui::Text("Tool:");
     ImGui::SameLine();
     ImGui::PushItemWidth(120);
-    if (ImGui::BeginCombo("##ToolSelector",
-                          tools[m_tool_index].display_name.c_str()))
+    if (ImGui::BeginCombo("##ToolSelector", CurrentToolDisplayName().c_str()))
     {
-        for (size_t i = 0; i < tools.size(); i++)
+        for (auto const& option : tools)
         {
-            bool selected = (static_cast<int>(i) == m_tool_index);
-            if (ImGui::Selectable(tools[i].display_name.c_str(), selected))
+            if (ImGui::Selectable(option.display_name.c_str(), option.tool == m_config.tool))
             {
-                m_tool_index = static_cast<int>(i);
-                m_config.tool_id = tools[i].id;
+                m_config.tool = option.tool;
+                m_execution_cache_dirty = true;
             }
         }
         ImGui::EndCombo();
@@ -461,16 +457,8 @@ void ProfilerLauncherDialog::RenderToolbar()
             m_config = loaded;
             m_execution_cache_dirty = true;
             m_backends[m_backend_index]->LoadSettings(m_config.backend_payload);
+            SyncToolWithBackend();
             backend = m_backends[m_backend_index].get();
-            tools = backend->GetTools();
-            for (size_t i = 0; i < tools.size(); i++)
-            {
-                if (tools[i].id == m_config.tool_id)
-                {
-                    m_tool_index = static_cast<int>(i);
-                    break;
-                }
-            }
 #ifdef ROCPROFVIS_ENABLE_REMOTE
             // Resolve the profile's referenced SSH connection (if any) so the
             // remote section reflects the saved connection.
@@ -491,7 +479,7 @@ void ProfilerLauncherDialog::RenderMainContent()
 
     // Backend tabs are split into "general" (shown here) and "advanced" (opened
     // in a separate window), so the common path stays clean.
-    auto tabs = backend->GetTabs(m_config.tool_id);
+    auto tabs = backend->GetTabs(m_config.tool);
     std::vector<TabDescriptor const*> general_tabs;
     std::vector<TabDescriptor const*> advanced_tabs;
     for (auto const& tab : tabs)
@@ -631,10 +619,39 @@ void ProfilerLauncherDialog::RenderMainContent()
     ImGui::PushStyleColor(ImGuiCol_Border, settings.GetColor(Colors::kPanelBorderSubtle));
     ImGui::BeginChild("cfg_preview", ImVec2(0.0f, 0.0f),
                       ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysUseWindowPadding);
+    RenderToolResolutionNotice();
     RenderCommandPreview(m_execution_cache.command_preview);
     ImGui::EndChild();
     ImGui::PopStyleColor(2);
     ImGui::PopStyleVar(2);
+}
+
+void ProfilerLauncherDialog::RenderToolResolutionNotice()
+{
+    SettingsManager& settings = SettingsManager::Get();
+
+    if (!m_execution_cache.resolve_error.empty())
+    {
+        // Said here rather than only on Launch, because "the profiler is not
+        // installed" is not something the user should discover by pressing a
+        // button. The command preview below still shows the bare tool name, so
+        // this line is what explains why it has no path.
+        ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextError));
+        ImGui::TextWrapped("%s", m_execution_cache.resolve_error.c_str());
+        ImGui::PopStyleColor();
+        return;
+    }
+
+    // A tool directory travels with the profile, so a profile from elsewhere can
+    // arrive with one set. Showing it means an imported profile cannot quietly
+    // run a different build of the tool than the user expects.
+    if (!m_config.tool_directory.empty())
+    {
+        ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kTextWarning));
+        ImGui::TextWrapped("Using tools from %s%s", m_config.tool_directory.c_str(),
+                           IsSshMode() ? " on the remote host" : "");
+        ImGui::PopStyleColor();
+    }
 }
 
 void ProfilerLauncherDialog::RenderAdvancedWindow()
@@ -665,7 +682,37 @@ void ProfilerLauncherDialog::RenderAdvancedWindow()
         ImGui::TextDisabled("Fine-grained settings, applied on top of the selected preset.");
         ImGui::Spacing();
 
-        auto tabs = backend->GetTabs(m_config.tool_id);
+        // Where the tools live is a property of the launch profile rather than of
+        // any one backend, so it sits above the backend tabs.
+        std::function<void()> on_browse_tool_dir;
+#ifdef ROCPROFVIS_ENABLE_REMOTE
+        if (IsSshMode())
+        {
+            on_browse_tool_dir = [this]()
+            {
+                ApplySelectedConnection();
+                EnsureRemoteFileBrowser();
+                m_remote_file_browser->Open(
+                    m_config.tool_directory, RemoteFileBrowser::PickMode::kDirectory,
+                    [this](const std::string& path)
+                    {
+                        m_config.tool_directory = path;
+                        m_execution_cache_dirty = true;
+                    });
+            };
+        }
+#endif
+        if (RenderToolLocationSection(m_config.tool_directory, m_config.connection, m_app_window,
+                                      IsSshMode() ? std::string() : m_execution_cache.argv0,
+                                      on_browse_tool_dir))
+        {
+            m_execution_cache_dirty = true;
+        }
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::Spacing();
+
+        auto tabs = backend->GetTabs(m_config.tool);
         if (ImGui::BeginTabBar("AdvancedWindowTabs"))
         {
             for (auto const& tab : tabs)
@@ -1170,14 +1217,54 @@ void ProfilerLauncherDialog::Update()
     }
 }
 
-rocprofvis_profiler_type_t ProfilerLauncherDialog::ResolveProfilerType() const
+void ProfilerLauncherDialog::SyncToolWithBackend()
 {
-    if (m_config.tool_id == "instrument")
+    if (m_backends.empty())
     {
-        return kRPVProfilerTypeRocprofSysInstrument;
+        m_config.tool = kRPVProfilerToolNone;
+        return;
     }
-    // "run" / "sample" / default
-    return kRPVProfilerTypeRocprofSysRun;
+
+    std::vector<ToolOption> tools = m_backends[m_backend_index]->GetTools();
+    if (tools.empty())
+    {
+        m_config.tool = kRPVProfilerToolNone;
+        return;
+    }
+
+    for (auto const& option : tools)
+    {
+        if (option.tool == m_config.tool)
+        {
+            return;
+        }
+    }
+
+    // Reached for a fresh config, and for a profile saved against a different
+    // profiler or by a build that knew a tool this one does not. Reported rather
+    // than silently substituted: the user asked for a specific tool.
+    if (m_config.tool != kRPVProfilerToolNone)
+    {
+        spdlog::warn("Launch profile names a tool that {} does not offer; using {} instead",
+                     m_backends[m_backend_index]->Id(), tools[0].display_name);
+    }
+    m_config.tool = tools[0].tool;
+}
+
+std::string ProfilerLauncherDialog::CurrentToolDisplayName() const
+{
+    if (m_backends.empty())
+    {
+        return std::string();
+    }
+    for (auto const& option : m_backends[m_backend_index]->GetTools())
+    {
+        if (option.tool == m_config.tool)
+        {
+            return option.display_name;
+        }
+    }
+    return std::string();
 }
 
 void ProfilerLauncherDialog::OnLaunchClicked()
@@ -1233,12 +1320,26 @@ void ProfilerLauncherDialog::OnLaunchClicked()
 
     RefreshExecutionCache();
 
+    // A tool that cannot be found is reported here rather than left to fail
+    // mid-launch. resolve_error is only ever set for a local run, since remote
+    // resolution happens on the other host (RefreshExecutionCache).
+    if (!m_execution_cache.resolve_error.empty())
+    {
+        m_error_message = "Error: " + m_execution_cache.resolve_error;
+        return;
+    }
+    if (m_execution_cache.tool == kRPVProfilerToolNone)
+    {
+        m_error_message = "Error: no profiler tool selected";
+        return;
+    }
+
     // Assemble the run request from the config / execution cache, then hand off
     // to the orchestrator. The backend scraper resolves the produced trace path
     // from the profiler's stdout (local and remote).
     ProfilerLaunchOrchestrator::LaunchRequest request;
-    request.spec.profiler_type     = ResolveProfilerType();
-    request.spec.profiler_path     = m_execution_cache.profiler_path;
+    request.spec.tool              = m_execution_cache.tool;
+    request.spec.tool_directory    = m_config.tool_directory;
     request.spec.target_executable = m_config.target.executable;
     request.spec.output_directory  = m_config.target.output_directory;
     request.spec.working_directory = m_config.target.working_directory;
@@ -1435,7 +1536,34 @@ void ProfilerLauncherDialog::RefreshExecutionCache()
     m_config.backend_payload = backend->SaveSettings();
 
     ExecutionCache cache;
-    cache.profiler_path = GetProfilerPath();
+    cache.tool = m_config.tool;
+
+    std::string const& tool_directory = m_config.tool_directory;
+    if (IsSshMode())
+    {
+        // The tool is on the remote host, so this machine's filesystem says
+        // nothing about it - resolving here would report a local install (or its
+        // absence) for a command that runs elsewhere. Show exactly what the
+        // remote will run, which is what ProfilerConfig::ResolveToolPathRemote
+        // composes: <tool_directory>/<name>, or the bare name for the remote
+        // $PATH. Joined with '/' because the remote is addressed as POSIX.
+        std::string const name = GetToolBinaryName(cache.tool);
+        cache.argv0 = tool_directory.empty()
+                          ? name
+                          : (tool_directory.back() == '/' ? tool_directory + name
+                                                          : tool_directory + "/" + name);
+    }
+    else
+    {
+        cache.argv0 = ResolveToolPath(cache.tool, tool_directory, cache.resolve_error);
+        if (cache.argv0.empty())
+        {
+            // Keep the preview a command line rather than "<not found>"; the
+            // notice above it carries the reason.
+            cache.argv0 = GetToolBinaryName(cache.tool);
+        }
+    }
+
     backend->FlattenToExecution(m_config, cache.curated_env_vars, cache.argv);
 
     cache.env_vars = cache.curated_env_vars;
@@ -1445,7 +1573,7 @@ void ProfilerLauncherDialog::RefreshExecutionCache()
     }
 
     cache.command_preview =
-        BuildCommandPreviewString(cache.profiler_path, cache.env_vars, cache.argv);
+        BuildCommandPreviewString(cache.argv0, cache.env_vars, cache.argv);
 
     m_execution_cache = std::move(cache);
 }
@@ -1457,9 +1585,11 @@ void ProfilerLauncherDialog::SwitchBackend(int index)
         return;
     }
     m_backend_index = index;
-    m_tool_index = 0;
     m_config.profiler_id = m_backends[index]->Id();
-    m_config.tool_id = m_backends[index]->GetTools()[0].id;
+    // Not carried across: a tool belongs to one profiler, so the new backend's
+    // default is the only sensible selection.
+    m_config.tool = kRPVProfilerToolNone;
+    SyncToolWithBackend();
     m_backends[index]->LoadSettings(jt::Json());
     m_config.backend_payload = m_backends[index]->SaveSettings();
     m_execution_cache_dirty = true;
@@ -1470,7 +1600,6 @@ void ProfilerLauncherDialog::LoadFromSettings()
     SettingsManager& settings = SettingsManager::Get();
     ProfilerSettings& ps = settings.GetProfilerSettings();
 
-    m_profiler_path_override = ps.profiler_path;
     m_config.target.output_directory = ps.profiler_output_directory;
     m_config.target.auto_load_trace = ps.auto_load_trace;
     m_current_preset_name = ps.last_preset_name;
@@ -1502,16 +1631,7 @@ void ProfilerLauncherDialog::LoadFromSettings()
             m_config = loaded;
             m_execution_cache_dirty = true;
             m_backends[m_backend_index]->LoadSettings(m_config.backend_payload);
-            IProfilerBackend const* backend = m_backends[m_backend_index].get();
-            std::vector<ToolOption> tools = backend->GetTools();
-            for (size_t i = 0; i < tools.size(); i++)
-            {
-                if (tools[i].id == m_config.tool_id)
-                {
-                    m_tool_index = static_cast<int>(i);
-                    break;
-                }
-            }
+            SyncToolWithBackend();
 #ifdef ROCPROFVIS_ENABLE_REMOTE
             // A ref to a since-deleted connection is left unbound rather than
             // remapped onto whichever connection is selected.
@@ -1534,7 +1654,6 @@ void ProfilerLauncherDialog::SaveToSettings()
     SettingsManager& settings = SettingsManager::Get();
     ProfilerSettings& ps = settings.GetProfilerSettings();
 
-    ps.profiler_path = m_profiler_path_override;
     ps.profiler_output_directory = m_config.target.output_directory;
     ps.auto_load_trace = m_config.target.auto_load_trace;
     ps.last_preset_name = m_current_preset_name;
@@ -1594,16 +1713,6 @@ void ProfilerLauncherDialog::AddRecentTarget(std::string const& exe)
     }
 
     settings.SaveProfilerSettings();
-}
-
-std::string ProfilerLauncherDialog::GetProfilerPath() const
-{
-    if (!m_profiler_path_override.empty())
-    {
-        return m_profiler_path_override;
-    }
-    IProfilerBackend const* backend = m_backends[m_backend_index].get();
-    return backend->GetDefaultBinary(m_config.tool_id);
 }
 
 }  // namespace View

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -1340,7 +1340,6 @@ void ProfilerLauncherDialog::OnLaunchClicked()
     ProfilerLaunchOrchestrator::LaunchRequest request;
     request.spec.tool              = m_execution_cache.tool;
     request.spec.tool_directory    = m_config.tool_directory;
-    request.spec.target_executable = m_config.target.executable;
     request.spec.output_directory  = m_config.target.output_directory;
     request.spec.working_directory = m_config.target.working_directory;
     request.spec.profiler_argv     = m_execution_cache.argv;

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
@@ -54,7 +54,16 @@ private:
         // backend. Both the launch and the command preview read this, so what
         // is shown is what runs.
         std::vector<std::string>                         argv;
-        std::string                                      profiler_path;
+        rocprofvis_profiler_tool_t                       tool = kRPVProfilerToolNone;
+        // argv[0] as the run will see it: for a local run the absolute path
+        // resolved on this machine, for a remote one what the remote will resolve
+        // (<tool_directory>/<name>, or the bare name for its $PATH). Display only
+        // - the launch passes the tool enum and the controller resolves it again.
+        std::string                                      argv0;
+        // Why local resolution failed, if it did. Always empty for a remote run:
+        // the tool lives on a filesystem this machine cannot search, so this
+        // machine's answer would be about the wrong host.
+        std::string                                      resolve_error;
         std::string                                      command_preview;
     };
 
@@ -76,7 +85,14 @@ private:
         return false;
 #endif
     }
-    rocprofvis_profiler_type_t ResolveProfilerType() const;
+    // Forces m_config.tool to be one the current backend actually offers, falling
+    // back to its first tool. Call after anything that can change either side of
+    // that pairing - a backend switch, or loading a profile that may name a tool
+    // this backend does not have (or none at all). Without it the combo could
+    // display one tool while the launch ran another.
+    void SyncToolWithBackend();
+    // Display name of the currently selected tool, for the combo and the title.
+    std::string CurrentToolDisplayName() const;
 
     // Top-level view routing: the dialog is either in "configure" mode (author
     // the launch) or "run" mode (a focused output console shown once a run has
@@ -86,6 +102,9 @@ private:
 
     void RenderToolbar();
     void RenderMainContent();
+    // One line above the command preview: why the tool could not be resolved, or
+    // that a configured tool directory is deciding which build runs.
+    void RenderToolResolutionNotice();
     // Deeper, less-common backend settings, shown in a separate floating window
     // opened from the "Advanced Options..." button.
     void RenderAdvancedWindow();
@@ -120,7 +139,6 @@ private:
     void EnsureRemoteFileBrowser();
 #endif
     void AddRecentTarget(std::string const& exe);
-    std::string GetProfilerPath() const;
 
     AppWindow* m_app_window;
 
@@ -171,11 +189,9 @@ private:
     // Backend system
     std::vector<std::unique_ptr<IProfilerBackend>> m_backends;
     int m_backend_index;
-    int m_tool_index;
 
     // Config
     LaunchConfig m_config;
-    std::string m_profiler_path_override;
     ExecutionCache m_execution_cache;
     // Rebuild m_execution_cache (SaveSettings/flatten/preview - all allocating)
     // only when inputs may have changed, not every frame. Set on open / backend

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
@@ -50,9 +50,11 @@ private:
     {
         std::vector<std::pair<std::string, std::string>> curated_env_vars;
         std::vector<std::pair<std::string, std::string>> env_vars;
+        // Complete argument list for the profiler process, as emitted by the
+        // backend. Both the launch and the command preview read this, so what
+        // is shown is what runs.
         std::vector<std::string>                         argv;
         std::string                                      profiler_path;
-        std::string                                      profiler_args;
         std::string                                      command_preview;
     };
 

--- a/src/view/src/profiler/rocprofvis_profiler_session.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_session.cpp
@@ -12,18 +12,11 @@ namespace View
 {
 
 bool
-ProfilerSession::Launch(rocprofvis_profiler_type_t profiler_type,
-                        const std::string&         profiler_path,
-                        const std::string&         target_executable,
-                        const std::string&         target_args,
-                        const std::string&         output_directory,
-                        const std::string&         profiler_args,
-                        const std::vector<std::pair<std::string, std::string>>& env_vars)
+ProfilerSession::Launch(const ProfilerLaunchSpec& spec)
 {
     Close();
 
-    if(!BuildConfig(profiler_type, profiler_path, target_executable, target_args,
-                    output_directory, profiler_args, env_vars))
+    if(!BuildConfig(spec))
     {
         return false;
     }

--- a/src/view/src/profiler/rocprofvis_profiler_session.h
+++ b/src/view/src/profiler/rocprofvis_profiler_session.h
@@ -27,13 +27,7 @@ public:
     // Launches a local profiler process asynchronously. On success the session
     // is registered with the AppMonitor and ProfilerStatusEvents are emitted as
     // the state changes. Any previous launch on this session is closed first.
-    bool Launch(rocprofvis_profiler_type_t profiler_type,
-                const std::string&         profiler_path,
-                const std::string&         target_executable,
-                const std::string&         target_args,
-                const std::string&         output_directory,
-                const std::string&         profiler_args,
-                const std::vector<std::pair<std::string, std::string>>& env_vars = {}) override;
+    bool Launch(const ProfilerLaunchSpec& spec) override;
 };
 
 }  // namespace View

--- a/src/view/src/profiler/rocprofvis_profiler_session_base.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_session_base.cpp
@@ -54,7 +54,6 @@ ProfilerSessionBase::BuildConfig(const ProfilerLaunchSpec& spec)
     {
         rocprofvis_profiler_config_set_tool_directory(m_config, spec.tool_directory.c_str());
     }
-    rocprofvis_profiler_config_set_target_executable(m_config, spec.target_executable.c_str());
     rocprofvis_profiler_config_set_output_directory(m_config, spec.output_directory.c_str());
     rocprofvis_profiler_config_set_working_directory(m_config, spec.working_directory.c_str());
 

--- a/src/view/src/profiler/rocprofvis_profiler_session_base.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_session_base.cpp
@@ -45,8 +45,15 @@ ProfilerSessionBase::BuildConfig(const ProfilerLaunchSpec& spec)
         return false;
     }
 
-    rocprofvis_profiler_config_set_type(m_config, spec.profiler_type);
-    rocprofvis_profiler_config_set_profiler_path(m_config, spec.profiler_path.c_str());
+    if(rocprofvis_profiler_config_set_tool(m_config, spec.tool) != kRocProfVisResultSuccess)
+    {
+        spdlog::error("Failed to set profiler tool ({})", static_cast<int>(spec.tool));
+        return false;
+    }
+    if(!spec.tool_directory.empty())
+    {
+        rocprofvis_profiler_config_set_tool_directory(m_config, spec.tool_directory.c_str());
+    }
     rocprofvis_profiler_config_set_target_executable(m_config, spec.target_executable.c_str());
     rocprofvis_profiler_config_set_output_directory(m_config, spec.output_directory.c_str());
     rocprofvis_profiler_config_set_working_directory(m_config, spec.working_directory.c_str());

--- a/src/view/src/profiler/rocprofvis_profiler_session_base.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_session_base.cpp
@@ -36,13 +36,7 @@ ProfilerSessionBase::~ProfilerSessionBase()
 }
 
 bool
-ProfilerSessionBase::BuildConfig(rocprofvis_profiler_type_t profiler_type,
-                                 const std::string&         profiler_path,
-                                 const std::string&         target_executable,
-                                 const std::string&         target_args,
-                                 const std::string&         output_directory,
-                                 const std::string&         profiler_args,
-                                 const std::vector<std::pair<std::string, std::string>>& env_vars)
+ProfilerSessionBase::BuildConfig(const ProfilerLaunchSpec& spec)
 {
     m_config = rocprofvis_profiler_config_alloc();
     if(m_config == nullptr)
@@ -51,14 +45,20 @@ ProfilerSessionBase::BuildConfig(rocprofvis_profiler_type_t profiler_type,
         return false;
     }
 
-    rocprofvis_profiler_config_set_type(m_config, profiler_type);
-    rocprofvis_profiler_config_set_profiler_path(m_config, profiler_path.c_str());
-    rocprofvis_profiler_config_set_target_executable(m_config, target_executable.c_str());
-    rocprofvis_profiler_config_set_target_args(m_config, target_args.c_str());
-    rocprofvis_profiler_config_set_output_directory(m_config, output_directory.c_str());
-    rocprofvis_profiler_config_set_profiler_args(m_config, profiler_args.c_str());
+    rocprofvis_profiler_config_set_type(m_config, spec.profiler_type);
+    rocprofvis_profiler_config_set_profiler_path(m_config, spec.profiler_path.c_str());
+    rocprofvis_profiler_config_set_target_executable(m_config, spec.target_executable.c_str());
+    rocprofvis_profiler_config_set_output_directory(m_config, spec.output_directory.c_str());
+    rocprofvis_profiler_config_set_working_directory(m_config, spec.working_directory.c_str());
 
-    for(auto const& kv : env_vars)
+    // One call per argument: the controller passes each entry through to the
+    // process untouched, so an argument containing spaces stays one argument.
+    for(auto const& arg : spec.profiler_argv)
+    {
+        rocprofvis_profiler_config_add_profiler_arg(m_config, arg.c_str());
+    }
+
+    for(auto const& kv : spec.env_vars)
     {
         rocprofvis_profiler_config_add_env_var(m_config, kv.first.c_str(), kv.second.c_str());
     }

--- a/src/view/src/profiler/rocprofvis_profiler_session_base.h
+++ b/src/view/src/profiler/rocprofvis_profiler_session_base.h
@@ -24,10 +24,14 @@ namespace View
 // command.
 struct ProfilerLaunchSpec
 {
-    rocprofvis_profiler_type_t profiler_type = kRPVProfilerTypeRocprofSysRun;
+    // Which binary to execute. Named rather than pathed so that argv[0] is
+    // decided by the controller's tool table, not by any string this struct
+    // carries; the controller resolves it to an absolute path at launch.
+    rocprofvis_profiler_tool_t tool = kRPVProfilerToolNone;
 
-    // Binary to execute (argv[0]).
-    std::string profiler_path;
+    // Directory to find that tool in (LaunchConfig::tool_directory), for a ROCm
+    // install in a non-standard location. Empty uses the default search.
+    std::string tool_directory;
 
     // Descriptive metadata for logging and artifact resolution. The profiled
     // program and the output path also appear in profiler_argv wherever the

--- a/src/view/src/profiler/rocprofvis_profiler_session_base.h
+++ b/src/view/src/profiler/rocprofvis_profiler_session_base.h
@@ -33,11 +33,11 @@ struct ProfilerLaunchSpec
     // install in a non-standard location. Empty uses the default search.
     std::string tool_directory;
 
-    // Descriptive metadata for logging and artifact resolution. The profiled
-    // program and the output path also appear in profiler_argv wherever the
-    // profiler's CLI expects them; setting these does not put them on the
-    // command line.
-    std::string target_executable;
+    // Where the profiler is expected to write its output. This does not put
+    // anything on the command line - the output path already appears in
+    // profiler_argv wherever the profiler's CLI expects it - and the controller
+    // has no reader for it yet; see
+    // rocprofvis_profiler_config_set_output_directory for why it is passed.
     std::string output_directory;
 
     // Directory to run the profiler process in. Empty inherits Optiq's own

--- a/src/view/src/profiler/rocprofvis_profiler_session_base.h
+++ b/src/view/src/profiler/rocprofvis_profiler_session_base.h
@@ -18,6 +18,36 @@ namespace RocProfVis
 namespace View
 {
 
+// Everything needed to configure one profiler process launch. These are grouped
+// into a struct rather than passed positionally because most of them are
+// strings: a transposed pair would compile cleanly and silently launch the wrong
+// command.
+struct ProfilerLaunchSpec
+{
+    rocprofvis_profiler_type_t profiler_type = kRPVProfilerTypeRocprofSysRun;
+
+    // Binary to execute (argv[0]).
+    std::string profiler_path;
+
+    // Descriptive metadata for logging and artifact resolution. The profiled
+    // program and the output path also appear in profiler_argv wherever the
+    // profiler's CLI expects them; setting these does not put them on the
+    // command line.
+    std::string target_executable;
+    std::string output_directory;
+
+    // Directory to run the profiler process in. Empty inherits Optiq's own
+    // working directory. Only the child is affected.
+    std::string working_directory;
+
+    // The complete argument list following argv[0], as emitted by
+    // IProfilerBackend::FlattenToExecution. Each entry becomes one argv entry
+    // verbatim - no whitespace splitting, no shell interpretation.
+    std::vector<std::string> profiler_argv;
+
+    std::vector<std::pair<std::string, std::string>> env_vars;
+};
+
 // Shared base for view-layer profiler sessions. Owns the profiler C API
 // objects (config / session handle / future) and the AppMonitor operation that
 // surfaces profiler state transitions as ProfilerStatusEvents. Subclasses
@@ -35,13 +65,7 @@ public:
 
     // Launches a profiler workflow asynchronously. The mechanism (local /
     // remote / multi-stage) is defined by the concrete subclass.
-    virtual bool Launch(rocprofvis_profiler_type_t profiler_type,
-                        const std::string&         profiler_path,
-                        const std::string&         target_executable,
-                        const std::string&         target_args,
-                        const std::string&         output_directory,
-                        const std::string&         profiler_args,
-                        const std::vector<std::pair<std::string, std::string>>& env_vars = {}) = 0;
+    virtual bool Launch(const ProfilerLaunchSpec& spec) = 0;
 
     virtual rocprofvis_profiler_state_t GetState() const;
     virtual std::string                 GetOutput();
@@ -63,13 +87,7 @@ protected:
     // Allocates m_config and applies the common profiler settings. Returns
     // false if allocation fails. Subclasses may apply additional settings
     // (e.g. SSH connection details) after a successful return.
-    bool BuildConfig(rocprofvis_profiler_type_t profiler_type,
-                     const std::string&         profiler_path,
-                     const std::string&         target_executable,
-                     const std::string&         target_args,
-                     const std::string&         output_directory,
-                     const std::string&         profiler_args,
-                     const std::vector<std::pair<std::string, std::string>>& env_vars);
+    bool BuildConfig(const ProfilerLaunchSpec& spec);
 
     // Registers the profiler op with the AppMonitor (status poller reads the
     // live controller state; the factory emits ProfilerStatusEvents). Stores

--- a/src/view/src/profiler/rocprofvis_remote_profiler_session.cpp
+++ b/src/view/src/profiler/rocprofvis_remote_profiler_session.cpp
@@ -92,13 +92,7 @@ RemoteProfilerSession::~RemoteProfilerSession()
 }
 
 bool
-RemoteProfilerSession::Launch(rocprofvis_profiler_type_t profiler_type,
-                              const std::string&         profiler_path,
-                              const std::string&         target_executable,
-                              const std::string&         target_args,
-                              const std::string&         output_directory,
-                              const std::string&         profiler_args,
-                              const std::vector<std::pair<std::string, std::string>>& env_vars)
+RemoteProfilerSession::Launch(const ProfilerLaunchSpec& spec)
 {
     if(m_running)
     {
@@ -107,8 +101,7 @@ RemoteProfilerSession::Launch(rocprofvis_profiler_type_t profiler_type,
 
     // Build the profiler config (same fields as local) and tag it as an SSH
     // launch so the controller selects the SshProfilerExecutor.
-    if(!BuildConfig(profiler_type, profiler_path, target_executable, target_args,
-                    output_directory, profiler_args, env_vars))
+    if(!BuildConfig(spec))
     {
         Fail("Failed to allocate profiler config.");
         return false;
@@ -121,7 +114,7 @@ RemoteProfilerSession::Launch(rocprofvis_profiler_type_t profiler_type,
             m_uri->GetRemoteUserString().c_str(),
             m_uri->GetRemotePortInt(),
             m_uri->GetRemoteIdentityFileString().c_str(),
-            output_directory.c_str());
+            spec.output_directory.c_str());
     }
 
     m_profiler = rocprofvis_profiler_alloc();

--- a/src/view/src/profiler/rocprofvis_remote_profiler_session.h
+++ b/src/view/src/profiler/rocprofvis_remote_profiler_session.h
@@ -66,13 +66,7 @@ public:
     // Begins the workflow (connect phase). Profiler parameters mirror the local
     // ProfilerSession::Launch. Returns false if the session/connection could not
     // be created.
-    bool Launch(rocprofvis_profiler_type_t profiler_type,
-                const std::string&         profiler_path,
-                const std::string&         target_executable,
-                const std::string&         target_args,
-                const std::string&         output_directory,
-                const std::string&         profiler_args,
-                const std::vector<std::pair<std::string, std::string>>& env_vars = {}) override;
+    bool Launch(const ProfilerLaunchSpec& spec) override;
 
     bool                        IsRunning() const { return m_running; }
     // True only while the trace download phase is active. The dialog uses this

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
@@ -511,26 +511,13 @@ const char* RocprofSysBackend::DisplayName() const
 std::vector<ToolOption> RocprofSysBackend::GetTools() const
 {
     return {
-        {"run",        "Run (LD_PRELOAD)"},
-        {"sample",     "Sample"},
-        {"instrument", "Instrument (Dyninst)"},
+        {kRPVProfilerToolRocprofSysRun,        "Run"},
+        {kRPVProfilerToolRocprofSysSample,     "Sample"},
+        {kRPVProfilerToolRocprofSysInstrument, "Instrument"},
     };
 }
 
-std::string RocprofSysBackend::GetDefaultBinary(std::string const& tool_id) const
-{
-    if (tool_id == "run")
-        return "rocprof-sys-run";
-    if (tool_id == "sample")
-        return "rocprof-sys-sample";
-    if (tool_id == "instrument")
-        return "rocprof-sys-instrument";
-    if (tool_id == "causal")
-        return "rocprof-sys-causal";
-    return "rocprof-sys-run";
-}
-
-std::vector<TabDescriptor> RocprofSysBackend::GetTabs(std::string const& tool_id) const
+std::vector<TabDescriptor> RocprofSysBackend::GetTabs(rocprofvis_profiler_tool_t tool) const
 {
     std::vector<TabDescriptor> tabs;
 
@@ -553,7 +540,7 @@ std::vector<TabDescriptor> RocprofSysBackend::GetTabs(std::string const& tool_id
     tabs.push_back({"parallelism", "Parallelism", [this]() {
         const_cast<RocprofSysBackend*>(this)->RenderParallelismTab(); }, true});
 
-    if (tool_id == "instrument")
+    if (tool == kRPVProfilerToolRocprofSysInstrument)
     {
         tabs.push_back({"instrument", "Instrument", [this]() {
             const_cast<RocprofSysBackend*>(this)->RenderInstrumentTab(); }, true});
@@ -634,7 +621,7 @@ std::vector<WarningMessage> RocprofSysBackend::GetWarnings(
     }
 
     // MPI + instrument tool
-    if (m_settings.use_mpip && config.tool_id == "instrument")
+    if (m_settings.use_mpip && config.tool == kRPVProfilerToolRocprofSysInstrument)
     {
         warnings.push_back({WarningMessage::kWarning,
             "Runtime instrumentation is incompatible with MPI spawn. "
@@ -642,7 +629,7 @@ std::vector<WarningMessage> RocprofSysBackend::GetWarnings(
     }
 
     // Tool routing: run + sampling
-    if (config.tool_id == "run" && m_settings.use_sampling &&
+    if (config.tool == kRPVProfilerToolRocprofSysRun && m_settings.use_sampling &&
         !m_settings.trace_backend)
     {
         warnings.push_back({WarningMessage::kInfo,
@@ -883,7 +870,7 @@ void RocprofSysBackend::FlattenToExecution(
     emit_bool("ROCPROFSYS_USE_PID", effective_use_pid, defaults.use_pid);
 
     // Instrument args
-    if (config.tool_id == "instrument")
+    if (config.tool == kRPVProfilerToolRocprofSysInstrument)
     {
         if (!m_settings.instr_include.empty())
         {

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
@@ -901,6 +901,33 @@ void RocprofSysBackend::FlattenToExecution(
             argv_out.push_back(std::to_string(m_settings.min_instructions));
         }
     }
+
+    // The user's raw escape hatch goes last among the profiler's own flags, so
+    // it can override anything emitted above, but still ahead of the "--"
+    // separator - past that point the tokens belong to the target, not to
+    // rocprof-sys.
+    for (auto const& arg : config.extra_argv)
+    {
+        argv_out.push_back(arg);
+    }
+
+    if (!config.target.output_directory.empty())
+    {
+        argv_out.push_back("--output");
+        argv_out.push_back(config.target.output_directory);
+    }
+
+    // Everything after "--" is the command rocprof-sys should run.
+    if (!config.target.executable.empty())
+    {
+        argv_out.push_back("--");
+        argv_out.push_back(config.target.executable);
+
+        for (auto const& arg : SplitArguments(config.target.arguments))
+        {
+            argv_out.push_back(arg);
+        }
+    }
 }
 
 // ==================================================================================
@@ -914,17 +941,35 @@ std::string RocprofSysBackend::ParseTraceOutputPath(std::string const& profiler_
     //   [...]database.cpp:151 database][info] Database: /path/rocpd-<pid>-0.db
     //   Output Summary box: "RocPD database" -> "File: /path/rocpd-<pid>-0.db"
     // We can't predict the exact filename (timestamp folder + PID suffix), so
-    // we scrape the path the tool actually printed. Strategy: scan lines and
-    // pull out a token ending in ".db". Prefer a line that explicitly names the
-    // database ("Database:" or "rocpd"); otherwise fall back to the last ".db"
-    // token seen anywhere in the output.
+    // we scrape the path the tool actually printed.
+    //
+    // Every candidate resolves to the LAST match in the stream, never the
+    // first. What we are handed is the whole child process tree's stdout and
+    // stderr, so the profiled application's own output is interleaved with the
+    // tool's and can name an unrelated database - profiling Optiq with Optiq
+    // logs "Opening file: <trace>.db" for whatever the user opens in the child.
+    // rocprof-sys reports its path during finalization, after the target has
+    // exited, so the tool's report is always the later one.
+    //
+    // Preference order, each resolved last-match: a path labelled "Database:",
+    // then one labelled "File:" (the Output Summary box), then any ".db" token
+    // for a tool that labels neither. The label has to appear before the path
+    // on the line, which is what keeps a lower-case "Opening file:" from
+    // passing itself off as the summary label.
+
+    struct DbToken
+    {
+        std::string text;
+        size_t      start = std::string::npos;
+    };
 
     // Extracts the last whitespace/quote-delimited token ending in ".db" from a
-    // single line, or empty if none. Trims surrounding quotes and punctuation.
-    auto extract_db_token = [](std::string const& line) -> std::string
+    // single line, or an empty token if none. Trims surrounding quotes and
+    // punctuation.
+    auto extract_db_token = [](std::string const& line) -> DbToken
     {
         const std::string ext = ".db";
-        std::string best;
+        DbToken best;
         size_t pos = 0;
         while ((pos = line.find(ext, pos)) != std::string::npos)
         {
@@ -959,36 +1004,46 @@ std::string RocprofSysBackend::ParseTraceOutputPath(std::string const& profiler_
                 --start;
             }
 
-            best = line.substr(start, end - start);
+            best.text  = line.substr(start, end - start);
+            best.start = start;
             pos = end;
         }
         return best;
     };
 
-    std::string fallback;
+    std::string labelled_database;
+    std::string labelled_file;
+    std::string unlabelled;
     std::istringstream stream(profiler_stdout);
     std::string line;
     while (std::getline(stream, line))
     {
-        std::string token = extract_db_token(line);
-        if (token.empty())
+        DbToken token = extract_db_token(line);
+        if (token.text.empty())
         {
             continue;
         }
 
-        // A line that explicitly labels the database is the strongest signal;
-        // return it immediately.
-        if (line.find("Database:") != std::string::npos ||
-            token.find("rocpd") != std::string::npos)
+        if (line.rfind("Database:", token.start) != std::string::npos)
         {
-            return token;
+            labelled_database = token.text;
         }
-
-        // Otherwise remember the most recent ".db" token as a fallback.
-        fallback = token;
+        else if (line.rfind("File:", token.start) != std::string::npos)
+        {
+            labelled_file = token.text;
+        }
+        unlabelled = token.text;
     }
 
-    return fallback;
+    if (!labelled_database.empty())
+    {
+        return labelled_database;
+    }
+    if (!labelled_file.empty())
+    {
+        return labelled_file;
+    }
+    return unlabelled;
 }
 
 // ==================================================================================

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.h
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.h
@@ -129,8 +129,7 @@ public:
     const char* DisplayName() const override;
 
     std::vector<ToolOption> GetTools() const override;
-    std::string GetDefaultBinary(std::string const& tool_id) const override;
-    std::vector<TabDescriptor> GetTabs(std::string const& tool_id) const override;
+    std::vector<TabDescriptor> GetTabs(rocprofvis_profiler_tool_t tool) const override;
 
     std::string Validate(LaunchConfig const& config) const override;
 

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -981,9 +981,6 @@ void
 SettingsManager::DeserializeProfilerSettings(jt::Json& json)
 {
     jt::Json& ps = json[JSON_KEY_GROUP_SETTINGS][JSON_KEY_SETTINGS_CATEGORY_PROFILER];
-    // A "profiler_path" key written by an older development build is read by
-    // nothing: the path is no longer part of the launch input, so a settings file
-    // cannot name the binary to execute.
     if(ps[JSON_KEY_SETTINGS_PROFILER_OUTPUT_DIR].isString())
     {
         m_profilersettings.profiler_output_directory = ps[JSON_KEY_SETTINGS_PROFILER_OUTPUT_DIR].getString();

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -964,7 +964,6 @@ void
 SettingsManager::SerializeProfilerSettings(jt::Json& json)
 {
     jt::Json& ps = json[JSON_KEY_GROUP_SETTINGS][JSON_KEY_SETTINGS_CATEGORY_PROFILER];
-    ps[JSON_KEY_SETTINGS_PROFILER_PATH] = m_profilersettings.profiler_path;
     ps[JSON_KEY_SETTINGS_PROFILER_OUTPUT_DIR] = m_profilersettings.profiler_output_directory;
     ps[JSON_KEY_SETTINGS_PROFILER_AUTO_LOAD] = m_profilersettings.auto_load_trace;
     ps["last_preset_name"] = m_profilersettings.last_preset_name;
@@ -982,10 +981,9 @@ void
 SettingsManager::DeserializeProfilerSettings(jt::Json& json)
 {
     jt::Json& ps = json[JSON_KEY_GROUP_SETTINGS][JSON_KEY_SETTINGS_CATEGORY_PROFILER];
-    if(ps[JSON_KEY_SETTINGS_PROFILER_PATH].isString())
-    {
-        m_profilersettings.profiler_path = ps[JSON_KEY_SETTINGS_PROFILER_PATH].getString();
-    }
+    // A "profiler_path" key written by an older development build is read by
+    // nothing: the path is no longer part of the launch input, so a settings file
+    // cannot name the binary to execute.
     if(ps[JSON_KEY_SETTINGS_PROFILER_OUTPUT_DIR].isString())
     {
         m_profilersettings.profiler_output_directory = ps[JSON_KEY_SETTINGS_PROFILER_OUTPUT_DIR].getString();

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -58,9 +58,14 @@ typedef struct InternalSettings
     std::list<std::string> recent_files;
 } InternalSettings;
 
+// Deliberately holds no path to a profiler binary. Which binary runs is chosen
+// by a rocprofvis_profiler_tool_t, so a settings file that is edited, corrupted,
+// or copied from another machine cannot decide what gets executed. A ROCm install
+// in a non-standard location is handled by LaunchConfig::tool_directory, which
+// names a directory rather than an executable and belongs to the launch profile
+// because a remote profile needs a directory on the remote host.
 typedef struct ProfilerSettings
 {
-    std::string profiler_path;
     std::string profiler_output_directory;
     bool        auto_load_trace = true;
     std::vector<std::string> recent_targets;
@@ -253,7 +258,6 @@ constexpr int LOG_VIEWER_DEFAULT_LEVEL_MASK = 0x3F;
 
 constexpr const char* JSON_KEY_SETTINGS_CATEGORY_HOTKEYS = "hotkeys";
 constexpr const char* JSON_KEY_SETTINGS_CATEGORY_PROFILER = "profiler";
-constexpr const char* JSON_KEY_SETTINGS_PROFILER_PATH = "profiler_path";
 constexpr const char* JSON_KEY_SETTINGS_PROFILER_OUTPUT_DIR = "profiler_output_directory";
 constexpr const char* JSON_KEY_SETTINGS_PROFILER_AUTO_LOAD = "auto_load_trace";
 


### PR DESCRIPTION
## Motivation

Tightens what a profiler launch can put on the command line.  
This is the first phase of necessary preparation work for supporting other profiling tools like rocprofv3 and Compute.
Ex:  working directory support, needed for running Compute profiler down the line. 

## Technical Details

**Compose the command as an explicit argv.** Backends emit the complete
argument list from `FlattenToExecution` and the controller passes each entry
to the process verbatim. Previously arguments were joined into a string and
re-split on whitespace, so any path or argument containing a space was torn
into several, and the command preview re-derived its own tail and could show
something other than what ran. `target_executable` / `output_directory`
become metadata that never reach the command line; `set_target_args` /
`set_profiler_args` are dropped from the C API. Adds quote-aware
`SplitArguments` and replaces seven positional launch strings with
`ProfilerLaunchSpec`.

**Name tools by enum, not by path.** A launch carries a
`rocprofvis_profiler_tool_t`; the controller maps it to a binary name and
resolves a validated absolute path before exec, so no caller-supplied string
becomes `argv[0]`. A missing tool reports `kRocProfVisResultToolNotFound`
rather than surfacing as exit code 127. `ProfilerSettings::profiler_path` is
deleted -- a ROCm install in a non-standard location uses
`LaunchConfig::tool_directory`, a directory whose filename still comes from
the tool table. Remote launches resolve on the remote host, never locally.

Also in scope: working-directory support (applied to the child only, failing
the run rather than writing output somewhere unasked-for), a fix for the
output getter dropping its last character, and trace-path scraping that
prefers the last labelled `.db` path -- profiling Optiq with Optiq
interleaves the child's own log lines with the tool's.

## Compatibility

- `profiler_path` in an existing settings file is now read by nothing.
- Launch profiles persist `tool` as the enum's integer, so the enum is
  append-only. A profile written with the old `tool_id` string loads with no
  tool selected, and the launcher substitutes the backend's first tool.

## Test plan

- [x] New `roc-optiq-controller-profiler-tests` target (gated on
      `ROCPROFVIS_ENABLE_PROFILER`): 17 cases, 111 assertions, covering argv
      composition, remote shell quoting, env-name rejection, resolution order,
      tool-directory strictness, working-directory behavior, and an
      unresolvable tool failing the launch without spawning. Passing on Linux.
- [x] Windows build and test run.
- [x] Manual: local launch, remote/SSH launch, and a target path containing a
      space, confirming the preview matches the logged command line.