### PR TITLE
Fixed track stuck loding data after request cancellation

### DIFF
--- a/src/controller/src/system/rocprofvis_controller_track.cpp
+++ b/src/controller/src/system/rocprofvis_controller_track.cpp
@@ -182,7 +182,10 @@ rocprofvis_result_t Track::FetchSegments(double start, double end, void* user_pt
             });
         }
 
-        result = m_segments.FetchSegments(start, end, user_ptr, future, func);
+        // Fetching segnents when request cancelled will change return status to kRocProfVisResultOutOfRange.
+        // We need return status to be kRocProfVisResultCancelled in order to re-request data when the track is back in the view
+        if (result != kRocProfVisResultCancelled)
+            result = m_segments.FetchSegments(start, end, user_ptr, future, func);
 
     }
 

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -3690,6 +3690,7 @@ DataProvider::CreateRawSampleData(const TrackRequestParams& params,
     rocprofvis_controller_array_t*               track_data   = req.request_array;
     const std::chrono::steady_clock::time_point& request_time = req.request_time;
     bool response_valid = (req.response_code == kRocProfVisResultSuccess);
+    bool request_cancelled = (req.response_code == kRocProfVisResultCancelled);
 
     uint64_t count = 0;
 
@@ -3786,7 +3787,11 @@ DataProvider::CreateRawSampleData(const TrackRequestParams& params,
         trace_counter.m_value    = value;
     }
 
-    raw_sample_data->AddChunk(params.m_chunk_index, std::move(buffer));
+    // skip ading chunk when request is cancelled. Missing chunks will trigger re-request in TimelineView::RequestDataIfEmpty
+    if (!request_cancelled)
+    {
+        raw_sample_data->AddChunk(params.m_chunk_index, std::move(buffer));
+    }
 
     m_model.GetTimeline().SetTrackData(params.m_track_id, raw_sample_data);
 }
@@ -3797,6 +3802,7 @@ DataProvider::CreateRawEventData(const TrackRequestParams& params, const Request
     rocprofvis_controller_array_t*               track_data   = req.request_array;
     const std::chrono::steady_clock::time_point& request_time = req.request_time;
     bool response_valid = (req.response_code == kRocProfVisResultSuccess);
+    bool request_cancelled = (req.response_code == kRocProfVisResultCancelled);
 
     uint64_t count = 0;
 
@@ -3924,7 +3930,12 @@ DataProvider::CreateRawEventData(const TrackRequestParams& params, const Request
     // Add the buffer to the raw event data
     spdlog::debug("Adding {} event entries to track id {}", real_count,
                   params.m_track_id);
-    raw_event_data->AddChunk(params.m_chunk_index, std::move(buffer));
+
+    // skip ading chunk when request is cancelled. Missing chunks will trigger re-request in TimelineView::RequestDataIfEmpty
+    if (!request_cancelled)
+    {
+        raw_event_data->AddChunk(params.m_chunk_index, std::move(buffer));
+    }
     m_model.GetTimeline().SetTrackData(params.m_track_id, raw_event_data);
 }
 

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -314,7 +314,8 @@ FlameTrackItem::ExtractPointsFromData()
         return false;
     }
 
-    if(event_track->AllDataReady())
+    // if data ready or no more pending requests, reset request state to idle
+    if(event_track->AllDataReady() || m_pending_requests.empty())
     {
         m_request_state = TrackDataRequestState::kIdle;
     }

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -376,7 +376,8 @@ LineTrackItem::ExtractPointsFromData()
         return false;
     }
 
-    if(sample_track->AllDataReady())
+    // if data ready or no more pending requests, reset request state to idle
+    if(sample_track->AllDataReady() || m_pending_requests.empty())
     {
         m_request_state = TrackDataRequestState::kIdle;
     }

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1934,19 +1934,26 @@ TimelineView::RenderTrack(int track_index, bool request_data,
 void
 TimelineView::RequestDataIfEmpty(TrackItem* track_item, bool request_data)
 {
-    // Request data for the chart if it doesn't have data.
-    if((!track_item->HasData() &&
-        track_item->GetRequestState() == TrackDataRequestState::kIdle) ||
-       request_data)
+    bool needs_data = !track_item->HasData() || !track_item->AllDataReady();
+    bool is_idle    = track_item->GetRequestState() == TrackDataRequestState::kIdle;
 
+    if((needs_data && is_idle) || request_data)
     {
-        // Request one viewport worth of data on each side of the current
-        // view.
+        // If partial data exists, free it before re-requesting
+        if(track_item->HasData() && !track_item->AllDataReady())
+        {
+            track_item->ReleaseData();
+            // If release failed (uncancellable in-flight requests remain),
+            // wait for them to land — ExtractPointsFromData will reset state
+            if(track_item->HasData())
+                return;
+        }
+
         double buffer_distance = m_tpt->GetVWidth();
         track_item->RequestData(
             (m_tpt->GetViewTimeOffsetNs() - buffer_distance) + m_tpt->GetMinX(),
             (m_tpt->GetViewTimeOffsetNs() + m_tpt->GetVWidth() + buffer_distance) +
-                m_tpt->GetMinX(),
+            m_tpt->GetMinX(),
             m_tpt->GetGraphSizeX() * 3);
     }
 }

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -996,16 +996,17 @@ TrackItem::HasData()
 }
 
 bool
+TrackItem::AllDataReady()
+{
+    const RawTrackData* data =
+        m_data_provider.DataModel().GetTimeline().GetTrackData(m_track_id);
+    return data != nullptr && data->AllDataReady();
+}
+
+bool
 TrackItem::ReleaseData()
 {
-    bool result =
-        m_data_provider.DataModel().GetTimeline().FreeTrackData(m_track_id, true);
-    if(!result)
-    {
-        spdlog::warn("Failed to release data for track {}", m_track_id);
-    }
-
-    // Clear pending requests
+    // Cancel all pending requests first
     for(auto it = m_pending_requests.begin(); it != m_pending_requests.end();)
     {
         const auto request_id = it->first;
@@ -1015,12 +1016,27 @@ TrackItem::ReleaseData()
         }
         else
         {
-            spdlog::warn("Failed to cancel pending request {} for track {}", request_id,
-                         m_track_id);
+            spdlog::warn("Failed to cancel pending request {} for track {}",
+                request_id, m_track_id);
             ++it;
         }
     }
 
+    // If all pending requests were cancelled, reset state to idle
+    // so the track can be re-requested when it scrolls back into view
+    if(m_pending_requests.empty())
+    {
+        m_request_state = TrackDataRequestState::kIdle;
+    }
+
+    // Only force-free if no in-flight requests remain
+    bool force  = m_pending_requests.empty();
+    bool result = m_data_provider.DataModel().GetTimeline().FreeTrackData(m_track_id, force);
+
+    if(!result)
+    {
+        spdlog::warn("Failed to release data for track {}", m_track_id);
+    }
     return result;
 }
 

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -116,6 +116,7 @@ public:
     static void SetSidebarSize(float sidebar_size);
 
     virtual bool HasData();
+    bool AllDataReady();
     virtual bool ReleaseData();
     virtual void RequestData(double min, double max, float width);
     void         RequestAnalysis();


### PR DESCRIPTION
## Motivation

After fixing dead lock on data model side, a timeline track may still be stuck in loading animation or be empty.

1. Fixed ReleaseData to cancel pending requests before freeing track data, and only force-free when all requests are successfully cancelled — preventing deletion of partially-assembled data while chunks are still in flight
2. Fixed ReleaseData to reset m_request_state to kIdle when all pending requests are cancelled, unblocking re-requests when the track scrolls back into view
3. Fixed ExtractPointsFromData to reset m_request_state to kIdle when m_pending_requests is empty, handling the case where some in-flight requests could not be cancelled and landed after partial data was freed
4. Fixed RequestDataIfEmpty to detect and re-request tracks with incomplete data (!AllDataReady()) in addition to tracks with no data
5. Fixed CreateRawSampleData and CreateRawEventData to skip AddChunk when the request was cancelled, preventing empty or stale chunks from being committed and falsely satisfying AllDataReady()
6. Fixed request cancellation on Controller level to correctly return cancellation status instead of an out-of-range status
