### PR TITLE
Harden track fetch and cancellation logic on the UI side

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ These features are in progress and available for preview only (build from src); 
 - Fixed loading workload Speed-of-Light for compute schema < 1.3.0; query builders now report and skip unsupported queries.
 - Fixed crash when invalid filter used in kernel selection table.
 - JobSystem fixes.
+- Fixed timeline tracks that could keep spinning, or show incomplete data, after scrolling or zooming quickly while track data was still loading.
 
 ## Optiq Beta 0.5.0
 

--- a/src/controller/src/system/rocprofvis_controller_track.cpp
+++ b/src/controller/src/system/rocprofvis_controller_track.cpp
@@ -182,8 +182,14 @@ rocprofvis_result_t Track::FetchSegments(double start, double end, void* user_pt
             });
         }
 
-        result = m_segments.FetchSegments(start, end, user_ptr, future, func);
-
+        // Walking the segments would report kRocProfVisResultOutOfRange for a
+        // cancelled fetch, because the segments it needs were never populated.
+        // The cancellation has to survive so the view knows the data is missing
+        // and must be re-requested when the track comes back into view.
+        if(result != kRocProfVisResultCancelled)
+        {
+            result = m_segments.FetchSegments(start, end, user_ptr, future, func);
+        }
     }
 
     return result;

--- a/src/view/src/model/rocprofvis_timeline_model.cpp
+++ b/src/view/src/model/rocprofvis_timeline_model.cpp
@@ -101,6 +101,15 @@ TimelineModel::FreeTrackData(uint64_t track_id, bool force /* = false */)
             m_raw_track_data.erase(it);
             return true;
         }
+        else
+        {
+            // Assert here as this should never happen
+            ROCPROFVIS_ASSERT(false, "Null pointer for track data");
+            spdlog::warn("No data to remove, null pointer for id: {}",
+                         track_id);
+            m_raw_track_data.erase(it);
+            return true;
+        }
     }
 
     spdlog::debug("Cannot delete track data, invalid id: {}", track_id);

--- a/src/view/src/model/rocprofvis_timeline_model.cpp
+++ b/src/view/src/model/rocprofvis_timeline_model.cpp
@@ -104,7 +104,7 @@ TimelineModel::FreeTrackData(uint64_t track_id, bool force /* = false */)
         else
         {
             // Assert here as this should never happen
-            ROCPROFVIS_ASSERT(false, "Null pointer for track data");
+            ROCPROFVIS_ASSERT(false);
             spdlog::warn("No data to remove, null pointer for id: {}",
                          track_id);
             m_raw_track_data.erase(it);

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -3611,7 +3611,17 @@ DataProvider::ProcessGraphRequest(RequestInfo& req)
     auto track_params = std::dynamic_pointer_cast<TrackRequestParams>(req.custom_params);
     if(!track_params)
     {
-        spdlog::error("Track request params are not set or invalid");
+        // Note: if this is a real response to a fetch request then the UI track item will not
+        // be updated. (loading icon will remain spinning). We have no way to notify...        
+        spdlog::error("Track request params are not set or invalid, cannot process data!");
+        rocprofvis_controller_array_free(req.request_array);
+        req.request_array = nullptr;
+
+        if(m_track_data_ready_callback)
+        {
+            m_track_data_ready_callback(INVALID_INDEX, m_model.GetTraceFilePath(), req);
+        }
+
         return;
     }
 
@@ -3643,8 +3653,12 @@ DataProvider::ProcessGraphRequest(RequestInfo& req)
                       track_params->m_track_id, item_count, min_ts, max_ts);
     }
     else
-    {
-        spdlog::warn("Graph request failed with code {}", req.response_code);
+    { 
+        // Silence out of range warnings as they are shown for empty areas of the track.
+        if(req.response_code != kRocProfVisResultOutOfRange)
+        {
+            spdlog::warn("Graph request failed with code {}", req.response_code);
+        }
     }
 
     // use the track type to determine what type of data is present in the graph array
@@ -3701,9 +3715,11 @@ DataProvider::CreateRawSampleData(const TrackRequestParams& params,
     }
     else
     {
-        // TODO: review the controller return codes to see if anycase should be escalated
-        // to a warning
-        spdlog::warn("Sample track data request failed with code {}", req.response_code);
+        // Silence out of range warnings as they are shown for empty areas of the track.         
+        if(req.response_code != kRocProfVisResultOutOfRange)
+        {
+            spdlog::warn("Sample track data request failed with code {}", req.response_code);
+        }
         count = 0;
     }
 
@@ -3730,8 +3746,15 @@ DataProvider::CreateRawSampleData(const TrackRequestParams& params,
                           existing_raw_data->GetDataGroupID());
             return;
         }
-        m_model.GetTimeline().FreeTrackData(params.m_track_id);
-        spdlog::debug("Replacing existing track data with id {}", params.m_track_id);
+
+        spdlog::debug(
+            "Replacing existing track data from group {} with group {} for id {}",
+            existing_raw_data->GetDataGroupID(), params.m_data_group_id,
+            params.m_track_id);
+        if(!m_model.GetTimeline().FreeTrackData(params.m_track_id))
+        {
+            spdlog::warn("Failed to free existing track data with id {}", params.m_track_id);
+        }
     }
 
     if(!raw_sample_data)
@@ -3808,9 +3831,11 @@ DataProvider::CreateRawEventData(const TrackRequestParams& params, const Request
     }
     else
     {
-        // TODO: review the controller return codes to see if anycase should be escalated
-        // to a warning
-        spdlog::warn("Event track data request failed with code {}", req.response_code);
+        // Silence out of range warnings as they are shown for empty areas of the track.         
+        if(req.response_code != kRocProfVisResultOutOfRange)
+        {
+            spdlog::warn("Event track data request failed with code {}", req.response_code);
+        }
         count = 0;
     }
 
@@ -3842,7 +3867,10 @@ DataProvider::CreateRawEventData(const TrackRequestParams& params, const Request
             "Replacing existing track data from group {} with group {} for id {}",
             existing_raw_data->GetDataGroupID(), params.m_data_group_id,
             params.m_track_id);
-        m_model.GetTimeline().FreeTrackData(params.m_track_id);
+        if(!m_model.GetTimeline().FreeTrackData(params.m_track_id))
+        {
+            spdlog::warn("Failed to free existing track data with id {}", params.m_track_id);
+        }
     }
 
     if(!raw_event_data)

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -3612,11 +3612,12 @@ DataProvider::ProcessGraphRequest(RequestInfo& req)
     if(!track_params)
     {
         // Note: if this is a real response to a fetch request then the UI track item will not
-        // be updated. (loading icon will remain spinning). We have no way to notify...        
+        // be updated. (loading icon will remain spinning).
         spdlog::error("Track request params are not set or invalid, cannot process data!");
         rocprofvis_controller_array_free(req.request_array);
         req.request_array = nullptr;
 
+        // call the new data ready callback with INVALID_INDEX to indicate an error
         if(m_track_data_ready_callback)
         {
             m_track_data_ready_callback(INVALID_INDEX, m_model.GetTraceFilePath(), req);
@@ -3665,22 +3666,32 @@ DataProvider::ProcessGraphRequest(RequestInfo& req)
     const TrackInfo* metadata = m_model.GetTimeline().GetTrack(track_params->m_track_id);
     ROCPROFVIS_ASSERT(metadata);
 
-    switch(metadata->track_type)
+    if(metadata)
     {
-        case kRPVControllerTrackTypeEvents:
+        switch(metadata->track_type)
         {
-            CreateRawEventData(*track_params, req);
-            break;
+            case kRPVControllerTrackTypeEvents:
+            {
+                CreateRawEventData(*track_params, req);
+                break;
+            }
+            case kRPVControllerTrackTypeSamples:
+            {
+                CreateRawSampleData(*track_params, req);
+                break;
+            }
+            default:
+            {
+                spdlog::error("Unknown track type for track id {}, cannot process data!",
+                              track_params->m_track_id);
+                break;
+            }
         }
-        case kRPVControllerTrackTypeSamples:
-        {
-            CreateRawSampleData(*track_params, req);
-            break;
-        }
-        default:
-        {
-            break;
-        }
+    }
+    else
+    {
+        spdlog::error("Track metadata not found for track id {}, cannot process data!",
+                      track_params->m_track_id);
     }
 
     // free the array
@@ -3751,7 +3762,7 @@ DataProvider::CreateRawSampleData(const TrackRequestParams& params,
             "Replacing existing track data from group {} with group {} for id {}",
             existing_raw_data->GetDataGroupID(), params.m_data_group_id,
             params.m_track_id);
-        if(!m_model.GetTimeline().FreeTrackData(params.m_track_id))
+        if(!m_model.GetTimeline().FreeTrackData(params.m_track_id, true))
         {
             spdlog::warn("Failed to free existing track data with id {}", params.m_track_id);
         }
@@ -3876,7 +3887,7 @@ DataProvider::CreateRawEventData(const TrackRequestParams& params, const Request
             "Replacing existing track data from group {} with group {} for id {}",
             existing_raw_data->GetDataGroupID(), params.m_data_group_id,
             params.m_track_id);
-        if(!m_model.GetTimeline().FreeTrackData(params.m_track_id))
+        if(!m_model.GetTimeline().FreeTrackData(params.m_track_id, true))
         {
             spdlog::warn("Failed to free existing track data with id {}", params.m_track_id);
         }

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -3759,6 +3759,15 @@ DataProvider::CreateRawSampleData(const TrackRequestParams& params,
 
     if(!raw_sample_data)
     {
+        // The track was unloaded and its requests cancelled. Creating an empty
+        // object here would make the track look loaded and block a refetch.
+        if(req.response_code == kRocProfVisResultCancelled)
+        {
+            spdlog::debug("Dropping cancelled response for sample track {}",
+                          params.m_track_id);
+            return;
+        }
+
         spdlog::debug("Create sample track {} data with {} entries", params.m_track_id,
                       count);
         raw_sample_data =
@@ -3875,6 +3884,15 @@ DataProvider::CreateRawEventData(const TrackRequestParams& params, const Request
 
     if(!raw_event_data)
     {
+        // The track was unloaded and its requests cancelled. Creating an empty
+        // object here would make the track look loaded and block a refetch.
+        if(req.response_code == kRocProfVisResultCancelled)
+        {
+            spdlog::debug("Dropping cancelled response for event track {}",
+                          params.m_track_id);
+            return;
+        }
+
         spdlog::debug("Creating event track {} data with {} entries", params.m_track_id,
                       count);
         raw_event_data =

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -289,7 +289,7 @@ FlameTrackItem::IsCompactMode() const
     return m_event_options ? m_event_options->m_compact : TrackItem::IsCompactMode();
 }
 
-bool
+void
 FlameTrackItem::ExtractPointsFromData()
 {
     const RawTrackData* rtd =
@@ -300,7 +300,7 @@ FlameTrackItem::ExtractPointsFromData()
     if(!rtd)
     {
         spdlog::debug("No raw track data found for track {}", m_track_id);
-        return true;
+        return;
     }
 
     const RawTrackEventData* event_track = dynamic_cast<const RawTrackEventData*>(rtd);
@@ -309,13 +309,13 @@ FlameTrackItem::ExtractPointsFromData()
     {
         spdlog::debug("Invalid track data type for track {}", m_track_id);
         m_request_state = TrackDataRequestState::kError;
-        return false;
+        return;
     }
 
     if(event_track->GetData().empty())
     {
         spdlog::debug("No data for track {}", m_track_id);
-        return true;
+        return;
     }
 
     // Update selection state cache.
@@ -339,7 +339,6 @@ FlameTrackItem::ExtractPointsFromData()
         }
         m_chart_items[i].child_info.clear();
     }
-    return true;
 }
 
 bool

--- a/src/view/src/rocprofvis_flame_track_item.cpp
+++ b/src/view/src/rocprofvis_flame_track_item.cpp
@@ -299,10 +299,8 @@ FlameTrackItem::ExtractPointsFromData()
     // response was processed
     if(!rtd)
     {
-        spdlog::error("No raw track data found for track {}", m_track_id);
-        // Reset the request state to idle
-        m_request_state = TrackDataRequestState::kIdle;
-        return false;
+        spdlog::debug("No raw track data found for track {}", m_track_id);
+        return true;
     }
 
     const RawTrackEventData* event_track = dynamic_cast<const RawTrackEventData*>(rtd);
@@ -314,15 +312,10 @@ FlameTrackItem::ExtractPointsFromData()
         return false;
     }
 
-    if(event_track->AllDataReady())
-    {
-        m_request_state = TrackDataRequestState::kIdle;
-    }
-
     if(event_track->GetData().empty())
     {
         spdlog::debug("No data for track {}", m_track_id);
-        return false;
+        return true;
     }
 
     // Update selection state cache.

--- a/src/view/src/rocprofvis_flame_track_item.h
+++ b/src/view/src/rocprofvis_flame_track_item.h
@@ -74,7 +74,7 @@ private:
     void DrawBox(ImVec2 start_position, ChartItem& flame, float duration,
                  ImDrawList* draw_list, bool use_highlight_color);
 
-    bool ExtractPointsFromData() override;
+    void ExtractPointsFromData() override;
     bool ExtractChildInfo(ChartItem& item);
     bool ParseChildInfo(const std::string& combined_name, ChildEventInfo& out_info);
 

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -353,7 +353,7 @@ LineTrackItem::ReleaseData()
     return false;
 }
 
-bool
+void
 LineTrackItem::ExtractPointsFromData()
 {
     const RawTrackData* rtd = m_data_provider.DataModel().GetTimeline().GetTrackData(m_track_id);
@@ -363,7 +363,7 @@ LineTrackItem::ExtractPointsFromData()
     if(!rtd)
     {
         spdlog::debug("No raw track data found for track {}", m_track_id);
-        return true;
+        return;
     }
 
     const RawTrackSampleData* sample_track = dynamic_cast<const RawTrackSampleData*>(rtd);
@@ -371,19 +371,17 @@ LineTrackItem::ExtractPointsFromData()
     {
         spdlog::debug("Invalid track data type for track {}", m_track_id);
         m_request_state = TrackDataRequestState::kError;
-        return false;
+        return;
     }
 
     if(sample_track->GetData().empty())
     {
         spdlog::debug("No data for track {}", m_track_id);
-        return true;
+        return;
     }
     const std::vector<TraceCounter>& track_data = sample_track->GetData();
 
     m_data = track_data;
-
-    return true;
 }
 
 float

--- a/src/view/src/rocprofvis_line_track_item.cpp
+++ b/src/view/src/rocprofvis_line_track_item.cpp
@@ -362,10 +362,8 @@ LineTrackItem::ExtractPointsFromData()
     // response was processed
     if(!rtd)
     {
-        spdlog::error("No raw track data found for track {}", m_track_id);
-        // Reset the request state to idle
-        m_request_state = TrackDataRequestState::kIdle;
-        return false;
+        spdlog::debug("No raw track data found for track {}", m_track_id);
+        return true;
     }
 
     const RawTrackSampleData* sample_track = dynamic_cast<const RawTrackSampleData*>(rtd);
@@ -376,15 +374,10 @@ LineTrackItem::ExtractPointsFromData()
         return false;
     }
 
-    if(sample_track->AllDataReady())
-    {
-        m_request_state = TrackDataRequestState::kIdle;
-    }
-
     if(sample_track->GetData().empty())
     {
         spdlog::debug("No data for track {}", m_track_id);
-        return false;
+        return true;
     }
     const std::vector<TraceCounter>& track_data = sample_track->GetData();
 

--- a/src/view/src/rocprofvis_line_track_item.h
+++ b/src/view/src/rocprofvis_line_track_item.h
@@ -81,7 +81,7 @@ private:
     void   GenerateYAxisTicks(float plot_height, std::vector<double>& out_ticks) const;
     // Refreshes m_grid_ticks only when the track height or Y range has changed.
     void   UpdateYAxisTicks();
-    bool   ExtractPointsFromData();
+    void   ExtractPointsFromData() override;
     float  CalculateMissingX(float x1, float y1, float x2, float y2, float known_y);
     void   BoxPlotRender(float graph_width);
     void   RenderHighlightBand(ImDrawList* draw_list, const ImVec2& cursor_position,

--- a/src/view/src/rocprofvis_raw_track_data.cpp
+++ b/src/view/src/rocprofvis_raw_track_data.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocprofvis_raw_track_data.h"
+#include "spdlog/spdlog.h"
 
 using namespace RocProfVis::View;
 
@@ -102,6 +103,7 @@ template <typename T>
 bool TemplatedRawTrackData<T>::AddChunk(size_t chunk_index, const std::vector<T> &&chunk_data) {
         // Prevent adding same chunk index
         if (m_chunk_info.count(chunk_index)) {
+            spdlog::error("Chunk index {} already exists for track ID {}", chunk_index, GetTrackID());
             return false;
         }
 

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1148,7 +1148,7 @@ TimelineView::HandleNewTrackData(std::shared_ptr<RocEvent> e)
             m_data_provider.DataModel().GetTimeline().GetTrack(tde->GetTrackID());
         if(!metadata)
         {
-            spdlog::error(
+            spdlog::warn(
                 "No metadata found for track id {}, cannot process new track data",
                 tde->GetTrackID());
             
@@ -1156,11 +1156,12 @@ TimelineView::HandleNewTrackData(std::shared_ptr<RocEvent> e)
             // be cleared from pending queue
             for(size_t i = 0; i < m_tracks->size(); ++i)
             {
-                auto track = (*m_tracks)[i];
+                TrackItem *track = (*m_tracks)[i];
                 if(track && track->HasPendingRequest(tde->GetRequestID()))
                 {
                     track->HandleTrackDataChanged(tde->GetRequestID(),
                                                   tde->GetResponseCode());
+                    break;
                 }
             }
             return;
@@ -2263,7 +2264,6 @@ TimelineView::MakeGraphView()
     for(int i = 0; i < track_list.size(); i++)
     {
         const TrackInfo* track_info = track_list[i];
-        bool             display    = true;
 
         if(project_valid)
         {
@@ -2271,7 +2271,8 @@ TimelineView::MakeGraphView()
             const TrackInfo* track_at_index_info = tlm.GetTrack(track_id_at_index);
             if(track_at_index_info && track_at_index_info->index != i)
             {
-                ROCPROFVIS_ASSERT(m_data_provider.SetGraphIndex(track_id_at_index, i));
+                bool success = m_data_provider.SetGraphIndex(track_id_at_index, i);
+                ROCPROFVIS_ASSERT(!success);
             }
             track_info = track_at_index_info;
         }

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -2283,7 +2283,7 @@ TimelineView::MakeGraphView()
             if(track_at_index_info && track_at_index_info->index != i)
             {
                 bool success = m_data_provider.SetGraphIndex(track_id_at_index, i);
-                ROCPROFVIS_ASSERT(!success);
+                ROCPROFVIS_ASSERT(success);
             }
             track_info = track_at_index_info;
         }

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1151,6 +1151,18 @@ TimelineView::HandleNewTrackData(std::shared_ptr<RocEvent> e)
             spdlog::error(
                 "No metadata found for track id {}, cannot process new track data",
                 tde->GetTrackID());
+            
+            // try to find request by request id on all tracks so that it can
+            // be cleared from pending queue
+            for(size_t i = 0; i < m_tracks->size(); ++i)
+            {
+                auto track = (*m_tracks)[i];
+                if(track && track->HasPendingRequest(tde->GetRequestID()))
+                {
+                    track->HandleTrackDataChanged(tde->GetRequestID(),
+                                                  tde->GetResponseCode());
+                }
+            }
             return;
         }
 

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1947,12 +1947,23 @@ TimelineView::RenderTrack(int track_index, bool request_data,
 void
 TimelineView::RequestDataIfEmpty(TrackItem* track_item, bool request_data)
 {
-    // Request data for the chart if it doesn't have data.
-    if((!track_item->HasData() &&
-        track_item->GetRequestState() == TrackDataRequestState::kIdle) ||
-       request_data)
+    bool idle = track_item->GetRequestState() == TrackDataRequestState::kIdle;
 
+    // True when the track holds no data at all, and also when it holds only some
+    // of its chunks: a track that scrolled out of view released its data and
+    // cancelled its requests, but cancellation is best effort, so whatever
+    // completed first recreates the data with just the chunks that landed.
+    bool incomplete = !track_item->AllDataReady();
+    bool refetch    = incomplete && idle;
+
+    // Request data for the chart if any of it is missing.
+    if(refetch || request_data)
     {
+        if(refetch && track_item->HasData())
+        {
+            track_item->ReleaseData();
+        }
+
         // Request one viewport worth of data on each side of the current
         // view.
         double buffer_distance = m_tpt->GetVWidth();

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -117,6 +117,7 @@ TrackItem::TrackItem(DataProvider& dp, uint64_t id, TimelineTrackOptions& track_
 , m_timeline_selection(timeline_selection)
 , m_chunk_duration_ns(DEFAULT_CHUNK_DURATION)
 , m_group_id_counter(0)
+, m_cancel_requested(false)
 , m_meta_area_label("")
 , m_has_node_color(false)
 , m_node_color_index(0)
@@ -654,12 +655,9 @@ TrackItem::RequestData(double min, double max, float width)
             "Fetch request deferred for track {}, requests are already pending...",
             m_track_id);
 
-        for(const auto& [request_id, req] : m_pending_requests)
-        {
-            spdlog::debug("RequestData: Found pending request {} for track {}",
-                          request_id, m_track_id);
-            m_data_provider.CancelRequest(request_id);
-        }
+        // The queue is fetched once the pending requests have drained and the
+        // state returns to idle.
+        CancelPendingRequests();
     }
 }
 
@@ -980,7 +978,7 @@ TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
     bool result = false;
     if(!m_pending_requests.erase(request_id))
     {
-        spdlog::warn("Failed to erase pending request {}", request_id);
+        spdlog::debug("Response {} is not pending on track {}", request_id, m_track_id);
     }
 
     // If the request was successful, extract the points from the data
@@ -992,6 +990,7 @@ TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
     // If there are no more pending requests, set the request state to idle
     if(m_pending_requests.empty())
     {
+        m_cancel_requested = false;
         if(m_request_state == TrackDataRequestState::kRequesting)
         {
             m_request_state = TrackDataRequestState::kIdle;
@@ -1010,30 +1009,46 @@ TrackItem::HasData()
 bool
 TrackItem::ReleaseData()
 {
-    bool result =
-        m_data_provider.DataModel().GetTimeline().FreeTrackData(m_track_id, true);
-    if(!result)
+    bool result = true;
+
+    // Having nothing to free is not a failure: the track can be unloaded while
+    // its first response is still in flight.
+    if(HasData())
     {
-        spdlog::warn("Failed to release data for track {}", m_track_id);
+        result = m_data_provider.DataModel().GetTimeline().FreeTrackData(m_track_id, true);
+        if(!result)
+        {
+            spdlog::warn("Failed to release data for track {}", m_track_id);
+        }
     }
 
-    // Clear pending requests
-    for(auto it = m_pending_requests.begin(); it != m_pending_requests.end();)
-    {
-        const auto request_id = it->first;
-        if(m_data_provider.CancelRequest(request_id))
-        {
-            it = m_pending_requests.erase(it);
-        }
-        else
-        {
-            spdlog::warn("Failed to cancel pending request {} for track {}", request_id,
-                         m_track_id);
-            ++it;
-        }
-    }
+    // Chunks that were queued but never issued can simply be dropped.
+    m_request_queue.clear();
+    CancelPendingRequests();
 
     return result;
+}
+
+void
+TrackItem::CancelPendingRequests()
+{
+    // Cancelling only asks the controller to stop early: the request stays in
+    // flight and leaves m_pending_requests when its future resolves. Ask once,
+    // otherwise every frame re-cancels the same ids while they drain.
+    if(m_cancel_requested || m_pending_requests.empty())
+    {
+        return;
+    }
+
+    for(const auto& [request_id, req] : m_pending_requests)
+    {
+        if(!m_data_provider.CancelRequest(request_id))
+        {
+            spdlog::debug("Failed to cancel pending request {} for track {}", request_id,
+                          m_track_id);
+        }
+    }
+    m_cancel_requested = true;
 }
 
 bool

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -982,7 +982,8 @@ TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
     }
 
     // If the request was successful, extract the points from the data
-    if(response_code == kRocProfVisResultSuccess) 
+    if(response_code == kRocProfVisResultSuccess ||
+       response_code == kRocProfVisResultOutOfRange)
     {
         result = ExtractPointsFromData();
     }

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -972,10 +972,9 @@ TrackItem::AddPill(bool shown, bool active)
     return m_pills.back().get();
 }
 
-bool
+void
 TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
 {
-    bool result = false;
     if(!m_pending_requests.erase(request_id))
     {
         spdlog::debug("Response {} is not pending on track {}", request_id, m_track_id);
@@ -985,7 +984,7 @@ TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
     if(response_code == kRocProfVisResultSuccess ||
        response_code == kRocProfVisResultOutOfRange)
     {
-        result = ExtractPointsFromData();
+        ExtractPointsFromData();
     }
 
     // If there are no more pending requests, set the request state to idle
@@ -997,8 +996,6 @@ TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
             m_request_state = TrackDataRequestState::kIdle;
         }
     }
-
-    return result;
 }
 
 bool

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -1002,9 +1002,17 @@ TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
 }
 
 bool
-TrackItem::HasData()
+TrackItem::HasData() const
 {
     return m_data_provider.DataModel().GetTimeline().GetTrackData(m_track_id) != nullptr;
+}
+
+bool
+TrackItem::AllDataReady() const
+{
+    const RawTrackData* data =
+        m_data_provider.DataModel().GetTimeline().GetTrackData(m_track_id);
+    return data != nullptr && data->AllDataReady();
 }
 
 bool

--- a/src/view/src/rocprofvis_track_item.cpp
+++ b/src/view/src/rocprofvis_track_item.cpp
@@ -620,8 +620,8 @@ TrackItem::RequestData(double min, double max, float width)
 
     for(size_t i = 0; i < chunk_count; ++i)
     {
-        double chunk_start = min + i * TimeConstants::minute_in_ns;
-        double chunk_end   = std::min(chunk_start + TimeConstants::minute_in_ns, max);
+        double chunk_start = min + i * m_chunk_duration_ns;
+        double chunk_end   = std::min(chunk_start + m_chunk_duration_ns, max);
 
         double chunk_range = chunk_end - chunk_start;
         float  percentage  = static_cast<float>(chunk_range / range);
@@ -977,14 +977,26 @@ TrackItem::AddPill(bool shown, bool active)
 bool
 TrackItem::HandleTrackDataChanged(uint64_t request_id, uint64_t response_code)
 {
-    (void) response_code;  // Unused at the moment
     bool result = false;
     if(!m_pending_requests.erase(request_id))
     {
         spdlog::warn("Failed to erase pending request {}", request_id);
     }
 
-    result = ExtractPointsFromData();
+    // If the request was successful, extract the points from the data
+    if(response_code == kRocProfVisResultSuccess) 
+    {
+        result = ExtractPointsFromData();
+    }
+
+    // If there are no more pending requests, set the request state to idle
+    if(m_pending_requests.empty())
+    {
+        if(m_request_state == TrackDataRequestState::kRequesting)
+        {
+            m_request_state = TrackDataRequestState::kIdle;
+        }
+    }
 
     return result;
 }
@@ -1028,6 +1040,12 @@ bool
 TrackItem::HasPendingRequests() const
 {
     return !m_pending_requests.empty();
+}
+
+bool
+TrackItem::HasPendingRequest(uint64_t request_id) const
+{
+    return m_pending_requests.find(request_id) != m_pending_requests.end();
 }
 
 void

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -115,7 +115,8 @@ public:
     bool        TrackHeightChanged();
     static void SetSidebarSize(float sidebar_size);
 
-    virtual bool HasData();
+    virtual bool HasData() const;
+    bool         AllDataReady() const;
     virtual bool ReleaseData();
     virtual void RequestData(double min, double max, float width);
     void         RequestAnalysis();

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -120,7 +120,7 @@ public:
     virtual bool ReleaseData();
     virtual void RequestData(double min, double max, float width);
     void         RequestAnalysis();
-    virtual bool HandleTrackDataChanged(uint64_t request_id, uint64_t response_code);
+    virtual void HandleTrackDataChanged(uint64_t request_id, uint64_t response_code);
     virtual bool HasPendingRequests() const;
     virtual bool HasPendingRequest(uint64_t request_id) const;
     virtual void UpdateMetaScaleAreaSize();
@@ -144,7 +144,7 @@ protected:
     virtual void  RenderMetaAreaExpand();
     virtual void  RenderChart(float graph_width) = 0;
     virtual void  RenderResizeBar(const ImVec2& parent_size);
-    virtual bool  ExtractPointsFromData() = 0;
+    virtual void  ExtractPointsFromData() = 0;
 
     void  FetchHelper();
     void  CancelPendingRequests();

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -121,6 +121,7 @@ public:
     void         RequestAnalysis();
     virtual bool HandleTrackDataChanged(uint64_t request_id, uint64_t response_code);
     virtual bool HasPendingRequests() const;
+    virtual bool HasPendingRequest(uint64_t request_id) const;
     virtual void UpdateMetaScaleAreaSize();
     virtual void UpdateMaxMetaScaleAreaSize();
     virtual bool IsCompactMode() const { return false; }

--- a/src/view/src/rocprofvis_track_item.h
+++ b/src/view/src/rocprofvis_track_item.h
@@ -146,6 +146,7 @@ protected:
     virtual bool  ExtractPointsFromData() = 0;
 
     void  FetchHelper();
+    void  CancelPendingRequests();
     void  SetDefaultPillLabel(const TrackInfo* track_info);
     void  SetMetaAreaLabel(const TrackInfo* track_info);
     void  SetNodeColor(const TrackInfo* track_info);
@@ -176,6 +177,9 @@ protected:
     std::shared_ptr<TimelineSelection>  m_timeline_selection;
     uint64_t m_chunk_duration_ns;  // Duration of each chunk in nanoseconds
     uint8_t  m_group_id_counter;   // Counter for grouping requests
+    // Cancellation has already been requested for everything in
+    // m_pending_requests; they stay pending until their futures resolve.
+    bool     m_cancel_requested;
 
     std::deque<TrackRequestParams>                   m_request_queue;
     std::unordered_map<uint64_t, TrackRequestParams> m_pending_requests;


### PR DESCRIPTION
## Motivation

Harden track fetch and cancellation logic on the UI side.

Fixes tracks that could be left showing a loading spinner forever, or silently rendering partial data, when in-flight data fetches were cancelled. 

## Technical Details

**Chunk range.** `TrackItem::RequestData` sized its chunk count from
`m_chunk_duration_ns` but advanced the loop by `TimeConstants::minute_in_ns`, so
roughly half of every request's chunks began past the requested end, producing
bogus chunk widths.

**Cancellation lifecycle.** Cancellation is now requested once per request
generation rather than re-requested every frame, and a track leaves the
requesting state only once its pending map has fully drained. Cancelling only
asks the controller to stop early — the request still completes — so waiting for
the drain is what keeps the track's view of what is in flight accurate.

**Unroutable responses.** A response whose track parameters or metadata are
missing now still invokes the data-ready callback, and the view falls back to
matching on request id, so a track can no longer wait forever on a response that
was dropped before reaching it.

**Track data replacement.** Replacing a track's data group now force-frees the
previous group instead of orphaning it, and a cancelled response no longer
creates an empty data object that makes an unloaded track look loaded.

**Partial data.** A track that returns to view holding only some of its chunks —
the requests that completed before their cancellation took effect — now refetches
instead of presenting incomplete data as finished.

**Controller.** `Track::FetchSegments` no longer overwrites
`kRocProfVisResultCancelled` with `kRocProfVisResultOutOfRange`, so the view can
distinguish a cancelled fetch from a genuinely empty time range. Taken from
PR #998.

## Test plan

- [x] Scroll rapidly up and down a trace with many tracks; no track should be
      left spinning or visibly missing data
- [x] Zoom and pan repeatedly across several LOD levels; tracks should always
      settle on complete data
- [x] Exercise both counter (line) and event (flame) tracks
- [x] Load a project file with a saved track order
- [x] Debug build: no assertions fire during any of the above
