### PR TITLE
Fix description-column resize panning the timeline and add test

### DIFF
--- a/src/app/test/app_tests.cpp
+++ b/src/app/test/app_tests.cpp
@@ -1276,6 +1276,89 @@ void RegisterAppTests(ImGuiTestEngine* e)
         IM_CHECK(inactive_after);
     };
 
+    // AIPROFVIS-333: dragging the Description-column splitter must
+    // resize the sidebar without panning the timeline.
+    t = IM_REGISTER_TEST(e, "app", "sys_splitter_resize_no_pan");
+    t->TestFunc = [](ImGuiTestContext* ctx)
+    {
+        TraceView* tv = GetTraceViewOrSkip(ctx);
+        if (!tv) return;
+        TimelineView* tlv = TraceViewTestPeer{*tv}.TimelineViewPtr();
+        IM_CHECK(tlv != nullptr);
+        if (tlv == nullptr) return;
+
+        ctx->SetRef("Main Window");
+        ctx->Yield(3);
+
+        auto tpt = tlv->GetTransform();
+        IM_CHECK(tpt != nullptr);
+        if (tpt == nullptr) return;
+        const double range = tpt->GetRangeX();
+        IM_CHECK(range > 0.0);
+        if (range <= 0.0) return;
+
+        // Restore before the asserts. IM_CHECK returns on failure, so a trailing
+        // restore would leak state into later tests on abort.
+        const float  orig_zoom    = tpt->GetZoom();
+        const double orig_offset  = tpt->GetViewTimeOffsetNs();
+        const float  orig_sidebar = TimelineViewTestPeer{*tlv}.SidebarSize();
+
+        auto restore = [&]()
+        {
+            tpt->SetZoom(orig_zoom);
+            tpt->SetViewTimeOffsetNs(orig_offset);
+            TimelineViewTestPeer{*tlv}.SetSidebarSize(orig_sidebar);
+        };
+
+        // At zoom 1 the view spans the full range and any pan offset clamps to 0,
+        // so the bug is invisible; zoom in to create pan headroom.
+        //
+        // SetZoom applies only the min bound; the max clamp (range/graph_size_x)
+        // runs at render in ComputePixelMapping. So read the effective zoom back
+        // after a Yield, center the offset on that, Yield again, then read the
+        // achieved offset: if the clamp left no headroom, skip instead of false-green.
+        tpt->SetZoom(4.0f);
+        ctx->Yield(3);
+        const float  zoom    = tpt->GetZoom();
+        const double max_off = range - range / static_cast<double>(zoom);
+        tpt->SetViewTimeOffsetNs(max_off * 0.5);
+        ctx->Yield(3);
+        const double achieved_off = tpt->GetViewTimeOffsetNs();
+        if (achieved_off <= range * 1e-6)
+        {
+            restore();
+            ctx->LogWarning("SKIP: zoom clamped, no pan headroom to detect the bug");
+            return;
+        }
+
+        const char* splitter_ref = "**/##MovePositionLineVert";
+        if (!ctx->ItemExists(splitter_ref))
+        {
+            restore();
+            ctx->LogWarning("SKIP: description-column splitter not present");
+            return;
+        }
+
+        const float  sidebar_before = TimelineViewTestPeer{*tlv}.SidebarSize();
+        const double v_min_before   = tlv->GetViewCoords().v_min_x;
+
+        ctx->ItemDragWithDelta(splitter_ref, ImVec2(40.0f, 0.0f));
+        ctx->Yield(3);
+
+        const float  sidebar_after = TimelineViewTestPeer{*tlv}.SidebarSize();
+        const double v_min_after   = tlv->GetViewCoords().v_min_x;
+        const double eps           = range * 1e-4;
+
+        restore();
+        ctx->Yield(2);
+
+        // Guard: the drag must have resized the sidebar, else the pan check is vacuous.
+        IM_CHECK(sidebar_after > sidebar_before);
+
+        // The defect: resizing shifts the timeline min-x; correct behavior holds it.
+        IM_CHECK(std::fabs(v_min_after - v_min_before) <= eps);
+    };
+
     t = IM_REGISTER_TEST(e, "app", "sys_timeline_track_expand_collapse");
     t->TestFunc = [](ImGuiTestContext* ctx)
     {

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1318,21 +1318,14 @@ TimelineView::RenderSplitter()
     {
         ImVec2 drag_delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left);
 
-        const float graph_w_before = m_tpt->GetGraphSizeX();
-        const float sidebar_before = m_sidebar_size;
-        m_sidebar_size             = std::clamp(m_sidebar_size + drag_delta.x,
-                                                m_max_meta_scale_area_size +
-                                                    2 * ImGui::GetFrameHeightWithSpacing(),
-                                                SIDEBAR_WIDTH_MAX);
-
-        // Hold pixels_per_ns constant (offset untouched) so resizing the
-        // description column neither pans nor rescales the timeline. AIPROFVIS-333.
-        const float applied       = m_sidebar_size - sidebar_before;
-        const float graph_w_after = graph_w_before - applied;
-        if(graph_w_after > 0.0f)
-        {
-            m_tpt->SetZoom(m_tpt->GetZoom() * graph_w_before / graph_w_after);
-        }
+        // Resize only; leave zoom/offset untouched. SetGraphSize() picks up the
+        // new width later this frame and recomputes pixels_per_ns on its own, so
+        // the visible ns-range (and thus v_min_x) never moves and this can't be
+        // mistaken for a real zoom change by IsRequestDataNeeded(). AIPROFVIS-333.
+        m_sidebar_size = std::clamp(m_sidebar_size + drag_delta.x,
+                                    m_max_meta_scale_area_size +
+                                        2 * ImGui::GetFrameHeightWithSpacing(),
+                                    SIDEBAR_WIDTH_MAX);
         ImGui::ResetMouseDragDelta();
         ImGui::EndDragDropSource();
         m_resize_activity |= true;

--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1317,15 +1317,22 @@ TimelineView::RenderSplitter()
     if(ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceNoPreviewTooltip))
     {
         ImVec2 drag_delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left);
-        m_sidebar_size    = std::clamp(m_sidebar_size + drag_delta.x,
-                                       m_max_meta_scale_area_size +
-                                           2 * ImGui::GetFrameHeightWithSpacing(),
-                                       SIDEBAR_WIDTH_MAX);
 
-        m_tpt->SetViewTimeOffsetNs(
-            m_tpt->GetViewTimeOffsetNs() -
-            (drag_delta.x / display_size.x) *
-                m_tpt->GetVWidth());  // Prevents chart from moving in unexpected way.
+        const float graph_w_before = m_tpt->GetGraphSizeX();
+        const float sidebar_before = m_sidebar_size;
+        m_sidebar_size             = std::clamp(m_sidebar_size + drag_delta.x,
+                                                m_max_meta_scale_area_size +
+                                                    2 * ImGui::GetFrameHeightWithSpacing(),
+                                                SIDEBAR_WIDTH_MAX);
+
+        // Hold pixels_per_ns constant (offset untouched) so resizing the
+        // description column neither pans nor rescales the timeline. AIPROFVIS-333.
+        const float applied       = m_sidebar_size - sidebar_before;
+        const float graph_w_after = graph_w_before - applied;
+        if(graph_w_after > 0.0f)
+        {
+            m_tpt->SetZoom(m_tpt->GetZoom() * graph_w_before / graph_w_after);
+        }
         ImGui::ResetMouseDragDelta();
         ImGui::EndDragDropSource();
         m_resize_activity |= true;

--- a/src/view/test/rocprofvis_view_test_access.h
+++ b/src/view/test/rocprofvis_view_test_access.h
@@ -179,6 +179,10 @@ struct TimelineViewTestPeer
 
     float MaxYScroll() const { return v.m_content_max_y_scroll; }
 
+    // Sidebar width, resized by dragging the "##MovePositionLineVert" splitter.
+    float SidebarSize() const { return v.m_sidebar_size; }
+    void  SetSidebarSize(float size) const { const_cast<TimelineView&>(v).m_sidebar_size = size; }
+
     FlameTrackItem* FirstFlameTrack() const
     {
         if(!v.m_tracks) return nullptr;


### PR DESCRIPTION
Adds sys_splitter_resize_no_pan, a UI test for [AIPROFVIS-333](https://amd-hub.atlassian.net/browse/AIPROFVIS-333). It drags the Description-column splitter and asserts the timeline view stays fixed, so resizing the column must not pan the timeline.

Also includes a potential fix so the test passes. The splitter drag was adjusting the timeline pan as a side effect of the resize. The fix keeps the pan anchored so the column resizes on its own.

Successor to [1004](https://github.com/ROCm/roc-optiq/compare/main...refs/heads/jnugara/uitest-splitter-333), which only included the test.

[AIPROFVIS-333]: https://amd-hub.atlassian.net/browse/AIPROFVIS-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ