### PR TITLE
Fix TEST and UI-test builds for remote configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,13 @@ target_link_libraries(${TARGET_NAME} PRIVATE sqlite3)
 target_link_libraries(${TARGET_NAME} PRIVATE json)
 
 if(BUILD_TESTING AND ROCPROFVIS_ENABLE_UI_TESTS)
+    # Fail at configure if imgui_te was dropped (e.g. BUILD_TESTING shadowed).
+    if(NOT TARGET imgui_te)
+        message(FATAL_ERROR
+            "ROCPROFVIS_ENABLE_UI_TESTS is ON but imgui_te was not created. "
+            "Check that BUILD_TESTING is still set in thirdparty/CMakeLists.txt.")
+    endif()
+
     set(IMGUI_TEST_ENGINE_DIR
         ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/imgui_test_engine/imgui_test_engine)
     add_library(imgui_test_engine STATIC
@@ -362,12 +369,17 @@ if(BUILD_TESTING AND ROCPROFVIS_ENABLE_UI_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/view/src
         ${CMAKE_CURRENT_SOURCE_DIR}/src/view/src/model
         ${CMAKE_CURRENT_SOURCE_DIR}/src/view/src/icons
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/view/src/widgets
         ${CMAKE_CURRENT_SOURCE_DIR}/src/view/test
         ${Vulkan_INCLUDE_DIRS}
         ${Vulkan_INCLUDE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/src/model/inc
         ${CMAKE_CURRENT_SOURCE_DIR}/src/core/inc
     )
+    # TEMPORARY (profiler launch): remove when the profiler feature graduates.
+    if(ROCPROFVIS_ENABLE_PROFILER)
+    target_include_directories(${TEST_TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/view/src/profiler)
+    endif(ROCPROFVIS_ENABLE_PROFILER)
     target_link_libraries(${TEST_TARGET} PRIVATE
         imgui_te
         imgui_test_engine

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,3 +15,8 @@ file(GLOB COMMON_SRC CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
 add_library(${TARGET_NAME} ${COMMON_SRC})
 target_link_libraries(${TARGET_NAME} PRIVATE spdlog)
+
+# Match model's -DTEST so TimeRecorder symbols used by PROFILE actually exist.
+if(TEST)
+target_compile_definitions(${TARGET_NAME} PRIVATE TEST)
+endif(TEST)

--- a/src/model/src/datamodel/rocprofvis_dm_ext_data.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_ext_data.cpp
@@ -156,7 +156,7 @@ const char*  ExtData::GetPropertySymbol(rocprofvis_dm_property_t property) {
         case kRPVDMExtDataNameCharPtrIndexed:
             return "kRPVDMExtDataNameCharPtrIndexed";
         case kRPVDMExtDataValueCharPtrIndexed:
-            return "kRPVDMExtDataCharPtrIndexed";
+            return "kRPVDMExtDataValueCharPtrIndexed";
         case kRPVDMExtDataTypeUint64Indexed:
             return "kRPVDMExtDataTypeUint64Indexed";
         default:

--- a/src/model/src/datamodel/rocprofvis_dm_trace.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_trace.cpp
@@ -921,8 +921,8 @@ const char*  Trace::GetPropertySymbol(rocprofvis_dm_property_t property) {
             return "kRPVDMStackTraceHandleByEventID";
         case kRPVDMExtInfoHandleByEventID:
             return "kRPVDMExtInfoHandleByEventID";
-        case kRPVDMTableHandleIndexed:
-            return "kRPVDMTableHandleIndexed";
+        case kRPVDMTableHandleByID:
+            return "kRPVDMTableHandleByID";
         case kRPVDMHistogramNumBuckets:
             return "kRPVDMHistogramNumBuckets";
         case kRPVDMHistogramBucketSize:

--- a/src/model/src/datamodel/rocprofvis_dm_track.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_track.cpp
@@ -378,9 +378,9 @@ const char*  Track::GetPropertySymbol(rocprofvis_dm_property_t property) {
             return "kRPVDMTrackMinimumTimestampUInt64";
         case kRPVDMTrackMaximumTimestampUInt64:
             return "kRPVDMTrackMaximumTimestampUInt64";
-        case kRPVDMTrackMinimumLevelDouble:
+        case kRPVDMTrackMinimumValueDouble:
             return "kRPVDMTrackMinimumValueDouble";
-        case kRPVDMTrackMaximumLevelDouble:
+        case kRPVDMTrackMaximumValueDouble:
             return "kRPVDMTrackMaximumValueDouble";
         default:
             return "Unknown property";

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -17,6 +17,10 @@ add_subdirectory(yaml-cpp)
 # nor a crypto dependency. Remove this guard when remote graduates.
 if(ROCPROFVIS_ENABLE_REMOTE)
 
+# mbedtls/libssh2 set BUILD_TESTING OFF; restore after so imgui_te is still built.
+set(_prev_build_testing ${BUILD_TESTING})
+set(_prev_build_examples ${BUILD_EXAMPLES})
+
 set(ENABLE_ZLIB_COMPRESSION OFF)
 # Default to the vendored mbedTLS backend so the out-of-the-box build needs no
 # system OpenSSL. OpenSSL is opt-in via -DCRYPTO_BACKEND=OpenSSL and is then
@@ -108,6 +112,9 @@ if (CRYPTO_BACKEND STREQUAL "mbedTLS")
     	mbedcrypto
 	)
 endif()
+
+set(BUILD_TESTING ${_prev_build_testing})
+set(BUILD_EXAMPLES ${_prev_build_examples})
 
 endif() # ROCPROFVIS_ENABLE_REMOTE
 


### PR DESCRIPTION
## Motivation

Fix -DTEST and UI-test builds that CI never compiles.

These un-built paths fail building when enabled.

## Technical Details

GetPropertySymbol still used renamed enums (kRPVDMTableHandleIndexed, kRPVDMTrackMinimum/MaximumLevelDouble), so -DTEST=ON failed to compile. The remote stack also did set(BUILD_TESTING OFF) without restoring it, so imgui_te was never created and roc-optiq-tests failed with a missing imgui.h. The test target was also missing the widgets/profiler include dirs, and core was not compiled with -DTEST, so TimeRecorder was an undefined reference.

Restore BUILD_TESTING after mbedtls/libssh2, fail configure if imgui_te is missing, keep the test includes in parity with the app, and define TEST in core as well as model. Default CI configures are unchanged.
