### PR TITLE
fix: avoid zoom-based refetch storm from splitter resize (AIPROFVIS-333)

### DIFF
--- a/src/view/src/rocprofvis_timeline_view.cpp
+++ b/src/view/src/rocprofvis_timeline_view.cpp
@@ -1318,21 +1318,14 @@ TimelineView::RenderSplitter()
     {
         ImVec2 drag_delta = ImGui::GetMouseDragDelta(ImGuiMouseButton_Left);
 
-        const float graph_w_before = m_tpt->GetGraphSizeX();
-        const float sidebar_before = m_sidebar_size;
-        m_sidebar_size             = std::clamp(m_sidebar_size + drag_delta.x,
-                                                m_max_meta_scale_area_size +
-                                                    2 * ImGui::GetFrameHeightWithSpacing(),
-                                                SIDEBAR_WIDTH_MAX);
-
-        // Hold pixels_per_ns constant (offset untouched) so resizing the
-        // description column neither pans nor rescales the timeline. AIPROFVIS-333.
-        const float applied       = m_sidebar_size - sidebar_before;
-        const float graph_w_after = graph_w_before - applied;
-        if(graph_w_after > 0.0f)
-        {
-            m_tpt->SetZoom(m_tpt->GetZoom() * graph_w_before / graph_w_after);
-        }
+        // Resize only; leave zoom/offset untouched. SetGraphSize() picks up the
+        // new width later this frame and recomputes pixels_per_ns on its own, so
+        // the visible ns-range (and thus v_min_x) never moves and this can't be
+        // mistaken for a real zoom change by IsRequestDataNeeded(). AIPROFVIS-333.
+        m_sidebar_size = std::clamp(m_sidebar_size + drag_delta.x,
+                                    m_max_meta_scale_area_size +
+                                        2 * ImGui::GetFrameHeightWithSpacing(),
+                                    SIDEBAR_WIDTH_MAX);
         ImGui::ResetMouseDragDelta();
         ImGui::EndDragDropSource();
         m_resize_activity |= true;


### PR DESCRIPTION
## Motivation

Changing the zoom trips track re-fetch logic.

## Details

The prior fix held pixels_per_ns constant by rescaling zoom on every
splitter-drag frame, but that changes v_width_ns, which is exactly the
signal IsRequestDataNeeded() uses to detect a real zoom change. Jittering
the splitter while zoomed in could repeatedly cross that threshold and
spam track refetches.

Leave zoom/offset untouched during the drag instead. SetGraphSize() picks
up the new width later the same frame and recomputes pixels_per_ns on its
own, so v_min_x/v_width_ns never move: no panning and no spurious refetch.