### PR TITLE
Resolve issue with version number for windows installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -795,10 +795,7 @@ if(WIN32)
   if(WIX_EXECUTABLE)
     set(_wix_src  "${CMAKE_SOURCE_DIR}/wix/roc-optiq.wxs")
     set(_wix_out  "${CMAKE_BINARY_DIR}/roc-optiq-${CPACK_PACKAGE_VERSION}-win64.msi")
-    # MSI only supports 3-part versions; encode Patch*1000+Build into the third component
-    # so upgrade detection works correctly when only the build number changes.
-    math(EXPR _wix_patch "${PROJECT_VERSION_PATCH} * 1000 + ${PROJECT_VERSION_BUILD}")
-    set(_wix_version "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${_wix_patch}")
+    set(_wix_version "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
     add_custom_target(PACKAGE_WIX
       COMMAND "${WIX_EXECUTABLE}" build
         -arch x64

--- a/wix/roc-optiq.wxs
+++ b/wix/roc-optiq.wxs
@@ -12,7 +12,7 @@
       wix extension add WixToolset.UI.wixext
 
   Variables supplied by CMake via -d flags:
-      Version    = 3-part MSI version: Major.Minor.(Patch*1000+Build), e.g. 0.5.1
+      Version    = 3-part MSI version: Major.Minor.Patch, e.g. 1.0.0
       ExeFile    = absolute path to roc-optiq.exe
       LicenseRtf = absolute path to the RTF license shown in the installer UI
       BannerBmp  = absolute path to the 493x58 banner bitmap


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Previously, we combined Patch + Build into a new build number since MSI expects a `major.minor.patch` setup that cannot accommodate a build number. However, this led to issues with the installed version appearing different than what the actual Optiq version was. 

This reverts that change to ensure that WiX does not modify the version number provided from Optiq.

JIRA ID : ROCM-29664

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `CMakeLists.txt` to remove the `_wix_patch` var and instead use `PROJECT_VERSION_PATCH` directly instead when providing the `_wix_version`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Build locally and ensure that the Windows installer correctly passes the correct version number to the installed application.

## Test Result

<!-- Briefly summarize test outcomes. -->
ROCm Optiq version shows the correct `major.minor.patch` version from the branch used.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.