### PR TITLE
Reduce spam from profiler launch dialog

### DIFF
--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -1780,7 +1780,16 @@ backends name a tool and never a path, so binary names live only in the
 controller's tool table), `GetTabs` (takes the selected tool; returns
 `TabDescriptor`s that each carry
 an ImGui `render_fn` - the backend supplies renderers, the dialog draws
-the tab bar), `Validate` (empty string = OK), `FlattenToExecution`
+the tab bar. **`render_fn` returns whether the user changed a setting
+this frame**, and every control in a tab must OR in its ImGui return
+value: that bool is the launcher's only signal that the command preview
+has gone stale, so an unreported change leaves the preview displaying a
+command the settings no longer describe. (Only the preview - launching
+rebuilds the cache unconditionally.) Do not try to infer this from
+`ImGui::IsAnyItemActive()`: it stays true while a field merely holds
+focus, and it is already false by the frame after a checkbox toggles,
+since `ButtonBehavior` clears `ActiveId` in the same frame it reports
+the press), `Validate` (empty string = OK), `FlattenToExecution`
 (curated settings -> env + the **complete** argv after `argv[0]`,
 including `extra_argv`, the output flag in this profiler's spelling, and
 the target plus its arguments; caller then merges `extra_env`),

--- a/src/view/src/profiler/rocprofvis_profiler_backend.h
+++ b/src/view/src/profiler/rocprofvis_profiler_backend.h
@@ -30,7 +30,8 @@ struct TabDescriptor
 {
     std::string id;
     std::string display_name;
-    std::function<void()> render_fn;
+    // Returns true if the user changed a setting this frame
+    std::function<bool()> render_fn;
     // false => shown in the always-visible "General Options" area of the
     // launcher; true => tucked under the collapsible "Advanced Options" section.
     bool advanced = false;

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -943,14 +943,17 @@ void ProfilerLauncherDialog::RenderRemoteSection()
     // binary choice.
     ImGui::TableSetColumnIndex(1);
     bool is_local = (m_config.connection == ConnectionType::kLocal);
+
     if (ImGui::RadioButton("This machine", is_local))
     {
-        m_config.connection = ConnectionType::kLocal;
+        m_config.connection     = ConnectionType::kLocal;
+        m_execution_cache_dirty = true;
     }
     ImGui::SameLine();
     if (ImGui::RadioButton("Remote (SSH)", !is_local))
     {
-        m_config.connection = ConnectionType::kSsh;
+        m_config.connection     = ConnectionType::kSsh;
+        m_execution_cache_dirty = true;
     }
 
     if (IsSshMode())
@@ -1316,6 +1319,10 @@ void ProfilerLauncherDialog::OnLaunchClicked()
     m_process_output_stripped.clear();
     m_output_text.clear();
 
+    // Re-resolve rather than reuse the memo: the user may have installed ROCm or
+    // corrected the tool directory since it was taken, and a launch is the one
+    // place where an out-of-date answer would be acted on rather than displayed.
+    RefreshToolPath(true);
     RefreshExecutionCache();
 
     // A tool that cannot be found is reported here rather than left to fail
@@ -1521,6 +1528,49 @@ void ProfilerLauncherDialog::ComputeConsoleStatus(std::string&        out_label,
     }
 }
 
+void ProfilerLauncherDialog::RefreshToolPath(bool force)
+{
+    bool const ssh = IsSshMode();
+    if (!force && m_tool_path.populated && m_tool_path.tool == m_config.tool &&
+        m_tool_path.ssh == ssh && m_tool_path.directory == m_config.tool_directory)
+    {
+        return;
+    }
+
+    m_tool_path.tool      = m_config.tool;
+    m_tool_path.directory = m_config.tool_directory;
+    m_tool_path.ssh       = ssh;
+    m_tool_path.populated = true;
+    m_tool_path.error.clear();
+
+    std::string const& tool_directory = m_config.tool_directory;
+    if (ssh)
+    {
+        // The tool is on the remote host, so this machine's filesystem says
+        // nothing about it - resolving here would report a local install (or its
+        // absence) for a command that runs elsewhere. Show exactly what the
+        // remote will run, which is what ProfilerConfig::ResolveToolPathRemote
+        // composes: <tool_directory>/<name>, or the bare name for the remote
+        // $PATH. Joined with '/' because the remote is addressed as POSIX.
+        std::string const name = GetToolBinaryName(m_config.tool);
+        m_tool_path.argv0 = tool_directory.empty()
+                                ? name
+                                : (tool_directory.back() == '/' ? tool_directory + name
+                                                                : tool_directory + "/" + name);
+    }
+    else
+    {
+        m_tool_path.argv0 =
+            ResolveToolPath(m_config.tool, tool_directory, m_tool_path.error);
+        if (m_tool_path.argv0.empty())
+        {
+            // Keep the preview a command line rather than "<not found>"; the
+            // notice above it carries the reason.
+            m_tool_path.argv0 = GetToolBinaryName(m_config.tool);
+        }
+    }
+}
+
 void ProfilerLauncherDialog::RefreshExecutionCache()
 {
     if (m_backends.empty())
@@ -1535,31 +1585,9 @@ void ProfilerLauncherDialog::RefreshExecutionCache()
     ExecutionCache cache;
     cache.tool = m_config.tool;
 
-    std::string const& tool_directory = m_config.tool_directory;
-    if (IsSshMode())
-    {
-        // The tool is on the remote host, so this machine's filesystem says
-        // nothing about it - resolving here would report a local install (or its
-        // absence) for a command that runs elsewhere. Show exactly what the
-        // remote will run, which is what ProfilerConfig::ResolveToolPathRemote
-        // composes: <tool_directory>/<name>, or the bare name for the remote
-        // $PATH. Joined with '/' because the remote is addressed as POSIX.
-        std::string const name = GetToolBinaryName(cache.tool);
-        cache.argv0 = tool_directory.empty()
-                          ? name
-                          : (tool_directory.back() == '/' ? tool_directory + name
-                                                          : tool_directory + "/" + name);
-    }
-    else
-    {
-        cache.argv0 = ResolveToolPath(cache.tool, tool_directory, cache.resolve_error);
-        if (cache.argv0.empty())
-        {
-            // Keep the preview a command line rather than "<not found>"; the
-            // notice above it carries the reason.
-            cache.argv0 = GetToolBinaryName(cache.tool);
-        }
-    }
+    RefreshToolPath(false);
+    cache.argv0         = m_tool_path.argv0;
+    cache.resolve_error = m_tool_path.error;
 
     backend->FlattenToExecution(m_config, cache.curated_env_vars, cache.argv);
 

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -556,7 +556,7 @@ void ProfilerLauncherDialog::RenderMainContent()
     LaunchCardHeader(ICON_CHART_BAR, "Profiling Options");
     if (general_tabs.size() == 1)
     {
-        general_tabs[0]->render_fn();
+        m_execution_cache_dirty |= general_tabs[0]->render_fn();
     }
     else if (!general_tabs.empty())
     {
@@ -566,7 +566,7 @@ void ProfilerLauncherDialog::RenderMainContent()
             {
                 if (ImGui::BeginTabItem(tab->display_name.c_str()))
                 {
-                    tab->render_fn();
+                    m_execution_cache_dirty |= tab->render_fn();
                     ImGui::EndTabItem();
                 }
             }
@@ -725,7 +725,7 @@ void ProfilerLauncherDialog::RenderAdvancedWindow()
                 {
                     ImGui::Spacing();
                     ImGui::BeginChild("adv_scroll", ImVec2(0.0f, 0.0f), ImGuiChildFlags_None);
-                    tab.render_fn();
+                    m_execution_cache_dirty |= tab.render_fn();
                     ImGui::EndChild();
                     ImGui::EndTabItem();
                 }
@@ -1183,13 +1183,11 @@ void ProfilerLauncherDialog::Update()
 {
     if (m_show_window)
     {
-        // Only rebuild the (allocation-heavy) execution cache / command preview
-        // when inputs may have changed: an explicit dirty request, or while the
-        // user is actively editing a widget (ImGui::IsAnyItemActive reflects the
-        // previous frame here, so the deactivation frame is still captured). This
-        // covers the backend-owned settings tabs without instrumenting each
-        // widget individually.
-        if (m_execution_cache_dirty || ImGui::IsAnyItemActive())
+        // Rebuild the (allocation-heavy) execution cache / command preview only
+        // when a control reported an actual change - every widget, including the
+        // backend-owned settings tabs, ORs its ImGui return value into the dirty
+        // flag. 
+        if (m_execution_cache_dirty)
         {
             RefreshExecutionCache();
             m_execution_cache_dirty = false;

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.h
@@ -67,6 +67,19 @@ private:
         std::string                                      command_preview;
     };
 
+    // Memoized argv[0]. Resolving it is a controller call that searches the
+    // filesystem, so it is not redone for edits that cannot affect it.
+    struct ToolPathCache
+    {
+        rocprofvis_profiler_tool_t tool = kRPVProfilerToolNone;
+        std::string                directory;
+        bool                       ssh       = false;
+        bool                       populated = false;
+
+        std::string argv0;
+        std::string error;
+    };
+
     void OnLaunchClicked();
     void OnCancelClicked();
     void OnCloseClicked();
@@ -75,6 +88,7 @@ private:
     void HandleStateTransition(rocprofvis_profiler_state_t new_state);
     void RebuildComposedOutput();
     void RefreshExecutionCache();
+    void RefreshToolPath(bool force);
 
     bool IsSshMode() const
     {
@@ -193,9 +207,10 @@ private:
     // Config
     LaunchConfig m_config;
     ExecutionCache m_execution_cache;
+    ToolPathCache  m_tool_path;
     // Rebuild m_execution_cache (SaveSettings/flatten/preview - all allocating)
-    // only when inputs may have changed, not every frame. Set on open / backend
-    // switch / preset load, and while the user is actively editing a field.
+    // only when a control reported an actual change, not every frame. Also set
+    // on open / backend switch / preset load.
     bool m_execution_cache_dirty = true;
 
     // Presets

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
@@ -175,12 +175,14 @@ void FieldLabel(const char* label, float item_w, float label_w = kFieldLabelW)
     ImGui::SetNextItemWidth(item_w);
 }
 
-void RenderCheckboxMap(
+// Returns true if any checkbox in the grid was toggled this frame.
+bool RenderCheckboxMap(
     std::map<std::string, bool>& map,
     CheckboxEntry const* entries,
     size_t count,
     char const* id_prefix)
 {
+    bool changed = false;
     // Long checkbox lists read better as a responsive grid than one tall column.
     int cols = static_cast<int>(ImGui::GetContentRegionAvail().x / kCheckboxColWidth);
     cols     = std::clamp(cols, 1, kCheckboxMaxCols);
@@ -207,10 +209,12 @@ void RenderCheckboxMap(
             if (ImGui::Checkbox(label.c_str(), &val))
             {
                 map[entries[i].id] = val;
+                changed            = true;
             }
         }
         ImGui::EndTable();
     }
+    return changed;
 }
 
 bool AnyEnabled(std::map<std::string, bool> const& m)
@@ -524,30 +528,32 @@ std::vector<TabDescriptor> RocprofSysBackend::GetTabs(rocprofvis_profiler_tool_t
     // General: the everyday controls (preset, output format, trace window).
     // Always visible in the launcher.
     tabs.push_back({"general", "General", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderBackendsTab();
+        return const_cast<RocprofSysBackend*>(this)->RenderBackendsTab();
     }, false});
 
     // Advanced: power-user detail, grouped by domain and tucked under the
     // collapsible "Advanced Options" section so the common case stays simple.
     tabs.push_back({"sampling", "Sampling", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderSamplingTab(); }, true});
+        return const_cast<RocprofSysBackend*>(this)->RenderSamplingTab(); }, true});
     tabs.push_back({"rocm", "ROCm", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderRocmTab(); }, true});
+        return const_cast<RocprofSysBackend*>(this)->RenderRocmTab(); }, true});
     tabs.push_back({"perfetto", "Perfetto", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderPerfettoTab(); }, true});
+        return const_cast<RocprofSysBackend*>(this)->RenderPerfettoTab(); }, true});
     tabs.push_back({"process_sampling", "Process Sampling", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderProcessSamplingTab(); }, true});
+        return const_cast<RocprofSysBackend*>(this)->RenderProcessSamplingTab(); },
+        true});
     tabs.push_back({"parallelism", "Parallelism", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderParallelismTab(); }, true});
+        return const_cast<RocprofSysBackend*>(this)->RenderParallelismTab(); }, true});
 
     if (tool == kRPVProfilerToolRocprofSysInstrument)
     {
         tabs.push_back({"instrument", "Instrument", [this]() {
-            const_cast<RocprofSysBackend*>(this)->RenderInstrumentTab(); }, true});
+            return const_cast<RocprofSysBackend*>(this)->RenderInstrumentTab(); },
+            true});
     }
 
     tabs.push_back({"advanced", "Config & Logging", [this]() {
-        const_cast<RocprofSysBackend*>(this)->RenderAdvancedTab(); }, true});
+        return const_cast<RocprofSysBackend*>(this)->RenderAdvancedTab(); }, true});
 
     return tabs;
 }
@@ -1123,34 +1129,43 @@ std::string RocprofSysBackend::ExportCfg() const
 // Tab render functions
 // ==================================================================================
 
-void RocprofSysBackend::RenderGeneralTraceOptions()
+bool RocprofSysBackend::RenderGeneralTraceOptions()
 {
+    bool changed = false;
+
     // Delay + Duration share a row; Region takes the next.
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Delay (s)");
     ImGui::SameLine();
     ImGui::SetNextItemWidth(kTraceInlineNumW);
-    ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
+    changed |=
+        ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
 
     ImGui::SameLine(0.0f, kTraceFieldGapX);
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Duration (s)");
     ImGui::SameLine();
     ImGui::SetNextItemWidth(kTraceInlineNumW);
-    ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0, 0.0, "%.2f");
+    changed |= ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0,
+                                  0.0, "%.2f");
 
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Region");
     ImGui::SameLine();
     ImGui::SetNextItemWidth(-kTraceRegionTrail);
-    InputTextStringWithHint("##TraceRegion", "ROCTX regions (comma-separated)",
-                            m_settings.trace_region);
+    changed |= InputTextStringWithHint("##TraceRegion",
+                                       "ROCTX regions (comma-separated)",
+                                       m_settings.trace_region);
     HelpMarker("ROCPROFSYS_TRACE_REGION",
                "Comma-separated ROCTX region names for selective tracing");
+
+    return changed;
 }
 
-void RocprofSysBackend::RenderBackendsTab()
+bool RocprofSysBackend::RenderBackendsTab()
 {
+    bool changed = false;
+
     // Headline choice: the built-in rocprof-sys preset.
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Preset");
@@ -1165,6 +1180,7 @@ void RocprofSysBackend::RenderBackendsTab()
         if (ImGui::Selectable("Custom", m_settings.rocprof_preset.empty()))
         {
             m_settings.rocprof_preset.clear();
+            changed = true;
         }
         for (size_t i = 0; i < kRocprofSysPresetsCount; i++)
         {
@@ -1172,6 +1188,7 @@ void RocprofSysBackend::RenderBackendsTab()
             if (ImGui::Selectable(kRocprofSysPresets[i].name, selected))
             {
                 m_settings.rocprof_preset = kRocprofSysPresets[i].name;
+                changed                   = true;
             }
             if (ImGui::IsItemHovered())
             {
@@ -1213,15 +1230,15 @@ void RocprofSysBackend::RenderBackendsTab()
 
         ImGui::TableNextColumn();
         LaunchSubHeader("OUTPUT FORMAT");
-        ToggleSwitch("Perfetto trace", &m_settings.trace_backend);
+        changed |= ToggleSwitch("Perfetto trace", &m_settings.trace_backend);
         HelpMarker("ROCPROFSYS_TRACE", "Enable the Perfetto trace backend");
-        ToggleSwitch("ROCpd database", &m_settings.use_rocpd);
+        changed |= ToggleSwitch("ROCpd database", &m_settings.use_rocpd);
         HelpMarker("ROCPROFSYS_USE_ROCPD", "Enable ROCpd SQLite output");
 
         ImGui::TableNextColumn();
         ImGui::BeginDisabled(has_preset);
         LaunchSubHeader("TRACE WINDOW");
-        RenderGeneralTraceOptions();
+        changed |= RenderGeneralTraceOptions();
         ImGui::EndDisabled();
 
         ImGui::EndTable();
@@ -1234,16 +1251,21 @@ void RocprofSysBackend::RenderBackendsTab()
                             "Choose Custom to edit them.",
                             m_settings.rocprof_preset.c_str());
     }
+
+    return changed;
 }
 
-void RocprofSysBackend::RenderSamplingTab()
+bool RocprofSysBackend::RenderSamplingTab()
 {
+    bool changed = false;
+
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
     LaunchSubHeader("ENABLE");
-    ToggleSwitch("Call-stack sampling", &m_settings.use_sampling);
+    changed |= ToggleSwitch("Call-stack sampling", &m_settings.use_sampling);
     HelpMarker("ROCPROFSYS_USE_SAMPLING", "Enable call-stack sampling");
-    ToggleSwitch("Process / system sampling", &m_settings.use_process_sampling);
+    changed |= ToggleSwitch("Process / system sampling",
+                            &m_settings.use_process_sampling);
     HelpMarker("ROCPROFSYS_USE_PROCESS_SAMPLING",
                "Background process/system metrics (CPU freq, memory, GPU via SMI)");
 
@@ -1251,28 +1273,30 @@ void RocprofSysBackend::RenderSamplingTab()
     ImGui::Separator();
 
     FieldLabel("Frequency (Hz)", kNumW);
-    ImGui::InputDouble("##SampFreq", &m_settings.sampling_freq, 10.0, 100.0, "%.0f");
+    changed |= ImGui::InputDouble("##SampFreq", &m_settings.sampling_freq, 10.0, 100.0,
+                                  "%.0f");
     HelpMarker("ROCPROFSYS_SAMPLING_FREQ", "Software interrupts per second");
 
     ImGui::Separator();
     ImGui::Text("Timer Sources:");
 
-    ImGui::Checkbox("CPU Time", &m_settings.sampling_cputime);
+    changed |= ImGui::Checkbox("CPU Time", &m_settings.sampling_cputime);
     HelpMarker("ROCPROFSYS_SAMPLING_CPUTIME",
                "Sample on CPU-time timer (ITIMER_PROF)");
 
-    ImGui::Checkbox("Real Time", &m_settings.sampling_realtime);
+    changed |= ImGui::Checkbox("Real Time", &m_settings.sampling_realtime);
     HelpMarker("ROCPROFSYS_SAMPLING_REALTIME",
                "Sample on real-time timer (ITIMER_REAL)");
 
-    ImGui::Checkbox("Hardware Overflow", &m_settings.sampling_overflow);
+    changed |= ImGui::Checkbox("Hardware Overflow", &m_settings.sampling_overflow);
     HelpMarker("ROCPROFSYS_SAMPLING_OVERFLOW",
                "Sample on hardware counter overflow");
 
     ImGui::Separator();
 
     FieldLabel("Duration (s)", kNumW);
-    ImGui::InputDouble("##SampDur", &m_settings.sampling_duration, 0.0, 0.0, "%.2f");
+    changed |= ImGui::InputDouble("##SampDur", &m_settings.sampling_duration, 0.0, 0.0,
+                                  "%.2f");
     HelpMarker("ROCPROFSYS_SAMPLING_DURATION",
                "Stop sampling after N seconds (0 = unlimited)");
 
@@ -1281,61 +1305,72 @@ void RocprofSysBackend::RenderSamplingTab()
     if (ImGui::InputInt("##AllocSz", &alloc_sz))
     {
         m_settings.sampling_allocator_size = alloc_sz;
+        changed                            = true;
     }
     HelpMarker("ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE",
                "Threads per background allocator");
 
     FieldLabel("Overflow Event", kTextW);
-    InputTextString("##OverflowEvt", m_settings.sampling_overflow_event);
+    changed |= InputTextString("##OverflowEvt", m_settings.sampling_overflow_event);
     HelpMarker("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
                "Linux perf metric name for overflow sampling");
 
     ImGui::Separator();
 
-    ImGui::Checkbox("Keep Internal Frames", &m_settings.sampling_keep_internal);
+    changed |=
+        ImGui::Checkbox("Keep Internal Frames", &m_settings.sampling_keep_internal);
     HelpMarker("ROCPROFSYS_SAMPLING_KEEP_INTERNAL",
                "Show rocprof-sys frames in call stacks");
 
-    ImGui::Checkbox("Include Inline Entries", &m_settings.sampling_include_inlines);
+    changed |=
+        ImGui::Checkbox("Include Inline Entries", &m_settings.sampling_include_inlines);
     HelpMarker("ROCPROFSYS_SAMPLING_INCLUDE_INLINES",
                "Include inline function entries in stacks");
 
     ImGui::EndDisabled();
+
+    return changed;
 }
 
-void RocprofSysBackend::RenderRocmTab()
+bool RocprofSysBackend::RenderRocmTab()
 {
+    bool changed = false;
+
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
     ImGui::Text("ROCm Domains:");
     HelpMarker("ROCPROFSYS_ROCM_DOMAINS",
                "ROCm SDK domains to trace (checked = enabled)");
 
-    RenderCheckboxMap(m_settings.rocm_domains,
-                      kRocmDomains, kRocmDomainsCount, "rd_");
+    changed |= RenderCheckboxMap(m_settings.rocm_domains,
+                                 kRocmDomains, kRocmDomainsCount, "rd_");
 
     ImGui::Spacing();
     FieldLabel("Custom Domains", kListW);
-    InputTextString("##RocmDomainsCustom", m_settings.rocm_domains_custom);
+    changed |= InputTextString("##RocmDomainsCustom", m_settings.rocm_domains_custom);
     HelpMarker("ROCPROFSYS_ROCM_DOMAINS",
                "Additional comma-separated domain names not in the list above");
 
     ImGui::Separator();
 
     FieldLabel("Hardware Counters", kListW);
-    InputTextString("##RocmEvents", m_settings.rocm_events);
+    changed |= InputTextString("##RocmEvents", m_settings.rocm_events);
     HelpMarker("ROCPROFSYS_ROCM_EVENTS",
                "HW counters (use :device=N syntax for specific GPU)");
 
-    ImGui::Checkbox("Group by Queue", &m_settings.rocm_group_by_queue);
+    changed |= ImGui::Checkbox("Group by Queue", &m_settings.rocm_group_by_queue);
     HelpMarker("ROCPROFSYS_ROCM_GROUP_BY_QUEUE",
                "Group by HSA queue instead of HIP stream");
 
     ImGui::EndDisabled();
+
+    return changed;
 }
 
-void RocprofSysBackend::RenderPerfettoTab()
+bool RocprofSysBackend::RenderPerfettoTab()
 {
+    bool changed = false;
+
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
     const char* backends[] = {"inprocess", "system", "all"};
@@ -1352,6 +1387,7 @@ void RocprofSysBackend::RenderPerfettoTab()
     if (ImGui::Combo("##PerfBackend", &backend_idx, backends, IM_ARRAYSIZE(backends)))
     {
         m_settings.perfetto_backend = backends[backend_idx];
+        changed                     = true;
     }
     HelpMarker("ROCPROFSYS_PERFETTO_BACKEND", "Perfetto tracing backend mode");
 
@@ -1360,6 +1396,7 @@ void RocprofSysBackend::RenderPerfettoTab()
     if (ImGui::InputInt("##BufKB", &buf_kb, 1024, 10240))
     {
         m_settings.perfetto_buffer_size_kb = buf_kb;
+        changed                            = true;
     }
     HelpMarker("ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB",
                "Perfetto shared memory buffer size");
@@ -1369,6 +1406,7 @@ void RocprofSysBackend::RenderPerfettoTab()
     if (ImGui::InputInt("##FlushMs", &flush_ms, 1000, 5000))
     {
         m_settings.perfetto_flush_period_ms = flush_ms;
+        changed                             = true;
     }
     HelpMarker("ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS",
                "Flush interval in milliseconds");
@@ -1379,15 +1417,16 @@ void RocprofSysBackend::RenderPerfettoTab()
     if (ImGui::Combo("##FillPolicy", &policy_idx, policies, IM_ARRAYSIZE(policies)))
     {
         m_settings.perfetto_fill_policy = policies[policy_idx];
+        changed                         = true;
     }
     HelpMarker("ROCPROFSYS_PERFETTO_FILL_POLICY",
                "Buffer fill policy: discard old or stop writing");
 
-    ImGui::Checkbox("Annotations", &m_settings.perfetto_annotations);
+    changed |= ImGui::Checkbox("Annotations", &m_settings.perfetto_annotations);
     HelpMarker("ROCPROFSYS_PERFETTO_ANNOTATIONS",
                "Function argument annotations (larger traces)");
 
-    ImGui::Checkbox("Combine Traces", &m_settings.perfetto_combine_traces);
+    changed |= ImGui::Checkbox("Combine Traces", &m_settings.perfetto_combine_traces);
     HelpMarker("ROCPROFSYS_PERFETTO_COMBINE_TRACES",
                "Combine per-process traces into one file");
 
@@ -1405,8 +1444,9 @@ void RocprofSysBackend::RenderPerfettoTab()
         ImGui::BeginDisabled();
         ImGui::TextDisabled("(disabled -- clear disable list first)");
     }
-    RenderCheckboxMap(m_settings.enable_categories,
-                      kPerfettoCategories, kPerfettoCategoriesCount, "encat_");
+    changed |= RenderCheckboxMap(m_settings.enable_categories,
+                                 kPerfettoCategories, kPerfettoCategoriesCount,
+                                 "encat_");
     if (has_disable)
         ImGui::EndDisabled();
 
@@ -1420,33 +1460,38 @@ void RocprofSysBackend::RenderPerfettoTab()
         ImGui::BeginDisabled();
         ImGui::TextDisabled("(disabled -- clear enable list first)");
     }
-    RenderCheckboxMap(m_settings.disable_categories,
-                      kPerfettoCategories, kPerfettoCategoriesCount, "discat_");
+    changed |= RenderCheckboxMap(m_settings.disable_categories,
+                                 kPerfettoCategories, kPerfettoCategoriesCount,
+                                 "discat_");
     if (has_enable)
         ImGui::EndDisabled();
 
     ImGui::Separator();
 
     FieldLabel("Output File", kTextW);
-    InputTextString("##PerfFile", m_settings.perfetto_file);
+    changed |= InputTextString("##PerfFile", m_settings.perfetto_file);
     HelpMarker("ROCPROFSYS_PERFETTO_FILE", "Output filename for perfetto trace");
 
     ImGui::EndDisabled();
+
+    return changed;
 }
 
-void RocprofSysBackend::RenderProcessSamplingTab()
+bool RocprofSysBackend::RenderProcessSamplingTab()
 {
+    bool changed = false;
+
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
     LaunchSubHeader("ENABLE");
-    ToggleSwitch("AMD SMI GPU metrics", &m_settings.use_amd_smi);
+    changed |= ToggleSwitch("AMD SMI GPU metrics", &m_settings.use_amd_smi);
     HelpMarker("ROCPROFSYS_USE_AMD_SMI", "GPU metrics via AMD SMI");
 
     ImGui::Spacing();
     ImGui::Separator();
 
-    ImGui::Checkbox("CPU Frequency / Mem / Context Switches",
-                    &m_settings.cpu_freq_enabled);
+    changed |= ImGui::Checkbox("CPU Frequency / Mem / Context Switches",
+                               &m_settings.cpu_freq_enabled);
     HelpMarker("ROCPROFSYS_CPU_FREQ_ENABLED",
                "Enable CPU frequency, memory, and context switch sampling");
 
@@ -1456,42 +1501,47 @@ void RocprofSysBackend::RenderProcessSamplingTab()
     HelpMarker("ROCPROFSYS_AMD_SMI_METRICS",
                "GPU metrics to collect (checked = enabled)");
 
-    RenderCheckboxMap(m_settings.amd_smi_metrics,
-                      kAmdSmiMetrics, kAmdSmiMetricsCount, "smi_");
+    changed |= RenderCheckboxMap(m_settings.amd_smi_metrics,
+                                 kAmdSmiMetrics, kAmdSmiMetricsCount, "smi_");
 
     ImGui::Spacing();
     FieldLabel("Custom Metrics", kListW);
-    InputTextString("##SmiMetricsCustom", m_settings.amd_smi_metrics_custom);
+    changed |= InputTextString("##SmiMetricsCustom",
+                               m_settings.amd_smi_metrics_custom);
     HelpMarker("ROCPROFSYS_AMD_SMI_METRICS",
                "Additional comma-separated metric names not in the list above");
 
     ImGui::Separator();
 
     FieldLabel("CPUs", kTextW);
-    InputTextString("##SampCPUs", m_settings.sampling_cpus);
+    changed |= InputTextString("##SampCPUs", m_settings.sampling_cpus);
     HelpMarker("ROCPROFSYS_SAMPLING_CPUS",
                "CPU list for frequency sampling ('none', 'all', or index list)");
 
     FieldLabel("GPUs", kTextW);
-    InputTextString("##SampGPUs", m_settings.sampling_gpus);
+    changed |= InputTextString("##SampGPUs", m_settings.sampling_gpus);
     HelpMarker("ROCPROFSYS_SAMPLING_GPUS",
                "AMD SMI device indices for GPU sampling");
 
-    ImGui::Checkbox("AI NIC Metrics", &m_settings.use_ainic);
+    changed |= ImGui::Checkbox("AI NIC Metrics", &m_settings.use_ainic);
     HelpMarker("ROCPROFSYS_USE_AINIC", "Enable AI NIC metrics collection");
 
     ImGui::EndDisabled();
+
+    return changed;
 }
 
-void RocprofSysBackend::RenderParallelismTab()
+bool RocprofSysBackend::RenderParallelismTab()
 {
+    bool changed = false;
+
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
-    auto toggle = [](char const* label, bool& val, char const* env,
-                     char const* help)
+    auto toggle = [&changed](char const* label, bool& val, char const* env,
+                             char const* help)
     {
         ImGui::TableNextColumn();
-        ToggleSwitch(label, &val);
+        changed |= ToggleSwitch(label, &val);
         HelpMarker(env, help);
     };
 
@@ -1513,22 +1563,26 @@ void RocprofSysBackend::RenderParallelismTab()
     }
 
     ImGui::EndDisabled();
+
+    return changed;
 }
 
-void RocprofSysBackend::RenderInstrumentTab()
+bool RocprofSysBackend::RenderInstrumentTab()
 {
+    bool changed = false;
+
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
     ImGui::Text("Binary Instrumentation Options");
     ImGui::Separator();
 
     FieldLabel("Include Regex", kListW);
-    InputTextString("##InstrInclude", m_settings.instr_include);
+    changed |= InputTextString("##InstrInclude", m_settings.instr_include);
     HelpMarker("-I / --function-include",
                "Regex for functions to include in instrumentation");
 
     FieldLabel("Exclude Regex", kListW);
-    InputTextString("##InstrExclude", m_settings.instr_exclude);
+    changed |= InputTextString("##InstrExclude", m_settings.instr_exclude);
     HelpMarker("-E / --function-exclude",
                "Regex for functions to exclude from instrumentation");
 
@@ -1538,15 +1592,20 @@ void RocprofSysBackend::RenderInstrumentTab()
     {
         if (min_instr < 0) min_instr = 0;
         m_settings.min_instructions = min_instr;
+        changed                     = true;
     }
     HelpMarker("--min-instructions",
                "Minimum instruction count for a function to be instrumented");
 
     ImGui::EndDisabled();
+
+    return changed;
 }
 
-void RocprofSysBackend::RenderAdvancedTab()
+bool RocprofSysBackend::RenderAdvancedTab()
 {
+    bool changed = false;
+
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
     LaunchSubHeader("SUMMARY PROFILE");
@@ -1558,18 +1617,21 @@ void RocprofSysBackend::RenderAdvancedTab()
     {
         m_settings.profile      = false;
         m_settings.flat_profile = false;
+        changed                 = true;
     }
     ImGui::SameLine();
     if (ImGui::RadioButton("Hierarchical", profile_mode == 1))
     {
         m_settings.profile      = true;
         m_settings.flat_profile = false;
+        changed                 = true;
     }
     ImGui::SameLine();
     if (ImGui::RadioButton("Flat", profile_mode == 2))
     {
         m_settings.profile      = false;
         m_settings.flat_profile = true;
+        changed                 = true;
     }
     ImGui::SameLine();
     HelpMarker("ROCPROFSYS_PROFILE / ROCPROFSYS_FLAT_PROFILE",
@@ -1579,7 +1641,7 @@ void RocprofSysBackend::RenderAdvancedTab()
     ImGui::Separator();
 
     FieldLabel("Config File", kListW);
-    InputTextString("##CfgFile", m_settings.config_file);
+    changed |= InputTextString("##CfgFile", m_settings.config_file);
     HelpMarker("ROCPROFSYS_CONFIG_FILE",
                "Path to rocprof-sys configuration file (overrides individual settings)");
     ImGui::TextDisabled("For full Perfetto control, point to a config file.");
@@ -1600,16 +1662,17 @@ void RocprofSysBackend::RenderAdvancedTab()
     if (ImGui::Combo("##LogLevel", &level_idx, levels, IM_ARRAYSIZE(levels)))
     {
         m_settings.log_level = levels[level_idx];
+        changed              = true;
     }
     HelpMarker("ROCPROFSYS_LOG_LEVEL", "Logging verbosity level");
 
     FieldLabel("Log File", kTextW);
-    InputTextString("##LogFile", m_settings.log_file);
+    changed |= InputTextString("##LogFile", m_settings.log_file);
     HelpMarker("ROCPROFSYS_LOG_FILE",
                "Log file name (empty disables file logging)");
 
     FieldLabel("Temp Directory", kTextW);
-    InputTextString("##TmpDir", m_settings.tmpdir);
+    changed |= InputTextString("##TmpDir", m_settings.tmpdir);
     HelpMarker("ROCPROFSYS_TMPDIR",
                "Base directory for temporary/spill files");
 
@@ -1623,6 +1686,7 @@ void RocprofSysBackend::RenderAdvancedTab()
     if (ImGui::Checkbox("Append process ID to output files", &pid_display))
     {
         m_settings.use_pid = pid_display;
+        changed            = true;
     }
     ImGui::EndDisabled();
     HelpMarker("ROCPROFSYS_USE_PID", "Suffix output filenames with the process ID");
@@ -1633,6 +1697,8 @@ void RocprofSysBackend::RenderAdvancedTab()
     }
 
     ImGui::EndDisabled();
+
+    return changed;
 }
 
 } // namespace View

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.h
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.h
@@ -151,15 +151,17 @@ public:
     std::string ParseTraceOutputPath(std::string const& profiler_stdout) const override;
 
 private:
-    void RenderGeneralTraceOptions();
-    void RenderBackendsTab();
-    void RenderSamplingTab();
-    void RenderRocmTab();
-    void RenderPerfettoTab();
-    void RenderProcessSamplingTab();
-    void RenderParallelismTab();
-    void RenderInstrumentTab();
-    void RenderAdvancedTab();
+    // Each returns true if the user changed a setting this frame - see
+    // TabDescriptor::render_fn, which is what these are bound to.
+    bool RenderGeneralTraceOptions();
+    bool RenderBackendsTab();
+    bool RenderSamplingTab();
+    bool RenderRocmTab();
+    bool RenderPerfettoTab();
+    bool RenderProcessSamplingTab();
+    bool RenderParallelismTab();
+    bool RenderInstrumentTab();
+    bool RenderAdvancedTab();
 
     static std::string JoinEnabledKeys(
         std::map<std::string, bool> const& m,


### PR DESCRIPTION
## Motivation

The launcher treated “a control is active” as “a setting changed.” A focused text field kept ImGui::IsAnyItemActive() true, so the command preview (and the controller tool-path search behind it) ran every frame even when nothing was edited.

## Technical Details

Backend tabs now report whether a widget actually changed; the preview rebuilds only then.
Tool-path resolution is memoized on tool, directory, and local/remote. A settings edit no longer calls the controller. Launch still re-resolves, in case the binary appeared after the last lookup.
Switching local/remote dirties the preview, since that choice decides how argv[0] is derived.
Launch itself was already rebuilding the cache; this only changes what the preview does while configuring.