### PR TITLE
View: Fix timeline tracks flickering during fast vertical scroll

### DIFF
--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -2226,7 +2226,11 @@ for nearly every common pattern.
   ahead of the layout the rows are placed with. Track positions come
   from `ImGui::GetCursorPos()`, so cull and hit-test against
   `ImGui::GetScrollY()` inside `Graph View Main` or rows draw at the
-  wrong offset for a frame while scrolling.
+  wrong offset for a frame while scrolling. ImGui also rounds
+  `window->Scroll` to whole pixels: keep `m_previous_scroll_position`
+  as a `float` and treat a sub-pixel gap as already applied, or a
+  leftover fraction looks like a pending wheel request and overwrites
+  the scrollbar.
 - **Forgetting to unsubscribe.** If you `Subscribe` to an event, store
   the token and `Unsubscribe` in your destructor. Otherwise the
   EventManager will dispatch into a dead `this`.

--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -2221,6 +2221,12 @@ for nearly every common pattern.
 
 ## 18. Common Pitfalls
 
+- **Culling timeline rows against `m_scroll_position_y`.** `SetScrollY`
+  only takes effect on the next `Begin`, so that member can be a frame
+  ahead of the layout the rows are placed with. Track positions come
+  from `ImGui::GetCursorPos()`, so cull and hit-test against
+  `ImGui::GetScrollY()` inside `Graph View Main` or rows draw at the
+  wrong offset for a frame while scrolling.
 - **Forgetting to unsubscribe.** If you `Subscribe` to an event, store
   the token and `Unsubscribe` in your destructor. Otherwise the
   EventManager will dispatch into a dead `this`.

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -34,6 +34,9 @@ constexpr float    SIDEBAR_WIDTH_MAX             = 600.0f;
 constexpr float    SIDEBAR_DEFAULT_SIZE          = 400.0f;
 constexpr float    LOADING_TRACK_DISTANCE        = DEFAULT_TRACK_HEIGHT * 14;
 constexpr float    SCROLL_SPEED                  = 100.0f;
+// ImGui rounds window->Scroll with ImRound64, so sub-pixel remainders are not
+// a distinct view position. Treat them as already applied.
+constexpr float    SCROLL_APPLY_TOLERANCE_PX     = 1.0f;
 constexpr uint64_t DEFAULT_LOADING_TIMER         = 150;  // milliseconds
 constexpr float    ARTIFICIAL_SCROLLBAR_HEIGHT   = 18.0f;
 constexpr float    SIDEBAR_SPLITTER_WIDTH        = 5.0f;
@@ -1748,20 +1751,29 @@ TimelineView::RenderGraphView()
                       window_flags);
     m_content_max_y_scroll = ImGui::GetScrollMaxY();
 
-    // The scrollbar writes ImGui's scroll directly, the wheel and hotkeys write
+    // The scrollbar writes ImGui's scroll directly; the wheel and hotkeys write
     // m_scroll_position_y and only land on the next Begin. Take the scrollbar's
     // value only when nothing newer of ours is pending, else a fast wheel flick
     // is overwritten by last frame's request.
-    float scroll_position = ImGui::GetScrollY();
-    if(m_previous_scroll_position != scroll_position)
+    //
+    // ImGui stores Scroll as whole pixels, so a fractional remainder is not a
+    // real pending jump. Exact equality would keep SetScrollY() every frame and
+    // treat that residue as "ours", which then fights a later scrollbar drag.
+    // Sub-pixel deltas stay in m_scroll_position_y so they can accumulate.
+    const float applied_scroll = ImGui::GetScrollY();
+    const bool  pending_request =
+        std::abs(m_scroll_position_y - m_previous_scroll_position) >=
+        SCROLL_APPLY_TOLERANCE_PX;
+
+    if(applied_scroll != m_previous_scroll_position)
     {
-        if(m_scroll_position_y == m_previous_scroll_position)
+        if(!pending_request)
         {
-            m_scroll_position_y = scroll_position;
+            m_scroll_position_y = applied_scroll;
         }
-        m_previous_scroll_position = scroll_position;
+        m_previous_scroll_position = applied_scroll;
     }
-    if(m_scroll_position_y != scroll_position)
+    if(std::abs(m_scroll_position_y - applied_scroll) >= SCROLL_APPLY_TOLERANCE_PX)
     {
         ImGui::SetScrollY(m_scroll_position_y);
     }

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1748,14 +1748,20 @@ TimelineView::RenderGraphView()
                       window_flags);
     m_content_max_y_scroll = ImGui::GetScrollMaxY();
 
-    // Prevent choppy behavior by preventing constant rerender.
-    float temp_scroll_position = ImGui::GetScrollY();
-    if(m_previous_scroll_position != temp_scroll_position)
+    // The scrollbar writes ImGui's scroll directly, the wheel and hotkeys write
+    // m_scroll_position_y and only land on the next Begin. Take the scrollbar's
+    // value only when nothing newer of ours is pending, else a fast wheel flick
+    // is overwritten by last frame's request.
+    float scroll_position = ImGui::GetScrollY();
+    if(m_previous_scroll_position != scroll_position)
     {
-        m_previous_scroll_position = temp_scroll_position;
-        m_scroll_position_y        = temp_scroll_position;
+        if(m_scroll_position_y == m_previous_scroll_position)
+        {
+            m_scroll_position_y = scroll_position;
+        }
+        m_previous_scroll_position = scroll_position;
     }
-    else if(m_scroll_position_y != temp_scroll_position)
+    if(m_scroll_position_y != scroll_position)
     {
         ImGui::SetScrollY(m_scroll_position_y);
     }
@@ -1892,13 +1898,16 @@ TimelineView::RenderTrack(int track_index, bool request_data,
             float track_top    = track_pos.y;
             float track_bottom = track_top + track_height;
 
+            // Cull against the scroll this window was laid out with, not
+            // m_scroll_position_y, which SetScrollY only applies next frame.
+            float view_top    = ImGui::GetScrollY();
+            float view_bottom = view_top + ImGui::GetWindowHeight();
+
             // Calculate deltas for out-of-view tracks
-            float delta_top = m_scroll_position_y -
-                              track_bottom;  // Positive if the track is above the view
+            float delta_top =
+                view_top - track_bottom;  // Positive if the track is above the view
             float delta_bottom =
-                track_top -
-                (m_scroll_position_y +
-                 m_tpt->GetGraphSizeY());  // Positive if the track is below the view
+                track_top - view_bottom;  // Positive if the track is below the view
 
             // Save distance for book keeping
             track_item->SetDistanceToView(std::max(std::max(delta_bottom, delta_top), 0.0f));
@@ -1909,9 +1918,8 @@ TimelineView::RenderTrack(int track_index, bool request_data,
                                  m_reorder_request.track_id == track_item->GetID();
 
             // Check if the track is visible
-            bool is_visible = (track_bottom >= m_scroll_position_y &&
-                               track_top <= m_scroll_position_y + m_tpt->GetGraphSizeY()) ||
-                              is_reordering;
+            bool is_visible =
+                (track_bottom >= view_top && track_top <= view_bottom) || is_reordering;
 
             track_item->SetInViewVertical(is_visible);
 

--- a/src/view/src/rocprofvis_timeline_view.h
+++ b/src/view/src/rocprofvis_timeline_view.h
@@ -219,7 +219,7 @@ private:
     float                               m_scroll_position_y;
     float                               m_content_max_y_scroll;
     bool                                m_can_drag_to_pan;
-    double                              m_previous_scroll_position;
+    float                               m_previous_scroll_position;
     bool                                m_meta_map_made;
     bool                                m_resize_activity;
     bool                                m_reorder_auto_scrolling;


### PR DESCRIPTION
Track positions in RenderTrack come from ImGui::GetCursorPos(), which is relative to the scroll the window was laid out with, but visibility was tested against m_scroll_position_y. The wheel and hotkeys only push that member to ImGui via SetScrollY, which lands on the next Begin, so for one frame the rows were placed at the old scroll while being culled against the new one. The two sets differ by roughly a row, leaving a track drawn over its neighbour at the leading edge for a frame.

Cull against the window's own scroll and height so layout and culling agree. This also drops the ruler and artificial scrollbar from the viewport height, which had been overestimated via GetGraphSizeY().

Also stop discarding wheel deltas: when a second flick arrived before ImGui caught up to the previous request, the stale GetScrollY() value overwrote the newer pending offset.