### PR TITLE
Profiler hub interface library draft

### DIFF
--- a/src/model/src/database/profiler_hub_lib_interface.cpp
+++ b/src/model/src/database/profiler_hub_lib_interface.cpp
@@ -1,0 +1,322 @@
+#include "profiler_hub_lib_interface.h"
+#include "spdlog/spdlog.h"
+#define ANSI_COLOR_ERROR     "\x1b[31m"
+
+const char* error_fmt = ANSI_COLOR_ERROR"Profiler hub failed : {}";
+
+profiler_hub_future_handle_t profiler_hub_future_alloc(profiler_hub::progress_callback_t progress_callback) {
+	try {
+		return profiler_hub::interface::FutureAlloc(progress_callback);
+	}
+	catch (const std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		return nullptr;
+	}
+}
+
+profiler_hub_result_t profiler_hub_future_free(profiler_hub_future_handle_t handle) {
+	try {
+		return profiler_hub::interface::FutureFree(handle);
+	}
+	catch (const std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		return kProfilerHubStatusUnknownError;
+	}
+}
+
+profiler_hub_result_t profiler_hub_future_wait(profiler_hub_future_handle_t handle, uint64_t timeout_ms) {
+	try {
+		return profiler_hub::interface::FutureWait(handle, timeout_ms);
+	}
+	catch (const std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		return kProfilerHubStatusUnknownError;
+	}
+}
+
+profiler_hub_result_t profiler_hub_future_cancel(profiler_hub_future_handle_t handle) {
+	try {
+		return profiler_hub::interface::FutureCancel(handle);
+	}
+	catch (const std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		return kProfilerHubStatusUnknownError;
+	}
+}
+
+profiler_hub_db_type_t profiler_hub_db_identify_type(
+	profiler_hub_string_t trace_file_path
+) {
+	profiler_hub_db_type_t type = kDbNotSupported;
+	try {
+		type = profiler_hub::interface::DetectTrace(trace_file_path);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		type = kDbNotSupported;
+	}
+	return type;
+}
+
+
+profiler_hub_trace_handle_t profiler_hub_open_trace(
+	profiler_hub_string_t trace_file_path
+) {
+	profiler_hub_trace_handle_t trace = nullptr;
+	try {
+		trace = profiler_hub::interface::OpenTrace(trace_file_path);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		trace = nullptr;
+	}
+	return trace;
+}
+
+profiler_hub_result_t profiler_hub_set_trace_properties(profiler_hub_trace_handle_t trace,
+	client_trace_handle_t client_trace,
+	profiler_hub_string_t config_path,
+	size_t histogram_bucket_count)
+{
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::SetTraceProperties(trace, client_trace, config_path, histogram_bucket_count);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+	
+
+profiler_hub_result_t profiler_hub_read_metadata(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace
+) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::ReadTraceMetadata(future_handle, trace);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+
+profiler_hub_result_t profiler_hub_close_trace(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace
+) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::CloseTrace(trace);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+
+profiler_hub_value_type_t profiler_hub_get_info(
+	profiler_hub_trace_handle_t trace,
+	profiler_hub_instance_id_t instance,
+	profiler_hub_property_category_t category,
+	uint64_t row_key,
+	profiler_hub_string_t property_tag,
+	profiler_hub_optional_t value // OUT
+) {
+	profiler_hub_value_type_t type = kPprofilerHubDataTypeUndefined;
+	try {
+		type = profiler_hub::interface::GetProperty(trace, instance, category, row_key, property_tag, value);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		type = kPprofilerHubDataTypeUndefined;
+	}
+	return type;
+}
+
+profiler_hub_result_t profiler_hub_get_time_slice(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace,
+	profiler_hub_track_id_t track_id,
+	uint64_t timestamp_start,
+	uint64_t timestamp_end
+) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::GetTimeSlice(future_handle, trace, track_id, timestamp_start, timestamp_end);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+
+profiler_hub_result_t profiler_hub_get_table_time_slice(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace,
+	profiler_hub_table_handle_t table_handle,
+	profiler_hub_track_id_t track_id,
+	uint64_t timestamp_start,
+	uint64_t timestamp_end
+) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::GetTableTimeSlice(
+			future_handle, 
+			trace, 
+			table_handle, 
+			track_id, 
+			timestamp_start, 
+			timestamp_end);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+
+profiler_hub_result_t profiler_hub_get_search_time_slice(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace,
+	profiler_hub_instance_id_t instance,
+	profiler_hub_table_handle_t table_handle,
+	size_t num_operations,
+	profiler_hub_event_operation_t* operations,
+	uint64_t timestamp_start,
+	uint64_t timestamp_end,
+	size_t num_search_strings,
+	profiler_hub_search_strings_t string_filters
+) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+			result = profiler_hub::interface::GetSearchTimeSlice(
+				future_handle, 
+				trace, 
+				instance, 
+				table_handle, 
+				num_operations, 
+				operations, 
+				timestamp_start, 
+				timestamp_end, 
+				num_search_strings,
+				string_filters);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+
+profiler_hub_result_t profiler_hub_get_event_data_flow(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace,
+	profiler_hub_instance_id_t instance,
+	profiler_hub_event_operation_t operation,
+	profiler_hub_event_id_t event_id
+) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::GetEventDataFlow(
+			future_handle, 
+			trace, 
+			instance, 
+			operation, 
+			event_id);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+
+profiler_hub_result_t profiler_hub_get_event_extended_data(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace,
+	profiler_hub_instance_id_t instance,
+	profiler_hub_event_operation_t operation,
+	profiler_hub_event_id_t event_id
+) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::GetEventExtendedData(
+			future_handle, 
+			trace, 
+			instance, 
+			operation, 
+			event_id);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+
+profiler_hub_result_t profiler_hub_get_event_stack_trace(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace,
+	profiler_hub_instance_id_t instance,
+	profiler_hub_event_operation_t operation,
+	profiler_hub_event_id_t event_id
+) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::GetEventStackTrace(
+			future_handle, 
+			trace, 
+			instance, 
+			operation, 
+			event_id);
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}
+
+profiler_hub_result_t profiler_hub_trim_save_trace(
+	profiler_hub_future_handle_t future_handle,
+	profiler_hub_trace_handle_t trace,
+	uint64_t timestamp_start,
+	uint64_t timestamp_end) {
+	profiler_hub_result_t result = kProfilerHubStatusUnknownError;
+	try {
+		result = profiler_hub::interface::TrimTraceDatabase(
+			future_handle, 
+			trace, 
+			timestamp_start, 
+			timestamp_end;
+	}
+	catch (std::exception& e)
+	{
+		spdlog::error(error_fmt, e.what());
+		result = kProfilerHubStatusUnknownError;
+	}
+	return result;
+}

--- a/src/model/src/database/profiler_hub_lib_interface.h
+++ b/src/model/src/database/profiler_hub_lib_interface.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "profiler_hub_interface.h"
+
+extern "C"
+{
+	profiler_hub_future_handle_t profiler_hub_future_alloc(profiler_hub::progress_callback_t progress_callback);
+	profiler_hub_result_t profiler_hub_future_free(profiler_hub_future_handle_t handle);
+	profiler_hub_result_t profiler_hub_future_wait(profiler_hub_future_handle_t handle, uint64_t timeout_ms);
+	profiler_hub_result_t profiler_hub_future_cancel(profiler_hub_future_handle_t handle);
+
+	profiler_hub_db_type_t profiler_hub_db_identify_type(
+		profiler_hub_string_t trace_file_path
+	);
+
+	profiler_hub_trace_handle_t profiler_hub_open_trace(
+		profiler_hub_string_t trace_file_path
+	);
+
+	profiler_hub_result_t profiler_hub_set_trace_properties(profiler_hub_trace_handle_t trace,
+		client_trace_handle_t client_trace,
+		profiler_hub_string_t config_path,
+		size_t histogram_bucket_count);
+
+	profiler_hub_result_t profiler_hub_read_metadata(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace
+	);
+
+	profiler_hub_result_t profiler_hub_close_trace(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace
+	);
+
+	profiler_hub_value_type_t profiler_hub_get_info(
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_property_category_t category,
+		uint64_t row_key,
+		profiler_hub_string_t property_tag,
+		profiler_hub_optional_t value // OUT
+	);
+
+	profiler_hub_result_t profiler_hub_get_time_slice(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_track_id_t track_id,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end
+	);
+
+	profiler_hub_result_t profiler_hub_get_table_time_slice(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_table_handle_t table_handle,
+		profiler_hub_track_id_t track_id,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end
+	);
+
+	profiler_hub_result_t profiler_hub_get_search_time_slice(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_table_handle_t table_handle,
+		size_t num_operations,
+		profiler_hub_event_operation_t* operations,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end,
+		size_t num_search_strings,
+		profiler_hub_search_strings_t string_filters
+	);
+
+	profiler_hub_result_t profiler_hub_get_event_data_flow(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_event_operation_t operation,
+		profiler_hub_event_id_t event_id
+	);
+
+	profiler_hub_result_t profiler_hub_get_event_extended_data(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_event_operation_t operation,
+		profiler_hub_event_id_t event_id
+	);
+
+	profiler_hub_result_t profiler_hub_get_event_stack_trace(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_event_operation_t operation,
+		profiler_hub_event_id_t event_id
+	);
+
+	profiler_hub_result_t profiler_hub_trim_save_trace(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end);
+
+}

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -4,6 +4,20 @@
 find_package(Vulkan REQUIRED)
 set(VULKAN_LIB "Vulkan::Vulkan")
 
+option(PROFILER_HUB_BUILD_ROC_OPTIQ_IFACE_LIB "Build RocOptiq interface library" OFF)
+
+if(PROFILER_HUB_BUILD_ROC_OPTIQ_IFACE_LIB)
+    message(
+        STATUS
+        "Build RocOptiq interface library"
+    )
+
+set(PROFILER_HUB_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(PROFILER_HUB_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+add_subdirectory(profiler-hub)
+add_subdirectory(profiler-hub-client/optiq)
+set(PROFILER_HUB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/profiler-hub/include)
+endif()
 add_subdirectory(spdlog)
 add_subdirectory(catch2)
 

--- a/thirdparty/profiler-hub-client/optiq/CMakeLists.txt
+++ b/thirdparty/profiler-hub-client/optiq/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.16)
+ 
+project(optiq_interface VERSION 1.0.0 LANGUAGES CXX)
+
+# Create the static library
+add_library(optiq_interface STATIC
+    profiler_hub_interface.cpp
+    profiler_hub_trace.cpp
+    profiler_hub_future.cpp
+)
+ 
+# Set include directories so consumers can find the headers
+target_include_directories(optiq_interface
+    PRIVATE
+        ${PROFILER_HUB_INCLUDE_DIR}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+ 
+# Require C++17 (adjust as needed)
+target_compile_features(optiq_interface PUBLIC cxx_std_17)

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_client_interface.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_client_interface.h
@@ -1,0 +1,320 @@
+#pragma once
+
+#include "profiler_hub_interface_types.h"
+
+namespace profiler_hub::client::interface
+{
+
+    extern "C"
+    {
+        // report a single trace instance. Usually based on GUID (for rocpd 3.x and later), otherwise just synthesized single instance.
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // id - instance index
+        // file - which file the instance comes from, in case of multi-file trace
+        // uuid - UUID of the instance, if applicable
+        profiler_hub_result_t AddInstance(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t id,
+            profiler_hub_string_t file,
+            profiler_hub_string_t uuid
+        );
+
+        // helps to collect strings table for a trace. It's better to replace any string passed to data-model in future requests with integer id. To do so profiler-hub must have keep remapping look-up tables.
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // string - a string from any column
+        // string_id - string index, expected to start with 0 when first string submitted, but can be re-purposed. The idea is data-model will match any string id from future calls to the strin in the table.
+        profiler_hub_result_t AddString(
+            client_trace_handle_t trace,
+            profiler_hub_string_t string,
+            uint32_t string_id
+        );
+
+        // This will convert profiler-hub track representation to data-model
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // instance - what trace instance the track belong to
+        // category - track category, as enumerated in profiler_hub_track_category_t
+        // track_id - expected to be sequential number, but can be re-mapped if needed
+        // track_name - optional track name
+        // node_id - full node id from database, 0 if not applicable
+        // node_name - node name if applicable
+        // process_id - full process id, not table index
+        // process_name - process name, if applicable
+        // thread_id - full thread id, not table index
+        // thread_name - thread name, if applicable
+        // stream_id - stream id
+        // thread_name - stream name, if applicable
+        // agent_type - agent type as defined in profiler_hub_agent_type_t
+        // agent_id - agent typed id
+        // agent_name - agent name, if applicable
+        // queue_id - queue id
+        // queue_name - queue name, if applicable
+        // counter_id - counter id (for rocpd 3.x it will be pmc info id, for original rocpd schema - synthesized, for perfetto - counter track id)
+        // counter_name - counter name, required, if counter track
+        // records_count - how many records the track have
+        // min_timestamp - minimum timestamp
+        // max_timestamp - maximum timestamp
+        // min_level_or_value - minimum level for event track - expected 0, minimum value for counter track 
+        // max_level_or_value - maximum level for event track, maximum value for counter track
+        profiler_hub_result_t AddTrack(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
+            profiler_hub_track_id_t track_id,
+            profiler_hub_string_t track_name, 
+            profiler_hub_track_category_t category,
+            profiler_hub_optional_int_t node_id,
+            profiler_hub_string_t node_name,
+            profiler_hub_optional_int_t process_id,
+            profiler_hub_string_t process_name,
+            profiler_hub_optional_int_t thread_id,
+            profiler_hub_string_t thread_name,
+            profiler_hub_optional_int_t stream_id,
+            profiler_hub_string_t stream_name,
+            profiler_hub_agent_type_t agent_type,
+            profiler_hub_optional_int_t agent_id,
+            profiler_hub_string_t agent_name,
+            profiler_hub_optional_int_t queue_id,
+            profiler_hub_string_t queue_name,
+            profiler_hub_optional_int_t counter_id,
+            profiler_hub_string_t counter_name,
+            uint32_t records_count,
+            uint64_t min_timestamp,
+            uint64_t max_timestamp,
+            double min_level_or_value,
+            double max_level_or_value
+        );
+
+        // Adds histogram bucket to track histogram
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // track_id - track id, the combination of trace+track_id can be replaced with track_handler, but then AddTrack has to return the handler and profiler-hub must keep it for reference
+        // bucket_number - bucket number, no need to send zero count buckets, so the value is not sequential
+        // events_count - number of events in the bucket, skip zero event buckets
+        // bucket_value - average value for counter sample buckets, for events can be max level (tbd)
+        profiler_hub_result_t AddTrackHistogramBucket(
+            client_trace_handle_t trace,
+            profiler_hub_track_id_t track_id,
+            uint32_t bucket_number,
+            uint32_t events_count,
+            double bucket_value
+        );
+
+        // Add track extended info
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // track_id - track id, the combination of trace+track_id can be replaced with track_handler, but then AddTrack has to return the handler and profiler-hub must keep it for reference
+        // category - can be table name from where extended data has been taken, or synthesized
+        // name - can be column name from where extended data has been taken, or synthesized
+        // type - SQL type, as described in profiler_hub_value_type_t
+        // value - value as a void pointer to a value , will be cast based on type
+        profiler_hub_result_t  AddTrackExtendedInfo(
+            client_trace_handle_t trace,
+            profiler_hub_track_id_t track_id,
+            profiler_hub_string_t category,
+            profiler_hub_string_t name,
+            profiler_hub_value_type_t type,
+            profiler_hub_value_handle_t value
+        );
+
+        // Add time slice container for requested track and time window
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // track_id - track id, the combination of trace+track_id can be replaced with track_handler, but then AddTrack has to return the handler and profiler-hub must keep it for reference
+        // timestamp_start - requested time start
+        // timestamp_end - requested time end
+        profiler_hub_timeslice_handle_t AddTimeSliceContainer(
+            client_trace_handle_t trace,
+            profiler_hub_track_id_t track_id,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end
+        );
+
+        // Add Event record to time slice container
+        // container - time slice container handle
+        // operation - event operation, as described in profiler_hub_event_operation_t
+        // event_id - event id relative to operation
+        // timestamp - start time of the event
+        // duration - event duration 
+        // category_id - index of category in string table, be ready to remap database table string index into data-model string table
+        // symbol_id - index of symbol in string table, be ready to remap database table string index into data-model string table
+        // level - event level for event stacking. The same level should be used to generate call stack trace. It seems to be most reliable and universal way, unlike parent_id/parent_stack_id combination
+        profiler_hub_result_t AddEventRecord(
+            profiler_hub_timeslice_handle_t container,
+            profiler_hub_event_operation_t operation,
+            profiler_hub_event_id_t event_id,
+            uint64_t timestamp,
+            uint64_t duration,
+            profiler_hub_string_id_t category_id,
+            profiler_hub_string_id_t symbol_id,
+            profiler_hub_event_level_t level
+        );
+
+        // Add PMC record to time slice container
+        // container - time slice container handle
+        // timestamp - start time of the counter sample
+        // value - counter sample value
+        profiler_hub_result_t AddPmcRecord(
+            profiler_hub_timeslice_handle_t container,
+            uint64_t timestamp,
+            double value
+        );
+
+        // Add an empty row to table processor container
+        // container - table processor container handle
+        profiler_hub_table_row_handle_t AddTableRowContainer(
+            profiler_hub_table_handle_t container
+        );
+
+        // Add column name and type to the table processor container
+        // container - table processor container handle
+        // name - column name
+        // type - column SQL type, as enumerated in profiler_hub_value_type_t
+        profiler_hub_result_t AddTableColumn(
+            profiler_hub_table_handle_t container,
+            profiler_hub_string_t name,
+            profiler_hub_value_type_t type
+        );
+
+        // Add table cell value as string. Although all strings should be converted to string table index inside profiler-hub
+        // container - table row container handle
+        // column_index - column index
+        // value - value as string
+        profiler_hub_result_t AddTableCellAsString(
+            profiler_hub_table_row_handle_t container,
+            uint32_t column_index,
+            profiler_hub_string_t value
+        );
+
+        // Add table cell value as integer. 
+        // container - table row container handle
+        // column_index - column index
+        // value - value as integer
+        profiler_hub_result_t AddTableCellAsInt(
+            profiler_hub_table_row_handle_t container,
+            uint32_t column_index,
+            uint64_t value
+        );
+
+        // Add table cell value as floating point. 
+        // container - table row container handle
+        // column_index - column index
+        // value - value as double
+        profiler_hub_result_t AddTableCellAsDouble(
+            profiler_hub_table_row_handle_t container,
+            uint32_t column_index,
+            double value
+        );
+
+        // Add flow trace container
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // instance - multi-node instance,
+        // operation - event operation, as described in profiler_hub_event_operation_t
+        // event_id - event id relative to operation
+        profiler_hub_flowtrace_handle_t AddEventFlowTraceContainer(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
+            profiler_hub_event_operation_t operation,
+            profiler_hub_event_id_t event_id
+        );
+
+        // Add flow trace endpoint
+        // container - flow trace container handle
+        // operation - event operation, as described in profiler_hub_event_operation_t
+        // event_id - event id relative to operation
+        // direction - incoming/outgoing
+        // timestamp - endpoint timestamp
+        // duration - endpoint duration
+        // category_id - endpoint category id
+        // symbol_id - endpoint symbol id
+        // level - endpoint level
+        profiler_hub_result_t AddEventDataFlowEndPoint(
+            profiler_hub_flowtrace_handle_t container,
+            profiler_hub_event_operation_t operation,
+            profiler_hub_event_id_t event_id,
+            profiler_hub_flow_direction_t direction,
+            uint64_t timestamp,
+            uint64_t duration,
+            profiler_hub_string_id_t category_id,
+            profiler_hub_string_id_t symbol_id,
+            profiler_hub_event_level_t level
+        );
+
+        // Add extended data container
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // instance - multi-node instance, based on GUID when applicable
+        // operation - event operation, as described in profiler_hub_event_operation_t
+        // event_id - event id relative to operation
+        profiler_hub_ext_data_handle_t AddEventExtDataContainer(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
+            profiler_hub_event_operation_t operation,
+            profiler_hub_event_id_t event_id
+        );
+
+        // Add extended data record
+        // container - extended data container
+        // category - data category. Can be table name
+        // name - can be column name
+        // type - SQL type, as described in profiler_hub_value_type_t
+        // value - pointer to a value of type
+        profiler_hub_result_t  AddEventExtendedInfo(
+            profiler_hub_ext_data_handle_t container,
+            profiler_hub_string_t category,
+            profiler_hub_string_t name,
+            profiler_hub_value_type_t type,
+            profiler_hub_string_t value
+        );
+
+        // Add essential data to extended data table
+        // container - extended data container
+        // track_id - event track id
+        // stream_track_id - event stream track id, set to -1 if event does not belong to any stream
+        // level - event level
+        // stream_level - event level on stream track, set to -1 if event doesn't belong to any stream
+        profiler_hub_result_t  AddEventEssentialInfo(
+            profiler_hub_ext_data_handle_t container,
+            profiler_hub_track_id_t track_id,
+            profiler_hub_track_id_t stream_track_id,
+            profiler_hub_event_level_t level,
+            profiler_hub_event_level_t stream_level
+        );
+
+        // Add event arguments info
+        // container - extended data container
+        // position - argument position
+        // name - argument name
+        // type - argument type
+        profiler_hub_result_t  AddEventArgumentsInfo(
+            profiler_hub_ext_data_handle_t container,
+            uint32_t position,
+            profiler_hub_string_t name,
+            profiler_hub_string_t type,
+            profiler_hub_string_t value
+        );
+
+        // Add event call stack container
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // instance - multi-node instance, based on GUID when applicable
+        // operation - event operation, as described in profiler_hub_event_operation_t
+        // event_id - event id relative to operation
+        profiler_hub_call_stack_handle_t AddEventCallStackContainer(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
+            profiler_hub_event_operation_t operation,
+            profiler_hub_event_id_t event_id
+        );
+
+        // Add call stack frame to container
+        // container - call stack container
+        // symbol - stack frame symbol
+        // file - stack frame file
+        // line - stack frame code line
+        // depth - stack frame depth
+        profiler_hub_result_t  AddEventCallStackFrame(
+            profiler_hub_call_stack_handle_t container,
+            profiler_hub_string_t function,
+            profiler_hub_string_t file,
+            profiler_hub_string_t line,
+            profiler_hub_string_t address,
+            uint32_t depth
+        );
+
+    }
+
+}  // namespace ProfilerHub

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_client_interface.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_client_interface.h
@@ -97,33 +97,23 @@ namespace profiler_hub::client::interface
             double bucket_value
         );
 
-        // Add track extended info
+        // Reports info property to a caller
         // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
-        // track_id - track id, the combination of trace+track_id can be replaced with track_handler, but then AddTrack has to return the handler and profiler-hub must keep it for reference
         // category - can be table name from where extended data has been taken, or synthesized
         // name - can be column name from where extended data has been taken, or synthesized
         // type - SQL type, as described in profiler_hub_value_type_t
+        // instance - what trace instance the track belongs to
         // value - value as a void pointer to a value , will be cast based on type
-        profiler_hub_result_t  AddTrackExtendedInfo(
+        profiler_hub_result_t  AddInfoProperty(
             client_trace_handle_t trace,
-            profiler_hub_track_id_t track_id,
+            profiler_hub_instance_id_t instance,
             profiler_hub_string_t category,
             profiler_hub_string_t name,
             profiler_hub_value_type_t type,
+            profiler_hub_row_id_t row_id,
             profiler_hub_value_handle_t value
         );
 
-        // Add time slice container for requested track and time window
-        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
-        // track_id - track id, the combination of trace+track_id can be replaced with track_handler, but then AddTrack has to return the handler and profiler-hub must keep it for reference
-        // timestamp_start - requested time start
-        // timestamp_end - requested time end
-        profiler_hub_timeslice_handle_t AddTimeSliceContainer(
-            client_trace_handle_t trace,
-            profiler_hub_track_id_t track_id,
-            uint64_t timestamp_start,
-            uint64_t timestamp_end
-        );
 
         // Add Event record to time slice container
         // container - time slice container handle
@@ -135,6 +125,8 @@ namespace profiler_hub::client::interface
         // symbol_id - index of symbol in string table, be ready to remap database table string index into data-model string table
         // level - event level for event stacking. The same level should be used to generate call stack trace. It seems to be most reliable and universal way, unlike parent_id/parent_stack_id combination
         profiler_hub_result_t AddEventRecord(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
             profiler_hub_timeslice_handle_t container,
             profiler_hub_event_operation_t operation,
             profiler_hub_event_id_t event_id,
@@ -150,6 +142,8 @@ namespace profiler_hub::client::interface
         // timestamp - start time of the counter sample
         // value - counter sample value
         profiler_hub_result_t AddPmcRecord(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
             profiler_hub_timeslice_handle_t container,
             uint64_t timestamp,
             double value
@@ -158,60 +152,28 @@ namespace profiler_hub::client::interface
         // Add an empty row to table processor container
         // container - table processor container handle
         profiler_hub_table_row_handle_t AddTableRowContainer(
-            profiler_hub_table_handle_t container
-        );
-
-        // Add column name and type to the table processor container
-        // container - table processor container handle
-        // name - column name
-        // type - column SQL type, as enumerated in profiler_hub_value_type_t
-        profiler_hub_result_t AddTableColumn(
-            profiler_hub_table_handle_t container,
-            profiler_hub_string_t name,
-            profiler_hub_value_type_t type
-        );
-
-        // Add table cell value as string. Although all strings should be converted to string table index inside profiler-hub
-        // container - table row container handle
-        // column_index - column index
-        // value - value as string
-        profiler_hub_result_t AddTableCellAsString(
-            profiler_hub_table_row_handle_t container,
-            uint32_t column_index,
-            profiler_hub_string_t value
-        );
-
-        // Add table cell value as integer. 
-        // container - table row container handle
-        // column_index - column index
-        // value - value as integer
-        profiler_hub_result_t AddTableCellAsInt(
-            profiler_hub_table_row_handle_t container,
-            uint32_t column_index,
-            uint64_t value
-        );
-
-        // Add table cell value as floating point. 
-        // container - table row container handle
-        // column_index - column index
-        // value - value as double
-        profiler_hub_result_t AddTableCellAsDouble(
-            profiler_hub_table_row_handle_t container,
-            uint32_t column_index,
-            double value
-        );
-
-        // Add flow trace container
-        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
-        // instance - multi-node instance,
-        // operation - event operation, as described in profiler_hub_event_operation_t
-        // event_id - event id relative to operation
-        profiler_hub_flowtrace_handle_t AddEventFlowTraceContainer(
             client_trace_handle_t trace,
-            profiler_hub_instance_id_t instance,
-            profiler_hub_event_operation_t operation,
-            profiler_hub_event_id_t event_id
+            profiler_hub_table_handle_t container,
+            size_t num_columns
         );
+
+
+        // Add table cell value
+        // container - table row container handle
+        // column_index - column index
+        // column_name - column name
+        // column_type - column value type
+        // value - value as string
+        profiler_hub_result_t AddTableCell(
+            client_trace_handle_t trace,
+            profiler_hub_table_row_handle_t container,
+            uint32_t column_index,
+            profiler_hub_string_t column_name,
+            profiler_hub_value_type_t column_type,
+            profiler_hub_value_handle_t value
+        );
+
+      
 
         // Add flow trace endpoint
         // container - flow trace container handle
@@ -224,27 +186,17 @@ namespace profiler_hub::client::interface
         // symbol_id - endpoint symbol id
         // level - endpoint level
         profiler_hub_result_t AddEventDataFlowEndPoint(
+            client_trace_handle_t trace,
             profiler_hub_flowtrace_handle_t container,
             profiler_hub_event_operation_t operation,
             profiler_hub_event_id_t event_id,
+            profiler_hub_track_id_t track_id,
             profiler_hub_flow_direction_t direction,
             uint64_t timestamp,
             uint64_t duration,
             profiler_hub_string_id_t category_id,
             profiler_hub_string_id_t symbol_id,
             profiler_hub_event_level_t level
-        );
-
-        // Add extended data container
-        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
-        // instance - multi-node instance, based on GUID when applicable
-        // operation - event operation, as described in profiler_hub_event_operation_t
-        // event_id - event id relative to operation
-        profiler_hub_ext_data_handle_t AddEventExtDataContainer(
-            client_trace_handle_t trace,
-            profiler_hub_instance_id_t instance,
-            profiler_hub_event_operation_t operation,
-            profiler_hub_event_id_t event_id
         );
 
         // Add extended data record
@@ -254,6 +206,8 @@ namespace profiler_hub::client::interface
         // type - SQL type, as described in profiler_hub_value_type_t
         // value - pointer to a value of type
         profiler_hub_result_t  AddEventExtendedInfo(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
             profiler_hub_ext_data_handle_t container,
             profiler_hub_string_t category,
             profiler_hub_string_t name,
@@ -268,6 +222,8 @@ namespace profiler_hub::client::interface
         // level - event level
         // stream_level - event level on stream track, set to -1 if event doesn't belong to any stream
         profiler_hub_result_t  AddEventEssentialInfo(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
             profiler_hub_ext_data_handle_t container,
             profiler_hub_track_id_t track_id,
             profiler_hub_track_id_t stream_track_id,
@@ -281,6 +237,8 @@ namespace profiler_hub::client::interface
         // name - argument name
         // type - argument type
         profiler_hub_result_t  AddEventArgumentsInfo(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
             profiler_hub_ext_data_handle_t container,
             uint32_t position,
             profiler_hub_string_t name,
@@ -288,17 +246,6 @@ namespace profiler_hub::client::interface
             profiler_hub_string_t value
         );
 
-        // Add event call stack container
-        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
-        // instance - multi-node instance, based on GUID when applicable
-        // operation - event operation, as described in profiler_hub_event_operation_t
-        // event_id - event id relative to operation
-        profiler_hub_call_stack_handle_t AddEventCallStackContainer(
-            client_trace_handle_t trace,
-            profiler_hub_instance_id_t instance,
-            profiler_hub_event_operation_t operation,
-            profiler_hub_event_id_t event_id
-        );
 
         // Add call stack frame to container
         // container - call stack container
@@ -307,6 +254,8 @@ namespace profiler_hub::client::interface
         // line - stack frame code line
         // depth - stack frame depth
         profiler_hub_result_t  AddEventCallStackFrame(
+            client_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
             profiler_hub_call_stack_handle_t container,
             profiler_hub_string_t function,
             profiler_hub_string_t file,

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_future.cpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_future.cpp
@@ -66,18 +66,6 @@ static std::atomic<uint64_t> s_next_id{1};
         return status;
     }
 
-    void future_t::reset()
-    {
-        // worker must be finished before reset
-        if (m_worker.joinable())
-            m_worker.join();
-
-        m_promise = std::promise<profiler_hub_result_t>{};
-        m_future  = m_promise.get_future();
-        m_progress.store(0.0, std::memory_order_relaxed);
-        m_interrupt_status.store(false, std::memory_order_release);
-    }
-
     // -----------------------------------------------------------------------------
     // Interruption
     // -----------------------------------------------------------------------------

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_future.cpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_future.cpp
@@ -1,0 +1,108 @@
+#include "profiler_hub_future.hpp"
+#include "profiler_hub_missing.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+
+namespace profiler_hub
+{
+
+// Module-level counter – each future_t gets a unique id at construction time.
+static std::atomic<uint64_t> s_next_id{1};
+
+    // -----------------------------------------------------------------------------
+    // Construction / destruction
+    // -----------------------------------------------------------------------------
+
+    future_t::future_t(progress_callback_t progress_callback, void* user_data)
+    : m_progress_callback(progress_callback)
+    , m_user_data(user_data)
+    , m_id(s_next_id.fetch_add(1, std::memory_order_relaxed))
+    , m_progress(0.0)
+    , m_interrupt_status(false)
+    , m_future(m_promise.get_future())
+    {}
+
+    future_t::~future_t()
+    {
+        // Ask a running worker to stop before we block on join.
+        set_interrupted();
+        if (m_worker.joinable())
+            m_worker.join();
+    }
+
+    // -----------------------------------------------------------------------------
+    // Synchronization
+    // -----------------------------------------------------------------------------
+
+    profiler_hub_result_t
+    future_t::wait_for_completion(uint64_t timeout_ms)
+    {
+        const auto wait_status =
+            m_future.wait_for(std::chrono::milliseconds(timeout_ms));
+
+        if (wait_status == std::future_status::timeout)
+        {
+            set_interrupted();
+            return profiler_hub_result_t::kProfilerHubStatusTimeout;
+        }
+
+        return m_future.get();
+    }
+
+    profiler_hub_result_t
+    future_t::set_promise(profiler_hub_result_t status)
+    {
+        try
+        {
+            m_promise.set_value(status);
+        }
+        catch (const std::future_error&)
+        {
+            // Promise was already fulfilled (e.g. called twice) – report error.
+            return profiler_hub_result_t::kProfilerHubStatusUnknownError;
+        }
+        return status;
+    }
+
+    void future_t::reset()
+    {
+        // worker must be finished before reset
+        if (m_worker.joinable())
+            m_worker.join();
+
+        m_promise = std::promise<profiler_hub_result_t>{};
+        m_future  = m_promise.get_future();
+        m_progress.store(0.0, std::memory_order_relaxed);
+        m_interrupt_status.store(false, std::memory_order_release);
+    }
+
+    // -----------------------------------------------------------------------------
+    // Interruption
+    // -----------------------------------------------------------------------------
+
+    void
+    future_t::set_interrupted()
+    {
+        m_interrupt_status.store(true, std::memory_order_release);
+        missing_t::function("query cancellation propagation");
+    }
+
+    // -----------------------------------------------------------------------------
+    // Progress reporting
+    // -----------------------------------------------------------------------------
+
+    void
+    future_t::show_progress(const char* db_name,
+                            double    progress_percent,
+                            const char* action,
+                            profiler_hub_async_status_t  status)
+    {
+        m_progress.store(progress_percent, std::memory_order_relaxed);
+
+        if (m_progress_callback)
+            m_progress_callback(db_name, m_id, progress_percent, status, action, nullptr);
+    }
+
+}  // namespace profiler_hub

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_future.hpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_future.hpp
@@ -93,10 +93,6 @@ namespace profiler_hub
         // @return the same status value that was stored, or an error code on failure.
         profiler_hub_result_t set_promise(profiler_hub_result_t status);
 
-        // It's suggested to use one future_t per operation
-        // If you did want to support reuse — say, for a task queue where the same object 
-        // dispatches many sequential jobs — you would need to reset the pair before each run
-        void future_t::reset();
 
         // -------------------------------------------------------------------------
         // Interruption
@@ -123,7 +119,7 @@ namespace profiler_hub
         // @param action  – human-readable description of the ongoing operation.
         // @param status  – current operation status.
         void show_progress(const char* db_name,
-                           double    step,
+                           double    weight,
                            const char* action,
                            profiler_hub_async_status_t  status);
 

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_future.hpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_future.hpp
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "profiler_hub_interface_types.h"
+
+#include <atomic>
+#include <cstdint>
+#include <future>
+#include <thread>
+
+// These types are assumed to be declared in the project's public API headers.
+// Included here symbolically – replace with the real include path.
+//   progress_callback_t
+//   timeout_ms_t
+//   status_t
+//   charptr_t
+//   result_t
+
+
+namespace profiler_hub
+{
+
+    typedef void ( *progress_callback_t)(
+        const char * file_name,
+        uint64_t future_id,
+        double progress_percent, 
+        profiler_hub_async_status_t status, 
+        const char* status_message,
+        void* user_data
+        );
+ 
+    // Represents a handle to an asynchronous database operation.
+    // The caller creates a future_t, optionally attaches a progress callback,
+    // moves a worker std::thread into it, and later calls wait_for_completion().
+    // The worker thread is responsible for calling set_promise() when it finishes
+    // and show_progress() as it advances.
+    class future_t
+    {
+    public:
+        // Constructs a future with an optional progress-reporting callback.
+        // @param progress_callback  – function invoked on each progress update; may be nullptr.
+        // @param user_data          – opaque pointer forwarded to every callback invocation.
+        future_t(progress_callback_t progress_callback,
+                 void*              user_data = nullptr);
+
+        // Joins the worker thread if it is still running, then destroys the object.
+        ~future_t();
+
+        // Non-copyable; move is intentionally left undefined – ownership is exclusive.
+        future_t(const future_t&)            = delete;
+        future_t& operator=(const future_t&) = delete;
+
+        // -------------------------------------------------------------------------
+        // Accessors
+        // -------------------------------------------------------------------------
+
+        // @return the progress callback supplied at construction (may be nullptr).
+        progress_callback_t get_progress_callback() const
+        {
+            return m_progress_callback;
+        }
+
+        // @return the unique numeric identifier assigned to this future at construction.
+        uint64_t get_id() const { return m_id; }
+
+        // @return current operation progress in the range [0.0, 100.0].
+        double get_progress() const { return m_progress.load(std::memory_order_relaxed); }
+
+        // -------------------------------------------------------------------------
+        // Worker thread management
+        // -------------------------------------------------------------------------
+
+        // Takes ownership of the worker thread that carries out the async operation.
+        // Must be called before the first wait_for_completion() call.
+        // @param thread – r-value reference to the thread to adopt.
+        void set_worker(std::thread&& thread) { m_worker = std::move(thread); }
+
+        // @return true while the worker thread is alive (joinable).
+        bool is_working() const { return m_worker.joinable(); }
+
+        // -------------------------------------------------------------------------
+        // Synchronisation
+        // -------------------------------------------------------------------------
+
+        // Blocks until the worker completes or the timeout elapses.
+        // On timeout the interrupted flag is set so the worker can react and exit early.
+        // @param timeout_ms – maximum wait time in milliseconds.
+        // @return the operation result reported by the worker, or a timeout status.
+        profiler_hub_result_t wait_for_completion(uint64_t timeout_ms);
+
+        // Called by the worker thread to deliver its final operation status.
+        // Safe to call at most once; subsequent calls are silently ignored.
+        // @param status – result of the completed operation.
+        // @return the same status value that was stored, or an error code on failure.
+        profiler_hub_result_t set_promise(profiler_hub_result_t status);
+
+        // It's suggested to use one future_t per operation
+        // If you did want to support reuse — say, for a task queue where the same object 
+        // dispatches many sequential jobs — you would need to reset the pair before each run
+        void future_t::reset();
+
+        // -------------------------------------------------------------------------
+        // Interruption
+        // -------------------------------------------------------------------------
+
+        // @return true if the operation was cut short by wait_for_completion() timeout.
+        bool is_interrupted() const
+        {
+            return m_interrupt_status.load(std::memory_order_acquire);
+        }
+
+        // Signals the worker thread that it should stop as soon as possible.
+        // Idempotent – safe to call multiple times.
+        void set_interrupted();
+
+        // -------------------------------------------------------------------------
+        // Progress reporting
+        // -------------------------------------------------------------------------
+
+        // Updates the stored progress value and, if a callback was supplied,
+        // forwards the event to the caller.
+        // @param db_name – path to the database file being processed.
+        // @param step    – progress percentage of the current operation step.
+        // @param action  – human-readable description of the ongoing operation.
+        // @param status  – current operation status.
+        void show_progress(const char* db_name,
+                           double    step,
+                           const char* action,
+                           profiler_hub_async_status_t  status);
+
+    private:
+        progress_callback_t    m_progress_callback;
+        void*                  m_user_data;
+        const uint64_t         m_id;
+        std::atomic<double>    m_progress;
+        std::atomic<bool>      m_interrupt_status;
+        std::thread            m_worker;
+        std::promise<profiler_hub_result_t> m_promise;
+        std::future<profiler_hub_result_t>  m_future;
+    };
+
+}  // namespace profiler_hub

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.cpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.cpp
@@ -6,34 +6,26 @@
 namespace profiler_hub::interface
 {
 
-	profiler_hub_future_handle_t FutureAlloc() {
-		try {
-			return new future_t(nullptr);
-		}
-		catch (const std::exception&)
-		{
-			return nullptr;
-		}
+	profiler_hub_future_handle_t FutureAlloc(progress_callback_t progress_callback) {
+		return new future_t(progress_callback, nullptr);
 	}
 
 	profiler_hub_result_t FutureFree(
 		profiler_hub_future_handle_t future_handle
 	) {
-		try {
-			future_t* future = static_cast<future_t*>(future_handle);
-			delete future;
-			return kProfilerHubStatusSuccess;
-		}
-		catch (const std::exception&)
-		{
-			return kProfilerHubStatusUnknownError;
-		}
+		if (!future_handle)
+			return kProfilerHubStatusInvalidArgument;
+		future_t* future = static_cast<future_t*>(future_handle);
+		delete future;
+		return kProfilerHubStatusSuccess;		
 	}
 
 	profiler_hub_result_t FutureWait(
 		profiler_hub_future_handle_t future_handle,
 		uint64_t timeout_ms
 	) {
+		if (!future_handle)
+			return kProfilerHubStatusInvalidArgument;
 		future_t* future = static_cast<future_t*>(future_handle);
 		return future->wait_for_completion(timeout_ms);
 	}
@@ -41,43 +33,46 @@ namespace profiler_hub::interface
 	profiler_hub_result_t FutureCancel(
 		profiler_hub_future_handle_t future_handle
 	) {
+		if (!future_handle)
+			return kProfilerHubStatusInvalidArgument;
 		future_t* future = static_cast<future_t*>(future_handle);
 		future->set_interrupted();
 		return kProfilerHubStatusSuccess;
 	}
 
-	profiler_hub_result_t FutureReset(
-		profiler_hub_future_handle_t future_handle
-	) {
-		future_t* future = static_cast<future_t*>(future_handle);
-		future->reset();
-		return kProfilerHubStatusSuccess;
-	}
-
-	profiler_hub_result_t DetectTrace(
-		profiler_hub_future_handle_t future_handle,
+	profiler_hub_db_type_t DetectTrace(
 		profiler_hub_string_t trace_file_path
 	) {
-		future_t* future = static_cast<future_t*>(future_handle);
-		if (future == nullptr)
+
+		return profiler_hub_trace_t::detect_trace(trace_file_path);
+	}
+
+	profiler_hub_trace_handle_t OpenTrace(
+		profiler_hub_string_t trace_file_path	
+		)
+	{
+		profiler_hub_trace_t* ph_trace = new profiler_hub_trace_t(trace_file_path);
+		return (profiler_hub_trace_handle_t)ph_trace;
+	}
+
+	profiler_hub_result_t SetTraceProperties(
+		profiler_hub_trace_handle_t trace,
+		client_trace_handle_t client_trace,
+		profiler_hub_string_t config_dir_path,
+		size_t histogram_bucket_count
+	)
+	{
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
 		{
 			return kProfilerHubStatusInvalidArgument;
 		}
-		std::thread worker([future, trace_file_path]()
-			{
-				future->set_promise(profiler_hub_trace_t::detect_trace(trace_file_path));
-			});
-		future->set_worker(std::move(worker));
-		return kProfilerHubStatusSuccess;
+		ph_trace->set_trace_properties(client_trace, config_dir_path, histogram_bucket_count);
 	}
 
-	profiler_hub_result_t OpenTrace(
+	profiler_hub_result_t ReadTraceMetadata(
 		profiler_hub_future_handle_t future_handle,
-		client_trace_handle_t client_trace,
-		profiler_hub_string_t trace_file_path,
-		profiler_hub_string_t config_dir_path,
-		size_t histogram_bucket_count,
-		profiler_hub_trace_handle_t* trace // OUT
+		profiler_hub_trace_handle_t trace
 	) 
 	{
 		future_t* future = static_cast<future_t*>(future_handle);
@@ -85,11 +80,14 @@ namespace profiler_hub::interface
 		{
 			return kProfilerHubStatusInvalidArgument;
 		}
-		profiler_hub_trace_t* ph_trace = new profiler_hub_trace_t(client_trace, trace_file_path, config_dir_path);
-		*trace = (profiler_hub_trace_handle_t)ph_trace;
-		std::thread worker([ph_trace, future, histogram_bucket_count]()
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future]()
 			{
-				future->set_promise(ph_trace->open_trace(future, histogram_bucket_count));
+				future->set_promise(ph_trace->open_trace(future));
 			});
 		future->set_worker(std::move(worker));
 		return kProfilerHubStatusSuccess;
@@ -299,6 +297,30 @@ namespace profiler_hub::interface
 		std::thread worker([ph_trace, future, instance, operation, event_id]()
 			{
 				future->set_promise(ph_trace->get_event_stack_trace(future, instance, operation, event_id));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t TrimTraceDatabase(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end)
+	{
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future, timestamp_start, timestamp_end]()
+			{
+				future->set_promise(ph_trace->trim_trace_database(future, timestamp_start, timestamp_end));
 			});
 		future->set_worker(std::move(worker));
 		return kProfilerHubStatusSuccess;

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.cpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.cpp
@@ -1,0 +1,307 @@
+#include "profiler_hub_trace.h"
+#include "profiler_hub_interface.h"
+#include "profiler_hub_future.hpp"
+
+
+namespace profiler_hub::interface
+{
+
+	profiler_hub_future_handle_t FutureAlloc() {
+		try {
+			return new future_t(nullptr);
+		}
+		catch (const std::exception&)
+		{
+			return nullptr;
+		}
+	}
+
+	profiler_hub_result_t FutureFree(
+		profiler_hub_future_handle_t future_handle
+	) {
+		try {
+			future_t* future = static_cast<future_t*>(future_handle);
+			delete future;
+			return kProfilerHubStatusSuccess;
+		}
+		catch (const std::exception&)
+		{
+			return kProfilerHubStatusUnknownError;
+		}
+	}
+
+	profiler_hub_result_t FutureWait(
+		profiler_hub_future_handle_t future_handle,
+		uint64_t timeout_ms
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		return future->wait_for_completion(timeout_ms);
+	}
+
+	profiler_hub_result_t FutureCancel(
+		profiler_hub_future_handle_t future_handle
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		future->set_interrupted();
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t FutureReset(
+		profiler_hub_future_handle_t future_handle
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		future->reset();
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t DetectTrace(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_string_t trace_file_path
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([future, trace_file_path]()
+			{
+				future->set_promise(profiler_hub_trace_t::detect_trace(trace_file_path));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t OpenTrace(
+		profiler_hub_future_handle_t future_handle,
+		client_trace_handle_t client_trace,
+		profiler_hub_string_t trace_file_path,
+		profiler_hub_string_t config_dir_path,
+		size_t histogram_bucket_count,
+		profiler_hub_trace_handle_t* trace // OUT
+	) 
+	{
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = new profiler_hub_trace_t(client_trace, trace_file_path, config_dir_path);
+		*trace = (profiler_hub_trace_handle_t)ph_trace;
+		std::thread worker([ph_trace, future, histogram_bucket_count]()
+			{
+				future->set_promise(ph_trace->open_trace(future, histogram_bucket_count));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t CloseTrace(
+		profiler_hub_trace_handle_t trace
+	) {
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		delete ph_trace;
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_value_type_t GetProperty(
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_property_category_t category,
+		uint64_t row_key,
+		profiler_hub_string_t property_tag,
+		profiler_hub_optional_t value // OUT
+	) {
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kPprofilerHubDataTypeUndefined;
+		}
+		if (value == nullptr)
+		{
+			return kPprofilerHubDataTypeUndefined;
+		}
+
+		switch (category)
+		{
+		case kProfilerHubPropertyNode:
+			return ph_trace->get_node_info_by_tag(row_key, property_tag, value);
+		case kProfilerHubPropertyProcess:
+			return ph_trace->get_process_info_by_tag(row_key, property_tag, value);
+		case kProfilerHubPropertyThread:
+			return ph_trace->get_thread_info_by_tag(row_key, property_tag, value);
+		case kProfilerHubPropertyAgent:
+			return ph_trace->get_agent_info_by_tag(row_key, property_tag, value);
+		case kProfilerHubPropertyQueue:
+			return ph_trace->get_queue_info_by_tag(row_key, property_tag, value);
+		case kProfilerHubPropertyStream:
+			return ph_trace->get_stream_info_by_tag(row_key, property_tag, value);
+		case kProfilerHubPropertyCounter:
+			return ph_trace->get_pmc_info_by_tag(row_key, property_tag, value);
+		}
+
+		return kPprofilerHubDataTypeUndefined;
+		
+	}
+
+	profiler_hub_result_t GetTimeSlice(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_track_id_t track_id,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future, track_id, timestamp_start, timestamp_end]()
+			{
+				future->set_promise(ph_trace->get_time_slice(future, track_id, timestamp_start, timestamp_end));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t GetTableTimeSlice(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_table_handle_t table_handle,
+		profiler_hub_track_id_t track_id,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future, table_handle, track_id, timestamp_start, timestamp_end]()
+			{
+				future->set_promise(ph_trace->get_table_time_slice(future, table_handle, track_id, timestamp_start, timestamp_end));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t GetSearchTimeSlice(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_table_handle_t table_handle,
+		size_t num_operations,
+		profiler_hub_event_operation_t* operations,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end,
+		size_t num_search_strings,
+		profiler_hub_search_strings_t string_filters
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future, table_handle, num_operations, operations, timestamp_start, timestamp_end, num_search_strings, string_filters]()
+			{
+				future->set_promise(ph_trace->get_search_time_slice(future, table_handle, num_operations, operations, timestamp_start, timestamp_end, num_search_strings, string_filters));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+
+	}
+
+	profiler_hub_result_t GetEventDataFlow(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_event_operation_t operation,
+		profiler_hub_event_id_t event_id
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future, instance, operation, event_id]()
+			{
+				future->set_promise(ph_trace->get_data_flow_for_event(future, instance, operation, event_id));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+	
+	profiler_hub_result_t GetEventExtendedData(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_event_operation_t operation,
+		profiler_hub_event_id_t event_id
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future, instance, operation, event_id]()
+			{
+				future->set_promise(ph_trace->get_event_details(future, instance, operation, event_id));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t GetEventStackTrace(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_instance_id_t instance,
+		profiler_hub_event_operation_t operation,
+		profiler_hub_event_id_t event_id
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future, instance, operation, event_id]()
+			{
+				future->set_promise(ph_trace->get_event_stack_trace(future, instance, operation, event_id));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+
+}

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.cpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.cpp
@@ -68,6 +68,7 @@ namespace profiler_hub::interface
 			return kProfilerHubStatusInvalidArgument;
 		}
 		ph_trace->set_trace_properties(client_trace, config_dir_path, histogram_bucket_count);
+		return kProfilerHubStatusSuccess;
 	}
 
 	profiler_hub_result_t ReadTraceMetadata(
@@ -105,50 +106,12 @@ namespace profiler_hub::interface
 		return kProfilerHubStatusSuccess;
 	}
 
-	profiler_hub_value_type_t GetProperty(
-		profiler_hub_trace_handle_t trace,
-		profiler_hub_instance_id_t instance,
-		profiler_hub_property_category_t category,
-		uint64_t row_key,
-		profiler_hub_string_t property_tag,
-		profiler_hub_optional_t value // OUT
-	) {
-		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
-		if (ph_trace == nullptr)
-		{
-			return kPprofilerHubDataTypeUndefined;
-		}
-		if (value == nullptr)
-		{
-			return kPprofilerHubDataTypeUndefined;
-		}
-
-		switch (category)
-		{
-		case kProfilerHubPropertyNode:
-			return ph_trace->get_node_info_by_tag(row_key, property_tag, value);
-		case kProfilerHubPropertyProcess:
-			return ph_trace->get_process_info_by_tag(row_key, property_tag, value);
-		case kProfilerHubPropertyThread:
-			return ph_trace->get_thread_info_by_tag(row_key, property_tag, value);
-		case kProfilerHubPropertyAgent:
-			return ph_trace->get_agent_info_by_tag(row_key, property_tag, value);
-		case kProfilerHubPropertyQueue:
-			return ph_trace->get_queue_info_by_tag(row_key, property_tag, value);
-		case kProfilerHubPropertyStream:
-			return ph_trace->get_stream_info_by_tag(row_key, property_tag, value);
-		case kProfilerHubPropertyCounter:
-			return ph_trace->get_pmc_info_by_tag(row_key, property_tag, value);
-		}
-
-		return kPprofilerHubDataTypeUndefined;
-		
-	}
 
 	profiler_hub_result_t GetTimeSlice(
 		profiler_hub_future_handle_t future_handle,
 		profiler_hub_trace_handle_t trace,
 		profiler_hub_track_id_t track_id,
+		profiler_hub_timeslice_handle_t slice_container,
 		uint64_t timestamp_start,
 		uint64_t timestamp_end
 	) {
@@ -162,9 +125,37 @@ namespace profiler_hub::interface
 		{
 			return kProfilerHubStatusInvalidArgument;
 		}
-		std::thread worker([ph_trace, future, track_id, timestamp_start, timestamp_end]()
+		std::thread worker([ph_trace, future, track_id, slice_container, timestamp_start, timestamp_end]()
 			{
-				future->set_promise(ph_trace->get_time_slice(future, track_id, timestamp_start, timestamp_end));
+				future->set_promise(ph_trace->get_time_slice(future, track_id, slice_container, timestamp_start, timestamp_end));
+			});
+		future->set_worker(std::move(worker));
+		return kProfilerHubStatusSuccess;
+	}
+
+	profiler_hub_result_t GetPmcTimeSlice(
+		profiler_hub_future_handle_t future_handle,
+		profiler_hub_trace_handle_t trace,
+		profiler_hub_track_id_t track_id,
+		profiler_hub_timeslice_handle_t slice_container,
+		uint64_t timestamp_start,
+		uint64_t timestamp_end,
+		bool left_neighbor,
+		bool right_neighbor
+	) {
+		future_t* future = static_cast<future_t*>(future_handle);
+		if (future == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		profiler_hub_trace_t* ph_trace = static_cast<profiler_hub_trace_t*>(trace);
+		if (ph_trace == nullptr)
+		{
+			return kProfilerHubStatusInvalidArgument;
+		}
+		std::thread worker([ph_trace, future, track_id, slice_container, timestamp_start, timestamp_end, left_neighbor, right_neighbor]()
+			{
+				future->set_promise(ph_trace->get_pmc_time_slice(future, track_id, slice_container, timestamp_start, timestamp_end, left_neighbor, right_neighbor));
 			});
 		future->set_worker(std::move(worker));
 		return kProfilerHubStatusSuccess;
@@ -201,8 +192,7 @@ namespace profiler_hub::interface
 		profiler_hub_trace_handle_t trace,
 		profiler_hub_instance_id_t instance,
 		profiler_hub_table_handle_t table_handle,
-		size_t num_operations,
-		profiler_hub_event_operation_t* operations,
+		profiler_hub_event_operation_t operation,
 		uint64_t timestamp_start,
 		uint64_t timestamp_end,
 		size_t num_search_strings,
@@ -218,9 +208,9 @@ namespace profiler_hub::interface
 		{
 			return kProfilerHubStatusInvalidArgument;
 		}
-		std::thread worker([ph_trace, future, table_handle, num_operations, operations, timestamp_start, timestamp_end, num_search_strings, string_filters]()
+		std::thread worker([ph_trace, future, table_handle, operation, timestamp_start, timestamp_end, num_search_strings, string_filters, instance]()
 			{
-				future->set_promise(ph_trace->get_search_time_slice(future, table_handle, num_operations, operations, timestamp_start, timestamp_end, num_search_strings, string_filters));
+				future->set_promise(ph_trace->get_search_time_slice(future, instance, table_handle, operation, timestamp_start, timestamp_end, num_search_strings, string_filters));
 			});
 		future->set_worker(std::move(worker));
 		return kProfilerHubStatusSuccess;
@@ -231,6 +221,7 @@ namespace profiler_hub::interface
 		profiler_hub_future_handle_t future_handle,
 		profiler_hub_trace_handle_t trace,
 		profiler_hub_instance_id_t instance,
+		profiler_hub_flowtrace_handle_t container,
 		profiler_hub_event_operation_t operation,
 		profiler_hub_event_id_t event_id
 	) {
@@ -244,9 +235,9 @@ namespace profiler_hub::interface
 		{
 			return kProfilerHubStatusInvalidArgument;
 		}
-		std::thread worker([ph_trace, future, instance, operation, event_id]()
+		std::thread worker([ph_trace, future, instance, container, operation, event_id]()
 			{
-				future->set_promise(ph_trace->get_data_flow_for_event(future, instance, operation, event_id));
+				future->set_promise(ph_trace->get_data_flow_for_event(future, instance, container, operation, event_id));
 			});
 		future->set_worker(std::move(worker));
 		return kProfilerHubStatusSuccess;
@@ -256,6 +247,7 @@ namespace profiler_hub::interface
 		profiler_hub_future_handle_t future_handle,
 		profiler_hub_trace_handle_t trace,
 		profiler_hub_instance_id_t instance,
+		profiler_hub_ext_data_handle_t container,
 		profiler_hub_event_operation_t operation,
 		profiler_hub_event_id_t event_id
 	) {
@@ -269,9 +261,9 @@ namespace profiler_hub::interface
 		{
 			return kProfilerHubStatusInvalidArgument;
 		}
-		std::thread worker([ph_trace, future, instance, operation, event_id]()
+		std::thread worker([ph_trace, future, instance, container, operation, event_id]()
 			{
-				future->set_promise(ph_trace->get_event_details(future, instance, operation, event_id));
+				future->set_promise(ph_trace->get_event_details(future, instance, container, operation, event_id));
 			});
 		future->set_worker(std::move(worker));
 		return kProfilerHubStatusSuccess;
@@ -281,6 +273,7 @@ namespace profiler_hub::interface
 		profiler_hub_future_handle_t future_handle,
 		profiler_hub_trace_handle_t trace,
 		profiler_hub_instance_id_t instance,
+		profiler_hub_call_stack_handle_t container,
 		profiler_hub_event_operation_t operation,
 		profiler_hub_event_id_t event_id
 	) {
@@ -294,9 +287,9 @@ namespace profiler_hub::interface
 		{
 			return kProfilerHubStatusInvalidArgument;
 		}
-		std::thread worker([ph_trace, future, instance, operation, event_id]()
+		std::thread worker([ph_trace, future, instance, container, operation, event_id]()
 			{
-				future->set_promise(ph_trace->get_event_stack_trace(future, instance, operation, event_id));
+				future->set_promise(ph_trace->get_event_stack_trace(future, instance, container, operation, event_id));
 			});
 		future->set_worker(std::move(worker));
 		return kProfilerHubStatusSuccess;
@@ -306,7 +299,8 @@ namespace profiler_hub::interface
 		profiler_hub_future_handle_t future_handle,
 		profiler_hub_trace_handle_t trace,
 		uint64_t timestamp_start,
-		uint64_t timestamp_end)
+		uint64_t timestamp_end,
+		profiler_hub_string_t new_path)
 	{
 		future_t* future = static_cast<future_t*>(future_handle);
 		if (future == nullptr)
@@ -318,9 +312,9 @@ namespace profiler_hub::interface
 		{
 			return kProfilerHubStatusInvalidArgument;
 		}
-		std::thread worker([ph_trace, future, timestamp_start, timestamp_end]()
+		std::thread worker([ph_trace, future, timestamp_start, timestamp_end, new_path]()
 			{
-				future->set_promise(ph_trace->trim_trace_database(future, timestamp_start, timestamp_end));
+				future->set_promise(ph_trace->trim_trace_database(future, timestamp_start, timestamp_end, new_path));
 			});
 		future->set_worker(std::move(worker));
 		return kProfilerHubStatusSuccess;

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "profiler_hub_interface_types.h"
+#include "profiler_hub_future.hpp"
 
 namespace profiler_hub::interface
 {
@@ -9,7 +9,7 @@ namespace profiler_hub::interface
     {
         // Allocate future object for asynchronous operations. 
         // Returns future object handle
-        profiler_hub_future_handle_t FutureAlloc();
+        profiler_hub_future_handle_t FutureAlloc(progress_callback_t progress_callback);
 
         // Delete future object after asynchronous operation is completed
         profiler_hub_result_t FutureFree(
@@ -29,32 +29,34 @@ namespace profiler_hub::interface
             profiler_hub_future_handle_t future
         );
 
-        // Reset future for next asynchronous operation
-        profiler_hub_result_t FutureReset(
-            profiler_hub_future_handle_t future
-        );
-
         // Detects if trace file format is supported by profiler hub
         // trace_file_path - path to the trace file
-        profiler_hub_result_t DetectTrace(
-            profiler_hub_future_handle_t future, 
-            profiler_hub_string_t trace_file_path
-        );
-
+	profiler_hub_db_type_t DetectTrace(
+		profiler_hub_string_t trace_file_path
+	);
         // Opens trace, read and compile metadata. 
         // This method should build tracks, collect node/instance information, cache information tables, calculate levels, build histograms, etc.
         // client_trace - client trace reference
         // trace_file_path - path to the trace file
+
+    profiler_hub_trace_handle_t OpenTrace(
+            profiler_hub_string_t trace_file_path 
+        );
+
+        // Set trace properties, just a setter for trace parameters, historically separated from constructor 
         // config_dir_path - path to the location temporary files should be stored
         // histogram_bucket_count - caller should decide density of the histogram 
-        // trace - output trace handle
-        profiler_hub_result_t OpenTrace(
-            profiler_hub_future_handle_t future, 
+        profiler_hub_result_t SetTraceProperties(
+            profiler_hub_trace_handle_t trace,
             client_trace_handle_t client_trace,
-            profiler_hub_string_t trace_file_path, 
-            profiler_hub_string_t config_dir_path, 
-            size_t histogram_bucket_count,
-            profiler_hub_trace_handle_t* trace // OUT
+            profiler_hub_string_t config_dir_path,
+            size_t histogram_bucket_count
+        );
+
+        // Read trace
+        profiler_hub_result_t ReadTraceMetadata(
+            profiler_hub_future_handle_t future_handle,
+            profiler_hub_trace_handle_t trace
         );
 
         // Close trace, destroy trace-related objects 
@@ -79,7 +81,7 @@ namespace profiler_hub::interface
             profiler_hub_property_category_t category,
             uint64_t row_key,
             profiler_hub_string_t property_tag,
-            profiler_hub_optional_string_t value // OUT
+            profiler_hub_optional_t value // OUT
         );
 
         // time slice request
@@ -122,6 +124,7 @@ namespace profiler_hub::interface
         profiler_hub_result_t GetSearchTimeSlice(
             profiler_hub_future_handle_t future,
             profiler_hub_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
             profiler_hub_table_handle_t table_handle,
             size_t num_operations,
             profiler_hub_event_operation_t * operations,
@@ -169,6 +172,16 @@ namespace profiler_hub::interface
             profiler_hub_event_operation_t operation,
             profiler_hub_event_id_t event_id
         );
+
+        // trim trace database to time range specified in parameters
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
+        // timestamp_start - trim start
+        // timestamp_end - trim end
+        profiler_hub_result_t TrimTraceDatabase(
+            profiler_hub_future_handle_t future_handle,
+            profiler_hub_trace_handle_t trace,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end);
 
     }
 

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include "profiler_hub_interface_types.h"
+
+namespace profiler_hub::interface
+{
+
+    extern "C"
+    {
+        // Allocate future object for asynchronous operations. 
+        // Returns future object handle
+        profiler_hub_future_handle_t FutureAlloc();
+
+        // Delete future object after asynchronous operation is completed
+        profiler_hub_result_t FutureFree(
+            profiler_hub_future_handle_t future
+        );
+
+        // Wait for asynchronous operation to complete. 
+        // Returns completion status
+        // timeout in milliseconds
+        profiler_hub_result_t FutureWait(
+            profiler_hub_future_handle_t future,
+            uint64_t timeout_ms
+        );
+
+        // Cancel asynchronous operation
+        profiler_hub_result_t FutureCancel(
+            profiler_hub_future_handle_t future
+        );
+
+        // Reset future for next asynchronous operation
+        profiler_hub_result_t FutureReset(
+            profiler_hub_future_handle_t future
+        );
+
+        // Detects if trace file format is supported by profiler hub
+        // trace_file_path - path to the trace file
+        profiler_hub_result_t DetectTrace(
+            profiler_hub_future_handle_t future, 
+            profiler_hub_string_t trace_file_path
+        );
+
+        // Opens trace, read and compile metadata. 
+        // This method should build tracks, collect node/instance information, cache information tables, calculate levels, build histograms, etc.
+        // client_trace - client trace reference
+        // trace_file_path - path to the trace file
+        // config_dir_path - path to the location temporary files should be stored
+        // histogram_bucket_count - caller should decide density of the histogram 
+        // trace - output trace handle
+        profiler_hub_result_t OpenTrace(
+            profiler_hub_future_handle_t future, 
+            client_trace_handle_t client_trace,
+            profiler_hub_string_t trace_file_path, 
+            profiler_hub_string_t config_dir_path, 
+            size_t histogram_bucket_count,
+            profiler_hub_trace_handle_t* trace // OUT
+        );
+
+        // Close trace, destroy trace-related objects 
+        profiler_hub_result_t CloseTrace(
+            profiler_hub_trace_handle_t trace
+        );
+
+        // Gets information tables property specified by caller
+        // Information tables list can be bigger that tables provided by schema
+        // Missing tables must be synthesized
+        // Use data-model code for reference
+        // trace - trace handle
+        // instance - multi-node instance, determined by GUID
+        // category - determines which cached table to use
+        // row_key - cached table row primary key
+        // property_tag - column name, usually provided by schema, sometimes synthesized
+        // value - return as string
+        // returns value type, kProfilerHubDataTypeUndefined if undefined
+        profiler_hub_value_type_t GetProperty(
+            profiler_hub_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
+            profiler_hub_property_category_t category,
+            uint64_t row_key,
+            profiler_hub_string_t property_tag,
+            profiler_hub_optional_string_t value // OUT
+        );
+
+        // time slice request
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
+        // track_id - it seems most practical to query time slice for single track, this method does not take instance id, because a single track must belong to single trace instance
+        // timestamp_start - time-slice start
+        // timestamp_end - time-slice end
+        profiler_hub_result_t GetTimeSlice(
+            profiler_hub_future_handle_t future,
+            profiler_hub_trace_handle_t trace,
+            profiler_hub_track_id_t track_id,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end
+        );
+
+        // get events data for the Table view. The rows will be post processed, aligned, grouped, filtered in the data-model
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
+        // table_handle - data-model table processor instance handle.
+        // track_id - table data is requested per track. 
+        // timestamp_start - time-slice start
+        // timestamp_end - time-slice end
+        profiler_hub_result_t GetTableTimeSlice(
+            profiler_hub_future_handle_t future,
+            profiler_hub_trace_handle_t trace,
+            profiler_hub_table_handle_t table_handle,
+            profiler_hub_track_id_t track_id,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end
+        );
+
+        // search for events by provided string filters
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces.
+        // table_handle - data-model table processor instance handle.
+        // num_operations - length of operations list. The search is done per operation (e.g. region/kernel/memalloc/memcopy) or list of operations
+        // operations - list of operations
+        // timestamp_start - time-slice start
+        // timestamp_end - time-slice end
+        // num_search_strings - number of strings in the string filter
+        // string_filters - array of string to filter events
+        profiler_hub_result_t GetSearchTimeSlice(
+            profiler_hub_future_handle_t future,
+            profiler_hub_trace_handle_t trace,
+            profiler_hub_table_handle_t table_handle,
+            size_t num_operations,
+            profiler_hub_event_operation_t * operations,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end,
+            size_t num_search_strings,
+            profiler_hub_search_strings_t string_filters               
+        );
+
+        // get data flow end-point events
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
+        // instance - multi-node instance, determined by GUID
+        // operation - operation type corresponds to specific event table
+        // event_id - event id. Historically event_id represents primary key relative to a specific event table
+        profiler_hub_result_t GetEventDataFlow(
+            profiler_hub_future_handle_t future,
+            profiler_hub_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
+            profiler_hub_event_operation_t operation,
+            profiler_hub_event_id_t event_id
+        );
+
+        // get extended data properties
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
+        // instance - multi-node instance, determined by GUID
+        // operation - operation type corresponds to specific event table
+        // event_id - event id. Historically event_id represents primary key relative to a specific event table
+        profiler_hub_result_t GetEventExtendedData(
+            profiler_hub_future_handle_t future,
+            profiler_hub_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
+            profiler_hub_event_operation_t operation,
+            profiler_hub_event_id_t event_id
+        );
+
+        // get event call stack trace
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
+        // instance - multi-node instance, determined by GUID
+        // operation - operation type corresponds to specific event table
+        // event_id - event id. Historically event_id represents primary key relative to a specific event table
+        profiler_hub_result_t GetEventStackTrace(
+            profiler_hub_future_handle_t future,
+            profiler_hub_trace_handle_t trace,
+            profiler_hub_instance_id_t instance,
+            profiler_hub_event_operation_t operation,
+            profiler_hub_event_id_t event_id
+        );
+
+    }
+
+}  // namespace ProfilerHub

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface.h
@@ -64,27 +64,8 @@ namespace profiler_hub::interface
             profiler_hub_trace_handle_t trace
         );
 
-        // Gets information tables property specified by caller
-        // Information tables list can be bigger that tables provided by schema
-        // Missing tables must be synthesized
-        // Use data-model code for reference
-        // trace - trace handle
-        // instance - multi-node instance, determined by GUID
-        // category - determines which cached table to use
-        // row_key - cached table row primary key
-        // property_tag - column name, usually provided by schema, sometimes synthesized
-        // value - return as string
-        // returns value type, kProfilerHubDataTypeUndefined if undefined
-        profiler_hub_value_type_t GetProperty(
-            profiler_hub_trace_handle_t trace,
-            profiler_hub_instance_id_t instance,
-            profiler_hub_property_category_t category,
-            uint64_t row_key,
-            profiler_hub_string_t property_tag,
-            profiler_hub_optional_t value // OUT
-        );
 
-        // time slice request
+        // event time slice request
         // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
         // track_id - it seems most practical to query time slice for single track, this method does not take instance id, because a single track must belong to single trace instance
         // timestamp_start - time-slice start
@@ -93,9 +74,29 @@ namespace profiler_hub::interface
             profiler_hub_future_handle_t future,
             profiler_hub_trace_handle_t trace,
             profiler_hub_track_id_t track_id,
+            profiler_hub_timeslice_handle_t slice_container,
             uint64_t timestamp_start,
             uint64_t timestamp_end
         );
+
+        // performance time slice request
+        // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
+        // track_id - it seems most practical to query time slice for single track, this method does not take instance id, because a single track must belong to single trace instance
+        // timestamp_start - time-slice start
+        // timestamp_end - time-slice end
+        // left_neighbor - start from sample to the left of timestamp_start
+        // right_neighbor - take extra sample to the right of timestamp_end
+        profiler_hub_result_t GetPmcTimeSlice(
+            profiler_hub_future_handle_t future,
+            profiler_hub_trace_handle_t trace,
+            profiler_hub_track_id_t track_id,
+            profiler_hub_timeslice_handle_t slice_container,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end,
+            bool left_neghbor,
+            bool right_neighbor
+        );
+
 
         // get events data for the Table view. The rows will be post processed, aligned, grouped, filtered in the data-model
         // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
@@ -126,8 +127,7 @@ namespace profiler_hub::interface
             profiler_hub_trace_handle_t trace,
             profiler_hub_instance_id_t instance,
             profiler_hub_table_handle_t table_handle,
-            size_t num_operations,
-            profiler_hub_event_operation_t * operations,
+            profiler_hub_event_operation_t operation,
             uint64_t timestamp_start,
             uint64_t timestamp_end,
             size_t num_search_strings,
@@ -143,6 +143,7 @@ namespace profiler_hub::interface
             profiler_hub_future_handle_t future,
             profiler_hub_trace_handle_t trace,
             profiler_hub_instance_id_t instance,
+            profiler_hub_flowtrace_handle_t container,
             profiler_hub_event_operation_t operation,
             profiler_hub_event_id_t event_id
         );
@@ -156,6 +157,7 @@ namespace profiler_hub::interface
             profiler_hub_future_handle_t future,
             profiler_hub_trace_handle_t trace,
             profiler_hub_instance_id_t instance,
+            profiler_hub_ext_data_handle_t container,
             profiler_hub_event_operation_t operation,
             profiler_hub_event_id_t event_id
         );
@@ -169,6 +171,7 @@ namespace profiler_hub::interface
             profiler_hub_future_handle_t future,
             profiler_hub_trace_handle_t trace,
             profiler_hub_instance_id_t instance,
+            profiler_hub_call_stack_handle_t container,
             profiler_hub_event_operation_t operation,
             profiler_hub_event_id_t event_id
         );
@@ -177,11 +180,13 @@ namespace profiler_hub::interface
         // trace - handle of a trace, considering single profiler hub instance handles multiple traces. 
         // timestamp_start - trim start
         // timestamp_end - trim end
+        // new_path - file path to save trimmed database
         profiler_hub_result_t TrimTraceDatabase(
             profiler_hub_future_handle_t future_handle,
             profiler_hub_trace_handle_t trace,
             uint64_t timestamp_start,
-            uint64_t timestamp_end);
+            uint64_t timestamp_end,
+            profiler_hub_string_t new_path);
 
     }
 

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface_types.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface_types.h
@@ -95,3 +95,12 @@ typedef enum profiler_hub_flow_direction_t
     kProfilerHubDirectionOutgoing,
     kProfilerHubDirectionIncoming,
 } profiler_hub_flow_direction_t;    
+
+// Database type
+typedef enum profiler_hub_db_type_t {
+    // not supported by profiler hub
+    kDbNotSupported, 
+    // supported by profiler hub
+    kDbSupported,
+
+} profiler_hub_db_type_t;

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface_types.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface_types.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <cstdint>
+#include <variant>
+#include <profiler-hub/reader_types.hpp>
+
+typedef void* profiler_hub_handle_t;
+typedef profiler_hub_handle_t profiler_hub_trace_handle_t;
+typedef profiler_hub_handle_t client_trace_handle_t;
+typedef profiler_hub_handle_t profiler_hub_future_handle_t;
+typedef profiler_hub_handle_t profiler_hub_value_handle_t;
+typedef profiler_hub_handle_t profiler_hub_timeslice_handle_t;
+typedef profiler_hub_handle_t profiler_hub_flowtrace_handle_t;
+typedef profiler_hub_handle_t profiler_hub_ext_data_handle_t;
+typedef profiler_hub_handle_t profiler_hub_table_handle_t;
+typedef profiler_hub_handle_t profiler_hub_table_row_handle_t;
+typedef profiler_hub_handle_t profiler_hub_call_stack_handle_t;
+typedef const char* profiler_hub_string_t;
+typedef const void** profiler_hub_optional_t;
+typedef const char** profiler_hub_optional_string_t;
+typedef const char** profiler_hub_search_strings_t;
+typedef uint64_t* profiler_hub_optional_int_t;
+typedef double* profiler_hub_optional_double_t;
+typedef uint32_t profiler_hub_instance_id_t;
+typedef uint32_t profiler_hub_track_id_t;
+typedef uint64_t profiler_hub_event_id_t;
+typedef uint32_t profiler_hub_string_id_t;
+typedef uint32_t profiler_hub_event_level_t;
+
+// Error status, the list to be updated during development
+typedef enum profiler_hub_result_t {
+    kProfilerHubStatusSuccess,
+    kProfilerHubStatusUnknownError,
+    kProfilerHubStatusNotSupported,
+    kProfilerHubStatusInvalidArgument,
+    kProfilerHubStatusTimeout,
+    kProfilerHubStatusNotLoaded,
+} profiler_hub_result_t;
+
+typedef enum profiler_hub_async_status_t {
+    kProfilerHubAsyncSuccess,
+    kProfilerHubAsyncFailed,
+    kProfilerHubAsyncBusy
+} profiler_hub_async_status_t;
+
+// value types, inherited from SQL types
+typedef enum profiler_hub_value_type_t
+{
+    kPprofilerHubDataTypeUndefined = 0,
+    kPprofilerHubDataTypeInt = 1,
+    kPprofilerHubDataTypeDouble = 2,
+    kPprofilerHubDataTypeString = 3,
+    kPprofilerHubDataTypeBlob = 4,
+    kPprofilerHubDataTypeNull = 5
+} profiler_hub_value_type_t;
+
+// track categories
+typedef enum profiler_hub_track_category_t {
+
+    kPprofilerHubCategoryUndefined = 0,
+    kPprofilerHubCategoryRegionInstrumented,
+    kPprofilerHubCategoryRegionSampled,
+    kPprofilerHubCategoryKernelDispatch,
+    kPprofilerHubCategoryMemoryAllocate,
+    kPprofilerHubCategoryMemoryCopy,
+    kPprofilerHubCategoryPerformanceCounter,
+    kPprofilerHubCategoryStream,
+} profiler_hub_track_category_t;
+
+// event operations
+typedef profiler_hub::reader_types::event_type_t profiler_hub_event_operation_t;
+
+// property category will determine which info table or join read the property from
+// all the info tables are supposed to be cached
+typedef enum profiler_hub_property_category_t{
+    kProfilerHubPropertyNode,
+    kProfilerHubPropertyProcess,
+    kProfilerHubPropertyAgent,
+    kProfilerHubPropertyThread,
+    kProfilerHubPropertyQueue,
+    kProfilerHubPropertyStream,
+    kProfilerHubPropertyCounter,
+
+} profiler_hub_property_category_t;
+
+typedef enum profiler_hub_agent_type_t{
+    kProfilerHubNotAgent,
+    kProfilerHubAgentCPU,
+    kProfilerHubAgentGPU,
+    kProfilerHubAgentNIC,
+} profiler_hub_agent_type_t;
+
+typedef enum profiler_hub_flow_direction_t
+{
+    kProfilerHubDirectionOutgoing,
+    kProfilerHubDirectionIncoming,
+} profiler_hub_flow_direction_t;    

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_interface_types.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_interface_types.h
@@ -26,6 +26,7 @@ typedef uint32_t profiler_hub_track_id_t;
 typedef uint64_t profiler_hub_event_id_t;
 typedef uint32_t profiler_hub_string_id_t;
 typedef uint32_t profiler_hub_event_level_t;
+typedef uint64_t profiler_hub_row_id_t;
 
 // Error status, the list to be updated during development
 typedef enum profiler_hub_result_t {
@@ -104,3 +105,8 @@ typedef enum profiler_hub_db_type_t {
     kDbSupported,
 
 } profiler_hub_db_type_t;
+
+typedef enum profiler_hub_string_source_t {
+    kProfilerHubStringNameOrCategory,
+    kProfilerHubStringKernelSymbol,
+} profiler_hub_string_source_t;

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_missing.hpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_missing.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "profiler_hub_interface_types.h"
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
+#include <variant>
 
 
 namespace profiler_hub::missing_types
@@ -106,16 +108,20 @@ public:
         return {};
     }
 
-    static profiler_hub_result_t detect_trace(std::string& file_name)
+    static profiler_hub_db_type_t detect_trace(std::string& file_name)
     {
         throw_missing("trace detection");
-        return kProfilerHubStatusNotSupported;
+        return profiler_hub_db_type_t::kDbNotSupported;
     }
 
-    static std::vector<track_histogram_bucket_t> get_track_histogram(profiler_hub::reader_types::track_info_ptr_t & track)
+    static std::vector<track_histogram_bucket_t> get_track_histogram(profiler_hub::reader_types::track_info_ptr_t & track, size_t histogram_bucket_count)
     {
         throw_missing("track histogram");
         return {};
+    }
+
+    static profiler_hub_result_t trim_trace_database(uint64_t timestamp_start, uint64_t timestamp_end) {
+        throw_missing("trimming trace database");
     }
 
     static missing_types::table_ptr_t get_event_table(
@@ -152,6 +158,14 @@ public:
         return "";
     }
 
+    [[noreturn]] static void check_missing_client(void * client)
+    {
+        if (client == nullptr)
+        {
+            throw missing_error_t("fatal error: client trace cannot be null!");
+        }
+    }
+
 protected:
     // Throws missing_error_t with a standardised message.
     // @param feature – short description of the missing feature or method.
@@ -159,6 +173,7 @@ protected:
     {
         throw missing_error_t("not implemented: " + std::string(feature));
     }
+
 
 };
 

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_missing.hpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_missing.hpp
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+
+namespace profiler_hub::missing_types
+{
+    /// A column descriptor: carries the name and the uniform type for all non-null cells in
+    /// this column. Positional index within table_t::columns is the column's identity.
+    struct table_column_t
+    {
+        std::string               name{};  ///< Column identifier.
+        profiler_hub_value_type_t type{};  ///< Declared type; all non-null cells must conform.
+    };
+
+    using table_column_list_t = std::vector<table_column_t>;
+
+    /// A single cell value. nullptr_t = null (absent); otherwise the held alternative must
+    /// conform to the type declared by the corresponding table_column_t. monostate is not
+    /// used here — a cell is either a typed value or null, never present-but-empty.
+    using table_cell_value_t = std::variant<std::nullptr_t, size_t, double, std::string>;
+
+    struct table_cell_t
+    {
+        table_cell_value_t value{ nullptr };  ///< Null by default; set to a typed value when populated.
+    };
+
+    using table_cell_list_t = std::vector<table_cell_t>;
+
+    /// A single row in a table_t. cells[i] corresponds to columns[i] in the parent table.
+    /// A null cell (nullptr_t) is valid for any column type.
+    struct table_row_t
+    {
+        size_t            row_index{};  ///< Zero-based position of this row in the table.
+        table_cell_list_t cells{};      ///< One entry per column, positionally aligned.
+    };
+
+    using table_row_ptr_t  = std::shared_ptr<table_row_t>;
+    using table_row_list_t = std::vector<table_row_t>;
+
+    /// A rectangular, typed table. Column identity (name + type) lives in columns;
+    /// cell values in each row are positionally aligned to columns and must conform
+    /// to the declared column type unless null.
+    struct table_t
+    {
+        std::string         name{};     ///< Optional display name for the table.
+        table_column_list_t columns{};  ///< Ordered column descriptors (name + type).
+        table_row_list_t    rows{};     ///< Ordered row set, each row aligned to columns.
+        std::string         extdata{};
+    };
+
+    using table_ptr_t  = std::shared_ptr<table_t>;
+    using table_list_t = std::vector<table_ptr_t>;
+
+    struct event_filter_t
+    {
+        reader_types::time_window_t         time_window;           ///< Time range filter
+        reader_types::pagination_t          pagination;            ///< Limit/offset for chunking
+        std::optional<reader_types::sort_t> sort{ std::nullopt };  ///< Sort order
+
+        /// Which event types to include (empty = all)
+        std::vector<reader_types::event_type_t> types;
+        std::vector<std::string> search_strings;
+    };
+}
+
+namespace profiler_hub
+{
+
+    class trace_instance_t;
+    class track_histogram_bucket_t;
+
+// Exception type raised by missing_t methods.
+// Carries a human-readable description of the unimplemented feature.
+class missing_error_t : public std::runtime_error
+{
+public:
+    explicit missing_error_t(std::string_view description)
+    : std::runtime_error(std::string(description))
+    {}
+};
+
+// Placeholder class whose methods throw missing_error_t.
+// Add one method per unimplemented feature; call throw_missing() with a
+// clear description of what is absent so callers get an actionable message.
+class missing_t
+{
+public:
+
+    static std::vector<trace_instance_t> get_trace_instances() 
+    { 
+        throw_missing("multi-trace instances");
+        return {};
+    }
+
+    static std::unordered_map<size_t, std::string> get_trace_string_table()
+    {
+        // string table may have trings from different sqlite tables, e.g. rocpd_string and rocpd_info_kernel_symbol
+        // so, there are two options for profiler hub:
+        // 1) put all the strings into single string table, then, when string id is among requested fields, do proper remapping
+        // 2) have multiple methods get_trace_string_table(), get_trace_kernel_symbols_table() to provide original mapping and rely on caller to do remapping
+        throw_missing("string table");
+        return {};
+    }
+
+    static profiler_hub_result_t detect_trace(std::string& file_name)
+    {
+        throw_missing("trace detection");
+        return kProfilerHubStatusNotSupported;
+    }
+
+    static std::vector<track_histogram_bucket_t> get_track_histogram(profiler_hub::reader_types::track_info_ptr_t & track)
+    {
+        throw_missing("track histogram");
+        return {};
+    }
+
+    static missing_types::table_ptr_t get_event_table(
+        missing_types::event_filter_t& filter,
+        size_t start,
+        size_t stop
+    ) {
+        throw_missing("event table");
+        return {};
+    }
+
+    static missing_types::table_ptr_t get_event_table_for_track(
+        profiler_hub::reader_types::track_info_ptr_t& track,
+        missing_types::event_filter_t& filter,
+        size_t start,
+        size_t stop
+    ) {
+        throw_missing("event table for track");
+        return {};
+    }
+
+    static void function(std::string_view feature)
+    {
+        throw_missing(feature);
+    }
+    static uint64_t integer(std::string_view feature)
+    {
+        throw_missing(feature);
+        return 0;
+    }
+    static const char * string(std::string_view feature)
+    {
+        throw_missing(feature);
+        return "";
+    }
+
+protected:
+    // Throws missing_error_t with a standardised message.
+    // @param feature – short description of the missing feature or method.
+    [[noreturn]] static void throw_missing(std::string_view feature)
+    {
+        throw missing_error_t("not implemented: " + std::string(feature));
+    }
+
+};
+
+class trace_instance_t
+{
+public:
+    trace_instance_t(std::string& file, std::string& guid, uint32_t index) :
+        m_file(file),
+        m_guid(guid),
+        m_index(index) {
+    }
+    const char* get_file() { return m_file.c_str(); }
+    const char* get_guid() { return m_guid.c_str(); }
+    uint32_t get_index() { return m_index; }
+private:
+    std::string m_file;
+    std::string m_guid;
+    uint32_t m_index;
+
+};
+
+class track_histogram_bucket_t 
+{
+public:
+    track_histogram_bucket_t(uint32_t bucket_number, uint32_t events_count, double bucket_value) :
+        m_bucket_number(bucket_number), m_events_count(events_count), m_bucket_value(bucket_value) {
+    };
+    uint32_t get_bucket_number() { return m_bucket_number; }
+    uint32_t get_events_count() { return m_events_count; }
+    double get_bucket_value() { return m_bucket_value; }
+private:
+    uint32_t m_bucket_number;
+    uint32_t m_events_count;
+    double m_bucket_value;
+};
+
+}  // namespace profiler_hub

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_missing.hpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_missing.hpp
@@ -64,8 +64,9 @@ namespace profiler_hub::missing_types
         std::optional<reader_types::sort_t> sort{ std::nullopt };  ///< Sort order
 
         /// Which event types to include (empty = all)
-        std::vector<reader_types::event_type_t> types;
+        reader_types::event_type_t type;
         std::vector<std::string> search_strings;
+        profiler_hub_instance_id_t instance;
     };
 }
 
@@ -100,10 +101,9 @@ public:
 
     static std::unordered_map<size_t, std::string> get_trace_string_table()
     {
-        // string table may have trings from different sqlite tables, e.g. rocpd_string and rocpd_info_kernel_symbol
-        // so, there are two options for profiler hub:
-        // 1) put all the strings into single string table, then, when string id is among requested fields, do proper remapping
-        // 2) have multiple methods get_trace_string_table(), get_trace_kernel_symbols_table() to provide original mapping and rely on caller to do remapping
+        // string table may have strings from different sqlite tables, e.g. rocpd_string and rocpd_info_kernel_symbol, maybe more
+        // put all the strings into single string table, then do proper remapping when send string id to a client
+
         throw_missing("string table");
         return {};
     }
@@ -120,8 +120,19 @@ public:
         return {};
     }
 
-    static profiler_hub_result_t trim_trace_database(uint64_t timestamp_start, uint64_t timestamp_end) {
+    static profiler_hub_result_t trim_trace_database(uint64_t timestamp_start, uint64_t timestamp_end, profiler_hub_string_t new_path) {
         throw_missing("trimming trace database");
+        return kProfilerHubStatusNotSupported;
+    }
+
+    static reader_types::counter_timeline_event_list_t missing_t::get_counter_events_for_track(
+        reader_types::track_info_ptr_t      track,
+        const reader_types::event_filter_t& filter,
+        bool left_neighbor,
+        bool right_neighbor)
+    {
+        throw_missing("performance counter events");
+        return {};
     }
 
     static missing_types::table_ptr_t get_event_table(

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.cpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.cpp
@@ -232,17 +232,19 @@ namespace profiler_hub::interface
         return kPprofilerHubDataTypeUndefined;
     }
 
-	profiler_hub_result_t profiler_hub_trace_t::detect_trace(std::string trace_path) {
+    profiler_hub_db_type_t profiler_hub_trace_t::detect_trace(std::string trace_path) {
 		return missing_t::detect_trace(trace_path);
 	}
 
-	profiler_hub_result_t profiler_hub_trace_t::open_trace(future_t * future, uint32_t histogram_bucket_count) {
-
-        profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
+	profiler_hub_result_t profiler_hub_trace_t::open_trace(future_t * future) {
+        missing_t::check_missing_client(m_client_trace);
+        profiler_hub_result_t result = kProfilerHubStatusInvalidArgument;
 		// initialize and compile trace metadata
+        future->show_progress(m_trace_path.c_str(), 80, "Read trace", kProfilerHubAsyncBusy);
         m_storage = std::make_unique<profiler_hub::storage_t>(m_trace_path, "");
         m_reader = std::make_shared<profiler_hub::reader_t>(std::move(m_storage));
 
+        future->show_progress(m_trace_path.c_str(), 1, "Add instances", kProfilerHubAsyncBusy);
 		auto& trace_instances = missing_t::get_trace_instances();
 		for (auto& instance : trace_instances)
 		{
@@ -253,6 +255,7 @@ namespace profiler_hub::interface
             }
 		}
 
+        future->show_progress(m_trace_path.c_str(), 1, "Add strings", kProfilerHubAsyncBusy);
 		auto & string_table = missing_t::get_trace_string_table();
 		for (auto& [id, string] : string_table)
 		{
@@ -262,6 +265,8 @@ namespace profiler_hub::interface
                 return result;
             }
 		}
+
+        future->show_progress(m_trace_path.c_str(), 3, "Add tracks", kProfilerHubAsyncBusy);
 
 		auto & tracks = m_reader->get_tracks();
 		for (auto& track : tracks)
@@ -299,9 +304,10 @@ namespace profiler_hub::interface
             }
 		}
 
+        future->show_progress(m_trace_path.c_str(), 3, "Add track histograms", kProfilerHubAsyncBusy);
 		for (auto& track : tracks)
 		{
-			auto & track_histogram = missing_t::get_track_histogram(track);
+			auto & track_histogram = missing_t::get_track_histogram(track, m_histogram_bucket_count);
 			for (auto& bucket : track_histogram)
 			{
 				result = client::interface::AddTrackHistogramBucket(m_client_trace, track->id.value, bucket.get_bucket_number(), bucket.get_events_count(), bucket.get_bucket_value());
@@ -321,6 +327,10 @@ namespace profiler_hub::interface
             uint64_t timestamp_start,
             uint64_t timestamp_end)
     {
+        if (!m_client_trace)
+        {
+            throw missing_error_t("fatal error: client trace cannot be null!");
+        }
         profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
         reader_types::event_filter_t filter = { {timestamp_start, timestamp_end} };
         auto& tracks = m_reader->get_tracks();
@@ -441,6 +451,7 @@ namespace profiler_hub::interface
         profiler_hub_instance_id_t instance,
         profiler_hub_event_operation_t operation,
         profiler_hub_event_id_t event_id) {
+        missing_t::check_missing_client(m_client_trace);
         profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
         auto & flow_endpoints = m_reader->get_flows_for_event(reader_types::detail::event_id_access::make(operation, event_id));
         profiler_hub_flowtrace_handle_t flow_container = client::interface::AddEventFlowTraceContainer(m_client_trace, instance, operation, event_id);
@@ -493,6 +504,7 @@ namespace profiler_hub::interface
         profiler_hub_instance_id_t instance,
         profiler_hub_event_operation_t operation,
         profiler_hub_event_id_t event_id) {
+        missing_t::check_missing_client(m_client_trace);
         profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
         auto & event_info = m_reader->get_event_info(reader_types::detail::event_id_access::make(operation, event_id));
         if (event_info.has_value())
@@ -549,6 +561,7 @@ namespace profiler_hub::interface
         profiler_hub_instance_id_t instance,
         profiler_hub_event_operation_t operation,
         profiler_hub_event_id_t event_id) {
+        missing_t::check_missing_client(m_client_trace);
         profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
         profiler_hub_call_stack_handle_t call_stack_container = client::interface::AddEventCallStackContainer(m_client_trace, instance, operation, event_id);
         auto & call_stack = m_reader->get_call_stack(reader_types::detail::event_id_access::make(operation, event_id));
@@ -571,5 +584,13 @@ namespace profiler_hub::interface
         return result;
     }
 
+
+    profiler_hub_result_t trim_trace_database(
+        future_t* future,
+        uint64_t timestamp_start,
+        uint64_t timestamp_end)
+    {
+        return missing_t::trim_trace_database(timestamp_start, timestamp_end);
+    }
     
 }

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.cpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.cpp
@@ -1,0 +1,575 @@
+#include "profiler_hub_interface.h"
+#include "profiler_hub_client_interface.h"
+#include "profiler_hub_trace.h"
+#include "profiler_hub_missing.hpp"
+#include "profiler_hub_future.hpp"
+
+
+namespace profiler_hub::interface
+{
+	profiler_hub_track_category_t profiler_hub_trace_t::get_track_category(profiler_hub::reader_types::track_type_t type, profiler_hub::reader_types::region_track_kind_t region_kind)
+	{
+		switch (type)
+		{
+		case profiler_hub::reader_types::track_type_t::cpu_thread: 
+			if (region_kind == profiler_hub::reader_types::region_track_kind_t::main)
+				return kPprofilerHubCategoryRegionInstrumented;
+			else if (region_kind == profiler_hub::reader_types::region_track_kind_t::sample)
+				return kPprofilerHubCategoryRegionSampled;
+			else return kPprofilerHubCategoryUndefined;
+		case profiler_hub::reader_types::track_type_t::gpu_queue: return kPprofilerHubCategoryKernelDispatch;
+		case profiler_hub::reader_types::track_type_t::memory : return kPprofilerHubCategoryMemoryCopy;
+		case profiler_hub::reader_types::track_type_t::memory_activity : return kPprofilerHubCategoryMemoryAllocate;
+		case profiler_hub::reader_types::track_type_t::kernel_dispatch_pmc : return kPprofilerHubCategoryPerformanceCounter;
+		case profiler_hub::reader_types::track_type_t::stream : return kPprofilerHubCategoryStream;
+		default: return kPprofilerHubCategoryUndefined;
+		}
+	}
+
+	profiler_hub_agent_type_t profiler_hub_trace_t::get_agent_type(std::string& type)
+	{
+		if (type == "CPU")
+			return kProfilerHubAgentCPU;
+		else if (type == "GPU")
+			return kProfilerHubAgentGPU;
+		else if (type == "NIC")
+			return kProfilerHubAgentNIC;
+		else
+			return kProfilerHubNotAgent;
+	}
+
+    profiler_hub_value_type_t profiler_hub_trace_t::get_node_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
+        auto& nodes = get_reader()->get_all_nodes();
+        auto it = std::find_if(nodes.begin(), nodes.end(), [row_key](profiler_hub::reader_types::node_info_ptr_t node_info) { return node_info->node_id == row_key; });
+        if (it != nodes.end())
+        {
+            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
+                properties_dispatcher =
+            {
+                { "id",            [it, value] { *value = &it->get()->node_id;              return kPprofilerHubDataTypeInt; }},
+                { "hash",          [it, value] { *value = &it->get()->hash;                 return kPprofilerHubDataTypeInt; }},
+                { "machine_id",    [it, value] { *value = it->get()->machine_id.c_str();    return kPprofilerHubDataTypeString; }},
+                { "system_name",   [it, value] { *value = it->get()->system_name.c_str();   return kPprofilerHubDataTypeString; }},
+                { "hostname",      [it, value] { *value = it->get()->hostname.c_str();      return kPprofilerHubDataTypeString; }},
+                { "release",       [it, value] { *value = it->get()->release.c_str();       return kPprofilerHubDataTypeString; }},
+                { "version",       [it, value] { *value = it->get()->version.c_str();       return kPprofilerHubDataTypeString; }},
+                { "hardware_name", [it, value] { *value = it->get()->hardware_name.c_str(); return kPprofilerHubDataTypeString; }},
+                { "domain_name",   [it, value] { *value = it->get()->domain_name.c_str();   return kPprofilerHubDataTypeString; }},
+            };
+            auto it = properties_dispatcher.find(property_tag);
+            if (it != properties_dispatcher.end())
+            {
+                return it->second();
+            }
+        }
+        return kPprofilerHubDataTypeUndefined;
+    }
+
+    profiler_hub_value_type_t profiler_hub_trace_t::get_process_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
+        auto& processes = get_reader()->get_all_processes();
+        auto it = std::find_if(processes.begin(), processes.end(), [row_key](profiler_hub::reader_types::process_info_ptr_t process_info) { return process_info->pid == row_key; });
+        if (it != processes.end())
+        {
+            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
+                properties_dispatcher =
+            {
+                { "id",          [it, value] { *value = &it->get()->pid;                        return kPprofilerHubDataTypeInt; }},
+                { "nid",         [it, value] { *value = &it->get()->node_info->node_id;         return kPprofilerHubDataTypeInt; }},
+                { "init",        [it, value] { if (!it->get()->init.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->init;  return kPprofilerHubDataTypeInt; }},
+                { "fini",        [it, value] { if (!it->get()->fini.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->fini;  return kPprofilerHubDataTypeInt; }},
+                { "start",       [it, value] { if (!it->get()->start.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->start; return kPprofilerHubDataTypeInt; }},
+                { "end",         [it, value] { if (!it->get()->end.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->end;   return kPprofilerHubDataTypeInt; }},
+                { "command",     [it, value] { *value = it->get()->command.c_str();              return kPprofilerHubDataTypeString; }},
+                { "environment", [it, value] { *value = it->get()->environment.c_str();          return kPprofilerHubDataTypeString; }},
+                { "extdata",     [it, value] { *value = it->get()->extdata.c_str();              return kPprofilerHubDataTypeString; }},
+            };
+            auto it = properties_dispatcher.find(property_tag);
+            if (it != properties_dispatcher.end())
+            {
+                return it->second();
+            }
+        }
+        return kPprofilerHubDataTypeUndefined;
+    }
+
+    profiler_hub_value_type_t profiler_hub_trace_t::get_agent_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
+        auto& agents = get_reader()->get_all_agents();
+        auto it = std::find_if(agents.begin(), agents.end(), [row_key](profiler_hub::reader_types::agent_info_ptr_t agent_info) { return agent_info->id == row_key; });
+        if (it != agents.end())
+        {
+            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
+                properties_dispatcher =
+            {
+                { "id",             [it, value] { *value = &it->get()->id;                          return kPprofilerHubDataTypeInt; }},
+                { "nid",            [it, value] { *value = &it->get()->node_info->node_id;          return kPprofilerHubDataTypeInt; }},
+                { "type_index",     [it, value] { *value = &it->get()->type_index;                  return kPprofilerHubDataTypeInt; }},
+                { "absolute_index", [it, value] { if (!it->get()->absolute_index.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->absolute_index; return kPprofilerHubDataTypeInt; }},
+                { "logical_index",  [it, value] { if (!it->get()->logical_index.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->logical_index;  return kPprofilerHubDataTypeInt; }},
+                { "uuid",           [it, value] { if (!it->get()->uuid.has_value())           return kPprofilerHubDataTypeUndefined; *value = &it->get()->uuid;           return kPprofilerHubDataTypeInt; }},
+                { "type",           [it, value] { *value = it->get()->agent_type.c_str();           return kPprofilerHubDataTypeString; }},
+                { "name",           [it, value] { *value = it->get()->name.c_str();                 return kPprofilerHubDataTypeString; }},
+                { "model_name",     [it, value] { *value = it->get()->model_name.c_str();           return kPprofilerHubDataTypeString; }},
+                { "vendor_name",    [it, value] { *value = it->get()->vendor_name.c_str();          return kPprofilerHubDataTypeString; }},
+                { "product_name",   [it, value] { *value = it->get()->product_name.c_str();         return kPprofilerHubDataTypeString; }},
+                { "user_name",      [it, value] { *value = it->get()->user_name.c_str();            return kPprofilerHubDataTypeString; }},
+                { "extdata",        [it, value] { *value = it->get()->extdata.c_str();              return kPprofilerHubDataTypeString; }},
+            };
+            auto it = properties_dispatcher.find(property_tag);
+            if (it != properties_dispatcher.end())
+            {
+                return it->second();
+            }
+        }
+        return kPprofilerHubDataTypeUndefined;
+    }
+
+    profiler_hub_value_type_t profiler_hub_trace_t::get_pmc_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
+        auto& pmcs = get_reader()->get_all_pmc_info();
+        auto it = std::find_if(pmcs.begin(), pmcs.end(), [row_key](profiler_hub::reader_types::pmc_info_ptr_t pmc_info) { return pmc_info->pmc_id == row_key; });
+        if (it != pmcs.end())
+        {
+            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
+                properties_dispatcher =
+            {
+                { "id",               [it, value] { *value = &it->get()->pmc_id;                        return kPprofilerHubDataTypeInt; }},
+                { "nid",              [it, value] { *value = &it->get()->node_info->node_id;            return kPprofilerHubDataTypeInt; }},
+                { "pid",              [it, value] { *value = &it->get()->process_info->pid;             return kPprofilerHubDataTypeInt; }},
+                { "agent_id",         [it, value] { *value = &it->get()->agent_info->id;                return kPprofilerHubDataTypeInt; }},
+                { "event_code",       [it, value] { if (!it->get()->event_code.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->event_code;   return kPprofilerHubDataTypeInt; }},
+                { "instance_id",      [it, value] { if (!it->get()->instance_id.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->instance_id;  return kPprofilerHubDataTypeInt; }},
+                { "is_constant",      [it, value] { if (!it->get()->is_constant.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->is_constant;  return kPprofilerHubDataTypeInt; }},
+                { "is_derived",       [it, value] { if (!it->get()->is_derived.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->is_derived;   return kPprofilerHubDataTypeInt; }},
+                { "name",             [it, value] { *value = it->get()->name.c_str();                   return kPprofilerHubDataTypeString; }},
+                { "target_arch",      [it, value] { *value = it->get()->target_arch.c_str();            return kPprofilerHubDataTypeString; }},
+                { "symbol",           [it, value] { *value = it->get()->symbol.c_str();                 return kPprofilerHubDataTypeString; }},
+                { "description",      [it, value] { *value = it->get()->description.c_str();            return kPprofilerHubDataTypeString; }},
+                { "long_description", [it, value] { *value = it->get()->long_description.c_str();       return kPprofilerHubDataTypeString; }},
+                { "component",        [it, value] { *value = it->get()->component.c_str();              return kPprofilerHubDataTypeString; }},
+                { "units",            [it, value] { *value = it->get()->units.c_str();                  return kPprofilerHubDataTypeString; }},
+                { "value_type",       [it, value] { *value = it->get()->value_type.c_str();             return kPprofilerHubDataTypeString; }},
+                { "block",            [it, value] { *value = it->get()->block.c_str();                  return kPprofilerHubDataTypeString; }},
+                { "expression",       [it, value] { *value = it->get()->expression.c_str();             return kPprofilerHubDataTypeString; }},
+                { "extdata",          [it, value] { *value = it->get()->extdata.c_str();                return kPprofilerHubDataTypeString; }},
+            };
+            auto it = properties_dispatcher.find(property_tag);
+            if (it != properties_dispatcher.end())
+            {
+                return it->second();
+            }
+        }
+        return kPprofilerHubDataTypeUndefined;
+    }
+
+    profiler_hub_value_type_t profiler_hub_trace_t::get_thread_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
+        auto& threads = get_reader()->get_all_threads();
+        auto it = std::find_if(threads.begin(), threads.end(), [row_key](profiler_hub::reader_types::thread_info_ptr_t thread_info) { return thread_info->thread_id == row_key; });
+        if (it != threads.end())
+        {
+            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
+                properties_dispatcher =
+            {
+                { "id",    [it, value] { *value = &it->get()->thread_id;                    return kPprofilerHubDataTypeInt; }},
+                { "nid",   [it, value] { *value = &it->get()->node_info->node_id;           return kPprofilerHubDataTypeInt; }},
+                { "pid",   [it, value] { *value = &it->get()->process_info->pid;            return kPprofilerHubDataTypeInt; }},
+                { "ppid",  [it, value] { if (!it->get()->parent_process_id.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->parent_process_id; return kPprofilerHubDataTypeInt; }},
+                { "start", [it, value] { if (!it->get()->start.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->start; return kPprofilerHubDataTypeInt; }},
+                { "end",   [it, value] { if (!it->get()->end.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->end;   return kPprofilerHubDataTypeInt; }},
+                { "name",    [it, value] { *value = it->get()->name.c_str();                return kPprofilerHubDataTypeString; }},
+                { "extdata", [it, value] { *value = it->get()->extdata.c_str();             return kPprofilerHubDataTypeString; }},
+            };
+            auto it = properties_dispatcher.find(property_tag);
+            if (it != properties_dispatcher.end())
+            {
+                return it->second();
+            }
+        }
+        return kPprofilerHubDataTypeUndefined;
+    }
+
+    profiler_hub_value_type_t profiler_hub_trace_t::get_stream_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
+        auto& streams = get_reader()->get_all_streams();
+        auto it = std::find_if(streams.begin(), streams.end(), [row_key](profiler_hub::reader_types::stream_info_ptr_t stream_info) { return stream_info->stream_id == row_key; });
+        if (it != streams.end())
+        {
+            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
+                properties_dispatcher =
+            {
+                { "id",      [it, value] { *value = &it->get()->stream_id;              return kPprofilerHubDataTypeInt; }},
+                { "nid",     [it, value] { *value = &it->get()->node_info->node_id;     return kPprofilerHubDataTypeInt; }},
+                { "pid",     [it, value] { *value = &it->get()->process_info->pid;      return kPprofilerHubDataTypeInt; }},
+                { "name",    [it, value] { *value = it->get()->name.c_str();            return kPprofilerHubDataTypeString; }},
+                { "extdata", [it, value] { *value = it->get()->extdata.c_str();         return kPprofilerHubDataTypeString; }},
+            };
+            auto it = properties_dispatcher.find(property_tag);
+            if (it != properties_dispatcher.end())
+            {
+                return it->second();
+            }
+        }
+        return kPprofilerHubDataTypeUndefined;
+    }
+
+    profiler_hub_value_type_t profiler_hub_trace_t::get_queue_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
+        auto& queues = get_reader()->get_all_queues();
+        auto it = std::find_if(queues.begin(), queues.end(), [row_key](profiler_hub::reader_types::queue_info_ptr_t queue_info) { return queue_info->queue_id == row_key; });
+        if (it != queues.end())
+        {
+            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
+                properties_dispatcher =
+            {
+                { "id",      [it, value] { *value = &it->get()->queue_id;               return kPprofilerHubDataTypeInt; }},
+                { "nid",     [it, value] { *value = &it->get()->node_info->node_id;     return kPprofilerHubDataTypeInt; }},
+                { "pid",     [it, value] { *value = &it->get()->process_info->pid;      return kPprofilerHubDataTypeInt; }},
+                { "name",    [it, value] { *value = it->get()->name.c_str();            return kPprofilerHubDataTypeString; }},
+                { "extdata", [it, value] { *value = it->get()->extdata.c_str();         return kPprofilerHubDataTypeString; }},
+            };
+            auto it = properties_dispatcher.find(property_tag);
+            if (it != properties_dispatcher.end())
+            {
+                return it->second();
+            }
+        }
+        return kPprofilerHubDataTypeUndefined;
+    }
+
+	profiler_hub_result_t profiler_hub_trace_t::detect_trace(std::string trace_path) {
+		return missing_t::detect_trace(trace_path);
+	}
+
+	profiler_hub_result_t profiler_hub_trace_t::open_trace(future_t * future, uint32_t histogram_bucket_count) {
+
+        profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
+		// initialize and compile trace metadata
+        m_storage = std::make_unique<profiler_hub::storage_t>(m_trace_path, "");
+        m_reader = std::make_shared<profiler_hub::reader_t>(std::move(m_storage));
+
+		auto& trace_instances = missing_t::get_trace_instances();
+		for (auto& instance : trace_instances)
+		{
+            result = client::interface::AddInstance(m_client_trace, instance.get_index(), instance.get_file(), instance.get_guid());
+            if (result != kProfilerHubStatusSuccess)
+            {
+                return result;
+            }
+		}
+
+		auto & string_table = missing_t::get_trace_string_table();
+		for (auto& [id, string] : string_table)
+		{
+			result = client::interface::AddString(m_client_trace, string.c_str(), id);
+            if (result != kProfilerHubStatusSuccess)
+            {
+                return result;
+            }
+		}
+
+		auto & tracks = m_reader->get_tracks();
+		for (auto& track : tracks)
+		{
+			result = client::interface::AddTrack(
+				m_client_trace,
+				missing_t::integer("track->instance_info->id"),
+				track->id.value,
+				track->name.c_str(),
+				get_track_category(track->type, track->region_kind),
+				&track->node_info->node_id,
+				track->node_info->hostname.c_str(),
+				&track->process_info->pid,
+				track->process_info->command.c_str(),
+				track->thread_info ? &track->thread_info->thread_id : nullptr,
+				nullptr,
+				track->stream_info ? &track->stream_info->stream_id : nullptr,
+				track->stream_info ? track->stream_info->name.c_str() : nullptr,
+				track->agent_info ? get_agent_type(track->agent_info->agent_type) : kProfilerHubNotAgent,
+				track->agent_info ? &track->agent_info->type_index : nullptr,
+				track->agent_info ? track->agent_info->name.c_str() : nullptr,
+				track->queue_info ? &track->queue_info->queue_id : nullptr,
+				track->queue_info ? track->queue_info->name.c_str() : nullptr,
+				track->pmc_info ? &track->pmc_info->pmc_id : nullptr,
+				track->pmc_info ? track->pmc_info->name.c_str() : nullptr,
+				missing_t::integer("track->records_count"), // records has to be counted using COUNT(*)
+				missing_t::integer("track->min_timestamp"), // min_timestamp has to be aggregated with MIN(start_ts)
+				missing_t::integer("track->max_timestamp"), // max_timestamp has to be aggregated with MAX(end_ts),
+				0, // in case of counter track use MIN(value)
+				track->max_lane //in case of counter track use MAX(value)
+			);
+            if (result != kProfilerHubStatusSuccess)
+            {
+                return result;
+            }
+		}
+
+		for (auto& track : tracks)
+		{
+			auto & track_histogram = missing_t::get_track_histogram(track);
+			for (auto& bucket : track_histogram)
+			{
+				result = client::interface::AddTrackHistogramBucket(m_client_trace, track->id.value, bucket.get_bucket_number(), bucket.get_events_count(), bucket.get_bucket_value());
+                if (result != kProfilerHubStatusSuccess)
+                {
+                    return result;
+                }
+			}	
+		}
+        return result;
+	}
+
+    profiler_hub_result_t 
+        profiler_hub_trace_t::get_time_slice(
+            future_t * future,
+            profiler_hub_track_id_t track_id,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end)
+    {
+        profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
+        reader_types::event_filter_t filter = { {timestamp_start, timestamp_end} };
+        auto& tracks = m_reader->get_tracks();
+        auto it = std::find_if(tracks.begin(), tracks.end(), [track_id](reader_types::track_info_ptr_t track_info) {return track_info->id.value == track_id; });
+        if (it != tracks.end())
+        {
+            auto& events = m_reader->get_events_for_track(*it, filter);
+            auto slice_container = client::interface::AddTimeSliceContainer(m_client_trace, track_id, timestamp_start, timestamp_end);
+            for (auto& event : events)
+            {
+                result = client::interface::AddEventRecord(
+                    slice_container,
+                    event.unique_identifier.type,
+                    event.unique_identifier.id,
+                    event.start_timestamp,
+                    event.end_timestamp,
+                    missing_t::integer("event.category_id"),
+                    missing_t::integer("event.symbol_id"),
+                    missing_t::integer("event.level"));
+                if (result != kProfilerHubStatusSuccess)
+                {
+                    return result;
+                }
+            }
+        }
+        return result;
+    }
+
+    profiler_hub_result_t profiler_hub_trace_t::add_table_to_client(missing_types::table_ptr_t table, profiler_hub_table_handle_t client_table_handle)
+    {
+        profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
+        for (auto& column : table->columns)
+        {
+            result = client::interface::AddTableColumn(client_table_handle, column.name.c_str(), column.type);
+            if (result != kProfilerHubStatusSuccess)
+            {
+                return result;
+            }
+        }
+        for (auto& row : table->rows)
+        {
+            if (row.cells.size() != table->columns.size())
+                return kProfilerHubStatusUnknownError;
+            profiler_hub_table_row_handle_t row_handle = client::interface::AddTableRowContainer(client_table_handle);
+            for (int i = 0; i < row.cells.size(); i++)
+            {
+                if (std::holds_alternative<std::string>(row.cells[i].value))
+                {
+                    result = client::interface::AddTableCellAsString(row_handle, i, std::get<std::string>(row.cells[i].value).c_str());
+                } else
+                    if (std::holds_alternative<size_t>(row.cells[i].value))
+                    {
+                        result = client::interface::AddTableCellAsInt(row_handle, i, std::get<size_t>(row.cells[i].value));
+                    } else
+                        if (std::holds_alternative<double>(row.cells[i].value))
+                        {
+                            result = client::interface::AddTableCellAsDouble(row_handle, i, std::get<double>(row.cells[i].value));
+                        }
+
+                    if (result != kProfilerHubStatusSuccess)
+                    {
+                        return result;
+                    }
+            }
+        }
+        return result;
+    }
+
+    profiler_hub_result_t 
+        profiler_hub_trace_t::get_table_time_slice(
+            future_t * future,
+            profiler_hub_table_handle_t client_table_handle,
+            profiler_hub_track_id_t track_id,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end)
+    {
+        missing_types::event_filter_t filter = { {timestamp_start, timestamp_end} };
+        auto& tracks = m_reader->get_tracks();
+        auto it = std::find_if(tracks.begin(), tracks.end(), [track_id](reader_types::track_info_ptr_t track_info) {return track_info->id.value == track_id; });
+        if (it != tracks.end())
+        {
+            auto& table = missing_t::get_event_table_for_track(*it, filter, timestamp_start, timestamp_end);
+            
+            return add_table_to_client(table, client_table_handle);
+        }
+        return kProfilerHubStatusNotLoaded;
+    }
+
+    profiler_hub_result_t 
+        profiler_hub_trace_t::get_search_time_slice(
+            future_t * future,
+            profiler_hub_table_handle_t client_table_handle,
+            size_t num_operations,
+            profiler_hub_event_operation_t* operations,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end,
+            size_t num_search_strings,
+            profiler_hub_search_strings_t string_filters)
+    {
+        std::vector<reader_types::event_type_t> op_types;
+        for (int i = 0; i < num_operations; i++)
+        {
+            op_types.push_back(operations[i]);
+        }
+        std::vector<std::string> search_strings;
+        for (int i = 0; i < num_search_strings; i++)
+        {
+            search_strings.push_back(string_filters[i]);
+        }
+        missing_types::event_filter_t filter = { {timestamp_start, timestamp_end}, {}, {}, op_types, search_strings };
+        
+        auto& table = missing_t::get_event_table(filter, timestamp_start, timestamp_end);
+        return add_table_to_client(table, client_table_handle);
+    }
+
+    profiler_hub_result_t profiler_hub_trace_t::get_data_flow_for_event(
+        future_t* future,
+        profiler_hub_instance_id_t instance,
+        profiler_hub_event_operation_t operation,
+        profiler_hub_event_id_t event_id) {
+        profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
+        auto & flow_endpoints = m_reader->get_flows_for_event(reader_types::detail::event_id_access::make(operation, event_id));
+        profiler_hub_flowtrace_handle_t flow_container = client::interface::AddEventFlowTraceContainer(m_client_trace, instance, operation, event_id);
+        for (auto& endpoint : flow_endpoints)
+        {
+            size_t dest_id = reader_types::detail::event_id_access::row_id(endpoint.dest);
+            profiler_hub_event_operation_t dest_type = reader_types::detail::event_id_access::type(endpoint.dest);
+            size_t src_id = reader_types::detail::event_id_access::row_id(endpoint.source);
+            profiler_hub_event_operation_t src_type = reader_types::detail::event_id_access::type(endpoint.source);
+            if (event_id == src_id)
+            {
+                result = client::interface::AddEventDataFlowEndPoint(
+                    flow_container,
+                    dest_type,
+                    dest_id,
+                    kProfilerHubDirectionOutgoing,
+                    missing_t::integer("reader_types::detail::event_id_access::timestamp(endpoint.dest)"),
+                    missing_t::integer("reader_types::detail::event_id_access::duration(endpoint.dest)"),
+                    missing_t::integer("reader_types::detail::event_id_access::category_id(endpoint.dest)"),
+                    missing_t::integer("reader_types::detail::event_id_access::symbol_id(endpoint.dest)"),
+                    missing_t::integer("reader_types::detail::event_id_access::level(endpoint.dest)"));
+                if (kProfilerHubStatusSuccess != result)
+                    return result;
+            }
+            else if (event_id == dest_id)
+            {
+                result = client::interface::AddEventDataFlowEndPoint(
+                    flow_container,
+                    src_type,
+                    src_id,
+                    kProfilerHubDirectionIncoming,
+                    missing_t::integer("reader_types::detail::event_id_access::timestamp(endpoint.src)"),
+                    missing_t::integer("reader_types::detail::event_id_access::duration(endpoint.src)"),
+                    missing_t::integer("reader_types::detail::event_id_access::category_id(endpoint.src)"),
+                    missing_t::integer("reader_types::detail::event_id_access::symbol_id(endpoint.src)"),
+                    missing_t::integer("reader_types::detail::event_id_access::level(endpoint.src)"));
+                if (kProfilerHubStatusSuccess != result)
+                    return result;
+            }
+            else
+            {
+                return kProfilerHubStatusUnknownError;
+            }
+        }
+        return result;
+    }
+
+    profiler_hub_result_t profiler_hub_trace_t::get_event_details(
+        future_t* future,
+        profiler_hub_instance_id_t instance,
+        profiler_hub_event_operation_t operation,
+        profiler_hub_event_id_t event_id) {
+        profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
+        auto & event_info = m_reader->get_event_info(reader_types::detail::event_id_access::make(operation, event_id));
+        if (event_info.has_value())
+        {
+            profiler_hub_ext_data_handle_t event_info_container = client::interface::AddEventExtDataContainer(m_client_trace, instance, operation, event_id);
+            for (auto& prop : event_info->properties)
+            {
+                if (std::holds_alternative<std::string>(prop.value))
+                {
+                    result = client::interface::AddEventExtendedInfo(event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeString, std::get<std::string>(prop.value).c_str());
+                } else
+                    if (std::holds_alternative<size_t>(prop.value))
+                    {
+                        result = client::interface::AddEventExtendedInfo(event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeInt, std::to_string(std::get<uint64_t>(prop.value)).c_str());
+                    } else
+                        if (std::holds_alternative<double>(prop.value))
+                        {
+                            result = client::interface::AddEventExtendedInfo(event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeInt, std::to_string(std::get<double>(prop.value)).c_str());
+                        }
+                        else
+                        {
+                            result = kProfilerHubStatusUnknownError;
+                        }
+
+                    if (kProfilerHubStatusSuccess != result)
+                        return result;
+            }
+            result = client::interface::AddEventEssentialInfo(event_info_container,
+                missing_t::integer("event_info->track->id.value"),
+                missing_t::integer("event_info->stream_track->id.value"),
+                missing_t::integer("event_info->level"),
+                missing_t::integer("event_info->stream_track_level")
+            );
+            if (kProfilerHubStatusSuccess != result)
+                return result;
+            auto event_arguments = m_reader->get_arguments(reader_types::detail::event_id_access::make(operation, event_id));
+            for (auto& arg : event_arguments)
+            {
+                result = client::interface::AddEventArgumentsInfo(event_info_container, arg->position, arg->name.c_str(), arg->type.c_str(), arg->value.c_str());
+                if (kProfilerHubStatusSuccess != result)
+                    return result;
+            }
+
+        }
+        else
+        {
+            return kProfilerHubStatusNotLoaded;
+        }
+        return result;
+    }
+
+    profiler_hub_result_t profiler_hub_trace_t::get_event_stack_trace(
+        future_t* future,
+        profiler_hub_instance_id_t instance,
+        profiler_hub_event_operation_t operation,
+        profiler_hub_event_id_t event_id) {
+        profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
+        profiler_hub_call_stack_handle_t call_stack_container = client::interface::AddEventCallStackContainer(m_client_trace, instance, operation, event_id);
+        auto & call_stack = m_reader->get_call_stack(reader_types::detail::event_id_access::make(operation, event_id));
+        size_t depth = 0;
+        for (auto& stack_frame : call_stack)
+        {
+            if (stack_frame.program_counter.has_value())
+            {
+                result = client::interface::AddEventCallStackFrame(
+                    call_stack_container,
+                    stack_frame.program_counter->function.c_str(),
+                    stack_frame.program_counter->filename.c_str(),
+                    stack_frame.program_counter->line_number.has_value() ? std::to_string(stack_frame.program_counter->line_number.value()).c_str() : "",
+                    stack_frame.address_range.has_value() ? std::to_string(stack_frame.address_range->address_base).c_str() : "",
+                    depth++);
+                if (kProfilerHubStatusSuccess != result)
+                    return result;
+            }
+        }
+        return result;
+    }
+
+    
+}

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.cpp
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.cpp
@@ -38,198 +38,167 @@ namespace profiler_hub::interface
 			return kProfilerHubNotAgent;
 	}
 
-    profiler_hub_value_type_t profiler_hub_trace_t::get_node_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
-        auto& nodes = get_reader()->get_all_nodes();
-        auto it = std::find_if(nodes.begin(), nodes.end(), [row_key](profiler_hub::reader_types::node_info_ptr_t node_info) { return node_info->node_id == row_key; });
-        if (it != nodes.end())
+    template <typename ListT>
+    profiler_hub_result_t profiler_hub_trace_t::report_info_properties(
+        ListT& collection,
+        const char* category,
+        profiler_hub_instance_id_t instance_id,
+        const std::unordered_map<std::string, std::function<profiler_hub_value_type_t(typename ListT::iterator, profiler_hub_optional_t)>>& properties_dispatcher)
+    {
+        for (auto it = collection.begin(); it != collection.end(); ++it)
         {
-            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
-                properties_dispatcher =
+            size_t* id_value = nullptr;
+            auto entry = properties_dispatcher.find("id");
+            if (entry != properties_dispatcher.end())
             {
-                { "id",            [it, value] { *value = &it->get()->node_id;              return kPprofilerHubDataTypeInt; }},
-                { "hash",          [it, value] { *value = &it->get()->hash;                 return kPprofilerHubDataTypeInt; }},
-                { "machine_id",    [it, value] { *value = it->get()->machine_id.c_str();    return kPprofilerHubDataTypeString; }},
-                { "system_name",   [it, value] { *value = it->get()->system_name.c_str();   return kPprofilerHubDataTypeString; }},
-                { "hostname",      [it, value] { *value = it->get()->hostname.c_str();      return kPprofilerHubDataTypeString; }},
-                { "release",       [it, value] { *value = it->get()->release.c_str();       return kPprofilerHubDataTypeString; }},
-                { "version",       [it, value] { *value = it->get()->version.c_str();       return kPprofilerHubDataTypeString; }},
-                { "hardware_name", [it, value] { *value = it->get()->hardware_name.c_str(); return kPprofilerHubDataTypeString; }},
-                { "domain_name",   [it, value] { *value = it->get()->domain_name.c_str();   return kPprofilerHubDataTypeString; }},
-            };
-            auto it = properties_dispatcher.find(property_tag);
-            if (it != properties_dispatcher.end())
-            {
-                return it->second();
+                auto type = entry->second(it, (profiler_hub_optional_t)&id_value);
+                if (type == kPprofilerHubDataTypeInt)
+                {
+                    for (auto& [name, fn] : properties_dispatcher)
+                    {
+                        void* cell_value = nullptr;
+                        auto type = fn(it, (profiler_hub_optional_t)&cell_value);
+                        if (type != kPprofilerHubDataTypeUndefined)
+                        {
+                            auto result = client::interface::AddInfoProperty(m_client_trace, instance_id, category, name.c_str(), type, *id_value, cell_value);
+                            if (result != kProfilerHubStatusSuccess) return result;
+                        }
+                    }
+                }
             }
         }
-        return kPprofilerHubDataTypeUndefined;
+        return kProfilerHubStatusSuccess;
     }
 
-    profiler_hub_value_type_t profiler_hub_trace_t::get_process_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
-        auto& processes = get_reader()->get_all_processes();
-        auto it = std::find_if(processes.begin(), processes.end(), [row_key](profiler_hub::reader_types::process_info_ptr_t process_info) { return process_info->pid == row_key; });
-        if (it != processes.end())
+    profiler_hub_result_t profiler_hub_trace_t::report_node_info(profiler_hub_instance_id_t instance_id) {
+        using it_t = profiler_hub::reader_types::node_info_list_t::iterator;
+        using fn_t = std::function<profiler_hub_value_type_t(it_t, profiler_hub_optional_t)>;
+        static const std::unordered_map<std::string, fn_t> properties_dispatcher =
         {
-            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
-                properties_dispatcher =
-            {
-                { "id",          [it, value] { *value = &it->get()->pid;                        return kPprofilerHubDataTypeInt; }},
-                { "nid",         [it, value] { *value = &it->get()->node_info->node_id;         return kPprofilerHubDataTypeInt; }},
-                { "init",        [it, value] { if (!it->get()->init.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->init;  return kPprofilerHubDataTypeInt; }},
-                { "fini",        [it, value] { if (!it->get()->fini.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->fini;  return kPprofilerHubDataTypeInt; }},
-                { "start",       [it, value] { if (!it->get()->start.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->start; return kPprofilerHubDataTypeInt; }},
-                { "end",         [it, value] { if (!it->get()->end.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->end;   return kPprofilerHubDataTypeInt; }},
-                { "command",     [it, value] { *value = it->get()->command.c_str();              return kPprofilerHubDataTypeString; }},
-                { "environment", [it, value] { *value = it->get()->environment.c_str();          return kPprofilerHubDataTypeString; }},
-                { "extdata",     [it, value] { *value = it->get()->extdata.c_str();              return kPprofilerHubDataTypeString; }},
-            };
-            auto it = properties_dispatcher.find(property_tag);
-            if (it != properties_dispatcher.end())
-            {
-                return it->second();
-            }
-        }
-        return kPprofilerHubDataTypeUndefined;
+            { "id",            [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->node_id;              return kPprofilerHubDataTypeInt; }},
+            { "hash",          [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->hash;                 return kPprofilerHubDataTypeInt; }},
+            { "machine_id",    [](it_t it, profiler_hub_optional_t value) { *value = it->get()->machine_id.c_str();    return kPprofilerHubDataTypeString; }},
+            { "system_name",   [](it_t it, profiler_hub_optional_t value) { *value = it->get()->system_name.c_str();   return kPprofilerHubDataTypeString; }},
+            { "hostname",      [](it_t it, profiler_hub_optional_t value) { *value = it->get()->hostname.c_str();      return kPprofilerHubDataTypeString; }},
+            { "release",       [](it_t it, profiler_hub_optional_t value) { *value = it->get()->release.c_str();       return kPprofilerHubDataTypeString; }},
+            { "version",       [](it_t it, profiler_hub_optional_t value) { *value = it->get()->version.c_str();       return kPprofilerHubDataTypeString; }},
+            { "hardware_name", [](it_t it, profiler_hub_optional_t value) { *value = it->get()->hardware_name.c_str(); return kPprofilerHubDataTypeString; }},
+            { "domain_name",   [](it_t it, profiler_hub_optional_t value) { *value = it->get()->domain_name.c_str();   return kPprofilerHubDataTypeString; }},
+        };
+        return report_info_properties(get_reader()->get_all_nodes(), "Node", instance_id, properties_dispatcher);
     }
 
-    profiler_hub_value_type_t profiler_hub_trace_t::get_agent_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
-        auto& agents = get_reader()->get_all_agents();
-        auto it = std::find_if(agents.begin(), agents.end(), [row_key](profiler_hub::reader_types::agent_info_ptr_t agent_info) { return agent_info->id == row_key; });
-        if (it != agents.end())
+    profiler_hub_result_t profiler_hub_trace_t::report_process_info(profiler_hub_instance_id_t instance_id) {
+        using it_t = profiler_hub::reader_types::process_info_list_t::iterator;
+        using fn_t = std::function<profiler_hub_value_type_t(it_t, profiler_hub_optional_t)>;
+        static const std::unordered_map<std::string, fn_t> properties_dispatcher =
         {
-            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
-                properties_dispatcher =
-            {
-                { "id",             [it, value] { *value = &it->get()->id;                          return kPprofilerHubDataTypeInt; }},
-                { "nid",            [it, value] { *value = &it->get()->node_info->node_id;          return kPprofilerHubDataTypeInt; }},
-                { "type_index",     [it, value] { *value = &it->get()->type_index;                  return kPprofilerHubDataTypeInt; }},
-                { "absolute_index", [it, value] { if (!it->get()->absolute_index.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->absolute_index; return kPprofilerHubDataTypeInt; }},
-                { "logical_index",  [it, value] { if (!it->get()->logical_index.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->logical_index;  return kPprofilerHubDataTypeInt; }},
-                { "uuid",           [it, value] { if (!it->get()->uuid.has_value())           return kPprofilerHubDataTypeUndefined; *value = &it->get()->uuid;           return kPprofilerHubDataTypeInt; }},
-                { "type",           [it, value] { *value = it->get()->agent_type.c_str();           return kPprofilerHubDataTypeString; }},
-                { "name",           [it, value] { *value = it->get()->name.c_str();                 return kPprofilerHubDataTypeString; }},
-                { "model_name",     [it, value] { *value = it->get()->model_name.c_str();           return kPprofilerHubDataTypeString; }},
-                { "vendor_name",    [it, value] { *value = it->get()->vendor_name.c_str();          return kPprofilerHubDataTypeString; }},
-                { "product_name",   [it, value] { *value = it->get()->product_name.c_str();         return kPprofilerHubDataTypeString; }},
-                { "user_name",      [it, value] { *value = it->get()->user_name.c_str();            return kPprofilerHubDataTypeString; }},
-                { "extdata",        [it, value] { *value = it->get()->extdata.c_str();              return kPprofilerHubDataTypeString; }},
-            };
-            auto it = properties_dispatcher.find(property_tag);
-            if (it != properties_dispatcher.end())
-            {
-                return it->second();
-            }
-        }
-        return kPprofilerHubDataTypeUndefined;
+            { "id",          [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->pid;                        return kPprofilerHubDataTypeInt; }},
+            { "nid",         [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->node_info->node_id;         return kPprofilerHubDataTypeInt; }},
+            { "init",        [](it_t it, profiler_hub_optional_t value) { if (!it->get()->init.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->init;  return kPprofilerHubDataTypeInt; }},
+            { "fini",        [](it_t it, profiler_hub_optional_t value) { if (!it->get()->fini.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->fini;  return kPprofilerHubDataTypeInt; }},
+            { "start",       [](it_t it, profiler_hub_optional_t value) { if (!it->get()->start.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->start; return kPprofilerHubDataTypeInt; }},
+            { "end",         [](it_t it, profiler_hub_optional_t value) { if (!it->get()->end.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->end;   return kPprofilerHubDataTypeInt; }},
+            { "command",     [](it_t it, profiler_hub_optional_t value) { *value = it->get()->command.c_str();              return kPprofilerHubDataTypeString; }},
+            { "environment", [](it_t it, profiler_hub_optional_t value) { *value = it->get()->environment.c_str();          return kPprofilerHubDataTypeString; }},
+            { "extdata",     [](it_t it, profiler_hub_optional_t value) { *value = it->get()->extdata.c_str();              return kPprofilerHubDataTypeString; }},
+        };
+        return report_info_properties(get_reader()->get_all_processes(), "Process", instance_id, properties_dispatcher);
     }
 
-    profiler_hub_value_type_t profiler_hub_trace_t::get_pmc_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
-        auto& pmcs = get_reader()->get_all_pmc_info();
-        auto it = std::find_if(pmcs.begin(), pmcs.end(), [row_key](profiler_hub::reader_types::pmc_info_ptr_t pmc_info) { return pmc_info->pmc_id == row_key; });
-        if (it != pmcs.end())
+    profiler_hub_result_t profiler_hub_trace_t::report_agent_info(profiler_hub_instance_id_t instance_id) {
+        using it_t = profiler_hub::reader_types::agent_info_list_t::iterator;
+        using fn_t = std::function<profiler_hub_value_type_t(it_t, profiler_hub_optional_t)>;
+        static const std::unordered_map<std::string, fn_t> properties_dispatcher =
         {
-            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
-                properties_dispatcher =
-            {
-                { "id",               [it, value] { *value = &it->get()->pmc_id;                        return kPprofilerHubDataTypeInt; }},
-                { "nid",              [it, value] { *value = &it->get()->node_info->node_id;            return kPprofilerHubDataTypeInt; }},
-                { "pid",              [it, value] { *value = &it->get()->process_info->pid;             return kPprofilerHubDataTypeInt; }},
-                { "agent_id",         [it, value] { *value = &it->get()->agent_info->id;                return kPprofilerHubDataTypeInt; }},
-                { "event_code",       [it, value] { if (!it->get()->event_code.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->event_code;   return kPprofilerHubDataTypeInt; }},
-                { "instance_id",      [it, value] { if (!it->get()->instance_id.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->instance_id;  return kPprofilerHubDataTypeInt; }},
-                { "is_constant",      [it, value] { if (!it->get()->is_constant.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->is_constant;  return kPprofilerHubDataTypeInt; }},
-                { "is_derived",       [it, value] { if (!it->get()->is_derived.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->is_derived;   return kPprofilerHubDataTypeInt; }},
-                { "name",             [it, value] { *value = it->get()->name.c_str();                   return kPprofilerHubDataTypeString; }},
-                { "target_arch",      [it, value] { *value = it->get()->target_arch.c_str();            return kPprofilerHubDataTypeString; }},
-                { "symbol",           [it, value] { *value = it->get()->symbol.c_str();                 return kPprofilerHubDataTypeString; }},
-                { "description",      [it, value] { *value = it->get()->description.c_str();            return kPprofilerHubDataTypeString; }},
-                { "long_description", [it, value] { *value = it->get()->long_description.c_str();       return kPprofilerHubDataTypeString; }},
-                { "component",        [it, value] { *value = it->get()->component.c_str();              return kPprofilerHubDataTypeString; }},
-                { "units",            [it, value] { *value = it->get()->units.c_str();                  return kPprofilerHubDataTypeString; }},
-                { "value_type",       [it, value] { *value = it->get()->value_type.c_str();             return kPprofilerHubDataTypeString; }},
-                { "block",            [it, value] { *value = it->get()->block.c_str();                  return kPprofilerHubDataTypeString; }},
-                { "expression",       [it, value] { *value = it->get()->expression.c_str();             return kPprofilerHubDataTypeString; }},
-                { "extdata",          [it, value] { *value = it->get()->extdata.c_str();                return kPprofilerHubDataTypeString; }},
-            };
-            auto it = properties_dispatcher.find(property_tag);
-            if (it != properties_dispatcher.end())
-            {
-                return it->second();
-            }
-        }
-        return kPprofilerHubDataTypeUndefined;
+            { "id",             [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->id;                          return kPprofilerHubDataTypeInt; }},
+            { "nid",            [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->node_info->node_id;          return kPprofilerHubDataTypeInt; }},
+            { "type_index",     [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->type_index;                  return kPprofilerHubDataTypeInt; }},
+            { "absolute_index", [](it_t it, profiler_hub_optional_t value) { if (!it->get()->absolute_index.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->absolute_index; return kPprofilerHubDataTypeInt; }},
+            { "logical_index",  [](it_t it, profiler_hub_optional_t value) { if (!it->get()->logical_index.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->logical_index;  return kPprofilerHubDataTypeInt; }},
+            { "uuid",           [](it_t it, profiler_hub_optional_t value) { if (!it->get()->uuid.has_value())           return kPprofilerHubDataTypeUndefined; *value = &it->get()->uuid;           return kPprofilerHubDataTypeInt; }},
+            { "type",           [](it_t it, profiler_hub_optional_t value) { *value = it->get()->agent_type.c_str();           return kPprofilerHubDataTypeString; }},
+            { "name",           [](it_t it, profiler_hub_optional_t value) { *value = it->get()->name.c_str();                 return kPprofilerHubDataTypeString; }},
+            { "model_name",     [](it_t it, profiler_hub_optional_t value) { *value = it->get()->model_name.c_str();           return kPprofilerHubDataTypeString; }},
+            { "vendor_name",    [](it_t it, profiler_hub_optional_t value) { *value = it->get()->vendor_name.c_str();          return kPprofilerHubDataTypeString; }},
+            { "product_name",   [](it_t it, profiler_hub_optional_t value) { *value = it->get()->product_name.c_str();         return kPprofilerHubDataTypeString; }},
+            { "user_name",      [](it_t it, profiler_hub_optional_t value) { *value = it->get()->user_name.c_str();            return kPprofilerHubDataTypeString; }},
+            { "extdata",        [](it_t it, profiler_hub_optional_t value) { *value = it->get()->extdata.c_str();              return kPprofilerHubDataTypeString; }},
+        };
+        return report_info_properties(get_reader()->get_all_agents(), "Agent", instance_id, properties_dispatcher);
     }
 
-    profiler_hub_value_type_t profiler_hub_trace_t::get_thread_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
-        auto& threads = get_reader()->get_all_threads();
-        auto it = std::find_if(threads.begin(), threads.end(), [row_key](profiler_hub::reader_types::thread_info_ptr_t thread_info) { return thread_info->thread_id == row_key; });
-        if (it != threads.end())
+    profiler_hub_result_t profiler_hub_trace_t::report_pmc_info(profiler_hub_instance_id_t instance_id) {
+        using it_t = profiler_hub::reader_types::pmc_info_list_t::iterator;
+        using fn_t = std::function<profiler_hub_value_type_t(it_t, profiler_hub_optional_t)>;
+        static const std::unordered_map<std::string, fn_t> properties_dispatcher =
         {
-            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
-                properties_dispatcher =
-            {
-                { "id",    [it, value] { *value = &it->get()->thread_id;                    return kPprofilerHubDataTypeInt; }},
-                { "nid",   [it, value] { *value = &it->get()->node_info->node_id;           return kPprofilerHubDataTypeInt; }},
-                { "pid",   [it, value] { *value = &it->get()->process_info->pid;            return kPprofilerHubDataTypeInt; }},
-                { "ppid",  [it, value] { if (!it->get()->parent_process_id.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->parent_process_id; return kPprofilerHubDataTypeInt; }},
-                { "start", [it, value] { if (!it->get()->start.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->start; return kPprofilerHubDataTypeInt; }},
-                { "end",   [it, value] { if (!it->get()->end.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->end;   return kPprofilerHubDataTypeInt; }},
-                { "name",    [it, value] { *value = it->get()->name.c_str();                return kPprofilerHubDataTypeString; }},
-                { "extdata", [it, value] { *value = it->get()->extdata.c_str();             return kPprofilerHubDataTypeString; }},
-            };
-            auto it = properties_dispatcher.find(property_tag);
-            if (it != properties_dispatcher.end())
-            {
-                return it->second();
-            }
-        }
-        return kPprofilerHubDataTypeUndefined;
+            { "id",               [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->pmc_id;                        return kPprofilerHubDataTypeInt; }},
+            { "nid",              [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->node_info->node_id;            return kPprofilerHubDataTypeInt; }},
+            { "pid",              [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->process_info->pid;             return kPprofilerHubDataTypeInt; }},
+            { "agent_id",         [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->agent_info->id;                return kPprofilerHubDataTypeInt; }},
+            { "event_code",       [](it_t it, profiler_hub_optional_t value) { if (!it->get()->event_code.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->event_code;   return kPprofilerHubDataTypeInt; }},
+            { "instance_id",      [](it_t it, profiler_hub_optional_t value) { if (!it->get()->instance_id.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->instance_id;  return kPprofilerHubDataTypeInt; }},
+            { "is_constant",      [](it_t it, profiler_hub_optional_t value) { if (!it->get()->is_constant.has_value())  return kPprofilerHubDataTypeUndefined; *value = &it->get()->is_constant;  return kPprofilerHubDataTypeInt; }},
+            { "is_derived",       [](it_t it, profiler_hub_optional_t value) { if (!it->get()->is_derived.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->is_derived;   return kPprofilerHubDataTypeInt; }},
+            { "name",             [](it_t it, profiler_hub_optional_t value) { *value = it->get()->name.c_str();                   return kPprofilerHubDataTypeString; }},
+            { "target_arch",      [](it_t it, profiler_hub_optional_t value) { *value = it->get()->target_arch.c_str();            return kPprofilerHubDataTypeString; }},
+            { "symbol",           [](it_t it, profiler_hub_optional_t value) { *value = it->get()->symbol.c_str();                 return kPprofilerHubDataTypeString; }},
+            { "description",      [](it_t it, profiler_hub_optional_t value) { *value = it->get()->description.c_str();            return kPprofilerHubDataTypeString; }},
+            { "long_description", [](it_t it, profiler_hub_optional_t value) { *value = it->get()->long_description.c_str();       return kPprofilerHubDataTypeString; }},
+            { "component",        [](it_t it, profiler_hub_optional_t value) { *value = it->get()->component.c_str();              return kPprofilerHubDataTypeString; }},
+            { "units",            [](it_t it, profiler_hub_optional_t value) { *value = it->get()->units.c_str();                  return kPprofilerHubDataTypeString; }},
+            { "value_type",       [](it_t it, profiler_hub_optional_t value) { *value = it->get()->value_type.c_str();             return kPprofilerHubDataTypeString; }},
+            { "block",            [](it_t it, profiler_hub_optional_t value) { *value = it->get()->block.c_str();                  return kPprofilerHubDataTypeString; }},
+            { "expression",       [](it_t it, profiler_hub_optional_t value) { *value = it->get()->expression.c_str();             return kPprofilerHubDataTypeString; }},
+            { "extdata",          [](it_t it, profiler_hub_optional_t value) { *value = it->get()->extdata.c_str();                return kPprofilerHubDataTypeString; }},
+        };
+        return report_info_properties(get_reader()->get_all_pmc_info(), "PMC", instance_id, properties_dispatcher);
     }
 
-    profiler_hub_value_type_t profiler_hub_trace_t::get_stream_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
-        auto& streams = get_reader()->get_all_streams();
-        auto it = std::find_if(streams.begin(), streams.end(), [row_key](profiler_hub::reader_types::stream_info_ptr_t stream_info) { return stream_info->stream_id == row_key; });
-        if (it != streams.end())
+    profiler_hub_result_t profiler_hub_trace_t::report_thread_info(profiler_hub_instance_id_t instance_id) {
+        using it_t = profiler_hub::reader_types::thread_info_list_t::iterator;
+        using fn_t = std::function<profiler_hub_value_type_t(it_t, profiler_hub_optional_t)>;
+        static const std::unordered_map<std::string, fn_t> properties_dispatcher =
         {
-            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
-                properties_dispatcher =
-            {
-                { "id",      [it, value] { *value = &it->get()->stream_id;              return kPprofilerHubDataTypeInt; }},
-                { "nid",     [it, value] { *value = &it->get()->node_info->node_id;     return kPprofilerHubDataTypeInt; }},
-                { "pid",     [it, value] { *value = &it->get()->process_info->pid;      return kPprofilerHubDataTypeInt; }},
-                { "name",    [it, value] { *value = it->get()->name.c_str();            return kPprofilerHubDataTypeString; }},
-                { "extdata", [it, value] { *value = it->get()->extdata.c_str();         return kPprofilerHubDataTypeString; }},
-            };
-            auto it = properties_dispatcher.find(property_tag);
-            if (it != properties_dispatcher.end())
-            {
-                return it->second();
-            }
-        }
-        return kPprofilerHubDataTypeUndefined;
+            { "id",      [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->thread_id;                    return kPprofilerHubDataTypeInt; }},
+            { "nid",     [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->node_info->node_id;           return kPprofilerHubDataTypeInt; }},
+            { "pid",     [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->process_info->pid;            return kPprofilerHubDataTypeInt; }},
+            { "ppid",    [](it_t it, profiler_hub_optional_t value) { if (!it->get()->parent_process_id.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->parent_process_id; return kPprofilerHubDataTypeInt; }},
+            { "start",   [](it_t it, profiler_hub_optional_t value) { if (!it->get()->start.has_value()) return kPprofilerHubDataTypeUndefined; *value = &it->get()->start; return kPprofilerHubDataTypeInt; }},
+            { "end",     [](it_t it, profiler_hub_optional_t value) { if (!it->get()->end.has_value())   return kPprofilerHubDataTypeUndefined; *value = &it->get()->end;   return kPprofilerHubDataTypeInt; }},
+            { "name",    [](it_t it, profiler_hub_optional_t value) { *value = it->get()->name.c_str();                  return kPprofilerHubDataTypeString; }},
+            { "extdata", [](it_t it, profiler_hub_optional_t value) { *value = it->get()->extdata.c_str();               return kPprofilerHubDataTypeString; }},
+        };
+        return report_info_properties(get_reader()->get_all_threads(), "Thread", instance_id, properties_dispatcher);
     }
 
-    profiler_hub_value_type_t profiler_hub_trace_t::get_queue_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value) {
-        auto& queues = get_reader()->get_all_queues();
-        auto it = std::find_if(queues.begin(), queues.end(), [row_key](profiler_hub::reader_types::queue_info_ptr_t queue_info) { return queue_info->queue_id == row_key; });
-        if (it != queues.end())
+    profiler_hub_result_t profiler_hub_trace_t::report_stream_info(profiler_hub_instance_id_t instance_id) {
+        using it_t = profiler_hub::reader_types::stream_info_list_t::iterator;
+        using fn_t = std::function<profiler_hub_value_type_t(it_t, profiler_hub_optional_t)>;
+        static const std::unordered_map<std::string, fn_t> properties_dispatcher =
         {
-            static const std::unordered_map<std::string, std::function<profiler_hub_value_type_t()>>
-                properties_dispatcher =
-            {
-                { "id",      [it, value] { *value = &it->get()->queue_id;               return kPprofilerHubDataTypeInt; }},
-                { "nid",     [it, value] { *value = &it->get()->node_info->node_id;     return kPprofilerHubDataTypeInt; }},
-                { "pid",     [it, value] { *value = &it->get()->process_info->pid;      return kPprofilerHubDataTypeInt; }},
-                { "name",    [it, value] { *value = it->get()->name.c_str();            return kPprofilerHubDataTypeString; }},
-                { "extdata", [it, value] { *value = it->get()->extdata.c_str();         return kPprofilerHubDataTypeString; }},
-            };
-            auto it = properties_dispatcher.find(property_tag);
-            if (it != properties_dispatcher.end())
-            {
-                return it->second();
-            }
-        }
-        return kPprofilerHubDataTypeUndefined;
+            { "id",      [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->stream_id;              return kPprofilerHubDataTypeInt; }},
+            { "nid",     [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->node_info->node_id;     return kPprofilerHubDataTypeInt; }},
+            { "pid",     [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->process_info->pid;      return kPprofilerHubDataTypeInt; }},
+            { "name",    [](it_t it, profiler_hub_optional_t value) { *value = it->get()->name.c_str();            return kPprofilerHubDataTypeString; }},
+            { "extdata", [](it_t it, profiler_hub_optional_t value) { *value = it->get()->extdata.c_str();         return kPprofilerHubDataTypeString; }},
+        };
+        return report_info_properties(get_reader()->get_all_streams(), "Stream", instance_id, properties_dispatcher);
+    }
+
+    profiler_hub_result_t profiler_hub_trace_t::report_queue_info(profiler_hub_instance_id_t instance_id) {
+        using it_t = profiler_hub::reader_types::queue_info_list_t::iterator;
+        using fn_t = std::function<profiler_hub_value_type_t(it_t, profiler_hub_optional_t)>;
+        static const std::unordered_map<std::string, fn_t> properties_dispatcher =
+        {
+            { "id",      [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->queue_id;               return kPprofilerHubDataTypeInt; }},
+            { "nid",     [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->node_info->node_id;     return kPprofilerHubDataTypeInt; }},
+            { "pid",     [](it_t it, profiler_hub_optional_t value) { *value = &it->get()->process_info->pid;      return kPprofilerHubDataTypeInt; }},
+            { "name",    [](it_t it, profiler_hub_optional_t value) { *value = it->get()->name.c_str();            return kPprofilerHubDataTypeString; }},
+            { "extdata", [](it_t it, profiler_hub_optional_t value) { *value = it->get()->extdata.c_str();         return kPprofilerHubDataTypeString; }},
+        };
+        return report_info_properties(get_reader()->get_all_queues(), "Queue", instance_id, properties_dispatcher);
     }
 
     profiler_hub_db_type_t profiler_hub_trace_t::detect_trace(std::string trace_path) {
@@ -255,16 +224,31 @@ namespace profiler_hub::interface
             }
 		}
 
+        future->show_progress(m_trace_path.c_str(), 1, "Add info properties", kProfilerHubAsyncBusy);
+
+        for (auto& instance : trace_instances)
+        {
+            if (kProfilerHubStatusSuccess != report_node_info(instance.get_index())) break;
+            if (kProfilerHubStatusSuccess != report_process_info(instance.get_index())) break;
+            if (kProfilerHubStatusSuccess != report_thread_info(instance.get_index())) break;
+            if (kProfilerHubStatusSuccess != report_agent_info(instance.get_index())) break;
+            if (kProfilerHubStatusSuccess != report_queue_info(instance.get_index())) break;
+            if (kProfilerHubStatusSuccess != report_stream_info(instance.get_index())) break;
+            if (kProfilerHubStatusSuccess != report_pmc_info(instance.get_index())) break;
+        }
+
         future->show_progress(m_trace_path.c_str(), 1, "Add strings", kProfilerHubAsyncBusy);
-		auto & string_table = missing_t::get_trace_string_table();
-		for (auto& [id, string] : string_table)
-		{
-			result = client::interface::AddString(m_client_trace, string.c_str(), id);
+
+        auto& string_table = missing_t::get_trace_string_table();
+        for (auto& [id, string] : string_table)
+        {
+            result = client::interface::AddString(m_client_trace, string.c_str(), id);
             if (result != kProfilerHubStatusSuccess)
             {
                 return result;
             }
-		}
+        }
+
 
         future->show_progress(m_trace_path.c_str(), 3, "Add tracks", kProfilerHubAsyncBusy);
 
@@ -324,6 +308,7 @@ namespace profiler_hub::interface
         profiler_hub_trace_t::get_time_slice(
             future_t * future,
             profiler_hub_track_id_t track_id,
+            profiler_hub_timeslice_handle_t slice_container,
             uint64_t timestamp_start,
             uint64_t timestamp_end)
     {
@@ -337,16 +322,18 @@ namespace profiler_hub::interface
         auto it = std::find_if(tracks.begin(), tracks.end(), [track_id](reader_types::track_info_ptr_t track_info) {return track_info->id.value == track_id; });
         if (it != tracks.end())
         {
+            // toto: consider pushing data to client rigth away
             auto& events = m_reader->get_events_for_track(*it, filter);
-            auto slice_container = client::interface::AddTimeSliceContainer(m_client_trace, track_id, timestamp_start, timestamp_end);
             for (auto& event : events)
             {
                 result = client::interface::AddEventRecord(
-                    slice_container,
+                    m_client_trace,
+                    missing_t::integer("it->get()->instance_info->id"),
+                    slice_container,                   
                     event.unique_identifier.type,
                     event.unique_identifier.id,
                     event.start_timestamp,
-                    event.end_timestamp,
+                    event.end_timestamp-event.start_timestamp,
                     missing_t::integer("event.category_id"),
                     missing_t::integer("event.symbol_id"),
                     missing_t::integer("event.level"));
@@ -359,37 +346,82 @@ namespace profiler_hub::interface
         return result;
     }
 
+
+    profiler_hub_result_t 
+        profiler_hub_trace_t::get_pmc_time_slice(
+            future_t * future,
+            profiler_hub_track_id_t track_id,
+            profiler_hub_timeslice_handle_t slice_container,
+            uint64_t timestamp_start,
+            uint64_t timestamp_end,
+            bool left_neighbor,
+            bool right_neighbor)
+    {
+        if (!m_client_trace)
+        {
+            throw missing_error_t("fatal error: client trace cannot be null!");
+        }
+        profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
+        reader_types::event_filter_t filter = { {timestamp_start, timestamp_end} };
+        auto& tracks = m_reader->get_tracks();
+        auto it = std::find_if(tracks.begin(), tracks.end(), [track_id](reader_types::track_info_ptr_t track_info) {return track_info->id.value == track_id; });
+        if (it != tracks.end())
+        {
+            auto& events = missing_t::get_counter_events_for_track(*it, filter, left_neighbor, right_neighbor);
+            for (auto& event : events)
+            {
+                result = client::interface::AddPmcRecord(
+                    m_client_trace,
+                    missing_t::integer("it->get()->instance_info->id"),
+                    slice_container,
+                    event.timestamp,
+                    event.value);
+                if (result != kProfilerHubStatusSuccess)
+                {
+                    return result;
+                }
+            }
+        }
+        return result;
+    }
+
     profiler_hub_result_t profiler_hub_trace_t::add_table_to_client(missing_types::table_ptr_t table, profiler_hub_table_handle_t client_table_handle)
     {
         profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
-        for (auto& column : table->columns)
+        for (int ri=0; ri < table->rows.size(); ri++)
         {
-            result = client::interface::AddTableColumn(client_table_handle, column.name.c_str(), column.type);
-            if (result != kProfilerHubStatusSuccess)
-            {
-                return result;
-            }
-        }
-        for (auto& row : table->rows)
-        {
-            if (row.cells.size() != table->columns.size())
+            if (table->rows[ri].cells.size() != table->columns.size())
                 return kProfilerHubStatusUnknownError;
-            profiler_hub_table_row_handle_t row_handle = client::interface::AddTableRowContainer(client_table_handle);
-            for (int i = 0; i < row.cells.size(); i++)
+            profiler_hub_table_row_handle_t row_handle = client::interface::AddTableRowContainer(m_client_trace, client_table_handle, table->columns.size());
+            for (int ci = 0; ci < table->rows[ri].cells.size(); ci++)
             {
-                if (std::holds_alternative<std::string>(row.cells[i].value))
+                size_t value_int;
+                double value_double;
+                std::string value_str;
+                const void* value_ptr = nullptr;
+                if (std::holds_alternative<std::string>(table->rows[ri].cells[ci].value))
                 {
-                    result = client::interface::AddTableCellAsString(row_handle, i, std::get<std::string>(row.cells[i].value).c_str());
+                    value_str = std::get<std::string>(table->rows[ri].cells[ci].value);
+                    value_ptr = value_str.c_str();
                 } else
-                    if (std::holds_alternative<size_t>(row.cells[i].value))
+                    if (std::holds_alternative<size_t>(table->rows[ri].cells[ci].value))
                     {
-                        result = client::interface::AddTableCellAsInt(row_handle, i, std::get<size_t>(row.cells[i].value));
+                        value_int = std::get<size_t>(table->rows[ri].cells[ci].value);
+                        value_ptr = &value_int;
                     } else
-                        if (std::holds_alternative<double>(row.cells[i].value))
+                        if (std::holds_alternative<double>(table->rows[ri].cells[ci].value))
                         {
-                            result = client::interface::AddTableCellAsDouble(row_handle, i, std::get<double>(row.cells[i].value));
+                            value_double = std::get<double>(table->rows[ri].cells[ci].value);
+                            value_ptr = &value_double;
                         }
 
+                    result = client::interface::AddTableCell(
+                        m_client_trace,
+                        row_handle, 
+                        ci, 
+                        table->columns[ci].name.c_str(), 
+                        table->columns[ci].type, 
+                        (profiler_hub_value_handle_t)value_ptr);
                     if (result != kProfilerHubStatusSuccess)
                     {
                         return result;
@@ -407,11 +439,13 @@ namespace profiler_hub::interface
             uint64_t timestamp_start,
             uint64_t timestamp_end)
     {
-        missing_types::event_filter_t filter = { {timestamp_start, timestamp_end} };
         auto& tracks = m_reader->get_tracks();
         auto it = std::find_if(tracks.begin(), tracks.end(), [track_id](reader_types::track_info_ptr_t track_info) {return track_info->id.value == track_id; });
         if (it != tracks.end())
         {
+            missing_types::event_filter_t filter = { {timestamp_start, timestamp_end}, {}, {}, {}, {}, (profiler_hub_instance_id_t)missing_t::integer("it->get()->instance_info->id") };
+            // todo : instead of reading the whole table, then adding it to client, add every row of the table as soon as you get it
+            // change add_table_to_client to add add_table_columns_to_client and add_table_row_to_client
             auto& table = missing_t::get_event_table_for_track(*it, filter, timestamp_start, timestamp_end);
             
             return add_table_to_client(table, client_table_handle);
@@ -422,25 +456,20 @@ namespace profiler_hub::interface
     profiler_hub_result_t 
         profiler_hub_trace_t::get_search_time_slice(
             future_t * future,
+            profiler_hub_instance_id_t instance,
             profiler_hub_table_handle_t client_table_handle,
-            size_t num_operations,
-            profiler_hub_event_operation_t* operations,
+            profiler_hub_event_operation_t operation,
             uint64_t timestamp_start,
             uint64_t timestamp_end,
             size_t num_search_strings,
             profiler_hub_search_strings_t string_filters)
     {
-        std::vector<reader_types::event_type_t> op_types;
-        for (int i = 0; i < num_operations; i++)
-        {
-            op_types.push_back(operations[i]);
-        }
         std::vector<std::string> search_strings;
         for (int i = 0; i < num_search_strings; i++)
         {
             search_strings.push_back(string_filters[i]);
         }
-        missing_types::event_filter_t filter = { {timestamp_start, timestamp_end}, {}, {}, op_types, search_strings };
+        missing_types::event_filter_t filter = { {timestamp_start, timestamp_end}, {}, {}, operation, search_strings, instance };
         
         auto& table = missing_t::get_event_table(filter, timestamp_start, timestamp_end);
         return add_table_to_client(table, client_table_handle);
@@ -449,12 +478,12 @@ namespace profiler_hub::interface
     profiler_hub_result_t profiler_hub_trace_t::get_data_flow_for_event(
         future_t* future,
         profiler_hub_instance_id_t instance,
+        profiler_hub_flowtrace_handle_t flow_container,
         profiler_hub_event_operation_t operation,
         profiler_hub_event_id_t event_id) {
         missing_t::check_missing_client(m_client_trace);
         profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
         auto & flow_endpoints = m_reader->get_flows_for_event(reader_types::detail::event_id_access::make(operation, event_id));
-        profiler_hub_flowtrace_handle_t flow_container = client::interface::AddEventFlowTraceContainer(m_client_trace, instance, operation, event_id);
         for (auto& endpoint : flow_endpoints)
         {
             size_t dest_id = reader_types::detail::event_id_access::row_id(endpoint.dest);
@@ -464,9 +493,11 @@ namespace profiler_hub::interface
             if (event_id == src_id)
             {
                 result = client::interface::AddEventDataFlowEndPoint(
+                    m_client_trace,
                     flow_container,
                     dest_type,
                     dest_id,
+                    missing_t::integer("reader_types::detail::event_id_access::track_id(endpoint.dest)"),
                     kProfilerHubDirectionOutgoing,
                     missing_t::integer("reader_types::detail::event_id_access::timestamp(endpoint.dest)"),
                     missing_t::integer("reader_types::detail::event_id_access::duration(endpoint.dest)"),
@@ -479,9 +510,11 @@ namespace profiler_hub::interface
             else if (event_id == dest_id)
             {
                 result = client::interface::AddEventDataFlowEndPoint(
+                    m_client_trace,
                     flow_container,
                     src_type,
                     src_id,
+                    missing_t::integer("reader_types::detail::event_id_access::track_id(endpoint.dest)"),
                     kProfilerHubDirectionIncoming,
                     missing_t::integer("reader_types::detail::event_id_access::timestamp(endpoint.src)"),
                     missing_t::integer("reader_types::detail::event_id_access::duration(endpoint.src)"),
@@ -502,6 +535,7 @@ namespace profiler_hub::interface
     profiler_hub_result_t profiler_hub_trace_t::get_event_details(
         future_t* future,
         profiler_hub_instance_id_t instance,
+        profiler_hub_ext_data_handle_t event_info_container,
         profiler_hub_event_operation_t operation,
         profiler_hub_event_id_t event_id) {
         missing_t::check_missing_client(m_client_trace);
@@ -509,20 +543,19 @@ namespace profiler_hub::interface
         auto & event_info = m_reader->get_event_info(reader_types::detail::event_id_access::make(operation, event_id));
         if (event_info.has_value())
         {
-            profiler_hub_ext_data_handle_t event_info_container = client::interface::AddEventExtDataContainer(m_client_trace, instance, operation, event_id);
             for (auto& prop : event_info->properties)
             {
                 if (std::holds_alternative<std::string>(prop.value))
                 {
-                    result = client::interface::AddEventExtendedInfo(event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeString, std::get<std::string>(prop.value).c_str());
+                    result = client::interface::AddEventExtendedInfo(m_client_trace, instance, event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeString, std::get<std::string>(prop.value).c_str());
                 } else
                     if (std::holds_alternative<size_t>(prop.value))
                     {
-                        result = client::interface::AddEventExtendedInfo(event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeInt, std::to_string(std::get<uint64_t>(prop.value)).c_str());
+                        result = client::interface::AddEventExtendedInfo(m_client_trace, instance, event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeInt, std::to_string(std::get<uint64_t>(prop.value)).c_str());
                     } else
                         if (std::holds_alternative<double>(prop.value))
                         {
-                            result = client::interface::AddEventExtendedInfo(event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeInt, std::to_string(std::get<double>(prop.value)).c_str());
+                            result = client::interface::AddEventExtendedInfo(m_client_trace, instance, event_info_container, "profiler-hub", prop.key.c_str(), kPprofilerHubDataTypeInt, std::to_string(std::get<double>(prop.value)).c_str());
                         }
                         else
                         {
@@ -532,7 +565,7 @@ namespace profiler_hub::interface
                     if (kProfilerHubStatusSuccess != result)
                         return result;
             }
-            result = client::interface::AddEventEssentialInfo(event_info_container,
+            result = client::interface::AddEventEssentialInfo(m_client_trace, instance, event_info_container,
                 missing_t::integer("event_info->track->id.value"),
                 missing_t::integer("event_info->stream_track->id.value"),
                 missing_t::integer("event_info->level"),
@@ -543,7 +576,7 @@ namespace profiler_hub::interface
             auto event_arguments = m_reader->get_arguments(reader_types::detail::event_id_access::make(operation, event_id));
             for (auto& arg : event_arguments)
             {
-                result = client::interface::AddEventArgumentsInfo(event_info_container, arg->position, arg->name.c_str(), arg->type.c_str(), arg->value.c_str());
+                result = client::interface::AddEventArgumentsInfo(m_client_trace, instance, event_info_container, arg->position, arg->name.c_str(), arg->type.c_str(), arg->value.c_str());
                 if (kProfilerHubStatusSuccess != result)
                     return result;
             }
@@ -559,11 +592,11 @@ namespace profiler_hub::interface
     profiler_hub_result_t profiler_hub_trace_t::get_event_stack_trace(
         future_t* future,
         profiler_hub_instance_id_t instance,
+        profiler_hub_call_stack_handle_t call_stack_container,
         profiler_hub_event_operation_t operation,
         profiler_hub_event_id_t event_id) {
         missing_t::check_missing_client(m_client_trace);
         profiler_hub_result_t result = kProfilerHubStatusNotLoaded;
-        profiler_hub_call_stack_handle_t call_stack_container = client::interface::AddEventCallStackContainer(m_client_trace, instance, operation, event_id);
         auto & call_stack = m_reader->get_call_stack(reader_types::detail::event_id_access::make(operation, event_id));
         size_t depth = 0;
         for (auto& stack_frame : call_stack)
@@ -571,6 +604,8 @@ namespace profiler_hub::interface
             if (stack_frame.program_counter.has_value())
             {
                 result = client::interface::AddEventCallStackFrame(
+                    m_client_trace, 
+                    instance,
                     call_stack_container,
                     stack_frame.program_counter->function.c_str(),
                     stack_frame.program_counter->filename.c_str(),
@@ -585,12 +620,13 @@ namespace profiler_hub::interface
     }
 
 
-    profiler_hub_result_t trim_trace_database(
+    profiler_hub_result_t profiler_hub_trace_t::trim_trace_database(
         future_t* future,
         uint64_t timestamp_start,
-        uint64_t timestamp_end)
+        uint64_t timestamp_end,
+        profiler_hub_string_t new_path)
     {
-        return missing_t::trim_trace_database(timestamp_start, timestamp_end);
+        return missing_t::trim_trace_database(timestamp_start, timestamp_end, new_path);
     }
     
 }

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.h
@@ -10,14 +10,17 @@ namespace profiler_hub::interface
 	class profiler_hub_trace_t
 	{
 	public:
-		profiler_hub_trace_t(client_trace_handle_t client_trace, std::string trace_path, std::string config_path) :
-			m_client_trace(client_trace), m_trace_path(trace_path), m_config_path(config_path) {
+		profiler_hub_trace_t(std::string trace_path) :
+			m_client_trace(nullptr), m_trace_path(trace_path), m_config_path(nullptr), m_histogram_bucket_count(300) {
+		}
+
+		void set_trace_properties(client_trace_handle_t client_trace, std::string config_path, size_t histogram_bucket_count) { 
+			m_client_trace = client_trace; m_config_path = config_path; m_histogram_bucket_count = histogram_bucket_count;
 		}
 
 		profiler_hub_result_t 
 			open_trace(
-				future_t * future, 
-				uint32_t histogram_bucket_count);
+				future_t * future);
 
 		profiler_hub_result_t 
 			get_time_slice(
@@ -67,7 +70,13 @@ namespace profiler_hub::interface
 				profiler_hub_event_id_t event_id);
 
 
-		static profiler_hub_result_t detect_trace(std::string trace_path);
+		static profiler_hub_db_type_t 
+			detect_trace(std::string trace_path);
+
+		profiler_hub_result_t trim_trace_database(
+			future_t* future, 
+			uint64_t timestamp_start, 
+			uint64_t timestamp_end);
 
 		profiler_hub::storage_t* get_storage() { return m_storage.get(); }
 		profiler_hub::reader_t* get_reader() { return m_reader.get(); }
@@ -92,6 +101,7 @@ namespace profiler_hub::interface
 		client_trace_handle_t m_client_trace;
 		std::string m_trace_path;
 		std::string m_config_path;
+		size_t m_histogram_bucket_count;
 		std::unique_ptr<profiler_hub::storage_t> m_storage;
 		std::shared_ptr<profiler_hub::reader_t>  m_reader;
 	};

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.h
@@ -1,0 +1,99 @@
+#include "profiler_hub_interface.h"
+#include "profiler_hub_client_interface.h"
+#include "profiler-hub/reader.hpp"
+#include "profiler-hub/storage.hpp"
+#include "profiler_hub_missing.hpp"
+#include "profiler_hub_future.hpp"
+
+namespace profiler_hub::interface
+{
+	class profiler_hub_trace_t
+	{
+	public:
+		profiler_hub_trace_t(client_trace_handle_t client_trace, std::string trace_path, std::string config_path) :
+			m_client_trace(client_trace), m_trace_path(trace_path), m_config_path(config_path) {
+		}
+
+		profiler_hub_result_t 
+			open_trace(
+				future_t * future, 
+				uint32_t histogram_bucket_count);
+
+		profiler_hub_result_t 
+			get_time_slice(
+				future_t * future,
+				profiler_hub_track_id_t track_id,
+				uint64_t timestamp_start,
+				uint64_t timestamp_end);
+
+		profiler_hub_result_t
+			get_table_time_slice(
+				future_t * future,
+				profiler_hub_table_handle_t table_handle,
+				profiler_hub_track_id_t track_id,
+				uint64_t timestamp_start,
+				uint64_t timestamp_end);
+
+		profiler_hub_result_t
+			get_search_time_slice(
+				future_t * future,
+				profiler_hub_table_handle_t table_handle,
+				size_t num_operations,
+				profiler_hub_event_operation_t* operations,
+				uint64_t timestamp_start,
+				uint64_t timestamp_end,
+				size_t num_search_strings,
+				profiler_hub_search_strings_t string_filters);
+
+		profiler_hub_result_t 
+			get_data_flow_for_event(
+				future_t* future, 
+				profiler_hub_instance_id_t instance, 
+				profiler_hub_event_operation_t operation, 
+				profiler_hub_event_id_t event_id);
+
+		profiler_hub_result_t 
+			get_event_details(
+				future_t* future, 
+				profiler_hub_instance_id_t instance, 
+				profiler_hub_event_operation_t operation, 
+				profiler_hub_event_id_t event_id);
+
+		profiler_hub_result_t 
+			get_event_stack_trace(
+				future_t* future,
+				profiler_hub_instance_id_t instance,
+				profiler_hub_event_operation_t operation,
+				profiler_hub_event_id_t event_id);
+
+
+		static profiler_hub_result_t detect_trace(std::string trace_path);
+
+		profiler_hub::storage_t* get_storage() { return m_storage.get(); }
+		profiler_hub::reader_t* get_reader() { return m_reader.get(); }
+
+		profiler_hub_value_type_t get_node_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
+		profiler_hub_value_type_t get_process_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
+		profiler_hub_value_type_t get_thread_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
+		profiler_hub_value_type_t get_agent_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
+		profiler_hub_value_type_t get_queue_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
+		profiler_hub_value_type_t get_stream_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
+		profiler_hub_value_type_t get_pmc_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
+		
+	private:
+		// Type conversion can be avoided if types match completely 
+		// Currently there is no corresponded track type for kProfilerHubCategoryRegionSampled on profiler hub side
+		// And there is no "dma" type of track on rocOptiq side
+		profiler_hub_track_category_t get_track_category(profiler_hub::reader_types::track_type_t type, profiler_hub::reader_types::region_track_kind_t region_kind);
+		profiler_hub_agent_type_t get_agent_type(std::string& type);
+		profiler_hub_result_t add_table_to_client(missing_types::table_ptr_t table, profiler_hub_table_handle_t client_table_handle);
+
+	private:
+		client_trace_handle_t m_client_trace;
+		std::string m_trace_path;
+		std::string m_config_path;
+		std::unique_ptr<profiler_hub::storage_t> m_storage;
+		std::shared_ptr<profiler_hub::reader_t>  m_reader;
+	};
+
+}

--- a/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.h
+++ b/thirdparty/profiler-hub-client/optiq/profiler_hub_trace.h
@@ -26,8 +26,19 @@ namespace profiler_hub::interface
 			get_time_slice(
 				future_t * future,
 				profiler_hub_track_id_t track_id,
+				profiler_hub_timeslice_handle_t slice_container,
 				uint64_t timestamp_start,
 				uint64_t timestamp_end);
+
+		profiler_hub_result_t 
+			get_pmc_time_slice(
+				future_t * future,
+				profiler_hub_track_id_t track_id,
+				profiler_hub_timeslice_handle_t slice_container,
+				uint64_t timestamp_start,
+				uint64_t timestamp_end,
+				bool left_neighbor,
+				bool right_neighbor);
 
 		profiler_hub_result_t
 			get_table_time_slice(
@@ -40,9 +51,9 @@ namespace profiler_hub::interface
 		profiler_hub_result_t
 			get_search_time_slice(
 				future_t * future,
+				profiler_hub_instance_id_t instance,
 				profiler_hub_table_handle_t table_handle,
-				size_t num_operations,
-				profiler_hub_event_operation_t* operations,
+				profiler_hub_event_operation_t operation,
 				uint64_t timestamp_start,
 				uint64_t timestamp_end,
 				size_t num_search_strings,
@@ -52,6 +63,7 @@ namespace profiler_hub::interface
 			get_data_flow_for_event(
 				future_t* future, 
 				profiler_hub_instance_id_t instance, 
+				profiler_hub_flowtrace_handle_t container,
 				profiler_hub_event_operation_t operation, 
 				profiler_hub_event_id_t event_id);
 
@@ -59,6 +71,7 @@ namespace profiler_hub::interface
 			get_event_details(
 				future_t* future, 
 				profiler_hub_instance_id_t instance, 
+				profiler_hub_ext_data_handle_t ontainer,
 				profiler_hub_event_operation_t operation, 
 				profiler_hub_event_id_t event_id);
 
@@ -66,6 +79,7 @@ namespace profiler_hub::interface
 			get_event_stack_trace(
 				future_t* future,
 				profiler_hub_instance_id_t instance,
+				profiler_hub_call_stack_handle_t container,
 				profiler_hub_event_operation_t operation,
 				profiler_hub_event_id_t event_id);
 
@@ -76,18 +90,19 @@ namespace profiler_hub::interface
 		profiler_hub_result_t trim_trace_database(
 			future_t* future, 
 			uint64_t timestamp_start, 
-			uint64_t timestamp_end);
+			uint64_t timestamp_end,
+			profiler_hub_string_t new_path);
 
 		profiler_hub::storage_t* get_storage() { return m_storage.get(); }
 		profiler_hub::reader_t* get_reader() { return m_reader.get(); }
 
-		profiler_hub_value_type_t get_node_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
-		profiler_hub_value_type_t get_process_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
-		profiler_hub_value_type_t get_thread_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
-		profiler_hub_value_type_t get_agent_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
-		profiler_hub_value_type_t get_queue_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
-		profiler_hub_value_type_t get_stream_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
-		profiler_hub_value_type_t get_pmc_info_by_tag(size_t row_key, const char* property_tag, profiler_hub_optional_t value);
+		profiler_hub_result_t report_node_info(profiler_hub_instance_id_t instance_id);
+		profiler_hub_result_t report_process_info(profiler_hub_instance_id_t instance_id);
+		profiler_hub_result_t report_thread_info(profiler_hub_instance_id_t instance_id);
+		profiler_hub_result_t report_agent_info(profiler_hub_instance_id_t instance_id);
+		profiler_hub_result_t report_queue_info(profiler_hub_instance_id_t instance_id);
+		profiler_hub_result_t report_stream_info(profiler_hub_instance_id_t instance_id);
+		profiler_hub_result_t report_pmc_info(profiler_hub_instance_id_t instance_id);
 		
 	private:
 		// Type conversion can be avoided if types match completely 
@@ -95,7 +110,16 @@ namespace profiler_hub::interface
 		// And there is no "dma" type of track on rocOptiq side
 		profiler_hub_track_category_t get_track_category(profiler_hub::reader_types::track_type_t type, profiler_hub::reader_types::region_track_kind_t region_kind);
 		profiler_hub_agent_type_t get_agent_type(std::string& type);
-		profiler_hub_result_t add_table_to_client(missing_types::table_ptr_t table, profiler_hub_table_handle_t client_table_handle);
+		profiler_hub_result_t add_table_to_client(
+			missing_types::table_ptr_t table, 
+			profiler_hub_table_handle_t client_table_handle);
+
+		template <typename ListT>
+		profiler_hub_result_t report_info_properties(
+			ListT& collection,
+			const char* category,
+			profiler_hub_instance_id_t instance_id,
+			const std::unordered_map<std::string, std::function<profiler_hub_value_type_t(typename ListT::iterator, profiler_hub_optional_t)>>& properties_dispatcher);
 
 	private:
 		client_trace_handle_t m_client_trace;


### PR DESCRIPTION
## Motivation

This PR is just to save and share the work done for Profiler Hub interface with Optiq.
It's a bridge library. It should speed up profiler-hub integration and make it functional.
The library code should be a part of profiler hub repository in future, if design is accepted.
We need to decide how profiler hub will be integrated into a client. One way is by just adding headers and library binary.
Another way integrating with "git add submodule" and "git sparse-checkout" from rocm-systems.
I do not currently have permissions to push it to rocm-systems branch, so I created temporary branch in roc-Optiq repository for profiler-hub interface library.
Proposing integrating profiler hub into roc-Optiq in 3 stages:
First stage of integration is creating a test utility, which will run profiler-hub and data-model in parallel and check functionality, data integrity and performance.
Second stage is using profiler hub as one of data-model adapters. 
Third stage is completely move to profiler hub with data-model as thin interface layer between profiler hub and controller.

## Technical Details

Profiler hub code is not a part of this change. We need to decide how do we integrate it first.
The interface library is to be used with profiler-hub test utility developed within roc-optiq repository as a first stage of integration.
The interface library is located in thirdparty/profiler-hub-client/optiq directory. Cmake file will require thirdparty/profiler-hub to build the library.
It's just a draft and main purpose is to speed up changes in profiler-hub. It also serves as a source of requirements.
All the required changes are listed in either missing_t class or  profiler_hub::missing_types namespace. 
The requirements may not be 100% complete at this point, but we need to set a direction and establish integration process first.