### PR TITLE
TrackOptions need a virtual destructor

### DIFF
--- a/src/view/src/rocprofvis_timeline_track_options.h
+++ b/src/view/src/rocprofvis_timeline_track_options.h
@@ -36,6 +36,8 @@ public:
     TrackOptions(const TrackItem& track, TimelineTrackOptions& ctx,
                  const std::string& project_id);
     TrackOptions(const TrackOptions& other);
+    // Derived options are owned through unique_ptr<TrackOptions>
+    virtual ~TrackOptions() = default;
 
     // Part of aggregation, types dictate how to combine themselves
     virtual TrackOptions& operator&=(const TrackOptions& other);


### PR DESCRIPTION
## Motivation

ASAN detected memory corruption on tab close.

## Technical Details

TrackOptions is a polymorphic base (virtual Render, ToJson, operator&=) but has no virtual destructor, while TrackItem::m_options is a std::unique_ptr<TrackOptions> that actually holds an EventTrackOptions/QueueTrackOptions/CounterTrackOptions. 

On delete a 64 vs 72 byte mismatch is detected, this matches the base vs. EventTrackOptions difference.