### PR TITLE
Simplified Table Filter

### DIFF
--- a/src/app/test/app_tests.cpp
+++ b/src/app/test/app_tests.cpp
@@ -1369,10 +1369,7 @@ void RegisterAppTests(ImGuiTestEngine* e)
         // (Launch/Dispatch/MemoryCopy/MemoryAllocate/LaunchSample -- see
         // EventSearch::Search). If the sample db changes, update it to a term the
         // new db contains.
-        char* buf = es->TextInput();
-        IM_CHECK(buf != nullptr);
-        if (buf == nullptr) return;
-        snprintf(buf, es->TextInputLimit(), "%s", "hipLaunchKernel");
+        es->TextInput() = "hipLaunchKernel";
         es->Search();
         ctx->Yield(2);
         IM_CHECK(es->Searched() == true);

--- a/src/controller/inc/rocprofvis_controller_enums.h
+++ b/src/controller/inc/rocprofvis_controller_enums.h
@@ -598,6 +598,8 @@ typedef enum rocprofvis_controller_array_properties_t : uint32_t
     kRPVControllerArrayNumEntries = __kRPVControllerArrayPropertiesFirst,
     // Indexed entry.
     kRPVControllerArrayEntryIndexed,
+    // Primitive type of the indexed entry.
+    kRPVControllerArrayEntryTypeIndexed,
     __kRPVControllerArrayPropertiesLast
 } rocprofvis_controller_array_properties_t;
 /* JSON: RPVArray

--- a/src/controller/src/compute/rocprofvis_controller_table_compute_pivot.cpp
+++ b/src/controller/src/compute/rocprofvis_controller_table_compute_pivot.cpp
@@ -20,6 +20,8 @@ namespace RocProfVis
 namespace Controller
 {
 
+constexpr const char* PIVOT_TABLE_TITLE = "Kernel Metrics Matrix";
+
 ComputePivotTable::ComputePivotTable(const uint64_t id)
 : Table(id, __kRPVControllerTablePropertiesFirst, __kRPVControllerTablePropertiesLast)
 , m_workload_id(0)
@@ -262,6 +264,7 @@ ComputePivotTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t index, uint64
                             }
                             m_rows[k] = std::move(row);
                         }
+                        m_num_items = m_rows.size();
                     }
                 }
                 rocprofvis_db_future_free(db_future);
@@ -320,52 +323,6 @@ ComputePivotTable::ExportCSV(rocprofvis_dm_trace_t dm_handle, Arguments& args,
 }
 
 rocprofvis_result_t
-ComputePivotTable::GetUInt64(rocprofvis_property_t property, uint64_t index,
-                             uint64_t* value)
-{
-    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
-    if(value)
-    {
-        switch(property)
-        {
-            case kRPVControllerTableId:
-            {
-                *value = m_id;
-                result = kRocProfVisResultSuccess;
-                break;
-            }
-            case kRPVControllerTableNumColumns:
-            {
-                *value = m_columns.size();
-                result = kRocProfVisResultSuccess;
-                break;
-            }
-            case kRPVControllerTableNumRows:
-            {
-                *value = m_rows.size();
-                result = kRocProfVisResultSuccess;
-                break;
-            }
-            case kRPVControllerTableColumnTypeIndexed:
-            {
-                if(index < m_columns.size())
-                {
-                    *value = m_columns[index].m_type;
-                    result = kRocProfVisResultSuccess;
-                }
-                break;
-            }
-            default:
-            {
-                result = UnhandledProperty(property);
-                break;
-            }
-        }
-    }
-    return result;
-}
-
-rocprofvis_result_t
 ComputePivotTable::GetString(rocprofvis_property_t property, uint64_t index, char* value,
                              uint32_t* length)
 {
@@ -374,44 +331,15 @@ ComputePivotTable::GetString(rocprofvis_property_t property, uint64_t index, cha
     {
         switch(property)
         {
-            case kRPVControllerTableColumnHeaderIndexed:
-            {
-                if(index < m_columns.size())
-                {
-                    if(!value && length)
-                    {
-                        *length = static_cast<uint32_t>(m_columns[index].m_name.size());
-                        result  = kRocProfVisResultSuccess;
-                    }
-                    else if(value && length && *length > 0)
-                    {
-                        const std::string& name = m_columns[index].m_name;
-                        const size_t copy = std::min(name.size(), static_cast<size_t>(*length));
-                        if (copy > 0) std::memcpy(value, name.data(), copy);
-                        result = kRocProfVisResultSuccess;
-                    }
-                }
-                break;
-            }
             case kRPVControllerTableTitle:
             {
-                std::string title = "Kernel Metrics Matrix";
-                if(!value && length)
-                {
-                    *length = static_cast<uint32_t>(title.size());
-                    result  = kRocProfVisResultSuccess;
-                }
-                else if(value && length && *length > 0)
-                {
-                    const size_t copy = std::min(title.size(), static_cast<size_t>(*length));
-                    if (copy > 0) std::memcpy(value, title.data(), copy);
-                    result = kRocProfVisResultSuccess;
-                }
+                result = GetStringImpl(value, length, PIVOT_TABLE_TITLE,
+                                       static_cast<uint32_t>(strlen(PIVOT_TABLE_TITLE)));
                 break;
             }
             default:
             {
-                result = UnhandledProperty(property);
+                result = Table::GetString(property, index, value, length);
                 break;
             }
         }

--- a/src/controller/src/compute/rocprofvis_controller_table_compute_pivot.h
+++ b/src/controller/src/compute/rocprofvis_controller_table_compute_pivot.h
@@ -31,7 +31,6 @@ public:
     rocprofvis_result_t ExportCSV(rocprofvis_dm_trace_t dm_handle, Arguments& args, Future* future, const char* path) const final;
 
     // Handlers for getters
-    rocprofvis_result_t GetUInt64(rocprofvis_property_t property, uint64_t index, uint64_t* value) final;
     rocprofvis_result_t GetString(rocprofvis_property_t property, uint64_t index, char* value, uint32_t* length) final;
 
 private:

--- a/src/controller/src/rocprofvis_controller_array.cpp
+++ b/src/controller/src/rocprofvis_controller_array.cpp
@@ -76,6 +76,19 @@ rocprofvis_result_t Array::GetUInt64(rocprofvis_property_t property, uint64_t in
                 }
                 break;
             }
+            case kRPVControllerArrayEntryTypeIndexed:
+            {
+                if(index < m_array.size())
+                {
+                    *value = static_cast<uint64_t>(m_array[index].GetType());
+                    result = kRocProfVisResultSuccess;
+                }
+                else
+                {
+                    result = kRocProfVisResultInvalidArgument;
+                }
+                break;
+            }
             case kRPVControllerArrayNumEntries:
             {
                 *value = m_array.size();

--- a/src/controller/src/rocprofvis_controller_table.cpp
+++ b/src/controller/src/rocprofvis_controller_table.cpp
@@ -25,6 +25,77 @@ rocprofvis_controller_object_type_t Table::GetType(void)
 	return kRPVControllerObjectTypeTable;
 }
 
+rocprofvis_result_t
+Table::GetUInt64(rocprofvis_property_t property, uint64_t index, uint64_t* value)
+{
+    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
+    if(value)
+    {
+        switch(property)
+        {
+            case kRPVControllerTableId:
+            {
+                *value = m_id;
+                result = kRocProfVisResultSuccess;
+                break;
+            }
+            case kRPVControllerTableNumColumns:
+            {
+                *value = m_columns.size();
+                result = kRocProfVisResultSuccess;
+                break;
+            }
+            case kRPVControllerTableNumRows:
+            {
+                *value = m_num_items;
+                result = kRocProfVisResultSuccess;
+                break;
+            }
+            case kRPVControllerTableColumnTypeIndexed:
+            {
+                if(index < m_columns.size())
+                {
+                    *value = m_columns[index].m_type;
+                    result = kRocProfVisResultSuccess;
+                }
+                break;
+            }
+            default:
+            {
+                result = UnhandledProperty(property);
+                break;
+            }
+        }
+    }
+    return result;
+}
+
+rocprofvis_result_t
+Table::GetString(rocprofvis_property_t property, uint64_t index, char* value, uint32_t* length)
+{
+    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
+    if(length)
+    {
+        switch(property)
+        {
+            case kRPVControllerTableColumnHeaderIndexed:
+            {
+                if(index < m_columns.size())
+                {
+                    result = GetStdStringImpl(value, length, m_columns[index].m_name);
+                }
+                break;
+            }
+            default:
+            {
+                result = UnhandledProperty(property);
+                break;
+            }
+        }
+    }
+    return result;
+}
+
 void
 Table::Reset()
 {

--- a/src/controller/src/rocprofvis_controller_table.h
+++ b/src/controller/src/rocprofvis_controller_table.h
@@ -30,6 +30,9 @@ public:
 
     virtual rocprofvis_controller_object_type_t GetType(void);
 
+    rocprofvis_result_t GetUInt64(rocprofvis_property_t property, uint64_t index, uint64_t* value) override;
+    rocprofvis_result_t GetString(rocprofvis_property_t property, uint64_t index, char* value, uint32_t* length) override;
+
     virtual void Reset();
 
     virtual rocprofvis_result_t SetupAndFetch(Trace& controller, Arguments& args, Array& array, Future* future);

--- a/src/controller/src/system/rocprofvis_controller_table_system.cpp
+++ b/src/controller/src/system/rocprofvis_controller_table_system.cpp
@@ -129,7 +129,7 @@ rocprofvis_result_t SystemTable::Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t
                                                     ROCPROFVIS_ASSERT(value);
 
                                                     Data& row_value = row[j];
-                                                    row_value.SetType(m_columns[j].m_type);
+                                                    row_value.SetType(kRPVControllerPrimitiveTypeString);
                                                     row_value.SetString(value);
                                                 }
 
@@ -315,8 +315,12 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
                                                         table,
                                                         kRPVDMExtTableColumnNameCharPtrIndexed,
                                                         i);
-                                                m_columns[i-1].m_type =
-                                                    kRPVControllerPrimitiveTypeString;
+                                                m_columns[i-1].m_type = PrimitiveType(
+                                                    (rocprofvis_db_data_type_t)
+                                                        rocprofvis_dm_get_property_as_uint64(
+                                                            table,
+                                                            kRPVDMExtTableColumnTypeUInt64Indexed,
+                                                            i));
                                             }
                                         }
                                     }
@@ -339,6 +343,30 @@ rocprofvis_result_t SystemTable::Setup(rocprofvis_dm_trace_t dm_handle, Argument
         Reset();
     }
     delete query_args;
+    return result;
+}
+
+rocprofvis_controller_primitive_type_t
+SystemTable::PrimitiveType(rocprofvis_db_data_type_t db_data_type) const
+{
+    rocprofvis_controller_primitive_type_t result = kRPVControllerPrimitiveTypeString;
+    switch(db_data_type)
+    {
+        case kRPVDataTypeInt:
+        {
+            result = kRPVControllerPrimitiveTypeUInt64;
+            break;
+        }
+        case kRPVDataTypeDouble:
+        {
+            result = kRPVControllerPrimitiveTypeDouble;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
     return result;
 }
 
@@ -380,75 +408,6 @@ rocprofvis_result_t SystemTable::ExportCSV(rocprofvis_dm_trace_t dm_handle, Argu
         }
     }
     delete query_args;
-    return result;
-}
-
-rocprofvis_result_t SystemTable::GetUInt64(rocprofvis_property_t property, uint64_t index, uint64_t* value)
-{
-    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
-    if(value)
-    {
-        switch(property)
-        {
-            case kRPVControllerTableId:
-            {
-                *value = m_id;
-                result = kRocProfVisResultSuccess;
-                break;
-            }
-            case kRPVControllerTableNumColumns:
-            {
-                *value = m_columns.size();
-                result = kRocProfVisResultSuccess;
-                break;
-            }
-            case kRPVControllerTableNumRows:
-            {
-                *value = m_num_items;
-                result = kRocProfVisResultSuccess;
-                break;
-            }
-            case kRPVControllerTableColumnTypeIndexed:
-            {
-                if(index < m_columns.size())
-                {
-                    *value = m_columns[index].m_type;
-                    result = kRocProfVisResultSuccess;
-                }
-                break;
-            }
-            default:
-            {
-                result = UnhandledProperty(property);
-                break;
-            }
-        }
-    }
-    return result;
-}
-
-rocprofvis_result_t SystemTable::GetString(rocprofvis_property_t property, uint64_t index, char* value, uint32_t* length)
-{
-    rocprofvis_result_t result = kRocProfVisResultInvalidArgument;
-    if(length)
-    {
-        switch(property)
-        {
-            case kRPVControllerTableColumnHeaderIndexed:
-            {
-                if (index < m_columns.size())
-                {
-                    result = GetStdStringImpl(value, length, m_columns[index].m_name);
-                }
-                break;
-            }
-            default:
-            {
-                result = UnhandledProperty(property);
-                break;
-            }
-        }
-    }
     return result;
 }
 

--- a/src/controller/src/system/rocprofvis_controller_table_system.h
+++ b/src/controller/src/system/rocprofvis_controller_table_system.h
@@ -31,9 +31,6 @@ public:
     rocprofvis_result_t SetupAndFetch(Trace& controller, Arguments& args, Array& array, Future* future) final;
     rocprofvis_result_t ExportCSV(rocprofvis_dm_trace_t dm_handle, Arguments& args, Future* future, const char* path) const final;
 
-    // Handlers for getters.
-    rocprofvis_result_t GetUInt64(rocprofvis_property_t property, uint64_t index, uint64_t* value) final;
-    rocprofvis_result_t GetString(rocprofvis_property_t property, uint64_t index, char* value, uint32_t* length) final;
 
 protected:
     struct SystemTableArguments : TableArguments
@@ -59,6 +56,7 @@ protected:
 private:
     rocprofvis_result_t Setup(rocprofvis_dm_trace_t dm_handle, Arguments& args, Future* future) final;
     rocprofvis_result_t Fetch(rocprofvis_dm_trace_t dm_handle, uint64_t index, uint64_t count, Array& array, Future* future) final;
+    rocprofvis_controller_primitive_type_t PrimitiveType(rocprofvis_db_data_type_t db_data_type) const;
 
     std::vector<uint32_t> m_tracks;
     rocprofvis_dm_table_use_case_enum_t m_use_case;

--- a/src/controller/tests/rocprofvis_controller_system_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_system_tests.cpp
@@ -746,8 +746,7 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
                                   num_columns);
                     uint64_t column_type = 0;
                     result               = rocprofvis_controller_get_uint64(
-                        table_handle, kRPVControllerTableColumnTypeIndexed, j,
-                        &column_type);
+                        row_array, kRPVControllerArrayEntryTypeIndexed, j, &column_type);
                     REQUIRE(result == kRocProfVisResultSuccess);
 
                     switch(column_type)
@@ -1046,8 +1045,7 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture, "System Trace Controll
                                   num_columns);
                     uint64_t column_type = 0;
                     result               = rocprofvis_controller_get_uint64(
-                        table_handle, kRPVControllerTableColumnTypeIndexed, j,
-                        &column_type);
+                        row_array, kRPVControllerArrayEntryTypeIndexed, j, &column_type);
                     REQUIRE(result == kRocProfVisResultSuccess);
 
                     switch(column_type)

--- a/src/model/src/database/rocprofvis_db_query_builder.h
+++ b/src/model/src/database/rocprofvis_db_query_builder.h
@@ -418,7 +418,59 @@ class Builder
             {STREAM_TRACK_ID_PUBLIC_NAME,{STREAM_TRACK_ID_PUBLIC_NAME, TRACK_ID_TYPE,SCHEMA_INDEX_STREAM_TRACK_ID}},
         };
 
+        // Data types of public columns...
+        inline static std::unordered_map<std::string, rocprofvis_db_data_type_t> public_column_types = {
+            {OPERATION_SERVICE_NAME, kRPVDataTypeInt},
+            {DB_ID_PUBLIC_NAME, kRPVDataTypeInt},
+            {ID_PUBLIC_NAME, kRPVDataTypeInt},
+            {CATEGORY_PUBLIC_NAME, kRPVDataTypeString},
+            {NAME_PUBLIC_NAME, kRPVDataTypeString},
+            {ARGS_PUBLIC_NAME, kRPVDataTypeString},
+            {STREAM_PUBLIC_NAME, kRPVDataTypeString},
+            {QUEUE_PUBLIC_NAME, kRPVDataTypeString},
+            {NODE_PUBLIC_NAME, kRPVDataTypeInt},
+            {PROCESS_ID_PUBLIC_NAME, kRPVDataTypeInt},
+            {THREAD_ID_PUBLIC_NAME, kRPVDataTypeInt},
+            {AGENT_ABS_INDEX_PUBLIC_NAME, kRPVDataTypeInt},
+            {AGENT_TYPE_PUBLIC_NAME, kRPVDataTypeString},
+            {AGENT_TYPE_INDEX_PUBLIC_NAME, kRPVDataTypeInt},
+            {AGENT_NAME_PUBLIC_NAME, kRPVDataTypeString},
+            {START_PUBLIC_NAME, kRPVDataTypeInt},
+            {END_PUBLIC_NAME, kRPVDataTypeInt},
+            {DURATION_PUBLIC_NAME, kRPVDataTypeInt},
+            {GRID_SIZEX_PUBLIC_NAME, kRPVDataTypeInt},
+            {GRID_SIZEY_PUBLIC_NAME, kRPVDataTypeInt},
+            {GRID_SIZEZ_PUBLIC_NAME, kRPVDataTypeInt},
+            {WORKGROUP_SIZEX_PUBLIC_NAME, kRPVDataTypeInt},
+            {WORKGROUP_SIZEY_PUBLIC_NAME, kRPVDataTypeInt},
+            {WORKGROUP_SIZEZ_PUBLIC_NAME, kRPVDataTypeInt},
+            {LDS_SIZE_PUBLIC_NAME, kRPVDataTypeInt},
+            {SCRATCH_SIZE_PUBLIC_NAME, kRPVDataTypeInt},
+            {STATIC_LDS_SIZE_PUBLIC_NAME, kRPVDataTypeInt},
+            {STATIC_SCRATCH_SIZE_PUBLIC_NAME, kRPVDataTypeInt},
+            {SIZE_PUBLIC_NAME, kRPVDataTypeInt},
+            {ADDRESS_PUBLIC_NAME, kRPVDataTypeInt},
+            {LEVEL_REFERENCE, kRPVDataTypeString},
+            {AGENT_SRC_ABS_INDEX_PUBLIC_NAME, kRPVDataTypeInt},
+            {AGENT_SRC_TYPE_PUBLIC_NAME, kRPVDataTypeString},
+            {AGENT_SRC_TYPE_INDEX_PUBLIC_NAME, kRPVDataTypeInt},
+            {AGENT_SRC_NAME_PUBLIC_NAME, kRPVDataTypeString},
+            {SRC_ADDRESS_PUBLIC_NAME, kRPVDataTypeInt},
+            {COUNTER_ID_PUBLIC_NAME, kRPVDataTypeString},
+            {COUNTER_VALUE_PUBLIC_NAME, kRPVDataTypeDouble},
+            {TRACK_ID_PUBLIC_NAME, kRPVDataTypeInt},
+            {STREAM_TRACK_ID_PUBLIC_NAME, kRPVDataTypeInt},
+        };
 
+        static rocprofvis_db_data_type_t PublicColumnDataType(const std::string& name)
+        {
+            rocprofvis_db_data_type_t result = kRPVDataTypeString;
+            if (public_column_types.count(name) > 0)
+            {
+                result = public_column_types.at(name);
+            }
+            return result;
+        }
 
         static std::optional<std::string> FindColumnNameByIndex(const std::unordered_map<std::string, ColumnData>& m, const uint8_t& index) {
             for (const auto& [key, val] : m) {

--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -366,6 +366,8 @@ namespace DataModel
             else
             {
                 result = m_db->BindObject()->FuncAddTableColumn(table, column.m_name.c_str());
+                if (result == kRocProfVisDmResultSuccess)
+                    result = m_db->BindObject()->FuncAddTableColumnType(table, Builder::PublicColumnDataType(column.m_name));
                 column_index++;
                 if (result != kRocProfVisDmResultSuccess)
                     break;
@@ -393,7 +395,19 @@ namespace DataModel
             }
             else
             {
+                rocprofvis_db_data_type_t type = kRPVDataTypeDouble;
+                if (column.command == FilterExpression::SqlCommand::Count)
+                {
+                    type = kRPVDataTypeInt;
+                }
+                else
+                if (column.command == FilterExpression::SqlCommand::Column)
+                {
+                    type = Builder::PublicColumnDataType(column.column);
+                }
                 result = m_db->BindObject()->FuncAddTableColumn(table, column.public_name.c_str());
+                if (result == kRocProfVisDmResultSuccess)
+                    result = m_db->BindObject()->FuncAddTableColumnType(table, type);
                 column_index++;
                 if (result != kRocProfVisDmResultSuccess)
                     break;
@@ -516,6 +530,10 @@ namespace DataModel
             rocprofvis_dm_result_t result = m_db->BindObject()->FuncAddTableColumn(table, "NumRecords");
             if (kRocProfVisDmResultSuccess == result)
             {
+                result = m_db->BindObject()->FuncAddTableColumnType(table, kRPVDataTypeInt);
+            }
+            if (kRocProfVisDmResultSuccess == result)
+            {
                 result = m_db->BindObject()->FuncAddTableRowCell(row, std::to_string(num_rows).c_str());
             }
             return result;
@@ -592,7 +610,7 @@ namespace DataModel
                                 try {
                                     valid = lfilter.Evaluate(row_map);
                                 }
-                                catch (std::runtime_error err)
+                                catch (const std::runtime_error& err)
                                 {
                                     valid = false;
                                     eptr = std::current_exception();
@@ -622,11 +640,10 @@ namespace DataModel
                                 std::rethrow_exception(eptr);
                             }
                     }
-                    catch (std::runtime_error e)
+                    catch (const std::runtime_error& e)
                     {
                         spdlog::error("Error: {} ", e.what());
                         m_filter_lookup.clear();
-                        filtered = false;
                     }
 
                 }

--- a/src/model/src/datamodel/rocprofvis_dm_table.cpp
+++ b/src/model/src/datamodel/rocprofvis_dm_table.cpp
@@ -77,14 +77,14 @@ rocprofvis_dm_result_t Table::GetColumnNameAt(const rocprofvis_dm_property_index
 }
 
 rocprofvis_dm_result_t Table::GetColumnEnumAt(const rocprofvis_dm_property_index_t index, rocprofvis_db_table_column_enum_t& column_enum) {
-    ROCPROFVIS_ASSERT_MSG_RETURN(index < m_columns.size(), ERROR_INDEX_OUT_OF_RANGE, kRocProfVisDmResultNotLoaded);
+    ROCPROFVIS_ASSERT_MSG_RETURN(index < m_column_enums.size(), ERROR_INDEX_OUT_OF_RANGE, kRocProfVisDmResultNotLoaded);
     column_enum = m_column_enums[index];
     return kRocProfVisDmResultSuccess;
 }
 
 rocprofvis_dm_result_t Table::GetColumnTypeAt(const rocprofvis_dm_property_index_t index, rocprofvis_db_data_type_t & column_type) {
     column_type = kRPVDataTypeString; // default, in case caller does not check return status;
-    ROCPROFVIS_ASSERT_MSG_RETURN(index < m_columns.size(), ERROR_INDEX_OUT_OF_RANGE, kRocProfVisDmResultNotLoaded);
+    ROCPROFVIS_ASSERT_MSG_RETURN(index < m_column_types.size(), ERROR_INDEX_OUT_OF_RANGE, kRocProfVisDmResultNotLoaded);
     column_type = m_column_types[index];
     return kRocProfVisDmResultSuccess;
 }

--- a/src/view/src/icons/rocprovfis_icon_defines.h
+++ b/src/view/src/icons/rocprovfis_icon_defines.h
@@ -25,10 +25,12 @@ constexpr ImWchar icon_ranges[] = {
     0xF2C9, 0xF2C9,
     0xF2D7, 0xF2D7,
     0xF306, 0xF306,
+    0xF31B, 0xF31B,
     0xF33F, 0xF33F,
     0xF35C, 0xF35D,
     0xF366, 0xF366,
     0xF37E, 0xF37F,
+    0xF385, 0xF385,
     0xF386, 0xF386,
     0xF39C, 0xF39C,
     0xF3A8, 0xF3A8,
@@ -36,7 +38,7 @@ constexpr ImWchar icon_ranges[] = {
     0xF454, 0xF454,
     0xF472, 0xF472,
     0xF484, 0xF484,
-    0xF41B, 0xF41B,
+    0xF41C, 0xF41C,
     0xF41E, 0xF41E,
     0xF30F, 0xF30F,
     0
@@ -63,12 +65,14 @@ inline constexpr const char* ICON_CHART_BAR     = u8"\uF2B5";
 inline constexpr const char* ICON_ARCHIVE       = u8"\uF2C9";
 inline constexpr const char* ICON_DELETE        = u8"\uF2D7";
 inline constexpr const char* ICON_EYE_SLASH     = u8"\uF306";
+inline constexpr const char* ICON_FUNNEL        = u8"\uF31B";
 inline constexpr const char* ICON_TREE          = u8"\uF33F";
 inline constexpr const char* ICON_GRID          = u8"\uF35C";
 inline constexpr const char* ICON_ARROW_DOWN    = u8"\uF35D";
 inline constexpr const char* ICON_ARROW_UP      = u8"\uF366";
 inline constexpr const char* ICON_EDIT          = u8"\uF37E";
 inline constexpr const char* ICON_TRASH_CAN     = u8"\uF37F";
+inline constexpr const char* ICON_ARROW_IN_BOX  = u8"\uF385";
 inline constexpr const char* ICON_EXPAND        = u8"\uF386";
 inline constexpr const char* ICON_OPEN          = u8"\uF39C";
 inline constexpr const char* ICON_ARROWS_CYCLE  = u8"\uF3A8";
@@ -76,7 +80,7 @@ inline constexpr const char* ICON_EYE_THIN      = u8"\uF424";
 inline constexpr const char* ICON_LIST          = u8"\uF454";
 inline constexpr const char* ICON_STICKY_NOTE   = u8"\uF472";
 inline constexpr const char* ICON_CHART_PIE     = u8"\uF484";
-inline constexpr const char* ICON_COPY          = u8"\uF41B";
+inline constexpr const char* ICON_COPY          = u8"\uF41C";
 inline constexpr const char* ICON_CROP          = u8"\uF41E";
 inline constexpr const char* ICON_ARROW_FORWARD = u8"\uF30F";
 

--- a/src/view/src/model/rocprofvis_model_types.h
+++ b/src/view/src/model/rocprofvis_model_types.h
@@ -272,11 +272,12 @@ struct FormattedColumnInfo
 
 struct TableInfo
 {
-    std::shared_ptr<TableRequestParams>   table_params;
-    std::vector<std::string>              table_header;
-    std::vector<std::vector<std::string>> table_data;
-    std::vector<FormattedColumnInfo>      formatted_column_data;
-    uint64_t                              total_row_count;
+    std::shared_ptr<TableRequestParams>                 table_params;
+    std::vector<std::string>                            table_header;
+    std::vector<rocprofvis_controller_primitive_type_t> table_column_types;
+    std::vector<std::vector<std::string>>               table_data;
+    std::vector<FormattedColumnInfo>                    formatted_column_data;
+    uint64_t                                            total_row_count;
 };
 
 struct AnalysisTrackStatistics

--- a/src/view/src/model/rocprofvis_tables_model.cpp
+++ b/src/view/src/model/rocprofvis_tables_model.cpp
@@ -34,6 +34,12 @@ TablesModel::GetTableHeader(TableType type) const
     return m_tables[static_cast<size_t>(type)].table_header;
 }
 
+const std::vector<rocprofvis_controller_primitive_type_t>&
+TablesModel::GetTableColumnTypes(TableType type) const
+{
+    return m_tables[static_cast<size_t>(type)].table_column_types;
+}
+
 const std::vector<std::vector<std::string>>&
 TablesModel::GetTableData(TableType type) const
 {
@@ -71,6 +77,13 @@ TablesModel::SetTableHeader(TableType type, std::vector<std::string>&& header)
 }
 
 void
+TablesModel::SetTableColumnTypes(
+    TableType type, std::vector<rocprofvis_controller_primitive_type_t>&& column_type)
+{
+    m_tables[static_cast<size_t>(type)].table_column_types = std::move(column_type);
+}
+
+void
 TablesModel::SetTableData(TableType type, std::vector<std::vector<std::string>>&& data)
 {
     m_tables[static_cast<size_t>(type)].table_data = std::move(data);
@@ -100,6 +113,7 @@ TablesModel::ClearTable(TableType type)
 {
     auto& table = m_tables[static_cast<size_t>(type)];
     table.table_header.clear();
+    table.table_column_types.clear();
     table.table_data.clear();
     table.total_row_count = 0;
     table.table_params.reset();

--- a/src/view/src/model/rocprofvis_tables_model.h
+++ b/src/view/src/model/rocprofvis_tables_model.h
@@ -44,6 +44,8 @@ public:
     TableInfo&       GetTable(TableType type);
 
     const std::vector<std::string>&              GetTableHeader(TableType type) const;
+    const std::vector<rocprofvis_controller_primitive_type_t>& GetTableColumnTypes(
+        TableType type) const;
     const std::vector<std::vector<std::string>>& GetTableData(TableType type) const;
     const std::vector<FormattedColumnInfo>& GetFormattedTableData(TableType type) const;
     std::vector<FormattedColumnInfo>&       GetMutableFormattedTableData(TableType type);
@@ -53,6 +55,9 @@ public:
 
     // Table modification
     void SetTableHeader(TableType type, std::vector<std::string>&& header);
+    void SetTableColumnTypes(
+        TableType                                             type,
+        std::vector<rocprofvis_controller_primitive_type_t>&& column_types);
     void SetTableData(TableType type, std::vector<std::vector<std::string>>&& data);
     void SetTableParams(TableType type, std::shared_ptr<TableRequestParams> params);
     void SetTableTotalRowCount(TableType type, uint64_t count);

--- a/src/view/src/rocprofvis_analysis_view.cpp
+++ b/src/view/src/rocprofvis_analysis_view.cpp
@@ -23,14 +23,14 @@ AnalysisView::AnalysisView(DataProvider& dp, std::shared_ptr<TrackTopology> topo
       dp, TableType::kEventTable, kRPVControllerTableTypeEvents,
       DataProvider::EVENT_TABLE_REQUEST_ID,
       [&dp]() -> const TablesModel& { return dp.DataModel().GetTables(); },
-      [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); }, true,
-      timeline_selection))
+      [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); }, timeline_selection,
+      MultiTrackTable::FilterMode::kBasic | MultiTrackTable::FilterMode::kAdvanced))
 , m_sample_table(std::make_shared<MultiTrackTable>(
       dp, TableType::kSampleTable, kRPVControllerTableTypeSamples,
       DataProvider::SAMPLE_TABLE_REQUEST_ID,
       [&dp]() -> const TablesModel& { return dp.DataModel().GetTables(); },
-      [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); }, true,
-      timeline_selection))
+      [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); }, timeline_selection,
+      MultiTrackTable::FilterMode::kBasic | MultiTrackTable::FilterMode::kAdvanced))
 , m_events_view(std::make_shared<EventsView>(dp, timeline_selection))
 , m_annotation_view(std::make_shared<AnnotationView>(dp, annotation_manager))
 , m_track_details(std::make_shared<TrackDetails>(dp, topology, timeline_selection))

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -3374,13 +3374,21 @@ DataProvider::ProcessTableRequest(RequestInfo& req)
             table_handle, kRPVControllerTableNumRows, 0, &total_num_rows);
         ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
 
-        // get the column names
-        std::vector<std::string> column_names;
+        // get the column names and types
+        std::vector<std::string>                            column_names;
+        std::vector<rocprofvis_controller_primitive_type_t> column_types;
         column_names.reserve(num_columns);
+        column_types.reserve(num_columns);
         for(int i = 0; i < num_columns; i++)
         {
             column_names.emplace_back(
                 GetString(table_handle, kRPVControllerTableColumnHeaderIndexed, i));
+            uint64_t column_type;
+            result = rocprofvis_controller_get_uint64(
+                table_handle, kRPVControllerTableColumnTypeIndexed, i, &column_type);
+            ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+            column_types.emplace_back(
+                static_cast<rocprofvis_controller_primitive_type_t>(column_type));
         }
 
         uint64_t num_rows = 0;
@@ -3409,7 +3417,7 @@ DataProvider::ProcessTableRequest(RequestInfo& req)
             {
                 uint64_t column_type = 0;
                 result               = rocprofvis_controller_get_uint64(
-                    table_handle, kRPVControllerTableColumnTypeIndexed, j, &column_type);
+                    row_array, kRPVControllerArrayEntryTypeIndexed, j, &column_type);
                 ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
                 std::string column_value = "";
                 switch(column_type)
@@ -3530,7 +3538,8 @@ DataProvider::ProcessTableRequest(RequestInfo& req)
         tables.SetTableData(table_type_enum, std::move(table_data));
         tables.SetTableParams(table_type_enum, table_params);
         tables.SetTableTotalRowCount(table_type_enum, total_num_rows);
-        tables.SetTableHeader(table_type_enum,  std::move(column_names));
+        tables.SetTableHeader(table_type_enum, std::move(column_names));
+        tables.SetTableColumnTypes(table_type_enum, std::move(column_types));
     }
     else
     {

--- a/src/view/src/rocprofvis_event_search.cpp
+++ b/src/view/src/rocprofvis_event_search.cpp
@@ -48,7 +48,6 @@ EventSearch::EventSearch(DataProvider&                      dp,
 , m_options_changed(false)
 , m_advanced_active(false)
 , m_width(1000.0f)
-, m_text_input("\0")
 , m_time_range_changed_token(EventManager::InvalidSubscriptionToken)
 {
     m_time_range_changed_token = EventManager::GetInstance()->Subscribe(
@@ -75,6 +74,7 @@ EventSearch::Update()
     if(m_is_open && m_search_deferred && !m_data_provider.IsRequestPending(m_request_id))
     {
         Search();
+        m_search_deferred = false;
     }
     if(m_options_changed)
     {
@@ -379,16 +379,16 @@ EventSearch::Show()
 void
 EventSearch::Search()
 {
-    size_t input_length = strlen(m_text_input);
+    size_t input_length = m_text_input.size();
     if(input_length > 0)
     {
-        bool                     valid = false;
-        std::vector<std::string> terms;
+        bool valid = false;
+        m_terms.clear();
         if(m_text_input[0] == '"')
         {
             std::string term;
             bool        open_quote = true;
-            for(int i = 1; i < input_length; i++)
+            for(size_t i = 1; i < input_length; i++)
             {
                 if(m_text_input[i] == '"')
                 {
@@ -396,7 +396,7 @@ EventSearch::Search()
                     {
                         if(!term.empty())
                         {
-                            terms.emplace_back(term);
+                            m_terms.emplace_back(term);
                             term = "";
                         }
                         open_quote = false;
@@ -411,35 +411,18 @@ EventSearch::Search()
                     term += m_text_input[i];
                 }
             }
-            valid = !terms.empty() && !open_quote;
+            valid = !m_terms.empty() && !open_quote;
         }
         else
         {
-            terms.emplace_back(m_text_input);
+            m_terms.emplace_back(m_text_input);
             valid = true;
         }
         if(valid)
         {
-            const TimelineModel& timeline = m_data_provider.DataModel().GetTimeline();
-            double               start_ts;
-            double               end_ts;
-            if(!(m_respect_range_selection && m_timeline_selection &&
-                 m_timeline_selection->GetSelectedTimeRange(start_ts, end_ts)))
-            {
-                start_ts = timeline.GetStartTime();
-                end_ts   = timeline.GetEndTime();
-            }
-            m_data_provider.CancelRequest(m_request_id);
-            m_search_deferred = !m_data_provider.FetchTable(EventSearchRequestParams(
-                m_request_table_type,
-                { kRocProfVisDmOperationLaunch, kRocProfVisDmOperationDispatch,
-                  kRocProfVisDmOperationMemoryCopy, kRocProfVisDmOperationMemoryAllocate,
-                  kRocProfVisDmOperationLaunchSample },
-                start_ts, end_ts, "", m_include_substrings, m_include_category,
-                m_partial_matching, { terms }, 0, m_fetch_chunk_size, m_sort_column_index,
-                m_sort_order));
-            m_searched        = true;
-            m_should_open     = true;
+            RequestFetch();
+            m_searched    = true;
+            m_should_open = true;
         }
         else
         {
@@ -454,8 +437,9 @@ EventSearch::Clear()
 {
     m_data_provider.CancelRequest(m_request_id);
     m_table_model_mutable().ClearTable(m_table_type);
-    m_text_input[0] = '\0';
-    m_searched      = false;
+    m_terms.clear();
+    m_text_input.clear();
+    m_searched = false;
     if(!m_show_options)
     {
         m_should_close = true;
@@ -486,16 +470,10 @@ EventSearch::SetWidth(float width)
     m_width = std::max(0.0f, width);
 }
 
-char*
+std::string&
 EventSearch::TextInput()
 {
     return m_text_input;
-}
-
-size_t
-EventSearch::TextInputLimit() const
-{
-    return IM_ARRAYSIZE(m_text_input);
 }
 
 bool
@@ -541,6 +519,41 @@ EventSearch::ResetOptions()
     m_include_category        = DEFAULT_INCLUDE_CATEGORY;
     m_partial_matching        = DEFAULT_PARTIAL_MATCHING;
     m_respect_range_selection = DEFAULT_RESPECT_RANGE_SELECTION;
+}
+
+void
+EventSearch::UpdateFetchParams(std::shared_ptr<TableRequestParams>& params) const
+{
+    if(!params)
+    {
+        params = std::make_shared<EventSearchRequestParams>();
+    }
+    InfiniteScrollTable::UpdateFetchParams(params);
+    if(params)
+    {
+        std::shared_ptr<EventSearchRequestParams> search_params =
+            std::static_pointer_cast<EventSearchRequestParams>(params);
+        const TimelineModel& timeline = m_data_provider.DataModel().GetTimeline();
+        double               start_ts;
+        double               end_ts;
+        if(!(m_respect_range_selection && m_timeline_selection &&
+             m_timeline_selection->GetSelectedTimeRange(start_ts, end_ts)))
+        {
+            start_ts = timeline.GetStartTime();
+            end_ts   = timeline.GetEndTime();
+        }
+        search_params->m_op_types             = { kRocProfVisDmOperationLaunch,
+                                                  kRocProfVisDmOperationDispatch,
+                                                  kRocProfVisDmOperationMemoryCopy,
+                                                  kRocProfVisDmOperationMemoryAllocate,
+                                                  kRocProfVisDmOperationLaunchSample };
+        search_params->m_string_table_filters = m_terms;
+        search_params->m_include_substrings   = m_include_substrings;
+        search_params->m_include_category     = m_include_category;
+        search_params->m_partial_matching     = m_partial_matching;
+        params->m_start_ts                    = start_ts;
+        params->m_end_ts                      = end_ts;
+    }
 }
 
 void

--- a/src/view/src/rocprofvis_event_search.h
+++ b/src/view/src/rocprofvis_event_search.h
@@ -28,15 +28,15 @@ public:
     void SetWidth(float width);
 
     // Getters...
-    char*  TextInput();
-    size_t TextInputLimit() const;
-    bool   FocusTextInput();
-    bool   Searched() const;
-    bool   Advanced() const;
-    float  Width() const;
+    std::string& TextInput();
+    bool         FocusTextInput();
+    bool         Searched() const;
+    bool         Advanced() const;
+    float        Width() const;
 
 private:
     void ResetOptions();
+    void UpdateFetchParams(std::shared_ptr<TableRequestParams>& params) const override;
     void FormatData() const override;
     void IndexColumns() override;
     void RowSelected(const ImGuiMouseButton mouse_button) override;
@@ -58,7 +58,8 @@ private:
     bool  m_advanced_active;
     float m_width;
 
-    char m_text_input[256];
+    std::string              m_text_input;
+    std::vector<std::string> m_terms;
 
     EventManager::SubscriptionToken m_time_range_changed_token;
 };

--- a/src/view/src/rocprofvis_multi_track_table.cpp
+++ b/src/view/src/rocprofvis_multi_track_table.cpp
@@ -28,8 +28,8 @@ MultiTrackTable::MultiTrackTable(DataProvider& dp, TableType table_type,
                                  uint64_t                           request_id,
                                  const std::function<const TablesModel&()> table_model,
                                  const std::function<TablesModel&()> table_model_mutable,
-                                 bool                                display_filters,
                                  std::shared_ptr<TimelineSelection>  timeline_selection,
+                                 int      available_filter_modes,
                                  uint64_t default_sort_column_index,
                                  rocprofvis_controller_sort_order_t default_sort_order,
                                  const std::string&                 friendly_name,
@@ -37,11 +37,20 @@ MultiTrackTable::MultiTrackTable(DataProvider& dp, TableType table_type,
 : InfiniteScrollTable(dp, table_type, request_table_type, request_id, table_model,
                       table_model_mutable, timeline_selection, default_sort_column_index,
                       default_sort_order, friendly_name, NO_DATA_TEXT)
-, m_retry_selection_fetch(false)
-, m_display_filters(display_filters)
 , m_group_by_selection_index(0)
+, m_available_filter_modes(available_filter_modes)
+, m_filter_mode(kNone)
+, m_filter_advanced({ "", "", "" })
 {
-    m_filter_store[0] = '\0';
+    if(m_available_filter_modes & kBasic)
+    {
+        m_filter_mode = kBasic;
+    }
+    else if(m_available_filter_modes & kAdvanced)
+    {
+        m_filter_mode = kAdvanced;
+    }
+    DisplayFilterRow(m_filter_mode == kBasic);
 }
 
 MultiTrackTable::~MultiTrackTable() {}
@@ -74,251 +83,220 @@ MultiTrackTable::Render()
     std::shared_ptr<TrackTableRequestParams> table_params =
         std::static_pointer_cast<TrackTableRequestParams>(
             m_table_model().GetTableParams(m_table_type));
-    if(m_display_filters || table_params)
+    if(table_params)
     {
         const ImGuiStyle& style = ImGui::GetStyle();
+        ImFont* icon_font       = m_settings.GetFontManager().GetFont(FontType::kIcon);
         ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding,
                             m_settings.GetDefaultStyle().ChildRounding);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
                             ImVec2(style.WindowPadding.x, style.WindowPadding.y * 0.75f));
         ImGui::PushStyleColor(ImGuiCol_ChildBg, m_settings.GetColor(Colors::kBgPanel));
         ImGui::PushStyleColor(ImGuiCol_Border, m_settings.GetColor(Colors::kBorderColor));
-        ImGui::BeginChild("##table_header", ImVec2(0.0f, 0.0f),
+        ImGui::BeginChild("##status", ImVec2(0.0f, 0.0f),
                           ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders |
                               ImGuiChildFlags_AlwaysUseWindowPadding);
-        if(m_display_filters)
-        {
-            ImGui::PushStyleVar(
-                ImGuiStyleVar_CellPadding,
-                ImVec2(style.FramePadding.x, style.ItemSpacing.y * 0.35f));
-            if(ImGui::BeginTable("##table_filter_controls", 3,
-                                 ImGuiTableFlags_SizingStretchProp |
-                                     ImGuiTableFlags_NoSavedSettings))
-            {
-                ImFont* icon_font = m_settings.GetFontManager().GetFont(FontType::kIcon);
-                const ImGuiStyle& base_style = m_settings.GetDefaultStyle();
-                const ImU32       input_bg   = m_settings.GetColor(Colors::kBgFrame);
-
-                ImGui::TableSetupColumn("label", ImGuiTableColumnFlags_WidthFixed,
-                                        ImGui::GetFontSize() * 10.0f);
-                ImGui::TableSetupColumn("control", ImGuiTableColumnFlags_WidthStretch);
-                ImGui::TableSetupColumn("submit", ImGuiTableColumnFlags_WidthFixed,
-                                        ImGui::GetFontSize() * 7.5f);
-
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn();
-                ImGui::AlignTextToFramePadding();
-                ImGui::TextDisabled("Aggregate");
-
-                ImGui::TableNextColumn();
-                ImGui::SetNextItemWidth(-FLT_MIN);
-                ImGui::PushFont(icon_font);
-                const ImVec2 clear_icon_size = ImGui::CalcTextSize(ICON_X_CIRCLED);
-                ImGui::PopFont();
-                const float clear_icon_hit_width =
-                    clear_icon_size.x + base_style.FramePadding.x * 2.0f;
-                const float  combo_arrow_w = ImGui::GetFrameHeight();
-                const ImVec2 combo_min     = ImGui::GetCursorScreenPos();
-                const ImVec2 combo_max(combo_min.x + ImGui::CalcItemWidth(),
-                                       combo_min.y + ImGui::GetFrameHeight());
-                const ImVec2 clear_min(combo_max.x - combo_arrow_w - clear_icon_hit_width,
-                                       combo_min.y);
-                const ImVec2 clear_max(combo_max.x - combo_arrow_w, combo_max.y);
-                const bool   has_group_by_selection = (m_group_by_selection_index != 0);
-                const bool   clear_icon_hit_hovered =
-                    has_group_by_selection &&
-                    ImGui::IsMouseHoveringRect(clear_min, clear_max, false);
-
-                PushComboStyles();
-                ImGui::SetNextItemAllowOverlap();
-                // Prevent the combo from also handling clicks in the overlaid clear-icon
-                // hit area.
-                if(clear_icon_hit_hovered)
-                {
-                    ImGui::BeginDisabled();
-                }
-                const bool group_by_changed =
-                    ImGui::Combo("##group_by", &m_group_by_selection_index,
-                                 m_group_by_choices_ptr.data(),
-                                 static_cast<int>(m_group_by_choices_ptr.size()));
-                if(clear_icon_hit_hovered)
-                {
-                    ImGui::EndDisabled();
-                }
-                PopComboStyles();
-
-                if(has_group_by_selection)
-                {
-                    const ImVec2 clear_size(clear_max.x - clear_min.x,
-                                            clear_max.y - clear_min.y);
-
-                    ImGui::SetCursorScreenPos(clear_min);
-                    ImGui::PushID("group_by_clear");
-                    const bool clear_clicked =
-                        ImGui::InvisibleButton("##clear_icon_hit", clear_size);
-                    const bool clear_icon_hovered = ImGui::IsItemHovered();
-                    ImGui::PopID();
-
-                    ImDrawList* draw_list = ImGui::GetWindowDrawList();
-                    if(clear_icon_hovered)
-                    {
-                        SetTooltipStyled("Clear");
-                    }
-                    const ImVec2 text_pos(
-                        clear_min.x + (clear_icon_hit_width - clear_icon_size.x) * 0.5f,
-                        clear_min.y +
-                            ((clear_max.y - clear_min.y) - clear_icon_size.y) * 0.5f);
-                    draw_list->AddText(icon_font, icon_font->LegacySize, text_pos,
-                                       m_settings.GetColor(Colors::kTextMain),
-                                       ICON_X_CIRCLED);
-
-                    if(clear_clicked)
-                    {
-                        m_pending_filter_options.group_by = "";
-                        m_group_by_selection_index        = 0;
-                        ImGui::CloseCurrentPopup();
-                    }
-                }
-
-                if(group_by_changed)
-                {
-                    if(m_group_by_selection_index == 0)
-                    {
-                        m_pending_filter_options.group_by = "";
-                    }
-                    else
-                    {
-                        m_pending_filter_options.group_by =
-                            m_group_by_choices_ptr[m_group_by_selection_index];
-                    }
-                }
-
-                ImGui::TableNextColumn();
-                if(ImGui::Button("Submit", ImVec2(-FLT_MIN, 0.0f)))
-                {
-                    m_filter_requested  = true;
-                    const bool grouping = (m_group_by_selection_index != 0);
-                    if(!grouping && m_filter_store[0] != '\0')
-                    {
-                        // Reinstate the filter that was stashed when grouping was
-                        // enabled.
-                        snprintf(m_pending_filter_options.filter,
-                                 IM_ARRAYSIZE(m_pending_filter_options.filter), "%s",
-                                 m_filter_store);
-                        m_filter_store[0] = '\0';
-                    }
-                    else if(grouping && m_pending_filter_options.filter[0] != '\0')
-                    {
-                        // Stash and clear the filter so it cannot fight the group-by
-                        // query.
-                        snprintf(m_filter_store, IM_ARRAYSIZE(m_filter_store), "%s",
-                                 m_pending_filter_options.filter);
-                        m_pending_filter_options.filter[0] = '\0';
-                    }
-                }
-
+        ImGui::Text(FOUND_ENTRIES_TEXT,
+                    m_table_model().GetTableTotalRowCount(m_table_type),
+                    table_params->m_track_ids.size());
 #ifdef ROCPROFVIS_DEVELOPER_MODE
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn();
-                ImGui::AlignTextToFramePadding();
-                ImGui::TextDisabled("Group columns");
-
-                ImGui::TableNextColumn();
-                ImGui::BeginDisabled(m_filter_options.group_by == "");
-                const float group_cols_width = ImGui::GetContentRegionAvail().x;
-                const std::pair<bool, bool> group_cols_input = InputTextWithClear(
-                    "group_columns",
-                    "name, COUNT(*) as num_invocations, AVG(duration) as avg_duration, "
-                    "MIN(duration) as min_duration, MAX(duration) as max_duration",
-                    m_pending_filter_options.group_columns,
-                    IM_ARRAYSIZE(m_pending_filter_options.group_columns), icon_font,
-                    input_bg, style, group_cols_width);
-                if(group_cols_input.second)
-                {
-                    m_pending_filter_options.group_columns[0] = '\0';
-                }
-                ImGui::EndDisabled();
-                ImGui::TableNextColumn();
+        ImGui::SameLine();
+        ImGui::Text(" | Cached %llu to %llu entries", table_params->m_start_row,
+                    table_params->m_start_row + table_params->m_req_row_count);
 #endif
-
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn();
-                ImGui::AlignTextToFramePadding();
-                ImGui::TextDisabled("Filter");
-
-                ImGui::TableNextColumn();
-                // Filter disabled when "group by" is selected
-                ImGui::BeginDisabled(m_filter_options.group_by != "");
-                const float filter_width = ImGui::GetContentRegionAvail().x;
-                const std::pair<bool, bool> filter_input = InputTextWithClear(
-                    "filters", "SQL WHERE comparisons", m_pending_filter_options.filter,
-                    IM_ARRAYSIZE(m_pending_filter_options.filter), icon_font, input_bg,
-                    style, filter_width);
-                if(filter_input.second)
-                {
-                    m_pending_filter_options.filter[0] = '\0';
-                }
-                ImGui::EndDisabled();
-
-                ImGui::EndTable();
-            }
-            ImGui::PopStyleVar();
-        }
-        if(table_params)
+        // Make it explicit whether these results are scoped to a time-range
+        // selection (accent) or the full trace (dim).
+        if(m_timeline_selection)
         {
-            ImGui::TextDisabled(FOUND_ENTRIES_TEXT,
-                                m_table_model().GetTableTotalRowCount(m_table_type),
-                                table_params->m_track_ids.size());
-#ifdef ROCPROFVIS_DEVELOPER_MODE
             ImGui::SameLine();
-            ImGui::TextDisabled(
-                " | Cached %llu to %llu entries", table_params->m_start_row,
-                table_params->m_start_row + table_params->m_req_row_count);
-#endif
-            // Make it explicit whether these results are scoped to a time-range
-            // selection (accent) or the full trace (dim).
-            if(m_timeline_selection)
+            ImGui::TextDisabled("|");
+            ImGui::SameLine();
+            if(m_timeline_selection->HasValidTimeRangeSelection())
             {
-                ImGui::SameLine();
-                ImGui::TextDisabled("|");
-                ImGui::SameLine();
-                if(m_timeline_selection->HasValidTimeRangeSelection())
+                double sel_start = 0.0;
+                double sel_end   = 0.0;
+                m_timeline_selection->GetSelectedTimeRange(sel_start, sel_end);
+                const ImVec4 accent = ThemeColor(m_settings, Colors::kAccent);
+                ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon),
+                                0.0f);
+                ImGui::TextColored(accent, "%s", ICON_CROP);
+                ImGui::PopFont();
+                ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+                ImGui::TextColored(accent, "Limited to time-range selection");
+                if(ImGui::IsItemHovered())
                 {
-                    double sel_start = 0.0;
-                    double sel_end   = 0.0;
-                    m_timeline_selection->GetSelectedTimeRange(sel_start, sel_end);
-                    const ImVec4 accent = ThemeColor(m_settings, Colors::kAccent);
-                    ImGui::PushFont(m_settings.GetFontManager().GetFont(FontType::kIcon),
-                                    0.0f);
-                    ImGui::TextColored(accent, "%s", ICON_CROP);
-                    ImGui::PopFont();
-                    ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
-                    ImGui::TextColored(accent, "Limited to time-range selection");
-                    if(ImGui::IsItemHovered())
-                    {
-                        SetTooltipStyled(
-                            "These results reflect the current time-range selection "
-                            "(span: %s).",
-                            nanosecond_to_formatted_str(
-                                sel_end - sel_start,
-                                m_settings.GetUserSettings().unit_settings.time_format,
-                                true)
-                                .c_str());
-                    }
+                    SetTooltipStyled(
+                        "These results reflect the current time-range selection "
+                        "(span: %s).",
+                        nanosecond_to_formatted_str(
+                            sel_end - sel_start,
+                            m_settings.GetUserSettings().unit_settings.time_format, true)
+                            .c_str());
+                }
+            }
+            else
+            {
+                ImGui::TextDisabled("Full trace");
+                if(ImGui::IsItemHovered())
+                {
+                    SetTooltipStyled(
+                        "No time-range selection - these results cover the full "
+                        "trace.");
+                }
+            }
+        }
+        if(m_available_filter_modes & (kBasic | kAdvanced))
+        {
+            ImGui::BeginDisabled(m_table_model().GetTableHeader(m_table_type).empty());
+            ImGui::PushFont(icon_font);
+            ImGui::SameLine(ImGui::GetContentRegionMax().x -
+                                ImGui::CalcTextSize(ICON_ARROWS_CYCLE).x -
+                                style.ItemSpacing.x - ImGui::CalcTextSize(ICON_FUNNEL).x,
+                            0.0f);
+            ImGui::PopFont();
+            ImGui::BeginDisabled(m_filter_options.group_by.empty() &&
+                                 m_filter_options.group_columns.empty() &&
+                                 m_filter_options.filter.empty());
+            if(IconButton(ICON_ARROWS_CYCLE, icon_font, ImVec2(0, 0), "Reset Filter",
+                          true, ImVec2(0, 0), m_settings.GetColor(Colors::kBgPanel),
+                          m_settings.GetColor(Colors::kBgPanel),
+                          m_settings.GetColor(Colors::kBgPanel)))
+            {
+                ApplyFilter(true);
+            }
+            ImGui::EndDisabled();
+            ImGui::SameLine();
+            IconButton(ICON_FUNNEL, icon_font, ImVec2(0, 0), "Filter Mode", true,
+                       ImVec2(0, 0), m_settings.GetColor(Colors::kBgPanel),
+                       m_settings.GetColor(Colors::kBgPanel),
+                       m_settings.GetColor(Colors::kBgPanel));
+            if(ImGui::IsPopupOpen("filter_controls"))
+            {
+                ImGui::SetNextWindowPos(ImGui::GetItemRectMax() + style.WindowPadding,
+                                        ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+            }
+            if(ImGui::BeginPopupContextItem("filter_controls",
+                                            ImGuiPopupFlags_MouseButtonLeft))
+            {
+                if(m_available_filter_modes & kBasic &&
+                   ImGui::MenuItem("Basic", nullptr, m_filter_mode == kBasic))
+                {
+                    m_filter_mode = kBasic;
+                    ApplyFilter(false);
+                }
+                if(m_available_filter_modes & kAdvanced &&
+                   ImGui::MenuItem("Advanced", nullptr, m_filter_mode == kAdvanced))
+                {
+                    m_filter_mode = kAdvanced;
+                    ApplyFilter(false);
+                }
+                if(ImGui::MenuItem("None", nullptr, m_filter_mode == kNone))
+                {
+                    m_filter_mode = kNone;
+                    ApplyFilter(false);
+                }
+                ImGui::EndPopup();
+            }
+            ImGui::EndDisabled();
+        }
+        ImGui::EndChild();
+        if(m_table_model().GetTableHeader(m_table_type).size() &&
+           m_filter_mode == kAdvanced)
+        {
+            ImGui::BeginChild("##advanced_filters", ImVec2(0.0f, 0.0f),
+                              ImGuiChildFlags_AutoResizeY | ImGuiChildFlags_Borders |
+                                  ImGuiChildFlags_AlwaysUseWindowPadding);
+            ImGui::BeginGroup();
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextDisabled("Aggregate");
+#ifdef ROCPROFVIS_DEVELOPER_MODE
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextDisabled("Group Columns");
+#endif
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextDisabled("Filter");
+            ImGui::SameLine();
+            ImGui::EndGroup();
+            ImGui::SameLine();
+            ImGui::BeginGroup();
+            ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x -
+                                    ImGui::CalcTextSize("Submit").x -
+                                    2.0f * style.FramePadding.x - style.ItemSpacing.x);
+            ImGui::BeginGroup();
+            ImGui::SetNextItemAllowOverlap();
+            if(ImGui::Combo("##group_by", &m_group_by_selection_index,
+                            m_group_by_choices_ptr.data(),
+                            static_cast<int>(m_group_by_choices_ptr.size())))
+            {
+                if(m_group_by_selection_index == 0)
+                {
+                    m_filter_advanced.group_by.clear();
                 }
                 else
                 {
-                    ImGui::TextDisabled("Full trace");
-                    if(ImGui::IsItemHovered())
-                    {
-                        SetTooltipStyled(
-                            "No time-range selection - these results cover the full "
-                            "trace.");
-                    }
+                    m_filter_advanced.group_by =
+                        m_group_by_choices[m_group_by_selection_index];
                 }
             }
+            if(m_group_by_selection_index != 0)
+            {
+                ImGui::SameLine();
+                ImGui::SetCursorScreenPos(ImVec2(
+                    ImGui::GetItemRectMax().x - 2 * style.FramePadding.x -
+                        ImGui::CalcTextSize(ICON_X_CIRCLED).x - ImGui::GetFrameHeight(),
+                    ImGui::GetCursorScreenPos().y));
+                if(XButton("clear_group", "Clear", &m_settings))
+                {
+                    m_filter_advanced.group_by.clear();
+                    m_group_by_selection_index = 0;
+                }
+            }
+            ImGui::EndGroup();
+#ifdef ROCPROFVIS_DEVELOPER_MODE
+            if(InputTextWithClear(
+                   "group_columns",
+                   "name, COUNT(*) as num_invocations, AVG(duration) as avg_duration, "
+                   "MIN(duration) as min_duration, MAX(duration) as max_duration",
+                   m_filter_advanced.group_columns, icon_font,
+                   m_settings.GetColor(Colors::kBgFrame), style,
+                   ImGui::GetItemRectSize().x)
+                   .second)
+            {
+                m_filter_advanced.group_columns.clear();
+            }
+#endif
+            ImGui::PushFont(icon_font);
+            float import_width =
+                ImGui::CalcTextSize(ICON_ARROW_IN_BOX).x + 2.0f * style.FramePadding.x;
+            ImGui::PopFont();
+            ImGui::BeginDisabled(!m_filter_options.group_by.empty());
+            if(InputTextWithClear(
+                   "filters", "SQL WHERE comparisons", m_filter_advanced.filter,
+                   icon_font, m_settings.GetColor(Colors::kBgFrame), style,
+                   ImGui::GetItemRectSize().x - style.ItemSpacing.x - import_width)
+                   .second)
+            {
+                m_filter_advanced.filter.clear();
+            }
+            ImGui::SameLine();
+            ImGui::BeginDisabled(ActiveFilterRowClause().empty());
+            if(IconButton(ICON_ARROW_IN_BOX, icon_font, ImVec2(0, 0), "Import from Basic",
+                          false, style.FramePadding, m_settings.GetColor(Colors::kButton),
+                          m_settings.GetColor(Colors::kButtonHovered),
+                          m_settings.GetColor(Colors::kButtonActive)))
+            {
+                m_filter_advanced.filter = ActiveFilterRowClause();
+            }
+            ImGui::EndDisabled();
+            ImGui::EndDisabled();
+            ImGui::EndGroup();
+            ImGui::SameLine();
+            if(ImGui::Button("Submit", ImVec2(0.0f, ImGui::GetItemRectSize().y)))
+            {
+                ApplyFilter(false);
+            }
+            ImGui::EndChild();
         }
-        ImGui::EndChild();
         ImGui::PopStyleColor(2);
         ImGui::PopStyleVar(2);
     }
@@ -331,19 +309,6 @@ MultiTrackTable::Render()
 void
 MultiTrackTable::Update()
 {
-    // Handle track selection changed event
-    if(m_retry_selection_fetch)
-    {
-        if(!m_data_provider.IsRequestPending(m_request_id))
-        {
-            // Try to reprocess the deferred track selection event.
-            spdlog::debug(
-                "Reprocessing deferred track selection changed event for table: {}",
-                m_widget_name);
-            FetchSelectionData();
-        }
-    }
-
     if(m_data_changed)
     {
         const std::vector<std::string>& column_names =
@@ -380,9 +345,8 @@ MultiTrackTable::Update()
         {
             std::string selected_option = m_filter_options.group_by;
             m_group_by_choices.resize(2);
-            m_group_by_choices[1]             = selected_option;
-            m_pending_filter_options.group_by = selected_option;
-            m_group_by_selection_index        = 1;
+            m_group_by_choices[1]      = selected_option;
+            m_group_by_selection_index = 1;
         }
         m_group_by_choices_ptr.resize(m_group_by_choices.size());
         for(size_t i = 0; i < m_group_by_choices.size(); i++)
@@ -408,6 +372,33 @@ MultiTrackTable::IncludeTrack(uint64_t track_id) const
                    m_table_type == TableType::kEventTable);
     }
     return include;
+}
+
+void
+MultiTrackTable::UpdateFetchParams(std::shared_ptr<TableRequestParams>& params) const
+{
+    if(!params)
+    {
+        params = std::make_shared<TrackTableRequestParams>();
+    }
+    InfiniteScrollTable::UpdateFetchParams(params);
+    if(params)
+    {
+        std::shared_ptr<TrackTableRequestParams> track_params =
+            std::static_pointer_cast<TrackTableRequestParams>(params);
+        double start_ns;
+        double end_ns;
+        // If no valid time range is provided, use the full trace range
+        if(!m_timeline_selection->GetSelectedTimeRange(start_ns, end_ns))
+        {
+            const TimelineModel& tlm = m_data_provider.DataModel().GetTimeline();
+            start_ns                 = tlm.GetStartTime();
+            end_ns                   = tlm.GetEndTime();
+        }
+        track_params->m_track_ids = m_included_tracks;
+        params->m_start_ts        = start_ns;
+        params->m_end_ts          = end_ns;
+    }
 }
 
 void
@@ -470,76 +461,95 @@ void
 MultiTrackTable::FetchSelectionData()
 {
     std::vector<uint64_t> tracks;
-    double                start_ns;
-    double                end_ns;
     m_timeline_selection->GetSelectedTracks(tracks);
-
-    const TimelineModel& tlm = m_data_provider.DataModel().GetTimeline();
-    // If no valid time range is provided, use the full trace range
-    if(m_timeline_selection->HasValidTimeRangeSelection())
-    {
-        m_timeline_selection->GetSelectedTimeRange(start_ns, end_ns);
-    }
-    else
-    {
-        start_ns = tlm.GetStartTime();
-        end_ns   = tlm.GetEndTime();
-    }
-
-    std::vector<uint64_t> included_tracks;
+    m_included_tracks.clear();
     for(uint64_t& track_id : tracks)
     {
         if(IncludeTrack(track_id))
         {
-            included_tracks.push_back(track_id);
+            m_included_tracks.push_back(track_id);
         }
     }
 
-    bool fetch_result = false;
-
-    // Cancel pending requests.
-    if(m_data_provider.IsRequestPending(m_request_id))
-    {
-        m_data_provider.CancelRequest(m_request_id);
-    }
     // if no tracks match the table type, clear the table
-    if(included_tracks.empty())
+    if(m_included_tracks.empty())
     {
         m_table_model_mutable().ClearTable(m_table_type);
-        fetch_result = true;
     }
     else
     {
         // Fetch table data for the selected tracks
-        fetch_result = m_data_provider.FetchTable(TrackTableRequestParams{
-            m_request_table_type, included_tracks, start_ns, end_ns,
-            m_filter_options.where, m_filter_options.filter,
-            m_filter_options.group_by.c_str(), m_filter_options.group_columns, 0,
-            m_fetch_chunk_size, m_sort_column_index, m_sort_order });
+        RequestFetch();
     }
-
-    if(!fetch_result)
-    {
-        spdlog::error("Failed to queue table request for tracks: {}",
-                      included_tracks.size());
-        // save this selection event to reprocess it later (it's ok to replace the
-        // previous one as the new one reflects the current selection)
-        m_retry_selection_fetch = true;
-    }
-    else
-    {
-        // clear any pending selection fetch
-        m_retry_selection_fetch = false;
-    }
-    // Update the included tracks for this table type
-    m_included_tracks = std::move(included_tracks);
 }
 
-bool
-MultiTrackTable::XButton(const char* id) const
+void
+MultiTrackTable::ApplyFilter(bool reset)
 {
-    bool clicked = RocProfVis::View::XButton(id, "Clear", &m_settings);
-    return clicked;
+    DisplayFilterRow(m_filter_mode == kBasic);
+    switch(m_filter_mode)
+    {
+        case kBasic:
+        {
+            if(reset)
+            {
+                ResetFilterRow();
+            }
+            else
+            {
+                RequestFilter();
+            }
+            break;
+        }
+        case kAdvanced:
+        {
+            if(reset)
+            {
+                m_filter_advanced.group_by.clear();
+                m_filter_advanced.group_columns.clear();
+                m_filter_advanced.filter.clear();
+                m_group_by_selection_index = 0;
+                m_filter_store.clear();
+                m_filter_options = m_filter_advanced;
+            }
+            else
+            {
+                const bool grouping = (m_group_by_selection_index != 0);
+                if(!grouping && !m_filter_store.empty())
+                {
+                    // Reinstate the filter that was stashed when grouping was
+                    // enabled.
+                    m_filter_advanced.filter = m_filter_store;
+                    m_filter_store.clear();
+                }
+                else if(grouping && !m_filter_advanced.filter.empty())
+                {
+                    // Stash and clear the filter so it cannot fight the group-by
+                    // query.
+                    m_filter_store = m_filter_advanced.filter;
+                    m_filter_advanced.filter.clear();
+                }
+                m_filter_options = m_filter_advanced;
+            }
+            RequestFilter();
+            break;
+        }
+        case kNone:
+        {
+            if(!reset)
+            {
+                m_filter_options.group_by.clear();
+                m_filter_options.group_columns.clear();
+                m_filter_options.filter.clear();
+                RequestFilter();
+            }
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_multi_track_table.h
+++ b/src/view/src/rocprofvis_multi_track_table.h
@@ -16,13 +16,20 @@ namespace View
 class MultiTrackTable : public InfiniteScrollTable
 {
 public:
+    enum FilterMode
+    {
+        kNone     = 0,
+        kBasic    = 1 << 0,
+        kAdvanced = 1 << 1,
+    };
+
     MultiTrackTable(DataProvider& dp, TableType table_type,
                     rocprofvis_controller_table_type_t        request_table_type,
                     uint64_t                                  request_id,
                     const std::function<const TablesModel&()> table_model,
                     const std::function<TablesModel&()>       table_model_mutable,
-                    bool                                      display_filters,
                     std::shared_ptr<TimelineSelection>        timeline_selection,
+                    int                                available_filter_modes    = kNone,
                     uint64_t                           default_sort_column_index = 1,
                     rocprofvis_controller_sort_order_t default_sort_order =
                         kRPVControllerSortOrderAscending,
@@ -39,6 +46,7 @@ public:
 
 protected:
     virtual bool IncludeTrack(uint64_t track_id) const;
+    virtual void UpdateFetchParams(std::shared_ptr<TableRequestParams>& params) const override;
     void         FormatData() const override;
     void         IndexColumns() override;
     void         RowSelected(const ImGuiMouseButton mouse_button) override;
@@ -48,16 +56,16 @@ protected:
 
 private:
     void FetchSelectionData();
-    bool XButton(const char* id) const;
-
-    bool m_retry_selection_fetch;
-    bool m_display_filters;
+    void ApplyFilter(bool reset);
 
     std::vector<std::string> m_group_by_choices;
     std::vector<const char*> m_group_by_choices_ptr;
     int                      m_group_by_selection_index;
 
-    char m_filter_store[FILTER_SIZE];
+    int           m_available_filter_modes;
+    FilterMode    m_filter_mode;
+    FilterOptions m_filter_advanced;
+    std::string   m_filter_store;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_presets.cpp
+++ b/src/view/src/rocprofvis_presets.cpp
@@ -287,7 +287,6 @@ PresetBrowser::PresetBrowser()
 , m_presets_list_changed(false)
 , m_pos_x(0.0f)
 , m_pos_y(0.0f)
-, m_text_input("\0")
 , m_presets(PresetManager::GetInstance())
 , m_notifications(NotificationManager::GetInstance())
 , m_settings(SettingsManager::GetInstance())
@@ -452,16 +451,15 @@ PresetBrowser::Render()
             }
             ImGui::EndChild();
             std::pair<bool, bool> input = InputTextWithClear(
-                "create", "New Preset Name", m_text_input,
-                static_cast<size_t>(IM_ARRAYSIZE(m_text_input)), icons,
+                "create", "New Preset Name", m_text_input, icons,
                 m_settings.GetColor(Colors::kBgMain), style,
                 ImGui::GetContentRegionAvail().x - edit_width - style.ItemSpacing.x);
             if(input.second)
             {
-                m_text_input[0] = '\0';
+                m_text_input.clear();
             }
             ImGui::SameLine();
-            ImGui::BeginDisabled(strlen(m_text_input) == 0);
+            ImGui::BeginDisabled(m_text_input.empty());
             if(IconButton(
                    ICON_ADD_NOTE, icons, ImVec2(0.0f, 0.0f),
                    "Create preset of current customizations", false, style.FramePadding,
@@ -481,29 +479,29 @@ PresetBrowser::Render()
                     case PresetManager::Success:
                     {
                         m_notifications.Show("Preset created: " +
-                                                 std::string(m_text_input),
+                                                 m_text_input,
                                              NotificationLevel::Success);
-                        m_text_input[0] = '\0';
+                        m_text_input.clear();
                         break;
                     }
                     case PresetManager::ErrorOverwrite:
                     {
                         m_notifications.Show("Preset already exists: " +
-                                                 std::string(m_text_input),
+                                                 m_text_input,
                                              NotificationLevel::Warning);
                         break;
                     }
                     case PresetManager::ErrorPresetEmpty:
                     {
                         m_notifications.Show("No customizations to create preset: " +
-                                                 std::string(m_text_input),
+                                                 m_text_input,
                                              NotificationLevel::Warning);
                         break;
                     }
                     default:
                     {
                         m_notifications.Show("Failed to create preset: " +
-                                                 std::string(m_text_input),
+                                                 m_text_input,
                                              NotificationLevel::Error);
                     }
                     break;

--- a/src/view/src/rocprofvis_presets.h
+++ b/src/view/src/rocprofvis_presets.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "json.h"
 #include <filesystem>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -181,7 +182,7 @@ private:
 
     float m_pos_x;
     float m_pos_y;
-    char  m_text_input[256];
+    std::string m_text_input;
 
     PresetManager&       m_presets;
     NotificationManager& m_notifications;

--- a/src/view/src/rocprofvis_requests.h
+++ b/src/view/src/rocprofvis_requests.h
@@ -195,6 +195,7 @@ protected:
     , m_group_columns(group_cols)
     , m_export_to_file_path(export_to_file_path)
     {}
+    TableRequestParams() = default;
 };
 
 class TrackTableRequestParams : public TableRequestParams
@@ -219,6 +220,7 @@ public:
                          export_to_file_path)
     , m_track_ids(track_ids)
     {}
+    TrackTableRequestParams() = default;
 };
 
 class EventSearchRequestParams : public TableRequestParams
@@ -254,6 +256,8 @@ public:
     , m_include_category(include_category)
     , m_partial_matching(partial_matching)
     {}
+
+    EventSearchRequestParams() = default;
 };
 
 // Event request parameters

--- a/src/view/src/rocprofvis_summary_view.cpp
+++ b/src/view/src/rocprofvis_summary_view.cpp
@@ -1072,19 +1072,8 @@ KernelInstanceTable::KernelInstanceTable(
       [&dp]() -> const TablesModel& { return dp.DataModel().GetTables(); },
       [&dp]() -> TablesModel& { return dp.DataModel().GetTables(); }, timeline_selection)
 , m_fetched(false)
-, m_fetch_deferred(false)
 {
     m_widget_name = GenUniqueName("summary_top_kernel_instances");
-}
-
-void
-KernelInstanceTable::Update()
-{
-    if(m_fetch_deferred && !m_data_provider.IsRequestPending(m_request_id))
-    {
-        Fetch();
-    }
-    InfiniteScrollTable::Update();
 }
 
 void
@@ -1123,7 +1112,8 @@ KernelInstanceTable::ToggleSelectKernel(const std::string& kernel_name,
             m_where += " AND agentId = " + std::to_string(*device_id & TOPOLOGY_ID_MASK);
         }
     }
-    Fetch();
+    RequestFetch();
+    m_fetched = true;
 }
 
 void
@@ -1138,6 +1128,30 @@ float
 KernelInstanceTable::MinHeight() const
 {
     return 4.0f * ImGui::GetFrameHeightWithSpacing() + ImGui::GetStyle().ScrollbarSize;
+}
+
+void
+KernelInstanceTable::UpdateFetchParams(std::shared_ptr<TableRequestParams>& params) const
+{
+    if(!params)
+    {
+        params = std::make_shared<EventSearchRequestParams>();
+    }
+    InfiniteScrollTable::UpdateFetchParams(params);
+    if(params)
+    {
+        std::shared_ptr<EventSearchRequestParams> search_params =
+            std::static_pointer_cast<EventSearchRequestParams>(params);
+        const TimelineModel& timeline         = m_data_provider.DataModel().GetTimeline();
+        search_params->m_op_types             = { kRocProfVisDmOperationDispatch };
+        search_params->m_string_table_filters = { m_kernel_name };
+        search_params->m_include_substrings   = false;
+        search_params->m_include_category     = false;
+        search_params->m_partial_matching     = false;
+        params->m_start_ts                    = timeline.GetStartTime();
+        params->m_end_ts                      = timeline.GetEndTime();
+        params->m_where                       = m_where;
+    }
 }
 
 void
@@ -1188,18 +1202,6 @@ KernelInstanceTable::RowSelected(const ImGuiMouseButton mouse_button)
         InfiniteScrollTable::SelectedRowContextMenu();
     }
     InfiniteScrollTable::RowSelected(mouse_button);
-}
-
-void
-KernelInstanceTable::Fetch()
-{
-    m_data_provider.CancelRequest(m_request_id);
-    const TimelineModel& tlm = m_data_provider.DataModel().GetTimeline();
-    m_fetch_deferred         = !m_data_provider.FetchTable(EventSearchRequestParams(
-        m_request_table_type, { kRocProfVisDmOperationDispatch }, tlm.GetStartTime(),
-        tlm.GetEndTime(), m_where.c_str(), false, false, false, { m_kernel_name }, 0,
-        m_fetch_chunk_size, m_sort_column_index, m_sort_order));
-    m_fetched                = true;
 }
 
 }  // namespace View

--- a/src/view/src/rocprofvis_summary_view.h
+++ b/src/view/src/rocprofvis_summary_view.h
@@ -165,7 +165,6 @@ class KernelInstanceTable : public InfiniteScrollTable
 public:
     KernelInstanceTable(DataProvider&                      dp,
                         std::shared_ptr<TimelineSelection> timeline_selection);
-    void Update() override;
     void Render() override;
 
     void  ToggleSelectKernel(const std::string& kernel_name, const uint64_t* node_id,
@@ -174,17 +173,15 @@ public:
     float MinHeight() const;
 
 private:
+    void UpdateFetchParams(std::shared_ptr<TableRequestParams>& params) const override;
     void FormatData() const override;
     void IndexColumns() override;
     void RowSelected(const ImGuiMouseButton mouse_button) override;
-
-    void Fetch();
 
     std::string m_kernel_name;
     std::string m_where;
 
     bool m_fetched;
-    bool m_fetch_deferred;
 };
 
 }  // namespace View

--- a/src/view/src/rocprofvis_top_events_view.cpp
+++ b/src/view/src/rocprofvis_top_events_view.cpp
@@ -133,8 +133,8 @@ TopEventsView::TopEventsTable::TopEventsTable(
 : MultiTrackTable(
       dp, table_type, request_table_type, request_id,
       [&dp]() -> const TablesModel& { return dp.DataModel().GetAnalysis().GetTables(); },
-      [&dp]() -> TablesModel& { return dp.DataModel().GetAnalysis().GetTables(); }, false,
-      timeline_selection, 2, kRPVControllerSortOrderDescending)
+      [&dp]() -> TablesModel& { return dp.DataModel().GetAnalysis().GetTables(); },
+      timeline_selection, kNone, 2, kRPVControllerSortOrderDescending)
 , m_duration_column_indices({ INVALID_UINT64_INDEX, INVALID_UINT64_INDEX,
                               INVALID_UINT64_INDEX, INVALID_UINT64_INDEX })
 , m_op(op)

--- a/src/view/src/rocprofvis_trace_view.cpp
+++ b/src/view/src/rocprofvis_trace_view.cpp
@@ -1122,7 +1122,7 @@ TraceView::RenderEventSearch()
         float reserved = options_width >= m_event_search->Width() ? 0.0f : options_width;
         std::pair<bool, bool> search_bar = InputTextWithClear(
             "search_bar", "Search: hipLaunchKernel or \"hip\"\"kernel\"",
-            m_event_search->TextInput(), m_event_search->TextInputLimit(),
+            m_event_search->TextInput(),
             settings.GetFontManager().GetFont(FontType::kIcon),
             settings.GetColor(Colors::kBgMain), settings.GetDefaultStyle(),
             m_event_search->Width() - reserved);

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -50,10 +50,22 @@ bool
 InputTextStringWithHint(const char* id, const char* hint, std::string& str,
                         ImGuiInputTextFlags flags)
 {
-    str.reserve(std::max(str.size() + 1, static_cast<size_t>(256)));
-    return ImGui::InputTextWithHint(id, hint, str.data(), str.capacity() + 1,
-                                    flags | ImGuiInputTextFlags_CallbackResize,
-                                    StringResizeCallback, static_cast<void*>(&str));
+    bool input_changed = InputTextString(id, str, flags);
+    if(str.empty())
+    {
+        const float& padding = ImGui::GetStyle().FramePadding.x;
+        ImGui::BeginDisabled();
+        ImGui::SetCursorScreenPos(
+            ImVec2(ImGui::GetItemRectMin().x + padding, ImGui::GetItemRectMin().y));
+        if(ElidedText(hint, ImGui::GetItemRectSize().x - 2.0f * padding, 0.0f,
+                   Alignment_Left, true) && BeginItemTooltipStyled())
+        {
+            ImGui::TextUnformatted(hint);
+            EndTooltipStyled();
+        }
+        ImGui::EndDisabled();
+    }
+    return input_changed;
 }
 
 ImVec2
@@ -273,9 +285,8 @@ IsMouseReleasedWithDragCheck(ImGuiMouseButton button, float drag_threshold)
 }
 
 std::pair<bool, bool>
-InputTextWithClear(const char* id, const char* hint, char* buf,
-                                     size_t buf_size, ImFont* icon_font, ImU32 bg_color,
-                                     const ImGuiStyle& style, float width)
+InputTextWithClear(const char* id, const char* hint, std::string& str, ImFont* icon_font,
+                   ImU32 bg_color, const ImGuiStyle& style, float width)
 {
     bool input_cleared = false;
     ImGui::BeginGroup();
@@ -283,13 +294,13 @@ InputTextWithClear(const char* id, const char* hint, char* buf,
     ImGui::PushID(id);
     ImGui::PushStyleColor(ImGuiCol_FrameBg, bg_color);
     ImGui::SetNextItemWidth(width);
-    bool input_changed =
-        ImGui::InputTextWithHint("##input_text_with_clear", hint, buf, buf_size);
+    bool input_changed = InputTextStringWithHint("##input_text_with_clear", hint, str, 
+                                                  ImGuiInputTextFlags_AutoSelectAll);
     ImGui::PopStyleColor();
-    if(strlen(buf) > 0)
+    if(!str.empty())
     {
         ImGui::PushFont(icon_font, 0.0f);
-        if(width >= ImGui::CalcTextSize(ICON_X_CIRCLED).x + 2 * style.FramePadding.x)
+        if(width >= 2.0f * (ImGui::CalcTextSize(ICON_X_CIRCLED).x + style.FramePadding.x))
         {
             ImGui::SameLine();
             ImGui::SetCursorScreenPos(
@@ -372,7 +383,7 @@ EndTooltipStyled()
     ImGui::PopStyleColor(2);
 }
 
-void
+bool
 ElidedText(const char* text, float available_width, float tooltip_width,
            Alignment alignment, bool imgui_AlignTextToFramePadding)
 {
@@ -380,16 +391,15 @@ ElidedText(const char* text, float available_width, float tooltip_width,
     SettingsManager& settings   = SettingsManager::GetInstance();
     float            text_width = ImGui::CalcTextSize(text).x;
     ImVec2           elide_size = ImGui::CalcTextSize(" [...]");
-    float  scroll_bar_width     = (ImGui::GetScrollMaxY() != 0.0f) ? style.ScrollbarSize : 0.0f;
-    bool   elide                = text_width + scroll_bar_width > available_width;
-    ImVec2 elide_pos;
+    bool             elide      = text_width > available_width;
+    ImVec2           elide_pos;
     // Dynamically sized containers do not adapt to clip rect...
     // Use a window to restrict our size and provide sizing hint to client.
     // Do not take input to avoid interfering with client.
     ImGui::BeginChild("elided",
                       ImVec2(available_width, imgui_AlignTextToFramePadding
-                                                  ? ImGui::GetFrameHeightWithSpacing()
-                                                  : ImGui::GetFontSize()),
+                                                  ? ImGui::GetFrameHeight()
+                                                  : ImGui::GetTextLineHeight()),
                       ImGuiChildFlags_None,
                       ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoInputs);
 
@@ -399,11 +409,11 @@ ElidedText(const char* text, float available_width, float tooltip_width,
     }
     if(elide)
     {
-        ImGui::PushClipRect(ImGui::GetCursorScreenPos(),
-                            ImGui::GetCursorScreenPos() +
-                                ImVec2(available_width - scroll_bar_width - elide_size.x,
-                                       ImGui::GetFrameHeightWithSpacing()),
-                            true);
+        ImGui::PushClipRect(
+            ImGui::GetCursorScreenPos(),
+            ImGui::GetCursorScreenPos() +
+                ImVec2(available_width - elide_size.x, ImGui::GetFrameHeight()),
+            true);
     }
     else if(alignment == Alignment_Right)
     {
@@ -417,31 +427,30 @@ ElidedText(const char* text, float available_width, float tooltip_width,
     if(elide)
     {
         ImGui::PopClipRect();
-        ImGui::SameLine(available_width - scroll_bar_width - elide_size.x);
+        ImGui::SameLine();
+        ImGui::SetCursorPosX(available_width - elide_size.x);
         elide_pos = ImGui::GetCursorScreenPos();
         ImGui::TextUnformatted(" [...]");
     }
     ImGui::EndChild();
-    if(elide)
+    if(elide && tooltip_width > 0.0f)
     {
         ImGui::SetCursorScreenPos(elide_pos);
         ImGui::InvisibleButton("elide_hover", elide_size);
-        if(tooltip_width > 0.0f)
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                            settings.GetDefaultStyle().WindowPadding);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
+                            settings.GetDefaultStyle().FrameRounding);
+        if(ImGui::BeginItemTooltip())
         {
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
-                                settings.GetDefaultIMGUIStyle().WindowPadding);
-            ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding,
-                                settings.GetDefaultStyle().FrameRounding);
-            if(ImGui::BeginItemTooltip())
-            {
-                ImGui::PushTextWrapPos(tooltip_width);
-                ImGui::TextWrapped("%s", text);
-                ImGui::PopTextWrapPos();
-                ImGui::EndTooltip();
-            }
-            ImGui::PopStyleVar(2);
+            ImGui::PushTextWrapPos(tooltip_width);
+            ImGui::TextWrapped("%s", text);
+            ImGui::PopTextWrapPos();
+            ImGui::EndTooltip();
         }
+        ImGui::PopStyleVar(2);
     }
+    return elide;
 }
 
 std::string

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -82,7 +82,7 @@ bool
 IsMouseReleasedWithDragCheck(ImGuiMouseButton button, float drag_threshold = 5.0f);
 
 std::pair<bool, bool>
-InputTextWithClear(const char* id, const char* hint, char* buf, size_t buf_size,
+InputTextWithClear(const char* id, const char* hint, std::string& str,
                    ImFont* icon_font, ImU32 bg_color, const ImGuiStyle& style,
                    float width = 0);
 
@@ -114,7 +114,7 @@ enum Alignment
     Alignment_Right,
 };
 
-void
+bool
 ElidedText(const char* text, float available_width, float tooltip_width = 0.0f,
            Alignment alignment                     = Alignment_Left,
            bool      imgui_AlignTextToFramePadding = false);

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -26,6 +26,8 @@ constexpr const char* END_TS_COLUMN_NAME         = "end";
 constexpr const char* DURATION_COLUMN_NAME       = "duration";
 constexpr const char* FILTER_TEXT_HINT_STR       = "Filter: hipLaunchKernel";
 constexpr const char* FILTER_TEXT_HINT_NUMERICAL = "Filter: {>, <, =, >=, <=, !=} 30";
+constexpr const char* FILTER_TEXT_HINT_TIME =
+    "Filter: {>, <, =, >=, <=, !=} {Nanoseconds}";
 
 InfiniteScrollTable::InfiniteScrollTable(
     DataProvider& dp, TableType table_type,
@@ -156,6 +158,7 @@ InfiniteScrollTable::Update()
         ROCPROFVIS_ASSERT(columns.size() == column_types.size());
         m_displayed_filter_row_inputs.resize(columns.size());
         std::unordered_set<FilterInput*> active_filter_row_inputs;
+        size_t                           j = 0;
         for(size_t i = 0; i < m_displayed_filter_row_inputs.size(); i++)
         {
             if(m_filter_row_inputs.count(columns[i]))
@@ -167,7 +170,36 @@ InfiniteScrollTable::Update()
             }
             else
             {
-                m_filter_row_inputs[columns[i]] = { columns[i], column_types[i], "" };
+                const char* tooltip;
+                switch(column_types[i])
+                {
+                    case kRPVControllerPrimitiveTypeUInt64:
+                    {
+                        if((j < m_time_column_indices.size() &&
+                            m_time_column_indices[j] == i))
+                        {
+                            tooltip = FILTER_TEXT_HINT_TIME;
+                            j++;
+                        }
+                        else
+                        {
+                            tooltip = FILTER_TEXT_HINT_NUMERICAL;
+                        }
+                        break;
+                    }
+                    case kRPVControllerPrimitiveTypeDouble:
+                    {
+                        tooltip = FILTER_TEXT_HINT_NUMERICAL;
+                        break;
+                    }
+                    default:
+                    {
+                        tooltip = FILTER_TEXT_HINT_STR;
+                        break;
+                    }
+                }
+                m_filter_row_inputs[columns[i]] = { columns[i], column_types[i], "",
+                                                    tooltip };
             }
             m_displayed_filter_row_inputs[i] = &m_filter_row_inputs.at(columns[i]);
         }
@@ -394,13 +426,7 @@ InfiniteScrollTable::Render()
                         ImGui::TableNextColumn();
                         ImGui::PushID(static_cast<int>(i));
                         std::pair<bool, bool> filter_input = InputTextWithClear(
-                            "",
-                            (m_displayed_filter_row_inputs[i]->column_type ==
-                                 kRPVControllerPrimitiveTypeUInt64 ||
-                             m_displayed_filter_row_inputs[i]->column_type ==
-                                 kRPVControllerPrimitiveTypeDouble)
-                                ? FILTER_TEXT_HINT_NUMERICAL
-                                : FILTER_TEXT_HINT_STR,
+                            "", m_displayed_filter_row_inputs[i]->tooltip,
                             m_displayed_filter_row_inputs[i]->input,
                             m_settings.GetFontManager().GetFont(FontType::kIcon),
                             m_settings.GetColor(Colors::kBgMain), style,

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -19,11 +19,13 @@ namespace RocProfVis
 namespace View
 {
 
-constexpr const char* ROWCONTEXTMENU_POPUP_NAME = "RowContextMenu";
-constexpr uint64_t    FETCH_CHUNK_SIZE          = 1000;
-constexpr const char* START_TS_COLUMN_NAME      = "start";
-constexpr const char* END_TS_COLUMN_NAME        = "end";
-constexpr const char* DURATION_COLUMN_NAME      = "duration";
+constexpr const char* ROWCONTEXTMENU_POPUP_NAME  = "RowContextMenu";
+constexpr uint64_t    FETCH_CHUNK_SIZE           = 1000;
+constexpr const char* START_TS_COLUMN_NAME       = "start";
+constexpr const char* END_TS_COLUMN_NAME         = "end";
+constexpr const char* DURATION_COLUMN_NAME       = "duration";
+constexpr const char* FILTER_TEXT_HINT_STR       = "Filter: hipLaunchKernel";
+constexpr const char* FILTER_TEXT_HINT_NUMERICAL = "Filter: {>, <, =, >=, <=, !=} 30";
 
 InfiniteScrollTable::InfiniteScrollTable(
     DataProvider& dp, TableType table_type,
@@ -46,16 +48,21 @@ InfiniteScrollTable::InfiniteScrollTable(
 , m_fetch_chunk_size(FETCH_CHUNK_SIZE)  // Number of items to fetch in one go
 , m_fetch_pad_items(30)                 // Number of items to pad the fetch range
 , m_fetch_threshold_items(10)  // Number of items from the edge to trigger a fetch
+, m_fetch_start_row(0)
 , m_last_table_size(0, 0)
 , m_settings(SettingsManager::GetInstance())
-, m_filter_options({ "", "", "", "" })
-, m_pending_filter_options({ "", "", "", "" })
+, m_filter_options({ "", "", "" })
 , m_sort_column_index(default_sort_column_index)
 , m_default_sort_column_index(default_sort_column_index)
 , m_sort_order(default_sort_order)
 , m_default_sort_order(default_sort_order)
+, m_display_filter_row(false)
+, m_update_filter_row(false)
+, m_reset_filter_row(false)
 , m_data_changed(true)
 , m_filter_requested(false)
+, m_fetch_data(false)
+, m_fetch_cancelled(false)
 , m_selected_row(-1)
 , m_selected_column(-1)
 , m_hovered_row(-1)
@@ -122,10 +129,76 @@ InfiniteScrollTable::~InfiniteScrollTable()
 void
 InfiniteScrollTable::Update()
 {
+    if(m_fetch_data)
+    {
+        FetchData();
+    }
     if(m_data_changed)
     {
         FormatData();
         m_data_changed = false;
+    }
+    if(m_reset_filter_row)
+    {
+        m_displayed_filter_row_inputs.clear();
+        m_active_filter_row_inputs.clear();
+        m_filter_row_inputs.clear();
+        m_active_filter_row_clause.clear();
+        m_update_filter_row = true;
+        m_reset_filter_row  = false;
+    }
+    if(m_update_filter_row)
+    {
+        const std::vector<std::string>& columns =
+            m_table_model().GetTableHeader(m_table_type);
+        const std::vector<rocprofvis_controller_primitive_type_t>& column_types =
+            m_table_model().GetTableColumnTypes(m_table_type);
+        ROCPROFVIS_ASSERT(columns.size() == column_types.size());
+        m_displayed_filter_row_inputs.resize(columns.size());
+        std::unordered_set<FilterInput*> active_filter_row_inputs;
+        for(size_t i = 0; i < m_displayed_filter_row_inputs.size(); i++)
+        {
+            if(m_filter_row_inputs.count(columns[i]))
+            {
+                if(!m_filter_row_inputs.at(columns[i]).input.empty())
+                {
+                    active_filter_row_inputs.insert(&m_filter_row_inputs.at(columns[i]));
+                }
+            }
+            else
+            {
+                m_filter_row_inputs[columns[i]] = { columns[i], column_types[i], "" };
+            }
+            m_displayed_filter_row_inputs[i] = &m_filter_row_inputs.at(columns[i]);
+        }
+        if(active_filter_row_inputs != m_active_filter_row_inputs)
+        {
+            m_active_filter_row_inputs = std::move(active_filter_row_inputs);
+            m_filter_requested         = true;
+        }
+        m_update_filter_row = false;
+    }
+}
+
+void
+InfiniteScrollTable::UpdateFetchParams(std::shared_ptr<TableRequestParams>& params) const
+{
+    if(!params)
+    {
+        // Derives should have set this up...
+        ROCPROFVIS_ASSERT(false);
+    }
+    else
+    {
+        params->m_table_type        = m_request_table_type;
+        params->m_start_row         = m_fetch_start_row;
+        params->m_req_row_count     = m_fetch_chunk_size;
+        params->m_sort_column_index = m_sort_column_index;
+        params->m_sort_order        = m_sort_order;
+        params->m_where             = "";
+        params->m_filter            = m_filter_options.filter;
+        params->m_group             = m_filter_options.group_by;
+        params->m_group_columns     = m_filter_options.group_columns;
     }
 }
 
@@ -140,7 +213,8 @@ InfiniteScrollTable::HandleNewTableData(std::shared_ptr<RocEvent> e)
 {
     if(e && e->GetSourceId() == m_data_provider.GetTraceFilePath())
     {
-        m_data_changed = true;
+        m_data_changed      = true;
+        m_update_filter_row = m_display_filter_row;
         IndexColumns();
     }
 }
@@ -194,7 +268,7 @@ InfiniteScrollTable::Render()
         start_row = table_params->m_start_row;
     }
     uint64_t end_row = start_row + row_count;
-    if(end_row >= total_row_count)
+    if(end_row >= total_row_count && total_row_count > 0)
     {
         end_row = total_row_count - 1;  // Ensure we don't exceed the total row count
     }
@@ -202,9 +276,7 @@ InfiniteScrollTable::Render()
     float start_row_position = start_row * row_height;
     float end_row_position   = end_row * row_height;
 
-    bool                               sort_requested    = false;
-    uint64_t                           sort_column_index = 0;
-    rocprofvis_controller_sort_order_t sort_order = kRPVControllerSortOrderAscending;
+    bool sort_requested = false;
 
     ImGuiTableFlags table_flags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_RowBg |
                                   ImGuiTableFlags_BordersOuter | ImGuiTableFlags_ScrollX |
@@ -243,7 +315,7 @@ InfiniteScrollTable::Render()
 
         ImGui::PushStyleColor(ImGuiCol_ChildBg,
                               m_settings.GetColor(Colors::kFillerColor));
-        if(!table_data.empty())
+        if(column_names.size())
         {
             ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, m_settings.GetDefaultStyle().WindowPadding);
             if(ImGui::BeginTable("infinite_scroll_table",
@@ -259,7 +331,8 @@ InfiniteScrollTable::Render()
                     ImGui::SetScrollY(0.0f);
                 }
 
-                ImGui::TableSetupScrollFreeze(0, 1);  // Freeze header row
+                ImGui::TableSetupScrollFreeze(
+                    0, m_display_filter_row ? 2 : 1);  // Freeze header row
                 int j = 0;
                 for(int i = 0; i < column_names.size(); i++)
                 {
@@ -290,13 +363,18 @@ InfiniteScrollTable::Render()
 
                 // Get sort specs
                 ImGuiTableSortSpecs* sort_specs = ImGui::TableGetSortSpecs();
-                if(sort_specs && (sort_specs->SpecsDirty ||
-                                  sort_specs->Specs->ColumnIndex != m_sort_column_index ||
-                                  sort_specs->Specs->SortOrder != m_sort_order))
+                if(sort_specs &&
+                   (sort_specs->SpecsDirty ||
+                    sort_specs->Specs->ColumnIndex != m_sort_column_index ||
+                    (sort_specs->Specs->SortDirection == ImGuiSortDirection_Ascending &&
+                     m_sort_order != kRPVControllerSortOrderAscending) ||
+                    (sort_specs->Specs->SortDirection == ImGuiSortDirection_Descending &&
+                     m_sort_order != kRPVControllerSortOrderDescending) ||
+                    sort_specs->Specs->SortDirection == ImGuiSortDirection_None))
                 {
-                    sort_requested    = true;
-                    sort_column_index = sort_specs->Specs->ColumnIndex;
-                    sort_order =
+                    sort_requested      = true;
+                    m_sort_column_index = sort_specs->Specs->ColumnIndex;
+                    m_sort_order =
                         (sort_specs->Specs->SortDirection == ImGuiSortDirection_Ascending)
                             ? kRPVControllerSortOrderAscending
                             : kRPVControllerSortOrderDescending;
@@ -305,6 +383,39 @@ InfiniteScrollTable::Render()
                 }
 
                 ImGui::TableHeadersRow();
+
+                if(m_display_filter_row)
+                {
+                    ImGui::TableNextRow();
+                    for(size_t i = 0; i < m_displayed_filter_row_inputs.size() &&
+                                      m_displayed_filter_row_inputs[i];
+                        i++)
+                    {
+                        ImGui::TableNextColumn();
+                        ImGui::PushID(static_cast<int>(i));
+                        std::pair<bool, bool> filter_input = InputTextWithClear(
+                            "",
+                            (m_displayed_filter_row_inputs[i]->column_type ==
+                                 kRPVControllerPrimitiveTypeUInt64 ||
+                             m_displayed_filter_row_inputs[i]->column_type ==
+                                 kRPVControllerPrimitiveTypeDouble)
+                                ? FILTER_TEXT_HINT_NUMERICAL
+                                : FILTER_TEXT_HINT_STR,
+                            m_displayed_filter_row_inputs[i]->input,
+                            m_settings.GetFontManager().GetFont(FontType::kIcon),
+                            m_settings.GetColor(Colors::kBgMain), style,
+                            ImGui::GetContentRegionAvail().x);
+                        if(filter_input.second)
+                        {
+                            m_displayed_filter_row_inputs[i]->input.clear();
+                        }
+                        if(ImGui::IsItemFocused() && ImGui::IsKeyPressed(ImGuiKey_Enter))
+                        {
+                            m_filter_requested = true;
+                        }
+                        ImGui::PopID();
+                    }
+                }
 
                 // Calculate the height of the top spacer based on the start row
                 float top_spacer_height = (float) start_row * row_height;
@@ -419,7 +530,8 @@ InfiniteScrollTable::Render()
 
                 // only check if we need to fetch based on the scroll position if we don't
                 // have all the data
-                if(!m_skip_data_fetch && table_data.size() < total_row_count - 1 && table_params)
+                if(!m_skip_data_fetch && table_data.size() + 1 < total_row_count &&
+                   table_params)
                 {
                     if(!m_data_provider.IsRequestPending(m_request_id))
                     {
@@ -427,7 +539,7 @@ InfiniteScrollTable::Render()
                                           m_fetch_threshold_items * row_height &&
                            start_row > 0)
                         {  // fetch data for the start row
-                            uint64_t new_start_pos =
+                            m_fetch_start_row =
                                 static_cast<uint64_t>(scroll_y / row_height);
                             int visible_rows =
                                 static_cast<int>(outer_size.y / row_height);
@@ -435,23 +547,22 @@ InfiniteScrollTable::Render()
                                 static_cast<int>(m_fetch_chunk_size - m_fetch_pad_items -
                                                  m_fetch_threshold_items - visible_rows);
                             // Ensure start position does not go below zero
-                            if(offset > new_start_pos)
+                            if(offset > m_fetch_start_row)
                             {
-                                new_start_pos = 0;
+                                m_fetch_start_row = 0;
                             }
                             else
                             {
-                                new_start_pos -= offset;
+                                m_fetch_start_row -= offset;
                             }
 
                             spdlog::debug(
                                 "Fetching more data for start row, new start pos: "
                                 "{}, frame count: {}, chunk size: {}, scroll y: {}",
-                                new_start_pos, frame_count, m_fetch_chunk_size, scroll_y);
+                                m_fetch_start_row, frame_count, m_fetch_chunk_size,
+                                scroll_y);
 
-                            table_params->m_start_row     = new_start_pos;
-                            table_params->m_req_row_count = m_fetch_chunk_size;
-                            m_data_provider.FetchTable(*table_params);
+                            m_fetch_data = true;
                         }
                         else if((scroll_y + ImGui::GetWindowHeight() >
                                  end_row_position -
@@ -459,7 +570,7 @@ InfiniteScrollTable::Render()
                                 (end_row != total_row_count - 1) && (scroll_max_y > 0.0f))
                         {
                             // fetch data for the end row
-                            uint64_t new_start_pos =
+                            m_fetch_start_row =
                                 static_cast<uint64_t>(scroll_y / row_height);
 
                             // Ensure start position does not go below zero
@@ -467,23 +578,22 @@ InfiniteScrollTable::Render()
                             // of the table if a previous fetch did not return enough
                             // rows)
                             int offset = m_fetch_pad_items + m_fetch_threshold_items;
-                            if(offset > new_start_pos)
+                            if(offset > m_fetch_start_row)
                             {
-                                new_start_pos = 0;
+                                m_fetch_start_row = 0;
                             }
                             else
                             {
-                                new_start_pos -= offset;
+                                m_fetch_start_row -= offset;
                             }
 
                             spdlog::debug(
                                 "Fetching more data for end row, new start pos: "
                                 "{}, frame count: {}, chunk size: {}, scroll y: {}",
-                                new_start_pos, frame_count, m_fetch_chunk_size, scroll_y);
+                                m_fetch_start_row, frame_count, m_fetch_chunk_size,
+                                scroll_y);
 
-                            table_params->m_start_row     = new_start_pos;
-                            table_params->m_req_row_count = m_fetch_chunk_size;
-                            m_data_provider.FetchTable(*table_params);
+                            m_fetch_data = true;
                         }
                     }
                 }
@@ -515,11 +625,54 @@ InfiniteScrollTable::Render()
 
     if(sort_requested || m_filter_requested)
     {
-        ProcessSortOrFilterRequest(sort_order, sort_column_index, frame_count);
+        ProcessSortOrFilterRequest(frame_count);
     }
 
     m_skip_data_fetch  = false;  // Reset the skip data fetch flag after rendering
     m_filter_requested = false;
+}
+
+void
+InfiniteScrollTable::FetchData()
+{
+    // Cancel pending requests.
+    if(m_data_provider.IsRequestPending(m_request_id))
+    {
+        if(!m_fetch_cancelled)
+        {
+            spdlog::debug("Cancelling previous table request: {}", m_widget_name);
+            m_data_provider.CancelRequest(m_request_id);
+            m_fetch_cancelled = true;
+        }
+    }
+    else
+    {
+        // Reuse the previous params if it exists...
+        std::shared_ptr<TableRequestParams> table_params =
+            m_table_model().GetTableParams(m_table_type);
+        // Update params...
+        UpdateFetchParams(table_params);
+        if(table_params)
+        {
+            // Fetch the event table with the updated params
+            m_fetch_data = !m_data_provider.FetchTable(*table_params);
+            if(m_fetch_data)
+            {
+                // reprocess it later (it's ok to replace the
+                // previous one as the new one reflects the latest state)
+                spdlog::warn("Failed to queue table request for: {}", m_widget_name);
+            }
+            else
+            {
+                spdlog::debug("Submitted table request: {}", m_widget_name);
+                m_fetch_cancelled = false;
+            }
+        }
+        else
+        {
+            ROCPROFVIS_ASSERT(false);
+        }
+    }
 }
 
 void
@@ -633,46 +786,75 @@ InfiniteScrollTable::RenderContextMenu()
 }
 
 void
-InfiniteScrollTable::ProcessSortOrFilterRequest(
-    rocprofvis_controller_sort_order_t sort_order,
-                                        uint64_t sort_column_index, uint64_t frame_count)
+InfiniteScrollTable::ProcessSortOrFilterRequest(uint64_t frame_count)
 {
     auto table_params = m_table_model().GetTableParams(m_table_type);
     if(table_params)
     {
-        FilterOptions& filter =
-            m_filter_requested ? m_pending_filter_options : m_filter_options;
-        if(filter.group_by == "")
+        if(m_filter_requested && m_display_filter_row)
         {
-            filter.group_columns[0] = '\0';
+            m_filter_options.group_by.clear();
+            m_filter_options.group_columns.clear();
+            m_active_filter_row_clause.clear();
+            m_active_filter_row_inputs.clear();
+            for(FilterInput* filter : m_displayed_filter_row_inputs)
+            {
+                if(filter && !filter->input.empty())
+                {
+                    if(m_active_filter_row_clause.size())
+                    {
+                        m_active_filter_row_clause += " AND ";
+                    }
+                    switch(filter->column_type)
+                    {
+                        case kRPVControllerPrimitiveTypeUInt64:
+                        case kRPVControllerPrimitiveTypeDouble:
+                        {
+                            m_active_filter_row_clause +=
+                                filter->column_name + " " + filter->input;
+                            m_active_filter_row_inputs.insert(filter);
+                            break;
+                        }
+                        case kRPVControllerPrimitiveTypeString:
+                        {
+                            m_active_filter_row_clause +=
+                                filter->column_name + " LIKE '%" + filter->input + "%'";
+                            m_active_filter_row_inputs.insert(filter);
+                            break;
+                        }
+                        default:
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+            m_filter_options.filter = m_active_filter_row_clause;
         }
-        // check that sort order and column index actually are different from the
-        // current values before fetching
-        if(m_filter_requested || sort_order != m_sort_order ||
-           sort_column_index != m_sort_column_index)
+        if(m_filter_options.group_by == "")
         {
-            m_sort_column_index = sort_column_index;
-            m_sort_order        = sort_order;
-            // Update the event table params with the new sort request
-            table_params->m_sort_column_index = m_sort_column_index;
-            table_params->m_sort_order        = m_sort_order;
-            table_params->m_filter            = filter.filter;
-            table_params->m_group = filter.group_by;
-            table_params->m_group_columns = filter.group_columns;
+            m_filter_options.group_columns.clear();
+        }
 
+        // check that requested actually are different from the
+        // current values before fetching
+        if(table_params->m_sort_order != m_sort_order ||
+           table_params->m_sort_column_index != m_sort_column_index ||
+           table_params->m_filter != m_filter_options.filter ||
+           table_params->m_group != m_filter_options.group_by ||
+           table_params->m_group_columns != m_filter_options.group_columns)
+        {
             // if filtering changed reset the start row as current row
             // may be beyond result length causing an assertion in controller
             if(m_filter_requested)
             {
-                table_params->m_start_row = 0;
+                m_fetch_start_row = 0;
             }
 
             spdlog::debug("Fetching data for sort, frame count: {}", frame_count);
 
             // Fetch the event table with the updated params
-            m_data_provider.FetchTable(*table_params);
-
-            m_filter_options = filter;
+            m_fetch_data = true;
         }
     }
     else
@@ -895,6 +1077,19 @@ InfiniteScrollTable::SelectedRowContextMenu()
 }
 
 void
+InfiniteScrollTable::RequestFetch()
+{
+    m_fetch_data      = true;
+    m_fetch_start_row = 0;
+}
+
+void
+InfiniteScrollTable::RequestFilter()
+{
+    m_filter_requested = true;
+}
+
+void
 InfiniteScrollTable::FormatTimeColumns() const
 {
     const std::vector<std::vector<std::string>>& table_data =
@@ -959,6 +1154,28 @@ InfiniteScrollTable::ExportToFile() const
                 table_params->m_export_to_file_path.clear();
             }
         });
+}
+
+void
+InfiniteScrollTable::DisplayFilterRow(bool display)
+{
+    if(m_display_filter_row != display)
+    {
+        m_display_filter_row = display;
+        m_update_filter_row  = display;
+    }
+}
+
+void
+InfiniteScrollTable::ResetFilterRow()
+{
+    m_reset_filter_row = true;
+}
+
+const std::string&
+InfiniteScrollTable::ActiveFilterRowClause() const
+{
+    return m_active_filter_row_clause;
 }
 
 }  // namespace View

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -135,6 +135,7 @@ private:
         std::string                            column_name;
         rocprofvis_controller_primitive_type_t column_type;
         std::string                            input;
+        const char*                            tooltip;
     };
 
     void FetchData();

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -66,15 +66,14 @@ protected:
         kNumTimeColumns
     };
 
-    constexpr static size_t FILTER_SIZE = 256;
     struct FilterOptions
     {
-        char        where[FILTER_SIZE];
         std::string group_by;
-        char        group_columns[FILTER_SIZE];
-        char        filter[FILTER_SIZE];
+        std::string group_columns;
+        std::string filter;
     };
 
+    virtual void UpdateFetchParams(std::shared_ptr<TableRequestParams>& params) const;
     virtual void FormatData() const;
     virtual void IndexColumns();
     virtual void RowSelected(const ImGuiMouseButton mouse_button);
@@ -88,11 +87,19 @@ protected:
                                                            size_t stream_id_column_index) const;
     void                          SelectedRowContextMenu();
 
+    // Signal for data fetch, caller should prepare to recieve UpdateFetchParams. 
+    void RequestFetch();
+    void RequestFilter();
+
     void FormatTimeColumns() const;
     void ExportToFile() const;
 
+    // Filter row...
+    const std::string& ActiveFilterRowClause() const;
+    void               DisplayFilterRow(bool display);
+    void               ResetFilterRow();
+
     FilterOptions                      m_filter_options;
-    FilterOptions                      m_pending_filter_options;
     uint64_t                           m_sort_column_index;
     uint64_t                           m_default_sort_column_index;
     rocprofvis_controller_sort_order_t m_sort_order;
@@ -114,7 +121,6 @@ protected:
     uint64_t m_fetch_chunk_size;
 
     bool m_data_changed;
-    bool m_filter_requested;
 
     // Track the selected row for context menu actions
     int m_selected_row;
@@ -124,19 +130,40 @@ protected:
     bool m_horizontal_scroll;
 
 private:
+    struct FilterInput
+    {
+        std::string                            column_name;
+        rocprofvis_controller_primitive_type_t column_type;
+        std::string                            input;
+    };
+
+    void FetchData();
     void RenderCell(const std::string* cell_text, int row, int column);
     void RenderContextMenu();
-    void ProcessSortOrFilterRequest(rocprofvis_controller_sort_order_t sort_order,
-                                    uint64_t sort_column_index, uint64_t frame_count);
+    void ProcessSortOrFilterRequest(uint64_t frame_count);
 
-    int m_fetch_pad_items;
-    int m_fetch_threshold_items;
+    int      m_fetch_pad_items;
+    int      m_fetch_threshold_items;
+    uint64_t m_fetch_start_row;
+    bool     m_fetch_data;
+    bool     m_fetch_cancelled;
+
+    bool m_filter_requested;
 
     // Internal state flags below
     bool     m_open_context_menu;
     bool     m_skip_data_fetch;
     uint64_t m_last_total_row_count;
     ImVec2   m_last_table_size;
+
+    // Filter row...
+    bool                                         m_display_filter_row;
+    bool                                         m_reset_filter_row;
+    bool                                         m_update_filter_row;
+    std::vector<FilterInput*>                    m_displayed_filter_row_inputs;
+    std::string                                  m_active_filter_row_clause;
+    std::unordered_set<FilterInput*>             m_active_filter_row_inputs;
+    std::unordered_map<std::string, FilterInput> m_filter_row_inputs;
 
     std::string m_no_data_text;
     std::string m_export_notification_id;


### PR DESCRIPTION
Add simplified UI for filtering paginated tables that abstracts SQL concepts. Existing controls still accessible under "Advanced" mode. Currently applicable to event and sample tables as others (search, top events, summary) ignore filtering parameter in backend, but easy to expand to them otherwise.

### DM
- `TableProcessor`
  - Defined column data types for public columns.
  - Corrected output of an invalid filter claiming to have identical row count to that of unfiltered result despite output contents being empty.

### Controller
- Added `Array` property `kRPVControllerArrayEntryTypeIndexed` for getting the data type of each entry.
- Populated `kRPVControllerTableColumnTypeIndexed` for `SystemTable`.
- Factored out common getters out of derived `Table`s into base `Table`.

### View
- Added column type to table models.
- `InfiniteScrollTable`
  - Consolidated data fetch, cancellation, deferral, into singe entry point.
    - Derives are responsible for a `UpdateFetchParams` implementation.
    - When data fetch is needed for any reason, signal request via private flag or public function call. Fetch sequence will pick up all parameters via `UpdateFetchParams` and handle the rest behind the scenes.
  - Added simplified filtering controls.
- `MultiTrackTable `
  - Reworked existing filtering controls. Previous implementation used nonstandard dimensions (ex. 
`ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(style.FramePadding.x, style.ItemSpacing.y * 0.35f))`, making it finicky to align new additions.
  - Updated for `InfiniteScrollTable` changes.
  - Added additional filtering controls.
- `KernelInstanceTable`, `EventSearchTable`
  - Updated for `InfiniteScrollTable` changes.
- Switched `TextInputWithClear` to use `InputTextStringWithHint`
- Switched `ICON_COPY` to non-outline version to be more consistent wiht other icons.