### PR TITLE
MemoryManager Improvements

### DIFF
--- a/src/controller/src/rocprofvis_controller.cpp
+++ b/src/controller/src/rocprofvis_controller.cpp
@@ -714,11 +714,14 @@ void rocprofvis_controller_array_free(rocprofvis_controller_array_t* object)
     RocProfVis::Controller::ArrayRef array(object);
     if (array.IsValid())
     {
-        if(array.Get()->GetContext() &&
-           ((RocProfVis::Controller::SystemTrace*) array.Get()->GetContext())->GetMemoryManager())
+        if(array.Get()->GetContext())
         {
-            ((RocProfVis::Controller::SystemTrace*)array.Get()->GetContext())->GetMemoryManager()->CancelArrayOwnership(&array.Get()->GetVector(),
-                                      RocProfVis::Controller::kRocProfVisOwnerTypeGraph);
+            RocProfVis::Controller::MemoryManager* mgr = ((RocProfVis::Controller::SystemTrace*) array.Get()->GetContext())->GetMemoryManager();
+            if(mgr)
+            {
+                mgr->CancelArrayOwnership(array.Get()->GetArrayId(), RocProfVis::Controller::kRocProfVisOwnerTypeTrack);
+                mgr->CancelArrayOwnership(array.Get()->GetArrayId(), RocProfVis::Controller::kRocProfVisOwnerTypeGraph);           
+            }
         }
         delete array.Get();
     }

--- a/src/controller/src/rocprofvis_controller_array.cpp
+++ b/src/controller/src/rocprofvis_controller_array.cpp
@@ -11,6 +11,7 @@ namespace Controller
 
 Array::Array()
 : Handle(__kRPVControllerArrayPropertiesFirst, __kRPVControllerArrayPropertiesLast)
+, m_array_id(s_next_array_id++)
 {
     m_ctx = nullptr;
 }
@@ -20,6 +21,11 @@ Array::~Array() {}
 std::vector<Data>& Array::GetVector(void)
 {
     return m_array;
+}
+
+uint64_t Array::GetArrayId(void) const
+{
+    return m_array_id;
 }
 
 rocprofvis_controller_object_type_t Array::GetType(void) 

--- a/src/controller/src/rocprofvis_controller_array.h
+++ b/src/controller/src/rocprofvis_controller_array.h
@@ -6,6 +6,7 @@
 #include "rocprofvis_controller.h"
 #include "rocprofvis_controller_handle.h"
 #include "rocprofvis_controller_data.h"
+#include <atomic>
 #include <vector>
 
 namespace RocProfVis
@@ -22,6 +23,8 @@ public:
     virtual ~Array();
 
     std::vector<Data>& GetVector(void);
+
+    uint64_t GetArrayId(void) const;
 
     void SetContext(Handle* ctx);
     Handle* GetContext(void) override;
@@ -57,6 +60,9 @@ public:
 private:
     std::vector<Data> m_array;
     Trace*            m_ctx;
+    uint64_t          m_array_id;
+
+    inline static std::atomic<uint64_t> s_next_array_id{1};
 };
 
 }

--- a/src/controller/src/system/rocprofvis_controller_event.cpp
+++ b/src/controller/src/system/rocprofvis_controller_event.cpp
@@ -55,7 +55,7 @@ Event::~Event()
 bool
 Event::IsDeletable()
 {
-    return --m_retain_counter <= 0;
+    return (m_retain_counter == 0) ? true : --m_retain_counter == 0;
 }
 
 void

--- a/src/controller/src/system/rocprofvis_controller_event.h
+++ b/src/controller/src/system/rocprofvis_controller_event.h
@@ -58,7 +58,7 @@ private:
     size_t m_category;
     size_t m_combined_top_name;
     uint8_t m_level;
-    uint8_t m_retain_counter;
+    uint32_t m_retain_counter;
 
 public:
     static rocprofvis_result_t FetchDataModelFlowTraceProperty(uint64_t event_id, Array& array, rocprofvis_dm_trace_t dm_trace_handle);

--- a/src/controller/src/system/rocprofvis_controller_graph.cpp
+++ b/src/controller/src/system/rocprofvis_controller_graph.cpp
@@ -46,6 +46,7 @@ Graph::Insert(uint32_t lod, double timestamp, uint8_t level, Handle* object)
     auto&               segments        = m_lods[lod];
     double              start_timestamp = 0;
     double              end_timestamp   = 0;
+    bool                stored_in_segment = false;
 
     result = GetDouble(kRPVControllerGraphStartTimestamp, 0, &start_timestamp);
     result = (result == kRocProfVisResultSuccess)
@@ -111,12 +112,19 @@ Graph::Insert(uint32_t lod, double timestamp, uint8_t level, Handle* object)
                 object->GetDouble(kRPVControllerSampleEndTimestamp, 0, &max_timestamp);
             }
             segment->SetMaxTimestamp(std::max(segment->GetMaxTimestamp(), max_timestamp));
-            segment->Insert(timestamp, level, object);
+            stored_in_segment = segment->Insert(timestamp, level, object);
         }
     }
     else
     {
         result = kRocProfVisResultOutOfRange;
+    }
+
+    if(!stored_in_segment && m_ctx && m_ctx->GetMemoryManager() &&
+       !m_ctx->GetMemoryManager()->IsShuttingDown())
+    {
+        // No segment kept the object...
+        m_ctx->GetMemoryManager()->Delete(object, &segments);
     }
 }
 
@@ -480,7 +488,8 @@ struct FetchTrackSegmentArgs
 };
 
 rocprofvis_result_t
-Graph::GenerateLOD(uint32_t lod_to_generate, double start, double end, Future* future)
+Graph::GenerateLOD(uint32_t lod_to_generate, double start, double end, Future* future,
+                   uint64_t array_id)
 {
     rocprofvis_result_t result = kRocProfVisResultOutOfRange;
     if(lod_to_generate > 0)
@@ -500,17 +509,23 @@ Graph::GenerateLOD(uint32_t lod_to_generate, double start, double end, Future* f
             double segment_duration = std::min(std::min(kScalableSegmentDuration * scale, max_ts - min_ts),
                          kMaxSegmentDuration);
 
-            auto it = m_lods.find(lod_to_generate);
-            if(it == m_lods.end())
+            std::map<uint32_t, SegmentTimeline>::iterator it = m_lods.end();
             {
-                uint32_t num_segments = static_cast<uint32_t>(ceil((max_ts - min_ts) / segment_duration));
-                uint64_t num_items = m_track->GetNumberOfEntries();
                 std::lock_guard lock(m_mutex);
-                SegmentTimeline& segments = m_lods[lod_to_generate];
-                segments.SetContext(this);
-                segments.Init(min_ts, segment_duration, num_segments, num_items);    
+
                 it = m_lods.find(lod_to_generate);
+                if(it == m_lods.end())
+                {
+                    uint32_t num_segments = static_cast<uint32_t>(ceil((max_ts - min_ts) / segment_duration));
+                    uint64_t num_items = m_track->GetNumberOfEntries();
+                    SegmentTimeline& segments = m_lods[lod_to_generate];
+                    segments.SetContext(this);
+                    segments.Init(min_ts, segment_duration, num_segments, num_items);
+                    it = m_lods.find(lod_to_generate);
+                }
             }
+
+            it->second.AddActiveArray(array_id);
 
             start = std::max(start, min_ts);
             end   = std::min(end, max_ts);
@@ -565,8 +580,9 @@ Graph::GenerateLOD(uint32_t lod_to_generate, double start, double end, Future* f
                         FetchTrackSegmentArgs args;
                         args.m_index       = 0;
                     	args.m_lru_params.m_ctx      = (SystemTrace*)m_track->GetContext();
-                    	args.m_lru_params.m_lod      = 0;
-                        m_ctx->GetMemoryManager()->EnterArrayOwnership(&args.m_entries, kRocProfVisOwnerTypeTrack);
+                        args.m_lru_params.m_array_id = array_id;
+
+                        m_track->GetSegments()->AddActiveArray(array_id);
 
                         result = m_track->FetchSegments(
                             fetch_start, fetch_end, &args, future,
@@ -600,7 +616,8 @@ Graph::GenerateLOD(uint32_t lod_to_generate, double start, double end, Future* f
                             
                         }
                         m_cv.notify_all();
-                        ((SystemTrace*)m_track->GetContext())->GetMemoryManager()->CancelArrayOwnership(&args.m_entries, kRocProfVisOwnerTypeTrack);
+
+                        m_track->GetSegments()->RemoveActiveArray(array_id);
                     }
                 }
                 else
@@ -622,6 +639,8 @@ Graph::GenerateLOD(uint32_t lod_to_generate, double start, double end, Future* f
                     });
                 }
             }
+
+            it->second.RemoveActiveArray(array_id);
         }
     }
     return result;
@@ -653,9 +672,12 @@ rocprofvis_result_t
 Graph::Fetch(uint32_t pixels, double start, double end, Array& array, uint64_t& index, Future* future)
 {
     rocprofvis_result_t result = kRocProfVisResultUnknownError;
+    MemoryManager* mgr = m_ctx ? m_ctx->GetMemoryManager() : nullptr;
+
     // Zero out the array - we don't know how many entries we will add and we don't want
     // to report a non-zero value to the caller.
     array.GetVector().clear();
+
     if(m_track)
     {
         uint32_t lod      = 0;
@@ -669,7 +691,14 @@ Graph::Fetch(uint32_t pixels, double start, double end, Array& array, uint64_t& 
         // calculate data for LOD 1 even LOD 0 is requested
         lod = std::max(lod, (uint32_t)1);
 
-        result = GenerateLOD(lod, start, end, future);
+        if(mgr)
+        {
+            mgr->EnterArrayOwnership(array.GetArrayId(), kRocProfVisOwnerTypeGraph);
+        }
+
+        array.SetContext(m_ctx);
+
+        result = GenerateLOD(lod, start, end, future, array.GetArrayId());
 
         auto it = m_lods.find(lod);
         if((it != m_lods.end()) && (result == kRocProfVisResultSuccess))
@@ -678,9 +707,7 @@ Graph::Fetch(uint32_t pixels, double start, double end, Array& array, uint64_t& 
             args.m_array = &array;
             args.m_index = &index;
             args.m_lru_params.m_ctx = m_ctx;
-            args.m_lru_params.m_lod   = lod;
-            m_ctx->GetMemoryManager()->EnterArrayOwnership(&args.m_array->GetVector(), kRocProfVisOwnerTypeGraph);
-            array.SetContext(m_ctx);
+            args.m_lru_params.m_array_id = array.GetArrayId();
 
             result = it->second.FetchSegments(
                 start, end, &args, future,

--- a/src/controller/src/system/rocprofvis_controller_graph.h
+++ b/src/controller/src/system/rocprofvis_controller_graph.h
@@ -20,7 +20,7 @@ class Future;
 class Graph : public Handle
 {
     rocprofvis_result_t GenerateLOD(uint32_t lod_to_generate, double start_ts, double end_ts, std::vector<Data>& entries, Future* future);
-    rocprofvis_result_t GenerateLOD(uint32_t lod_to_generate, double start, double end, Future* future);
+    rocprofvis_result_t GenerateLOD(uint32_t lod_to_generate, double start, double end, Future* future, uint64_t array_id);
     void Insert(uint32_t lod, double timestamp, uint8_t level, Handle* object);
 
 public:

--- a/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
+++ b/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
@@ -241,22 +241,29 @@ bool
 MemoryManager::CheckInUse(LRUMember* lru)
 {
     bool is_in_use = false;
-
-    std::unique_lock lru_lock(m_lru_mutex);
-    std::unique_lock track_lock(m_lru_inuse_mutex[kRocProfVisOwnerTypeTrack]);
-    std::unique_lock graph_lock(m_lru_inuse_mutex[kRocProfVisOwnerTypeGraph]);
-
-    for(auto it = lru->m_array_ids.begin(); it != lru->m_array_ids.end();)
     {
-        if(m_lru_inuse_lookup[kRocProfVisOwnerTypeTrack].count(*it) > 0 ||
-           m_lru_inuse_lookup[kRocProfVisOwnerTypeGraph].count(*it) > 0)
+        std::unique_lock lock(m_lru_inuse_mutex[kRocProfVisOwnerTypeTrack]);
+        for(auto array_id : lru->m_array_ids)
         {
-            is_in_use = true;
-            ++it;
+            auto inuse = m_lru_inuse_lookup[kRocProfVisOwnerTypeTrack].find(array_id);
+            if(inuse != m_lru_inuse_lookup[kRocProfVisOwnerTypeTrack].end())
+            {
+                is_in_use = true;
+                break;
+            }
         }
-        else
+    }
+    if (!is_in_use)
+    {
+        std::unique_lock lock(m_lru_inuse_mutex[kRocProfVisOwnerTypeGraph]);
+        for(auto array_id : lru->m_array_ids)
         {
-            it = lru->m_array_ids.erase(it);
+            auto inuse = m_lru_inuse_lookup[kRocProfVisOwnerTypeGraph].find(array_id);
+            if(inuse != m_lru_inuse_lookup[kRocProfVisOwnerTypeGraph].end())
+            {
+                is_in_use = true;
+                break;
+            }
         }
     }
     return is_in_use;
@@ -398,9 +405,7 @@ MemoryManager::ManageLRU()
                         .count();
                 for(auto& [owner, member] : sorted_entries)
                 {
-                    if(couldnt_take_lock.size() > 0 &&
-                       std::find(couldnt_take_lock.begin(), couldnt_take_lock.end(),
-                                 owner) != couldnt_take_lock.end())
+                    if(std::find(locked.begin(), locked.end(), owner) == locked.end())
                     {
                         continue;
                     }

--- a/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
+++ b/src/controller/src/system/rocprofvis_controller_mem_mgmt.cpp
@@ -30,11 +30,14 @@ namespace Controller
 {
 
 MemoryManager::MemoryManager(uint64_t id)
-: m_lru_storage_memory_used(0)
+: m_id(id)
 , m_lru_mgmt_shutdown(false)
+, m_lru_configured(false)
 , m_mem_mgmt_initialized(false)
+, m_lru_storage_memory_used(0)
 , m_mem_block_size(1024)
-, m_id(id)
+, m_lru_size_limit(0)
+, m_trace_size(0)
 , m_trace_weight(1.0)
 { 
     //for(int type = 0; type < kRocProfVisNumberOfObjectTypes; type++)
@@ -202,11 +205,11 @@ MemoryManager::Configure(double weight)
 //}
 
 rocprofvis_result_t
-MemoryManager::CancelArrayOwnership(void* array_ptr, rocprofvis_owner_type_t type)
+MemoryManager::CancelArrayOwnership(uint64_t array_id, rocprofvis_owner_type_t type)
 {
 
     std::unique_lock lock(m_lru_inuse_mutex[type]);
-    auto             it = m_lru_inuse_lookup[type].find(array_ptr);
+    auto             it = m_lru_inuse_lookup[type].find(array_id);
     if(it != m_lru_inuse_lookup[type].end())
     {
         m_lru_inuse_lookup[type].erase(it);
@@ -222,13 +225,13 @@ MemoryManager::CancelArrayOwnership(void* array_ptr, rocprofvis_owner_type_t typ
 }
 
 rocprofvis_result_t
-MemoryManager::EnterArrayOwnership(void* array_ptr, rocprofvis_owner_type_t type)
+MemoryManager::EnterArrayOwnership(uint64_t array_id, rocprofvis_owner_type_t type)
 {
     std::unique_lock lock(m_lru_inuse_mutex[type]);
-    auto             it = m_lru_inuse_lookup[type].find(array_ptr);
+    auto             it = m_lru_inuse_lookup[type].find(array_id);
     if(it == m_lru_inuse_lookup[type].end())
     {
-        m_lru_inuse_lookup[type].insert(array_ptr);
+        m_lru_inuse_lookup[type].insert(array_id);
     }
 
     return kRocProfVisResultSuccess;
@@ -238,29 +241,22 @@ bool
 MemoryManager::CheckInUse(LRUMember* lru)
 {
     bool is_in_use = false;
+
+    std::unique_lock lru_lock(m_lru_mutex);
+    std::unique_lock track_lock(m_lru_inuse_mutex[kRocProfVisOwnerTypeTrack]);
+    std::unique_lock graph_lock(m_lru_inuse_mutex[kRocProfVisOwnerTypeGraph]);
+
+    for(auto it = lru->m_array_ids.begin(); it != lru->m_array_ids.end();)
     {
-        std::unique_lock lock(m_lru_inuse_mutex[kRocProfVisOwnerTypeTrack]);
-        for(auto ptr : lru->m_array_ptr)
+        if(m_lru_inuse_lookup[kRocProfVisOwnerTypeTrack].count(*it) > 0 ||
+           m_lru_inuse_lookup[kRocProfVisOwnerTypeGraph].count(*it) > 0)
         {
-            auto inuse = m_lru_inuse_lookup[kRocProfVisOwnerTypeTrack].find(ptr);
-            if(inuse != m_lru_inuse_lookup[kRocProfVisOwnerTypeTrack].end())
-            {
-                is_in_use = true;
-                break;
-            }
+            is_in_use = true;
+            ++it;
         }
-    }
-    if (!is_in_use)
-    {
-        std::unique_lock lock(m_lru_inuse_mutex[kRocProfVisOwnerTypeGraph]);
-        for(auto ptr : lru->m_array_ptr)
+        else
         {
-            auto inuse = m_lru_inuse_lookup[kRocProfVisOwnerTypeGraph].find(ptr);
-            if(inuse != m_lru_inuse_lookup[kRocProfVisOwnerTypeGraph].end())
-            {
-                is_in_use = true;
-                break;
-            }
+            it = lru->m_array_ids.erase(it);
         }
     }
     return is_in_use;
@@ -298,10 +294,8 @@ MemoryManager::CheckInUse(LRUMember* lru)
 //}
 
 void
-MemoryManager::AddLRUReference(SegmentTimeline* owner, Segment* reference, uint32_t lod,
-                               void* array_ptr)
+MemoryManager::AddLRUReference(SegmentTimeline* owner, Segment* reference, uint64_t array_id)
 {
-    (void) lod;
     std::unique_lock lock(m_lru_mutex);
     auto& member_ptr = m_lru_array[owner];
     if(!member_ptr)
@@ -319,7 +313,7 @@ MemoryManager::AddLRUReference(SegmentTimeline* owner, Segment* reference, uint3
         lru = std::make_unique<LRUMember>();
     }
 
-    lru->m_array_ptr.insert(array_ptr);
+    lru->m_array_ids.insert(array_id);
 
 }
 
@@ -327,9 +321,13 @@ void
 MemoryManager::LockTimelines(std::vector<SegmentTimeline*>& locked, std::vector<SegmentTimeline*>& failed_to_lock)
 {
     std::set<SegmentTimeline*> timelines;
-    for(auto& pair : m_lru_array)
     {
-        timelines.insert(pair.first);
+        std::unique_lock lock(m_lru_mutex);
+        for(std::pair<SegmentTimeline* const, std::unique_ptr<LRUOwnerMember>>& pair :
+            m_lru_array)
+        {
+            timelines.insert(pair.first);
+        }
     }
 
     for(auto* timeline : timelines)
@@ -387,12 +385,12 @@ MemoryManager::ManageLRU()
                     std::unique_lock lock(m_lru_mutex);
                     for(auto& [handle, member_ptr] : m_lru_array)
                         sorted_entries.emplace_back(handle, member_ptr.get());
-                }
 
-                std::sort(sorted_entries.begin(), sorted_entries.end(),
-                          [](const auto& a, const auto& b) {
-                              return a.second->m_timestamp < b.second->m_timestamp;
-                          });
+                    std::sort(sorted_entries.begin(), sorted_entries.end(),
+                              [](const auto& a, const auto& b) {
+                                  return a.second->m_timestamp < b.second->m_timestamp;
+                              });
+                }
 
                 uint64_t ts = std::chrono::time_point_cast<std::chrono::nanoseconds>(
                         std::chrono::system_clock::now())
@@ -515,8 +513,6 @@ static_assert(std::is_base_of<Handle, SampleLOD>::value,
               "Pooled SampleLOD must derive from Handle");
 
 void MemoryManager::CleanUp() {
-    std::lock_guard<std::mutex> lock(m_pool_mutex);
-
     for(auto& [owner, member_ptr] : m_lru_array)
     {
         for(auto& [segment, lru] : member_ptr.get()->m_lru_segment_array)
@@ -524,6 +520,8 @@ void MemoryManager::CleanUp() {
             owner->Remove(segment);
         }
     }
+
+    std::lock_guard<std::mutex> lock(m_pool_mutex);
     
     for(auto it = m_object_pools.begin(); it != m_object_pools.end(); ++it)
     {
@@ -597,6 +595,8 @@ void
 MemoryManager::Delete(Handle* handle, SegmentTimeline* owner)
 {
     if(!handle->IsDeletable()) return;
+
+    std::lock_guard<std::mutex> lock(m_pool_mutex);
 
     uint64_t pool_idetifier = uint64_t(owner);
 

--- a/src/controller/src/system/rocprofvis_controller_mem_mgmt.h
+++ b/src/controller/src/system/rocprofvis_controller_mem_mgmt.h
@@ -103,7 +103,8 @@ namespace RocProfVis
 
         struct LRUMember
         {
-            std::set<void*>  m_array_ptr;
+            // Arrays that depend on this segment. AddLRUReference adds, CheckInUse drops.
+            std::unordered_set<uint64_t>  m_array_ids;
         };
 
 
@@ -131,12 +132,16 @@ namespace RocProfVis
 
             virtual ~MemoryManager();
 
-            void AddLRUReference(SegmentTimeline* owner,
-                                                    Segment* reference, uint32_t lod,
-                                                    void* array_ptr);
-            rocprofvis_result_t EnterArrayOwnership(void* array_ptr,
+            /* Makes the segment an eviction candidate and records that `array_id`
+               depends on it. The segment stays pinned while that array is entered.
+               @param array_id: the fetch result array the segment was created for or
+                                read into. */
+            void                AddLRUReference(SegmentTimeline* owner, Segment* reference,
+                                                uint64_t array_id);
+
+            rocprofvis_result_t EnterArrayOwnership(uint64_t array_id,
                                                    rocprofvis_owner_type_t type);
-            rocprofvis_result_t CancelArrayOwnership(void* array_ptr,
+            rocprofvis_result_t CancelArrayOwnership(uint64_t array_id,
                                                     rocprofvis_owner_type_t type);
             void                Configure(double weight);
 
@@ -150,7 +155,7 @@ namespace RocProfVis
         private:
 
             uint64_t                                                    m_id;
-            std::unordered_set<void*>                                   m_lru_inuse_lookup[kRocProfVisNumberOfOwnerTypes];
+            std::unordered_set<uint64_t>                                m_lru_inuse_lookup[kRocProfVisNumberOfOwnerTypes];
             std::map <SegmentTimeline*, std::unique_ptr<LRUOwnerMember>>  m_lru_array;
             std::condition_variable                                     m_lru_cv;
             std::thread                                                 m_lru_thread;

--- a/src/controller/src/system/rocprofvis_controller_mem_mgmt.h
+++ b/src/controller/src/system/rocprofvis_controller_mem_mgmt.h
@@ -103,7 +103,7 @@ namespace RocProfVis
 
         struct LRUMember
         {
-            // Arrays that depend on this segment. AddLRUReference adds, CheckInUse drops.
+            // Arrays that depend on this segment.
             std::unordered_set<uint64_t>  m_array_ids;
         };
 

--- a/src/controller/src/system/rocprofvis_controller_segment.cpp
+++ b/src/controller/src/system/rocprofvis_controller_segment.cpp
@@ -99,11 +99,16 @@ void Segment::SetMaxTimestamp(double value)
     m_max_timestamp = value;
 }
 
-void Segment::Insert(double timestamp, uint8_t level, Handle* event)
+bool Segment::Insert(double timestamp, uint8_t level, Handle* event)
 {
     std::unique_lock<std::shared_mutex> lock(m_mutex);
-    event->IncreaseRetainCounter();
-    m_entries[level].insert(std::make_pair(timestamp, event));
+    std::pair<std::map<double, Handle*>::iterator, bool> insert_result =
+        m_entries[level].insert(std::make_pair(timestamp, event));
+    if(insert_result.second)
+    {
+        event->IncreaseRetainCounter();
+    }
+    return insert_result.second;
 }
 
 rocprofvis_result_t Segment::Fetch(double start, double end, std::vector<Data>& array, uint64_t& index, std::unordered_set<uint64_t>* event_id_set, SegmentLRUParams* lru_params)
@@ -113,10 +118,10 @@ rocprofvis_result_t Segment::Fetch(double start, double end, std::vector<Data>& 
     double last_timestamp = std::max(m_end_timestamp, m_max_timestamp);
     if(m_start_timestamp <= end && last_timestamp >= start)
     {
-        if(lru_params)
+        if(lru_params && lru_params->m_ctx && lru_params->m_ctx->GetMemoryManager())
         {
             lru_params->m_ctx->GetMemoryManager()->AddLRUReference(
-                lru_params->m_owner, this, lru_params->m_lod, &array);
+                lru_params->m_owner, this, lru_params->m_array_id);
         }
         result = kRocProfVisResultSuccess;
         for(auto& level : m_entries)
@@ -262,10 +267,11 @@ size_t Segment::GetNumEntries()
 
 
 SegmentTimeline::SegmentTimeline()
-: m_segment_duration(0)
+: m_segment_start_time(0)
+, m_segment_duration(0)
 , m_num_segments(0)
 , m_max_num_items(0)
-, m_segment_start_time(0)
+, m_ctx(nullptr)
 {
 }
 
@@ -277,10 +283,12 @@ SegmentTimeline::SegmentTimeline(SegmentTimeline&& other)
 : m_segments(std::move(other.m_segments))
 , m_valid_segments(std::move(other.m_valid_segments))
 , m_processed_segments(std::move(other.m_processed_segments))
+, m_segment_start_time(other.m_segment_start_time)
 , m_segment_duration(other.m_segment_duration)
 , m_num_segments(other.m_num_segments)
 , m_max_num_items(other.m_max_num_items)
-, m_segment_start_time(other.m_segment_start_time)
+, m_ctx(other.m_ctx)
+, m_active_array_ids(std::move(other.m_active_array_ids))
 {
 
 }
@@ -294,6 +302,8 @@ SegmentTimeline& SegmentTimeline::operator=(SegmentTimeline&& other)
     m_valid_segments = std::move(other.m_valid_segments);
     m_processed_segments     = std::move(other.m_processed_segments);
     m_segment_start_time = other.m_segment_start_time;
+    m_ctx                = other.m_ctx;
+    m_active_array_ids   = std::move(other.m_active_array_ids);
     return *this;
 }
 
@@ -377,6 +387,19 @@ SegmentTimeline::Insert(double segment_start, std::unique_ptr<Segment>&& segment
     if(pair.second)
     {
         pair.first->second.get()->SetTimelineIterator(pair.first);
+        if(m_ctx && m_ctx->GetContext())
+        {
+            SystemTrace* trace = (SystemTrace*) m_ctx->GetContext();
+            if(trace->GetMemoryManager())
+            {
+                ROCPROFVIS_ASSERT(!m_active_array_ids.empty());
+                for(uint64_t array_id : m_active_array_ids)
+                {
+                    trace->GetMemoryManager()->AddLRUReference(
+                        this, pair.first->second.get(), array_id);
+                }
+            }
+        }
         result = kRocProfVisResultSuccess;
     }
     else
@@ -458,6 +481,18 @@ SegmentTimeline::GetMaxNumItems() const
 
 std::shared_mutex* SegmentTimeline::GetMutex() {
     return &m_mutex;
+}
+
+void SegmentTimeline::AddActiveArray(uint64_t array_id)
+{
+    std::unique_lock<std::shared_mutex> lock(m_mutex);
+    m_active_array_ids.insert(array_id);
+}
+
+void SegmentTimeline::RemoveActiveArray(uint64_t array_id)
+{
+    std::unique_lock<std::shared_mutex> lock(m_mutex);
+    m_active_array_ids.erase(array_id);
 }
 
 rocprofvis_result_t SegmentTimeline::Remove(Segment* target)

--- a/src/controller/src/system/rocprofvis_controller_segment.h
+++ b/src/controller/src/system/rocprofvis_controller_segment.h
@@ -34,7 +34,7 @@ struct SegmentLRUParams
 {
     SystemTrace* m_ctx;
     SegmentTimeline* m_owner;
-    uint32_t m_lod;
+    uint64_t m_array_id;
 };
 
 struct SegmentItemKey
@@ -75,7 +75,9 @@ public:
 
     void SetMaxTimestamp(double value);
 
-    void Insert(double timestamp, uint8_t level, Handle* event);
+    // Returns false when this level already holds an entry at this timestamp,
+    // meaning the object was not stored and the caller still owns it.
+    bool Insert(double timestamp, uint8_t level, Handle* event);
 
     rocprofvis_result_t Fetch(double start, double end, std::vector<Data>& array, uint64_t& index, std::unordered_set<uint64_t>* event_id_set, SegmentLRUParams* lru_params);
 
@@ -127,6 +129,13 @@ public:
     double GetSegmentDuration() const;
     size_t GetMaxNumItems() const;
 
+    /* Marks a fetch result array as currently populating this timeline. Segments
+       created while it is registered are retained by it, so they cannot be evicted
+       before the fetch that produced them has handed them to the caller. Must be
+       paired with RemoveActiveArray. */
+    void AddActiveArray(uint64_t array_id);
+    void RemoveActiveArray(uint64_t array_id);
+
 private:
     std::map<double, std::unique_ptr<Segment>> m_segments;
     BitSet                                     m_valid_segments;
@@ -136,6 +145,7 @@ private:
     uint32_t                                   m_num_segments;
     size_t                                     m_max_num_items;
     Handle*                                    m_ctx;
+    std::unordered_set<uint64_t>               m_active_array_ids;
     mutable std::shared_mutex                  m_mutex;
 
 };

--- a/src/controller/src/system/rocprofvis_controller_track.cpp
+++ b/src/controller/src/system/rocprofvis_controller_track.cpp
@@ -466,11 +466,20 @@ struct FetchEventsArgs
 
 rocprofvis_result_t Track::Fetch(double start, double end, Array& array, uint64_t& index, Future* future)
 {
+    SystemTrace*   trace = (SystemTrace*) GetContext();
+    MemoryManager* mgr   = trace ? trace->GetMemoryManager() : nullptr;
+
+    if(mgr)
+    {
+        mgr->EnterArrayOwnership(array.GetArrayId(), kRocProfVisOwnerTypeTrack);
+    }
+    m_segments.AddActiveArray(array.GetArrayId());
+
     FetchEventsArgs args;
     args.m_array = &array;
     args.m_index = &index;
-    args.lru_params.m_ctx   = (SystemTrace*)GetContext();
-    args.lru_params.m_lod      = 0;
+    args.lru_params.m_ctx   = trace;
+    args.lru_params.m_array_id = array.GetArrayId();
     array.SetContext(GetContext());
 
     rocprofvis_result_t result = FetchSegments(start, end, &args, future, [](double start, double end, Segment& segment, void* user_ptr, SegmentTimeline* owner) -> rocprofvis_result_t
@@ -480,6 +489,8 @@ rocprofvis_result_t Track::Fetch(double start, double end, Array& array, uint64_
         rocprofvis_result_t result = segment.Fetch(start, end, args->m_array->GetVector(), *args->m_index, &args->m_event_ids, &args->lru_params);
         return result;
     });
+
+    m_segments.RemoveActiveArray(array.GetArrayId());
 
     return result;
 }
@@ -1227,6 +1238,7 @@ rocprofvis_result_t Track::SetObject(rocprofvis_property_t property, uint64_t in
                                   GetStartTimestamp() < GetEndTimestamp());
                 Handle* object = (Handle*)value;
                 auto object_type = object->GetType();
+				bool stored_in_segment = false;
                 if (((GetTrackType() == kRPVControllerTrackTypeEvents) && (object_type == kRPVControllerObjectTypeEvent))
                     || ((GetTrackType() == kRPVControllerTrackTypeSamples) && (object_type == kRPVControllerObjectTypeSample)))
                 {
@@ -1308,20 +1320,20 @@ rocprofvis_result_t Track::SetObject(rocprofvis_property_t property, uint64_t in
                                         segment->GetMaxTimestamp(), timestamp.second));
                                     if (range.second-range.first == 0)
                                     {
-                                        segment->Insert(timestamp.first, static_cast<uint8_t>(level), object);
+                                        stored_in_segment |= segment->Insert(timestamp.first, static_cast<uint8_t>(level), object);
                                     } else
                                     if (object_type == kRPVControllerObjectTypeEvent)
                                     {
                                         if (current_segment == range.first)
                                         {
-                                            segment->Insert(timestamp.first, static_cast<uint8_t>(level), object);
+                                            stored_in_segment |= segment->Insert(timestamp.first, static_cast<uint8_t>(level), object);
                                         }
                                         else
                                         {
                                             if (object_type == kRPVControllerObjectTypeEvent)
                                             {
                                                 Event* event = (Event*)object;
-                                                segment->Insert(timestamp.first, static_cast<uint8_t>(level), event);
+                                                stored_in_segment |= segment->Insert(timestamp.first, static_cast<uint8_t>(level), event);
                                             }
                                         }
                                     }
@@ -1329,7 +1341,7 @@ rocprofvis_result_t Track::SetObject(rocprofvis_property_t property, uint64_t in
                                     {
                                         if (current_segment == range.first)
                                         {
-                                            segment->Insert(timestamp.first, static_cast<uint8_t>(level), object);
+                                            stored_in_segment |= segment->Insert(timestamp.first, static_cast<uint8_t>(level), object);
                                         }
                                     }
                                 }
@@ -1339,6 +1351,13 @@ rocprofvis_result_t Track::SetObject(rocprofvis_property_t property, uint64_t in
                         {
                             result = kRocProfVisResultOutOfRange;
                         }
+                    }
+
+                    if(!stored_in_segment && m_ctx && m_ctx->GetMemoryManager() &&
+                       !m_ctx->GetMemoryManager()->IsShuttingDown())
+                    {
+                        // No segment kept the object...
+                        m_ctx->GetMemoryManager()->Delete(object, GetSegments());
                     }
                 }
                 break;

--- a/src/controller/tests/rocprofvis_controller_system_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_system_tests.cpp
@@ -67,7 +67,11 @@ TEST_CASE("Memory Manager LRU Eviction")
     mm_a.Init(trace_size);
     mm_a.Configure(1.0);
 
-    int dummy_array = 0;
+    // Stands in for an in-flight request's result array. Entered while the segments
+    // are built, then cancelled so the LRU is allowed to reclaim them.
+    uint64_t dummy_array_id = 1;
+    mm_a.EnterArrayOwnership(dummy_array_id,
+                             RocProfVis::Controller::kRocProfVisOwnerTypeTrack);
 
     for(uint32_t i = 0; i < num_segments; i++)
     {
@@ -93,7 +97,7 @@ TEST_CASE("Memory Manager LRU Eviction")
         REQUIRE(result == kRocProfVisResultSuccess);
 
         timeline.SetValid(i, true);
-        mm_a.AddLRUReference(&timeline, seg_ptr, 0, &dummy_array);
+        mm_a.AddLRUReference(&timeline, seg_ptr, dummy_array_id);
     }
 
     spdlog::info("Validating segments are valid after insertion");
@@ -105,6 +109,10 @@ TEST_CASE("Memory Manager LRU Eviction")
     RocProfVis::Controller::MemoryManager mm_b(2);
     mm_b.Init(trace_size);
     mm_b.Configure(DBL_MAX);
+
+    // Nothing is evictable until the request that built the segments finishes.
+    mm_a.CancelArrayOwnership(dummy_array_id,
+                              RocProfVis::Controller::kRocProfVisOwnerTypeTrack);
 
     spdlog::info("Wait for LRU eviction");
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);


### PR DESCRIPTION
Addresses following issues observed while navigating the timeline:
1.  Intermittent crash in `MemoryManager::ManageLRU`
    - Acquire lru lock to prevent `std::sort` from running while contents were being manipulated in other threads.
2.  Intermittent crash in `MemoryManager::Delete`
    - Acquire pool lock to prevent it and `NewEvent`, `NewSample`, `NewSampleLod`, `Cleanup` from modifying pool simultaneously.
3.  Memory usage growing over time
    - Added deletion of events not stored in a segment. `Segment::Insert` will not store an event if it already holds an event with the same timestamp. These events were invisible to `MemoryManager` and could not be evicted. 
    - Registered all fetched segments with `MemoryManager`. Only segments that are read in `Segment::Fetch` were registered with `MemoryManager` (`MemoryManager::AddLRUReference`). If fetch was cancelled, there would be skipped segments in aforementioned function who are never registered with `MemoryManager` and cannot be evicted.
    - Replaced array identifier in `LRUMember` with `uint64_t id` instead of array's ptr. It is possible for a newly allocated array to reuse address of an array that had already be freed. This would cause `LRUMembers` of the already freed array to be considered in use.

Tested using automated test that constantly pans and zooms timeline and switches between ten tabs for 46 hours and counting.
| Time Window| Beginning Total App Memory Usage (MB) | End Total App Memory Usage (MB) | Rate (MB/hr) |
|---|---|---|---|
| last 36h | 9,496 | 11,066 | +43.6 |
| last 24h | 10,259 | 11,066 | +33.6 |
| last 18h | 10,388 | 11,066 | +37.7 |
| last 12h | 10,584 | 11,066 | +40.2 |
| last 8h | 10,981 | 11,066 | +10.6 |
| last 6h | 10,996 | 11,066 | +11.7 |
| last 4h | 11,010 | 11,066 | +14.0 |

(For reference, unmodified app would trigger Ubuntu OOM killer in ~22 hours on 128 GB system)