### PR TITLE
  ROCM-29662 [Optiq-Compute]: Roofline chart: app crashes on open when a .db has roofline bandwidth ceilings but no compute ceilings (uncaught std::out_of_range)

### DIFF
--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -5087,6 +5087,12 @@ DataProvider::LoadRoofLineCeilingsCompute(WorkloadInfo&        workload,
                     ceiling;
             }
         }
+        else
+        {
+            spdlog::warn("DataProvider::LoadRoofLineCeilingsBandwidth - No ridge point "
+                         "found for ceiling type {}",
+                         static_cast<uint32_t>(ceiling.bandwidth_type));       
+        }
     }
 }
 
@@ -5145,6 +5151,12 @@ DataProvider::LoadRoofLineCeilingsBandwidth(WorkloadInfo&        workload,
                     ceiling;
             }
         }
+        else
+        {
+            spdlog::warn("DataProvider::LoadRoofLineCeilingsCompute - No ridge point "
+                         "found for ceiling type {}",
+                         static_cast<uint32_t>(ceiling.compute_type));
+        }
     }
 }
 
@@ -5191,6 +5203,11 @@ DataProvider::LoadRoofLineKernels(WorkloadInfo&        workload,
                 std::min(workload.roofline.min.y, intensity.position.y);
             workload.kernels[kernel_id].roofline.intensities[intensity.type] =
                 std::move(intensity);
+        }
+        else
+        {
+            spdlog::warn("DataProvider::LoadRoofLineKernels - Unexpected kernel id {}",
+                         kernel_id);
         }
     }
 }

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -4983,7 +4983,7 @@ DataProvider::LoadRoofLine(WorkloadInfo& workload, rocprofvis_handle_t* workload
 
     LoadRoofLineCeilingsBandwidth(workload, roofline_handle, bandwidth_ridge);
 
-    LoadRoofLineNumKernels(workload, roofline_handle, compute_ridge, bandwidth_ridge);
+    LoadRoofLineKernels(workload, roofline_handle);
 }
 
 inline void
@@ -5054,33 +5054,38 @@ DataProvider::LoadRoofLineCeilingsCompute(WorkloadInfo&        workload,
         ceiling.compute_type =
             static_cast<rocprofvis_controller_roofline_ceiling_compute_type_t>(
                 uint64_data);
-        ROCPROFVIS_ASSERT(compute_ridge.count(ceiling.compute_type) > 0);
-        for(const std::pair<const rocprofvis_controller_roofline_ceiling_bandwidth_type_t,
-                            Point>& ridge : compute_ridge.at(ceiling.compute_type))
+        if(compute_ridge.count(ceiling.compute_type) > 0)
         {
-            ceiling.bandwidth_type = ridge.first;
-            ceiling.position.p1    = ridge.second;
-            result                 = rocprofvis_controller_get_double(
-                roofline_handle, kRPVControllerRooflineCeilingComputeXIndexed, j,
-                &double_data);
-            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            ceiling.position.p2.x = double_data;
-            result                = rocprofvis_controller_get_double(
-                roofline_handle, kRPVControllerRooflineCeilingComputeYIndexed, j,
-                &double_data);
-            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            ceiling.position.p2.y = double_data;
-            result                = rocprofvis_controller_get_double(
-                roofline_handle, kRPVControllerRooflineCeilingComputeThroughputIndexed, j,
-                &double_data);
-            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            ceiling.throughput = double_data;
-            workload.roofline.max.x =
-                std::max(workload.roofline.max.x, ceiling.position.p2.x);
-            workload.roofline.max.y =
-                std::max(workload.roofline.max.y, ceiling.position.p2.y);
-            workload.roofline
-                .ceiling_compute[ceiling.compute_type][ceiling.bandwidth_type] = ceiling;
+            for(const std::pair<
+                    const rocprofvis_controller_roofline_ceiling_bandwidth_type_t, Point>&
+                    ridge : compute_ridge.at(ceiling.compute_type))
+            {
+                ceiling.bandwidth_type = ridge.first;
+                ceiling.position.p1    = ridge.second;
+                result                 = rocprofvis_controller_get_double(
+                    roofline_handle, kRPVControllerRooflineCeilingComputeXIndexed, j,
+                    &double_data);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                ceiling.position.p2.x = double_data;
+                result                = rocprofvis_controller_get_double(
+                    roofline_handle, kRPVControllerRooflineCeilingComputeYIndexed, j,
+                    &double_data);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                ceiling.position.p2.y = double_data;
+                result                = rocprofvis_controller_get_double(
+                    roofline_handle,
+                    kRPVControllerRooflineCeilingComputeThroughputIndexed, j,
+                    &double_data);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                ceiling.throughput = double_data;
+                workload.roofline.max.x =
+                    std::max(workload.roofline.max.x, ceiling.position.p2.x);
+                workload.roofline.max.y =
+                    std::max(workload.roofline.max.y, ceiling.position.p2.y);
+                workload.roofline
+                    .ceiling_compute[ceiling.compute_type][ceiling.bandwidth_type] =
+                    ceiling;
+            }
         }
     }
 }
@@ -5107,43 +5112,45 @@ DataProvider::LoadRoofLineCeilingsBandwidth(WorkloadInfo&        workload,
         ceiling.bandwidth_type =
             static_cast<rocprofvis_controller_roofline_ceiling_bandwidth_type_t>(
                 uint64_data);
-        ROCPROFVIS_ASSERT(bandwidth_ridge.count(ceiling.bandwidth_type) > 0);
-        for(const std::pair<const rocprofvis_controller_roofline_ceiling_compute_type_t,
-                            Point>& ridge : bandwidth_ridge.at(ceiling.bandwidth_type))
+        if(bandwidth_ridge.count(ceiling.bandwidth_type) > 0)
         {
-            ceiling.compute_type = ridge.first;
-            result               = rocprofvis_controller_get_double(
-                roofline_handle, kRPVControllerRooflineCeilingBandwidthXIndexed, j,
-                &double_data);
-            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            ceiling.position.p1.x = double_data;
-            result                = rocprofvis_controller_get_double(
-                roofline_handle, kRPVControllerRooflineCeilingBandwidthYIndexed, j,
-                &double_data);
-            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            ceiling.position.p1.y = double_data;
-            ceiling.position.p2   = ridge.second;
-            result                = rocprofvis_controller_get_double(
-                roofline_handle, kRPVControllerRooflineCeilingBandwidthThroughputIndexed,
-                j, &double_data);
-            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-            ceiling.throughput = double_data;
-            workload.roofline.min.x =
-                std::min(workload.roofline.min.x, ceiling.position.p1.x);
-            workload.roofline.min.y =
-                std::min(workload.roofline.min.y, ceiling.position.p1.y);
-            workload.roofline
-                .ceiling_bandwidth[ceiling.bandwidth_type][ceiling.compute_type] =
-                ceiling;
+            for(const std::pair<
+                    const rocprofvis_controller_roofline_ceiling_compute_type_t, Point>&
+                    ridge : bandwidth_ridge.at(ceiling.bandwidth_type))
+            {
+                ceiling.compute_type = ridge.first;
+                result               = rocprofvis_controller_get_double(
+                    roofline_handle, kRPVControllerRooflineCeilingBandwidthXIndexed, j,
+                    &double_data);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                ceiling.position.p1.x = double_data;
+                result                = rocprofvis_controller_get_double(
+                    roofline_handle, kRPVControllerRooflineCeilingBandwidthYIndexed, j,
+                    &double_data);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                ceiling.position.p1.y = double_data;
+                ceiling.position.p2   = ridge.second;
+                result                = rocprofvis_controller_get_double(
+                    roofline_handle,
+                    kRPVControllerRooflineCeilingBandwidthThroughputIndexed, j,
+                    &double_data);
+                ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+                ceiling.throughput = double_data;
+                workload.roofline.min.x =
+                    std::min(workload.roofline.min.x, ceiling.position.p1.x);
+                workload.roofline.min.y =
+                    std::min(workload.roofline.min.y, ceiling.position.p1.y);
+                workload.roofline
+                    .ceiling_bandwidth[ceiling.bandwidth_type][ceiling.compute_type] =
+                    ceiling;
+            }
         }
     }
 }
 
 inline void
-DataProvider::LoadRoofLineNumKernels(WorkloadInfo&        workload,
-                                     rocprofvis_handle_t* roofline_handle,
-                                     compute_ridge_map&   compute_ridge,
-                                     bandwidth_ridge_map& bandwidth_ridge)
+DataProvider::LoadRoofLineKernels(WorkloadInfo&        workload,
+                                  rocprofvis_handle_t* roofline_handle)
 {
     uint64_t num_entries = 0;
     double   double_data = 0.0;
@@ -5153,34 +5160,38 @@ DataProvider::LoadRoofLineNumKernels(WorkloadInfo&        workload,
     ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
     for(uint64_t j = 0; j < num_entries; j++)
     {
-        KernelInfo::Roofline::Intensity intensity;
-        result = rocprofvis_controller_get_uint64(
-            roofline_handle, kRPVControllerRooflineKernelIntensityTypeIndexed, j,
-            &uint64_data);
-        ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-        intensity.type =
-            static_cast<rocprofvis_controller_roofline_kernel_intensity_type_t>(
-                uint64_data);
-        result = rocprofvis_controller_get_double(
-            roofline_handle, kRPVControllerRooflineKernelIntensityXIndexed, j,
-            &double_data);
-        ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-        intensity.position.x = double_data;
-        result               = rocprofvis_controller_get_double(
-            roofline_handle, kRPVControllerRooflineKernelIntensityYIndexed, j,
-            &double_data);
-        ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
-        intensity.position.y = double_data;
         uint32_t kernel_id;
         result = rocprofvis_controller_get_uint64(
             roofline_handle, kRPVControllerRooflineKernelIdIndexed, j, &uint64_data);
         ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
         kernel_id = static_cast<uint32_t>(uint64_data);
-        ROCPROFVIS_ASSERT(workload.kernels.count(kernel_id));
-        workload.roofline.max.y = std::max(workload.roofline.max.y, intensity.position.y);
-        workload.roofline.min.y = std::min(workload.roofline.min.y, intensity.position.y);
-        workload.kernels[kernel_id].roofline.intensities[intensity.type] =
-            std::move(intensity);
+        if(workload.kernels.count(kernel_id))
+        {
+            KernelInfo::Roofline::Intensity intensity;
+            result = rocprofvis_controller_get_uint64(
+                roofline_handle, kRPVControllerRooflineKernelIntensityTypeIndexed, j,
+                &uint64_data);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            intensity.type =
+                static_cast<rocprofvis_controller_roofline_kernel_intensity_type_t>(
+                    uint64_data);
+            result = rocprofvis_controller_get_double(
+                roofline_handle, kRPVControllerRooflineKernelIntensityXIndexed, j,
+                &double_data);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            intensity.position.x = double_data;
+            result               = rocprofvis_controller_get_double(
+                roofline_handle, kRPVControllerRooflineKernelIntensityYIndexed, j,
+                &double_data);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            intensity.position.y = double_data;
+            workload.roofline.max.y =
+                std::max(workload.roofline.max.y, intensity.position.y);
+            workload.roofline.min.y =
+                std::min(workload.roofline.min.y, intensity.position.y);
+            workload.kernels[kernel_id].roofline.intensities[intensity.type] =
+                std::move(intensity);
+        }
     }
 }
 

--- a/src/view/src/rocprofvis_data_provider.h
+++ b/src/view/src/rocprofvis_data_provider.h
@@ -411,10 +411,8 @@ private:
                                               rocprofvis_handle_t* roofline_handle,
                                               bandwidth_ridge_map& bandwidth_ridge);
 
-    inline void LoadRoofLineNumKernels(WorkloadInfo&        workload,
-                                       rocprofvis_handle_t* roofline_handle,
-                                       compute_ridge_map&   compute_ridge,
-                                       bandwidth_ridge_map& bandwidth_ridge);
+    inline void LoadRoofLineKernels(WorkloadInfo&        workload,
+                                    rocprofvis_handle_t* roofline_handle);
 
     void ProcessMetricsRequest(RequestInfo& req);
     void ProcessMetricPivotTable(RequestInfo& req);


### PR DESCRIPTION
## Problem

In v1.0.0 RC2, opening a ROCm Compute Profiler `.db` whose roofline has bandwidth
ceilings but no recognized compute ceilings closes the application immediately on
**File > Open** — SIGABRT, no dialog, no log.

## Cause

Ridge points are an unconditional cross product of compute × bandwidth ceilings
(`rocprofvis_controller_trace_compute.cpp:1023`), and `Roofline::QueryToPropertyEnum`
silently drops benchmark columns it does not recognize. If every compute column is
unrecognized the product is `0 × N == 0`, so **both** ridge maps come back empty.

`LoadRoofLineCeilingsBandwidth` still iterated the non-empty bandwidth list and called
`bandwidth_ridge.at(...)` on the empty map → `std::out_of_range` → `std::terminate`.
`ROCPROFVIS_ASSERT` expands to `assert()`, a no-op under `NDEBUG`, so release builds
walked straight past the guard. `LoadRoofLineCeilingsCompute` has the mirror-image bug.

## Fix

Guard the ridge and kernel map lookups in the three roofline loaders so a missing key
skips the entry instead of throwing. Also renames `LoadRoofLineNumKernels` →
`LoadRoofLineKernels` and drops its two unused ridge parameters.

## Result

Not a partial roofline. The ridge point *is* the endpoint of every ceiling segment
(`position.p1` for compute, `position.p2` for bandwidth), so a ceiling without one has
no geometry to draw. With either category empty both ceiling maps end up empty and
`Roofline::Render` falls through to its existing "No data available." placeholder. The
file opens and the rest of the compute UI loads normally.

## Risk

The cross product is unconditional, so the ridge maps are either fully populated or
empty — the guards never skip an individual entry.

| compute | bandwidth | before | after |
| --- | --- | --- | --- |
| non-empty | non-empty | renders | identical |
| empty | non-empty | **SIGABRT** | "No data available." |
| non-empty | empty | **SIGABRT** | "No data available." |

## Testing

- [ ] Reporting `.db` — app stays up, Roofline shows "No data available.", other tabs populate
- [ ] `sample/rocprof_compute_23ed6f36.db` — roofline unchanged (ceilings, ridge points, kernel markers)
- [ ] `ctest --test-dir build/<preset> --output-on-failure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
