### PR TITLE
Fix wrong thread id shown for compare/multinode traces

### DIFF
--- a/src/model/src/datamodel/rocprofvis_dm_topology.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_topology.cpp
@@ -43,7 +43,8 @@ rocprofvis_dm_result_t   TopologyNode::SetBasicProperty(const char* name, rocpro
 			it->second == kRPVControllerQueueId ||
 			it->second == kRPVControllerCounterId ||
 			it->second == kRPVControllerProcessorId || 
-			it->second == kRPVControllerStreamId;
+			it->second == kRPVControllerStreamId ||
+			it->second == kRPVControllerThreadId;
 		switch (type)
 		{
 		case kRPVTopologyDataTypeInt:
@@ -560,7 +561,7 @@ std::string TopologyNodeThread::GetNodeName() {
 	if (it != m_properties.end())
 	{
 		name += "(";
-		name += std::to_string(std::get<std::uint64_t>(it->second));
+		name += std::to_string(std::get<std::uint64_t>(it->second) & TOPOLOGY_ID_MASK);
 		name += ")";
 	}
 


### PR DESCRIPTION
Thread ids are only unique within a single source database, but unlike queue, counter, processor and stream ids they were not tagged with the source instance index. When several traces were loaded as one, the threads of the last source overwrote the earlier ones in the view's topology map, so every thread track showed that source's TID and only its main thread could be detected.

Tag thread ids the same way as the other topology ids, and mask the instance bits back off where the id is used to build the display name.

