### PR TITLE
Compare: union A/B group-by columns in the shared combo

### DIFF
--- a/.agents/UI.md
+++ b/.agents/UI.md
@@ -1096,7 +1096,11 @@ The bottom-right tabbed panel. Hosts, in source order:
   for the Event and Sample tables; `BuildCompareGroup` and
   `RenderCompareTab` are reused for both. The table pairs share one
   filter/aggregation form (`RenderSharedFilterControls` /
-  `ApplySharedFiltersFrom`) without pooling results. `TopEventsView`
+  `ApplySharedFiltersFrom`) without pooling results. The group-by combo
+  is the union of each source's last ungrouped header (`BuildCompareGroupByChoices`);
+  columns that exist on only one source are tagged (A) or (B), and
+  `AdjustFilterForRequest` drops a group-by that the sending table does
+  not have. `TopEventsView`
   renders each category header once with A/B tables side by side
   (per-source analysis-table slots `kAnalysisTop*TableB`). `EventsView`
   and `TrackDetails` partition their selected-item cards into A/B
@@ -1125,6 +1129,11 @@ stay identical:
   elided source name, optional right-aligned summary, separator.
   `MultiTrackTable::SetHeaderRenderer` + `RenderCard` draw a table
   inside such a card.
+- `BuildCompareGroupByChoices(columns_a, columns_b, names, labels)` -
+  union of group-by column names for the shared combo (A's order, then
+  B-only). `names` is what the query uses; `labels` tags A-only / B-only
+  columns. Each table still filters with its own header in non-compare
+  views.
 
 ### `EventsView` (`rocprofvis_events_view.{h,cpp}`)
 
@@ -1141,7 +1150,10 @@ via `AddCopyRowCellMenuItems`.
 
 `InfiniteScrollTable` subclass that aggregates rows across multiple
 selected tracks. Supports `group_by_choices`, custom filter store,
-optional compare-source filtering, and context menu copy.
+optional compare-source filtering, and context menu copy. Eligible
+group-by columns are cached from the last ungrouped header so compare
+mode can union A and B without changing the per-table combo used in
+non-compare views.
 
 ### `TrackDetails` (`rocprofvis_track_details.{h,cpp}`)
 
@@ -2428,7 +2440,8 @@ For fast lookup. Each entry: class -> file -> one-line role.
 - `TopEventsView`, `TopEventsView::TopEventsTable` ->
   `rocprofvis_top_events_view.h` -> Category-specific top-event tables.
 - `IsCompareTrace`, `MakeCompareSplit`, `BeginCompareCard`,
-  `EndCompareCard`, `RenderCompareCardTitle` ->
+  `EndCompareCard`, `RenderCompareCardTitle`,
+  `BuildCompareGroupByChoices` ->
   `rocprofvis_compare_panes.h` -> Shared chrome of the A/B compare
   layouts.
 - `EventSearch` -> `rocprofvis_event_search.h` -> Toolbar event search.

--- a/src/view/src/rocprofvis_analysis_view.cpp
+++ b/src/view/src/rocprofvis_analysis_view.cpp
@@ -235,8 +235,16 @@ AnalysisView::RenderCompareTab(CompareGroup& group, const char* child_id)
                       ImGuiChildFlags_AlwaysUseWindowPadding,
                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
 
-    // One filter form above the split drives both tables.
-    group.tables[COMPARE_SOURCE_A]->RenderSharedFilterControls();
+    // One filter form above the split drives both tables. Group-by choices are
+    // the union of each source's last ungrouped header; Apply still sends a
+    // column only if that source has it.
+    std::vector<std::string> group_by_names;
+    std::vector<std::string> group_by_labels;
+    BuildCompareGroupByChoices(group.tables[COMPARE_SOURCE_A]->EligibleGroupByColumns(),
+                               group.tables[COMPARE_SOURCE_B]->EligibleGroupByColumns(),
+                               group_by_names, group_by_labels);
+    group.tables[COMPARE_SOURCE_A]->RenderSharedFilterControls(group_by_names,
+                                                               group_by_labels);
 
     ImGui::Separator();
     ImGui::Spacing();

--- a/src/view/src/rocprofvis_compare_panes.cpp
+++ b/src/view/src/rocprofvis_compare_panes.cpp
@@ -10,6 +10,7 @@
 #include "widgets/rocprofvis_split_containers.h"
 
 #include <algorithm>
+#include <vector>
 
 namespace RocProfVis
 {
@@ -79,6 +80,54 @@ EndCompareCard()
     ImGui::EndChild();
     ImGui::PopStyleColor(2);
     ImGui::PopStyleVar(2);
+}
+
+void
+BuildCompareGroupByChoices(const std::vector<std::string>& columns_a,
+                           const std::vector<std::string>& columns_b,
+                           std::vector<std::string>&       names_out,
+                           std::vector<std::string>&       labels_out)
+{
+    names_out.clear();
+    labels_out.clear();
+    names_out.reserve(columns_a.size() + columns_b.size());
+    labels_out.reserve(columns_a.size() + columns_b.size());
+
+    for(size_t i = 0; i < columns_a.size(); i++)
+    {
+        names_out.push_back(columns_a[i]);
+    }
+    for(size_t i = 0; i < columns_b.size(); i++)
+    {
+        if(std::find(names_out.begin(), names_out.end(), columns_b[i]) == names_out.end())
+        {
+            names_out.push_back(columns_b[i]);
+        }
+    }
+
+    const std::string tag_a =
+        std::string(" (") + COMPARE_SOURCE_LABEL[COMPARE_SOURCE_A] + ")";
+    const std::string tag_b =
+        std::string(" (") + COMPARE_SOURCE_LABEL[COMPARE_SOURCE_B] + ")";
+    for(size_t i = 0; i < names_out.size(); i++)
+    {
+        const bool in_a =
+            std::find(columns_a.begin(), columns_a.end(), names_out[i]) != columns_a.end();
+        const bool in_b =
+            std::find(columns_b.begin(), columns_b.end(), names_out[i]) != columns_b.end();
+        if(in_a && in_b)
+        {
+            labels_out.push_back(names_out[i]);
+        }
+        else if(in_a)
+        {
+            labels_out.push_back(names_out[i] + tag_a);
+        }
+        else
+        {
+            labels_out.push_back(names_out[i] + tag_b);
+        }
+    }
 }
 
 void

--- a/src/view/src/rocprofvis_compare_panes.h
+++ b/src/view/src/rocprofvis_compare_panes.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "imgui.h"
 #include "widgets/rocprofvis_widget.h"
@@ -69,6 +70,16 @@ EndCompareCard();
 void
 RenderCompareCardTitle(const CompareSourceInfo& source, SettingsManager& settings,
                        const std::string& summary = "");
+
+/* Union of eligible group-by columns from the two sources, A then B-only.
+ * Shared names keep the raw column text; names that exist on only one source
+ * are tagged (A) or (B) in labels_out. names_out is what the query uses.
+ */
+void
+BuildCompareGroupByChoices(const std::vector<std::string>& columns_a,
+                           const std::vector<std::string>& columns_b,
+                           std::vector<std::string>&       names_out,
+                           std::vector<std::string>&       labels_out);
 
 }  // namespace View
 }  // namespace RocProfVis

--- a/src/view/src/rocprofvis_multi_track_table.cpp
+++ b/src/view/src/rocprofvis_multi_track_table.cpp
@@ -23,8 +23,12 @@ constexpr const char* EVENT_ID_COLUMN_NAME  = "id";
 constexpr const char* FOUND_ENTRIES_TEXT    = "Found %llu item(s) on %llu track(s)";
 
 constexpr const char* SHARED_APPLY_LABEL  = "Apply to Both";
-constexpr float       SHARED_LABEL_GAP    = 2.0f;
-constexpr float       SHARED_COMBO_GLYPHS = 12.0f;
+constexpr const char* GROUP_BY_NONE_LABEL = "-- None --";
+constexpr const char* SHARED_GROUP_BY_TOOLTIP =
+    "Aggregate both tables by a column, or leave as -- None --. Columns tagged "
+    "(A) or (B) exist on only that source and are not applied to the other.";
+constexpr float SHARED_LABEL_GAP    = 2.0f;
+constexpr float SHARED_COMBO_GLYPHS = 12.0f;
 
 MultiTrackTable::MultiTrackTable(DataProvider& dp, TableType table_type,
                                  rocprofvis_controller_table_type_t request_table_type,
@@ -124,7 +128,8 @@ MultiTrackTable::GetIncludedTrackCount() const
 }
 
 void
-MultiTrackTable::RenderSharedFilterControls()
+MultiTrackTable::RenderSharedFilterControls(const std::vector<std::string>& column_names,
+                                            const std::vector<std::string>& column_labels)
 {
     // Same shape as the per table form: a label column, the group by combo, the
     // apply button on the right, then a filter input filling the row.
@@ -137,6 +142,64 @@ MultiTrackTable::RenderSharedFilterControls()
     const float apply_width =
         ImGui::CalcTextSize(SHARED_APPLY_LABEL).x + style.FramePadding.x * 2.0f;
 
+    std::vector<std::string> names  = column_names;
+    std::vector<std::string> labels = column_labels;
+    if(labels.size() < names.size())
+    {
+        labels.resize(names.size());
+        for(size_t i = 0; i < names.size(); i++)
+        {
+            if(labels[i].empty())
+            {
+                labels[i] = names[i];
+            }
+        }
+    }
+    else if(labels.size() > names.size())
+    {
+        labels.resize(names.size());
+    }
+    if(!m_pending_filter_options.group_by.empty())
+    {
+        bool found = false;
+        for(size_t i = 0; i < names.size(); i++)
+        {
+            if(names[i] == m_pending_filter_options.group_by)
+            {
+                found = true;
+                break;
+            }
+        }
+        if(!found)
+        {
+            names.push_back(m_pending_filter_options.group_by);
+            labels.push_back(m_pending_filter_options.group_by);
+        }
+    }
+
+    std::vector<std::string> combo_items;
+    combo_items.reserve(labels.size() + 1);
+    combo_items.push_back(GROUP_BY_NONE_LABEL);
+    for(size_t i = 0; i < labels.size(); i++)
+    {
+        combo_items.push_back(labels[i]);
+    }
+    std::vector<const char*> combo_items_ptr(combo_items.size());
+    for(size_t i = 0; i < combo_items.size(); i++)
+    {
+        combo_items_ptr[i] = combo_items[i].c_str();
+    }
+
+    m_group_by_selection_index = 0;
+    for(size_t i = 0; i < names.size(); i++)
+    {
+        if(names[i] == m_pending_filter_options.group_by)
+        {
+            m_group_by_selection_index = static_cast<int>(i + 1);
+            break;
+        }
+    }
+
     ImGui::Spacing();
 
     ImGui::AlignTextToFramePadding();
@@ -145,18 +208,23 @@ MultiTrackTable::RenderSharedFilterControls()
     ImGui::SetNextItemWidth(ImGui::GetFontSize() * SHARED_COMBO_GLYPHS);
     PushComboStyles();
     if(ImGui::Combo("##shared_group_by", &m_group_by_selection_index,
-                    m_group_by_choices_ptr.data(),
-                    static_cast<int>(m_group_by_choices_ptr.size())))
+                    combo_items_ptr.data(), static_cast<int>(combo_items_ptr.size())))
     {
-        m_pending_filter_options.group_by =
-            m_group_by_selection_index == 0
-                ? ""
-                : m_group_by_choices_ptr[m_group_by_selection_index];
+        if(m_group_by_selection_index <= 0 ||
+           static_cast<size_t>(m_group_by_selection_index) > names.size())
+        {
+            m_pending_filter_options.group_by = "";
+        }
+        else
+        {
+            m_pending_filter_options.group_by =
+                names[static_cast<size_t>(m_group_by_selection_index) - 1];
+        }
     }
     PopComboStyles();
     if(ImGui::IsItemHovered())
     {
-        SetTooltipStyled("Aggregate both tables by a column, or leave as -- None --.");
+        SetTooltipStyled(SHARED_GROUP_BY_TOOLTIP);
     }
 
     ImGui::SameLine();
@@ -460,40 +528,25 @@ MultiTrackTable::Update()
 {
     if(m_data_changed)
     {
-        const std::vector<std::string>& column_names =
-            m_table_model().GetTableHeader(m_table_type);
-
+        if(!m_last_fetch_grouped)
+        {
+            RebuildEligibleGroupByColumns();
+        }
         if(m_filter_options.group_by == "")
         {
             m_group_by_selection_index = 0;
             m_group_by_choices.clear();
-
-            // Create a list of choices for the combo box for selecting the group
-            // column. Populate the combo box with column names but filter out empty
-            // and internal columns (those starting with '_')
-            m_group_by_choices.reserve(column_names.size() + 1);
-            m_group_by_choices.push_back("-- None --");
-
-            // Filter out columns
-            for(size_t i = 0; i < column_names.size(); i++)
+            m_group_by_choices.push_back(GROUP_BY_NONE_LABEL);
+            for(size_t i = 0; i < m_eligible_group_by_columns.size(); i++)
             {
-                const auto& col = column_names[i];
-                if(col.empty() || col[0] == '_')
-                {
-                    continue;  // Skip empty or internal columns
-                }
-                // skip event id column too
-                if(i == m_important_column_idxs[ImportantColumns::kDbEventId])
-                {
-                    continue;
-                }
-                m_group_by_choices.push_back(col);
+                m_group_by_choices.push_back(m_eligible_group_by_columns[i]);
             }
         }
         else
         {
             std::string selected_option = m_filter_options.group_by;
             m_group_by_choices.resize(2);
+            m_group_by_choices[0]             = GROUP_BY_NONE_LABEL;
             m_group_by_choices[1]             = selected_option;
             m_pending_filter_options.group_by = selected_option;
             m_group_by_selection_index        = 1;
@@ -626,17 +679,80 @@ MultiTrackTable::FetchSelectionData()
     }
     else
     {
+        FilterOptions request_filter = m_filter_options;
+        AdjustFilterForRequest(request_filter);
+        m_last_fetch_grouped = !request_filter.group_by.empty();
         // Fetch table data for the selected tracks. The request waits its turn when
         // the other compare source is holding the controller table.
         QueueTableRequest(std::make_shared<TrackTableRequestParams>(
             m_request_table_type, included_tracks, start_ns, end_ns,
-            m_filter_options.where, m_filter_options.filter,
-            m_filter_options.group_by.c_str(), m_filter_options.group_columns, 0,
-            m_fetch_chunk_size, m_sort_column_index, m_sort_order, "", m_table_type,
-            m_request_id));
+            request_filter.where, request_filter.filter, request_filter.group_by.c_str(),
+            request_filter.group_columns, 0, m_fetch_chunk_size, m_sort_column_index,
+            m_sort_order, "", m_table_type, m_request_id));
     }
     // Update the included tracks for this table type
     m_included_tracks = std::move(included_tracks);
+}
+
+const std::vector<std::string>&
+MultiTrackTable::EligibleGroupByColumns() const
+{
+    return m_eligible_group_by_columns;
+}
+
+void
+MultiTrackTable::RebuildEligibleGroupByColumns()
+{
+    // Same skip rules as the per-table combo: empty names, internal '_'
+    // columns, and the event id column.
+    const std::vector<std::string>& column_names =
+        m_table_model().GetTableHeader(m_table_type);
+    m_eligible_group_by_columns.clear();
+    m_eligible_group_by_columns.reserve(column_names.size());
+    for(size_t i = 0; i < column_names.size(); i++)
+    {
+        const std::string& col = column_names[i];
+        if(col.empty() || col[0] == '_')
+        {
+            continue;
+        }
+        if(i == m_important_column_idxs[ImportantColumns::kDbEventId])
+        {
+            continue;
+        }
+        m_eligible_group_by_columns.push_back(col);
+    }
+}
+
+bool
+MultiTrackTable::HasEligibleGroupByColumn(const std::string& name) const
+{
+    if(name.empty())
+    {
+        return false;
+    }
+    for(size_t i = 0; i < m_eligible_group_by_columns.size(); i++)
+    {
+        if(m_eligible_group_by_columns[i] == name)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void
+MultiTrackTable::AdjustFilterForRequest(FilterOptions& filter) const
+{
+    if(filter.group_by.empty())
+    {
+        return;
+    }
+    if(!HasEligibleGroupByColumn(filter.group_by))
+    {
+        filter.group_by.clear();
+        filter.group_columns[0] = '\0';
+    }
 }
 
 bool

--- a/src/view/src/rocprofvis_multi_track_table.h
+++ b/src/view/src/rocprofvis_multi_track_table.h
@@ -48,8 +48,14 @@ public:
 
     // Filter form driving an A/B pair. Submitting it fetches this table and
     // hands the same options to the other one through the submit callback.
-    void RenderSharedFilterControls();
+    // column_names is the query text; column_labels is what the combo shows.
+    void RenderSharedFilterControls(const std::vector<std::string>& column_names,
+                                    const std::vector<std::string>& column_labels);
     void ApplySharedFiltersFrom(const MultiTrackTable& source);
+
+    // Last ungrouped header's group-by candidates. Empty until the first
+    // ungrouped fetch. Compare mode unions this with the peer table.
+    const std::vector<std::string>& EligibleGroupByColumns() const;
     void SetFilterSubmitCallback(const FilterSubmitCallback& callback);
 
     // Adopts the peer table's sort; a no-op when it already matches, which breaks the echo.
@@ -72,6 +78,7 @@ protected:
     void         IndexColumns() override;
     void         RowSelected(const ImGuiMouseButton mouse_button) override;
     void         OnSortChanged() override;
+    void         AdjustFilterForRequest(FilterOptions& filter) const override;
 
     // Subset of selected tracks applicable to this table type
     std::vector<uint64_t> m_included_tracks;
@@ -83,6 +90,8 @@ private:
     void FetchSelectionData();
     void SubmitFilters();
     bool XButton(const char* id) const;
+    void RebuildEligibleGroupByColumns();
+    bool HasEligibleGroupByColumn(const std::string& name) const;
 
     bool                  m_display_filters;
     bool                  m_display_summary;
@@ -93,6 +102,9 @@ private:
     std::vector<std::string> m_group_by_choices;
     std::vector<const char*> m_group_by_choices_ptr;
     int                      m_group_by_selection_index;
+    // Ungrouped header columns that can be sent as group_by. Kept across
+    // grouped fetches so a later request still knows the original schema.
+    std::vector<std::string> m_eligible_group_by_columns;
 
     char m_filter_store[FILTER_SIZE];
 };

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -63,6 +63,7 @@ InfiniteScrollTable::InfiniteScrollTable(
 , m_default_sort_order(default_sort_order)
 , m_data_changed(true)
 , m_filter_requested(false)
+, m_last_fetch_grouped(false)
 , m_selected_row(-1)
 , m_selected_column(-1)
 , m_hovered_row(-1)
@@ -751,6 +752,8 @@ InfiniteScrollTable::ProcessSortOrFilterRequest(
         {
             filter.group_columns[0] = '\0';
         }
+        FilterOptions request_filter = filter;
+        AdjustFilterForRequest(request_filter);
         // check that sort order and column index actually are different from the
         // current values before fetching
         const bool sort_changed = (sort_order != m_sort_order ||
@@ -762,9 +765,9 @@ InfiniteScrollTable::ProcessSortOrFilterRequest(
             // Update the event table params with the new sort request
             table_params->m_sort_column_index = m_sort_column_index;
             table_params->m_sort_order        = m_sort_order;
-            table_params->m_filter            = filter.filter;
-            table_params->m_group = filter.group_by;
-            table_params->m_group_columns = filter.group_columns;
+            table_params->m_filter            = request_filter.filter;
+            table_params->m_group             = request_filter.group_by;
+            table_params->m_group_columns     = request_filter.group_columns;
 
             // if filtering changed reset the start row as current row
             // may be beyond result length causing an assertion in controller
@@ -776,6 +779,7 @@ InfiniteScrollTable::ProcessSortOrFilterRequest(
             spdlog::debug("Fetching data for sort, frame count: {}", frame_count);
 
             // Fetch the event table with the updated params
+            m_last_fetch_grouped = !request_filter.group_by.empty();
             QueueTableRequest(table_params);
 
             m_filter_options = filter;

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -110,6 +110,9 @@ protected:
     void         SetPendingSort(uint64_t column_index,
                                 rocprofvis_controller_sort_order_t order);
     virtual void OnSortChanged() {}
+    // Drops or rewrites filter fields that this table cannot send. Default is
+    // a no-op so non-compare tables keep the values the user applied.
+    virtual void AdjustFilterForRequest(FilterOptions&) const {}
 
     FilterOptions                      m_filter_options;
     FilterOptions                      m_pending_filter_options;
@@ -135,6 +138,9 @@ protected:
 
     bool m_data_changed;
     bool m_filter_requested;
+    // True when the last queued request included a group_by. Grouped results
+    // must not rebuild the eligible column cache from the aggregate header.
+    bool m_last_fetch_grouped;
 
     // Track the selected row for context menu actions
     int m_selected_row;


### PR DESCRIPTION
Compare: union A/B group-by columns in the shared combo

Show every eligible column from either source, tag A-only and B-only names, and skip grouping on a pane that does not have the chosen column. Non-compare tables still use their own header.
