### PR TITLE
View: Add setting to hide the topology sidebar row icons

### DIFF
--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -1036,6 +1036,11 @@ Renders the topology tree in the left pane:
   `DataProvider`.
 - The active-node accent mirrors timeline node coloring when
   `SettingsManager::ShowNodeColors()` is enabled.
+- `SettingsManager::CompactSidebar()` drops the per-row eye and
+  scroll-to-track buttons (leaf and branch) so labels sit flush against
+  the tree. Nothing is reserved in their place; the context menus below
+  remain the way to toggle visibility and jump to a track, and hidden
+  tracks stay marked by their dimmed label.
 - Right-click a leaf track (`##track_ctx`): Go to Track, Hide/Show
   Track, Show All Tracks, Hide All But This Track, and Show/Hide
   Selected Tracks (enabled when
@@ -1533,6 +1538,10 @@ through this** - never hardcode `IM_COL32(...)` in feature code.
   `SettingsManager::ShowNodeColors()` enables node color-coding (only
   when the trace has more than one node). It tints the track's node
   pill and the sidebar tree connectors, not the chart lane itself.
+- `DisplaySettings::compact_sidebar` /
+  `SettingsManager::CompactSidebar()` hides the topology sidebar's
+  per-row icons in favor of the right-click menus (see `SideBar` in
+  section 9).
 - `UserSettings::log_viewer` stores level mask, entry limit, search and
   presentation preferences for `LogViewer`.
 - `GetInternalSettings()` -> recent files (`MAX_RECENT_FILES = 5`).

--- a/src/view/src/rocprofvis_settings_manager.cpp
+++ b/src/view/src/rocprofvis_settings_manager.cpp
@@ -453,6 +453,8 @@ SettingsManager::SerializeDisplaySettings(jt::Json& json)
         m_usersettings.display_settings.font_size_index;
     ds[JSON_KEY_SETTINGS_DISPLAY_NODE_COLORS] =
         m_usersettings.display_settings.show_node_colors;
+    ds[JSON_KEY_SETTINGS_DISPLAY_COMPACT_SIDEBAR] =
+        m_usersettings.display_settings.compact_sidebar;
 }
 
 void
@@ -476,6 +478,11 @@ SettingsManager::DeserializeDisplaySettings(jt::Json& json)
         {
             m_usersettings.display_settings.show_node_colors =
                 ds[JSON_KEY_SETTINGS_DISPLAY_NODE_COLORS].getBool();
+        }
+        if(ds[JSON_KEY_SETTINGS_DISPLAY_COMPACT_SIDEBAR].isBool())
+        {
+            m_usersettings.display_settings.compact_sidebar =
+                ds[JSON_KEY_SETTINGS_DISPLAY_COMPACT_SIDEBAR].getBool();
         }
     }
 }
@@ -607,7 +614,7 @@ SettingsManager::GetContrastColormapName() const
 SettingsManager::SettingsManager()
 : m_color_store(nullptr)
 , m_usersettings_default(
-      { DisplaySettings{ false, 6, true }, UnitSettings{ TimeFormat::kTimecode },
+      { DisplaySettings{ false, 6, true, false }, UnitSettings{ TimeFormat::kTimecode },
         false, false, LOG_VIEWER_MAX_ENTRIES_DEFAULT,
         LogViewerSettings{ LOG_VIEWER_DEFAULT_LEVEL_MASK, true, false, false, false } })
 , m_usersettings(m_usersettings_default)

--- a/src/view/src/rocprofvis_settings_manager.h
+++ b/src/view/src/rocprofvis_settings_manager.h
@@ -24,6 +24,7 @@ typedef struct DisplaySettings
     bool use_dark_mode;
     int  font_size_index;
     bool show_node_colors;  // color-code timeline tracks by node
+    bool compact_sidebar;   // drop the per-row icons in the topology sidebar
 
 } DisplaySettings;
 
@@ -222,9 +223,10 @@ constexpr const char* JSON_KEY_SETTINGS_CATEGORY_UNITS    = "units";
 constexpr const char* JSON_KEY_SETTINGS_CATEGORY_OTHER    = "other";
 constexpr const char* JSON_KEY_SETTINGS_CATEGORY_INTERNAL = "internal";
 
-constexpr const char* JSON_KEY_SETTINGS_DISPLAY_DARK_MODE   = "use_dark_mode";
-constexpr const char* JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE   = "font_size_index";
-constexpr const char* JSON_KEY_SETTINGS_DISPLAY_NODE_COLORS = "show_node_colors";
+constexpr const char* JSON_KEY_SETTINGS_DISPLAY_DARK_MODE       = "use_dark_mode";
+constexpr const char* JSON_KEY_SETTINGS_DISPLAY_FONT_SIZE       = "font_size_index";
+constexpr const char* JSON_KEY_SETTINGS_DISPLAY_NODE_COLORS     = "show_node_colors";
+constexpr const char* JSON_KEY_SETTINGS_DISPLAY_COMPACT_SIDEBAR = "compact_sidebar";
 
 constexpr const char* JSON_KEY_SETTINGS_UNITS_TIME_FORMAT = "time_format";
 
@@ -272,6 +274,7 @@ public:
 
     // Styling
     bool ShowNodeColors() const { return m_usersettings.display_settings.show_node_colors; }
+    bool CompactSidebar() const { return m_usersettings.display_settings.compact_sidebar; }
     ImU32                     GetColor(Colors color) const;
     const std::vector<ImU32>& GetColorWheel() const;
     const std::vector<ImU32>& GetHighlightedEventColorWheel() const;

--- a/src/view/src/rocprofvis_settings_panel.cpp
+++ b/src/view/src/rocprofvis_settings_panel.cpp
@@ -240,6 +240,16 @@ SettingsPanel::RenderDisplayOptions()
         SetTooltipStyled("Color-code tracks and sidebar nodes by node on multi-node traces.");
     }
 
+    if(ImGui::Checkbox("Compact topology sidebar",
+                       &m_usersettings.display_settings.compact_sidebar))
+    {
+        m_settings_changed = true;
+    }
+    if(ImGui::IsItemHovered())
+    {
+        SetTooltipStyled("Drop the sidebar row icons and use the right-click menu instead.");
+    }
+
     ImGui::Spacing();
     ImGui::TextUnformatted("Fonts");
     ImGui::Separator();

--- a/src/view/src/rocprofvis_sidebar.cpp
+++ b/src/view/src/rocprofvis_sidebar.cpp
@@ -311,6 +311,10 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     const TrackInfo* track_info =
         m_data_provider.DataModel().GetTimeline().GetTrack(track.GetID());
 
+    // Compact mode drops the row buttons entirely; the context menu below still
+    // toggles visibility and goes to the track.
+    const bool draw_buttons = show_eye_button && !m_settings.CompactSidebar();
+
     ImGui::PushID(static_cast<int>(track.GetID()));
     ImGui::PushStyleColor(ImGuiCol_Button, m_settings.GetColor(Colors::kTransparent));
     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, m_settings.GetColor(Colors::kHighlightChart));
@@ -318,7 +322,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(2, 0));
 
     bool display = track.IsDisplayed();
-    if(show_eye_button)
+    if(draw_buttons)
     {
         ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon), 0.0f);
         if(ImGui::Button(display ? ICON_EYE : ICON_EYE_SLASH))
@@ -345,7 +349,7 @@ SideBar::RenderTrackItem(const uint64_t& index, bool show_eye_button)
 
     ImGui::PopStyleVar();
     ImGui::PopStyleColor(3);
-    if(show_eye_button)
+    if(draw_buttons)
     {
         ImGui::SameLine();
     }
@@ -694,7 +698,7 @@ SideBar::RenderBranchNode(const TreeNode& node, const TreeNode* state_node,
     const TreeNode& apply_target = target_node ? *target_node : node;
 
     ImGui::PushID(static_cast<const void*>(&node));
-    if(node.show_eye_button)
+    if(node.show_eye_button && !m_settings.CompactSidebar())
     {
         EyeButtonState current_state = GetTreeState(state_source);
         EyeButtonState new_state     = DrawEyeButton(current_state);


### PR DESCRIPTION
The sidebar repeated an eye and a go-to-track button on every row, which crowded the tree on traces with many queues and counters. Both actions were already available from the row context menus, so the new Display setting drops the buttons and lets the labels sit flush against the tree. Hidden tracks stay marked by their dimmed label.

 
<img width="1737" height="1341" alt="image" src="https://github.com/user-attachments/assets/d72c4257-7ee3-47dc-8460-11b48368f931" />
<img width="1702" height="1513" alt="image" src="https://github.com/user-attachments/assets/708b909e-dcd9-4eb2-a5f3-b280978524a5" />
