### PR TITLE
ROCM-29676 [Optiq-Compute]: Baseline Comparison crashes when a kernel with a non-finite (Inf) metric value is compared to itself (Inf − Inf = NaN not handled)

### DIFF
--- a/src/view/src/compute/rocprofvis_compute_comparison.cpp
+++ b/src/view/src/compute/rocprofvis_compute_comparison.cpp
@@ -465,7 +465,9 @@ ComputeComparisonView::UpdateMetrics()
                                                      std::nullopt } });
                             row_value[0].emplace_back(Table::Value{
                                 DIFFERENCE_COLUMN_PREFIX + value_name,
-                                valid_match && baseline_value && target_value
+                                valid_match && baseline_value && target_value &&
+                                        std::isfinite(rounded_baseline) &&
+                                        std::isfinite(rounded_target)
                                     ? std::make_optional(rounded_target -
                                                          rounded_baseline)
                                     : std::nullopt,
@@ -474,6 +476,8 @@ ComputeComparisonView::UpdateMetrics()
                             row_value[0].emplace_back(Table::Value{
                                 DIFFERENCE_PCT_COLUMN_PREFIX + value_name,
                                 valid_match && baseline_value && target_value &&
+                                        std::isfinite(rounded_baseline) &&
+                                        std::isfinite(rounded_target) &&
                                         rounded_baseline != 0.0
                                     ? std::make_optional(
                                           std::round((rounded_target - rounded_baseline) /


### PR DESCRIPTION
## Problem

In Baseline Comparison, selecting the same kernel on both sides crashes ROCm Optiq when
that kernel has a non-finite metric. Reproduced with `__amd_rocclr_copyBuffer`, whose
"Wavefront Occupancy (Memory Chart)" is `Inf`. Comparing that kernel against a *different*
kernel does not crash, and self-comparing a kernel with finite metrics does not crash.

## Cause

`std::bad_optional_access` at `rocprofvis_compute_comparison.cpp:1066`.

Self-comparison makes `rounded_baseline == rounded_target`, so the equality check at `:422`
is false and `bg_color_difference` is never assigned — correct, since nothing changed. But
the difference is still computed as `inf - inf`, which is **NaN**, and the percent column's
`rounded_baseline != 0.0` guard passes for `inf`.

`UpdateDifferenceGroups:1038` then admits the row, because its "skip unchanged rows" gate is
`value.dbl_data != 0.0` and **NaN compares unequal to everything**, including `0.0`.
`UpdateDifferenceHighlight:1066` dereferences `display_props.bg_color.value()` on the
disengaged optional and throws.

A finite self-comparison yields exactly `0.0` and is correctly skipped; comparing against a
different kernel yields `-Inf` and does assign `bg_color`. NaN is the only value that both
passes the gate and leaves `bg_color` empty.

## Fix

Gate the difference and percent values on `std::isfinite` for both operands, so a
non-finite metric produces no difference value and the row is never admitted as a
highlight group.

## Testing

- [ ] Self-compare `__amd_rocclr_copyBuffer` (Wavefront Occupancy = Inf) — no crash,
      difference cells blank
- [ ] Compare it against a different kernel — still shows the `-Inf` difference as before
- [ ] Self-compare a kernel with finite metrics — unchanged, no highlight
- [ ] Two different kernels with finite metrics — thresholds and highlighting unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
