### PR TITLE
View: Limit and auto-fit table column widths (#1023)

### DIFF
--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -456,16 +456,33 @@ ElidedText(const char* text, float available_width, float tooltip_width,
 std::string
 ElideWithEllipsis(const std::string& text, float max_width, size_t max_chars)
 {
-    std::string out       = text.substr(0, max_chars);
-    bool        truncated = text.size() > max_chars;
-    while(!out.empty() && ImGui::CalcTextSize((out + "...").c_str()).x > max_width)
+    // Optional hard character cap first.
+    const std::string capped =
+        (max_chars < text.size()) ? text.substr(0, max_chars) : text;
+    bool truncated = capped.size() < text.size();
+
+    // Trim to fit max_width in one pass (CalcTextSizeA reports where it stopped).
+    const char* begin      = capped.c_str();
+    const char* end        = begin + capped.size();
+    const float ellipsis_w = ImGui::CalcTextSize(TEXT_ELLIPSIS).x;
+    const char* remaining  = begin;
+    ImGui::GetFont()->CalcTextSizeA(ImGui::GetFontSize(),
+                                    std::max(max_width - ellipsis_w, 0.0f), 0.0f, begin,
+                                    end, &remaining);
+    if(remaining < end)
     {
-        out.pop_back();
         truncated = true;
     }
+    // Keep at least one character so a shortened value is not just the ellipsis.
+    if(remaining == begin && end > begin)
+    {
+        remaining = begin + 1;
+    }
+
+    std::string out(begin, remaining);
     if(truncated)
     {
-        out += "...";
+        out += TEXT_ELLIPSIS;
     }
     return out;
 }

--- a/src/view/src/widgets/rocprofvis_gui_helpers.h
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.h
@@ -114,15 +114,19 @@ enum Alignment
     Alignment_Right,
 };
 
+// Ellipsis appended to shortened text, so every caller renders the same marker.
+inline constexpr const char* TEXT_ELLIPSIS = "...";
+
 bool
 ElidedText(const char* text, float available_width, float tooltip_width = 0.0f,
            Alignment alignment                     = Alignment_Left,
            bool      imgui_AlignTextToFramePadding = false);
 
-// Trims text to a single line fitting max_width (and max_chars), appending "..."
-// when shortened. Uses the current font for measurement.
+// Trims text to fit max_width (current font), appending TEXT_ELLIPSIS when
+// shortened. max_chars optionally caps the character count.
 std::string
-ElideWithEllipsis(const std::string& text, float max_width, size_t max_chars);
+ElideWithEllipsis(const std::string& text, float max_width,
+                  size_t max_chars = std::string::npos);
 
 void
 CenterNextTextItem(const char* text);

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -11,6 +11,7 @@
 #include "spdlog/spdlog.h"
 #include "widgets/rocprofvis_gui_helpers.h"
 #include "widgets/rocprofvis_notification_manager.h"
+#include "imgui_internal.h"
 #include <algorithm>
 #include <sstream>
 
@@ -28,6 +29,9 @@ constexpr const char* FILTER_TEXT_HINT_STR       = "Filter: hipLaunchKernel";
 constexpr const char* FILTER_TEXT_HINT_NUMERICAL = "Filter: {>, <, =, >=, <=, !=} 30";
 constexpr const char* FILTER_TEXT_HINT_TIME =
     "Filter: {>, <, =, >=, <=, !=} {Nanoseconds}";
+
+// Cap on a column's fitted width, in multiples of the current font size.
+constexpr float MAX_COLUMN_FIT_WIDTH_EM = 40.0f;
 
 InfiniteScrollTable::InfiniteScrollTable(
     DataProvider& dp, TableType table_type,
@@ -62,6 +66,9 @@ InfiniteScrollTable::InfiniteScrollTable(
 , m_update_filter_row(false)
 , m_reset_filter_row(false)
 , m_data_changed(true)
+, m_refit_pending(false)
+, m_refit_requested(false)
+, m_columns_emptied(false)
 , m_filter_requested(false)
 , m_fetch_data(false)
 , m_fetch_cancelled(false)
@@ -248,6 +255,17 @@ InfiniteScrollTable::HandleNewTableData(std::shared_ptr<RocEvent> e)
         m_data_changed      = true;
         m_update_filter_row = m_display_filter_row;
         IndexColumns();
+
+        // Re-fit columns only for a content change (select/filter), not a sort or
+        // scroll page - else sorting would fit to whatever loaded at the top.
+        std::shared_ptr<TableDataEvent> table_event =
+            std::dynamic_pointer_cast<TableDataEvent>(e);
+        if(table_event && table_event->GetRequestID() == m_request_id &&
+           m_refit_requested)
+        {
+            m_refit_pending   = true;
+            m_refit_requested = false;
+        }
     }
 }
 
@@ -290,6 +308,12 @@ InfiniteScrollTable::Render()
     {
         m_skip_data_fetch      = true;
         m_last_total_row_count = total_row_count;
+    }
+
+    // Emptying the table forgets manual sizes so the next content re-fits fresh.
+    if(total_row_count == 0)
+    {
+        m_columns_emptied = true;
     }
 
     uint64_t row_count = 0;
@@ -415,6 +439,15 @@ InfiniteScrollTable::Render()
                 }
 
                 ImGui::TableHeadersRow();
+
+                // Note manual resizes before re-fitting so it skips user-sized columns.
+                DetectUserColumnResizes();
+
+                if(m_refit_pending)
+                {
+                    FitColumnsToContent();
+                    m_refit_pending = false;
+                }
 
                 if(m_display_filter_row)
                 {
@@ -702,15 +735,127 @@ InfiniteScrollTable::FetchData()
 }
 
 void
+InfiniteScrollTable::FitColumnsToContent()
+{
+    ImGuiTable* table = ImGui::GetCurrentTable();
+    if(!table)
+    {
+        return;
+    }
+
+    const std::vector<std::string>& column_names =
+        m_table_model().GetTableHeader(m_table_type);
+    const std::vector<std::vector<std::string>>& table_data =
+        m_table_model().GetTableData(m_table_type);
+    const std::vector<FormattedColumnInfo>& formatted =
+        m_table_model().GetFormattedTableData(m_table_type);
+
+    // Keep current widths on an empty result instead of collapsing to headers.
+    if(table_data.empty())
+    {
+        return;
+    }
+
+    // Forget manual sizes when the column set changes or the table was emptied.
+    const int cols = table->ColumnsCount;
+    if(m_columns_emptied || static_cast<int>(m_user_sized_columns.size()) != cols)
+    {
+        m_user_sized_columns.assign(cols, false);
+        m_column_fit_widths.assign(cols, -1.0f);
+        m_columns_emptied = false;
+    }
+
+    const float max_width = ImGui::GetFontSize() * MAX_COLUMN_FIT_WIDTH_EM;
+    const float padding   = ImGui::GetStyle().ItemSpacing.x;
+    const int   column_count = std::min(static_cast<int>(column_names.size()), cols);
+
+    for(int c = 0; c < column_count; c++)
+    {
+        if(column_names[c].empty() || column_names[c][0] == '_')
+        {
+            continue;  // Internal / hidden column.
+        }
+        if(m_user_sized_columns[c])
+        {
+            continue;  // Respect the user's manual width.
+        }
+
+        // Header label plus room for the sort arrow, then the widest cached cell.
+        float width = ImGui::CalcTextSize(column_names[c].c_str()).x + ImGui::GetFontSize();
+
+        const FormattedColumnInfo* formatting =
+            (c < static_cast<int>(formatted.size())) ? &formatted[c] : nullptr;
+        for(size_t row = 0; row < table_data.size(); row++)
+        {
+            if(c >= static_cast<int>(table_data[row].size()))
+            {
+                continue;
+            }
+            const std::string* value = &table_data[row][c];
+            if(formatting && formatting->needs_formatting &&
+               row < formatting->formatted_row_value.size())
+            {
+                value = &formatting->formatted_row_value[row];
+            }
+            width = std::max(width, ImGui::CalcTextSize(value->c_str()).x);
+        }
+
+        width                          = std::min(width, max_width) + padding;
+        table->Columns[c].WidthRequest = width;
+        table->Columns[c].AutoFitQueue = 0;
+        m_column_fit_widths[c]         = width;
+    }
+}
+
+void
+InfiniteScrollTable::DetectUserColumnResizes()
+{
+    ImGuiTable* table = ImGui::GetCurrentTable();
+    if(!table)
+    {
+        return;
+    }
+
+    const int count =
+        std::min(table->ColumnsCount, static_cast<int>(m_column_fit_widths.size()));
+    for(int c = 0; c < count; c++)
+    {
+        if(m_user_sized_columns[c] || m_column_fit_widths[c] < 0.0f)
+        {
+            continue;
+        }
+        // WidthRequest only diverges from our applied value on a user drag.
+        const float delta = table->Columns[c].WidthRequest - m_column_fit_widths[c];
+        if(delta > 0.5f || delta < -0.5f)
+        {
+            m_user_sized_columns[c] = true;
+        }
+    }
+}
+
+void
 InfiniteScrollTable::RenderCell(const std::string* cell_text, int row, int column)
 {
-    if(CopyableTextUnformatted(cell_text->c_str(),
+    // Elide to the live column width (widths are set by FitColumnsToContent); the
+    // full value stays in the tooltip and copy actions.
+    const float        avail_width = ImGui::GetContentRegionAvail().x;
+    const bool         is_elided   = ImGui::CalcTextSize(cell_text->c_str()).x > avail_width;
+    std::string        elided_text = is_elided ? ElideWithEllipsis(*cell_text, avail_width)
+                                               : std::string();
+    const std::string* display_text = is_elided ? &elided_text : cell_text;
+
+    if(CopyableTextUnformatted(display_text->c_str(),
                                std::to_string(row) + ":" + std::to_string(column),
                                COPY_DATA_NOTIFICATION, false, false))
     {
         m_selected_row    = row;
         m_selected_column = column;
         RowSelected(ImGuiMouseButton_Left);
+    }
+
+    if(is_elided && ImGui::IsItemHovered())
+    {
+        SetTooltipStyled("%s", cell_text->c_str());
     }
 
     if(ImGui::IsItemClicked(ImGuiMouseButton_Right))
@@ -862,13 +1007,18 @@ InfiniteScrollTable::ProcessSortOrFilterRequest(uint64_t frame_count)
             m_filter_options.group_columns.clear();
         }
 
+        // Only a filter/group change (not a sort) re-fits the columns.
+        const bool filter_changed =
+            table_params->m_filter != m_filter_options.filter ||
+            table_params->m_group != m_filter_options.group_by ||
+            table_params->m_group_columns != m_filter_options.group_columns;
+        const bool sort_changed =
+            table_params->m_sort_order != m_sort_order ||
+            table_params->m_sort_column_index != m_sort_column_index;
+
         // check that requested actually are different from the
         // current values before fetching
-        if(table_params->m_sort_order != m_sort_order ||
-           table_params->m_sort_column_index != m_sort_column_index ||
-           table_params->m_filter != m_filter_options.filter ||
-           table_params->m_group != m_filter_options.group_by ||
-           table_params->m_group_columns != m_filter_options.group_columns)
+        if(sort_changed || filter_changed)
         {
             // if filtering changed reset the start row as current row
             // may be beyond result length causing an assertion in controller
@@ -876,8 +1026,12 @@ InfiniteScrollTable::ProcessSortOrFilterRequest(uint64_t frame_count)
             {
                 m_fetch_start_row = 0;
             }
+            if(filter_changed)
+            {
+                m_refit_requested = true;
+            }
 
-            spdlog::debug("Fetching data for sort, frame count: {}", frame_count);
+            spdlog::debug("Fetching data for sort/filter, frame count: {}", frame_count);
 
             // Fetch the event table with the updated params
             m_fetch_data = true;
@@ -1107,6 +1261,7 @@ InfiniteScrollTable::RequestFetch()
 {
     m_fetch_data      = true;
     m_fetch_start_row = 0;
+    m_refit_requested = true;  // New content: re-fit columns.
 }
 
 void

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.cpp
@@ -25,12 +25,10 @@ constexpr uint64_t    FETCH_CHUNK_SIZE           = 1000;
 constexpr const char* START_TS_COLUMN_NAME       = "start";
 constexpr const char* END_TS_COLUMN_NAME         = "end";
 constexpr const char* DURATION_COLUMN_NAME       = "duration";
-constexpr const char* FILTER_TEXT_HINT_STR       = "Filter: hipLaunchKernel";
-constexpr const char* FILTER_TEXT_HINT_NUMERICAL = "Filter: {>, <, =, >=, <=, !=} 30";
-constexpr const char* FILTER_TEXT_HINT_TIME =
-    "Filter: {>, <, =, >=, <=, !=} {Nanoseconds}";
+constexpr const char* FILTER_INPUT_PLACEHOLDER = "Filter";
+constexpr const char* FILTER_OPERATORS         = "> < = >= <= !=";
 
-// Cap on a column's fitted width, in multiples of the current font size.
+constexpr float MIN_COLUMN_WIDTH_EM     = 6.0f;
 constexpr float MAX_COLUMN_FIT_WIDTH_EM = 40.0f;
 
 InfiniteScrollTable::InfiniteScrollTable(
@@ -68,6 +66,7 @@ InfiniteScrollTable::InfiniteScrollTable(
 , m_data_changed(true)
 , m_refit_pending(false)
 , m_refit_requested(false)
+, m_grow_pending(false)
 , m_columns_emptied(false)
 , m_filter_requested(false)
 , m_fetch_data(false)
@@ -165,7 +164,6 @@ InfiniteScrollTable::Update()
         ROCPROFVIS_ASSERT(columns.size() == column_types.size());
         m_displayed_filter_row_inputs.resize(columns.size());
         std::unordered_set<FilterInput*> active_filter_row_inputs;
-        size_t                           j = 0;
         for(size_t i = 0; i < m_displayed_filter_row_inputs.size(); i++)
         {
             if(m_filter_row_inputs.count(columns[i]))
@@ -177,36 +175,12 @@ InfiniteScrollTable::Update()
             }
             else
             {
-                const char* tooltip;
-                switch(column_types[i])
-                {
-                    case kRPVControllerPrimitiveTypeUInt64:
-                    {
-                        if((j < m_time_column_indices.size() &&
-                            m_time_column_indices[j] == i))
-                        {
-                            tooltip = FILTER_TEXT_HINT_TIME;
-                            j++;
-                        }
-                        else
-                        {
-                            tooltip = FILTER_TEXT_HINT_NUMERICAL;
-                        }
-                        break;
-                    }
-                    case kRPVControllerPrimitiveTypeDouble:
-                    {
-                        tooltip = FILTER_TEXT_HINT_NUMERICAL;
-                        break;
-                    }
-                    default:
-                    {
-                        tooltip = FILTER_TEXT_HINT_STR;
-                        break;
-                    }
-                }
+                const bool is_time =
+                    i == m_time_column_indices[kTimeStartNs] ||
+                    i == m_time_column_indices[kTimeEndNs] ||
+                    i == m_time_column_indices[kDurationNs];
                 m_filter_row_inputs[columns[i]] = { columns[i], column_types[i], "",
-                                                    tooltip };
+                                                    is_time };
             }
             m_displayed_filter_row_inputs[i] = &m_filter_row_inputs.at(columns[i]);
         }
@@ -256,15 +230,21 @@ InfiniteScrollTable::HandleNewTableData(std::shared_ptr<RocEvent> e)
         m_update_filter_row = m_display_filter_row;
         IndexColumns();
 
-        // Re-fit columns only for a content change (select/filter), not a sort or
-        // scroll page - else sorting would fit to whatever loaded at the top.
+        // A content change (select/filter) re-fits the columns fresh; any other
+        // page-in of this table's data just lets columns grow to newly loaded values.
         std::shared_ptr<TableDataEvent> table_event =
             std::dynamic_pointer_cast<TableDataEvent>(e);
-        if(table_event && table_event->GetRequestID() == m_request_id &&
-           m_refit_requested)
+        if(table_event && table_event->GetRequestID() == m_request_id)
         {
-            m_refit_pending   = true;
-            m_refit_requested = false;
+            if(m_refit_requested)
+            {
+                m_refit_pending   = true;
+                m_refit_requested = false;
+            }
+            else
+            {
+                m_grow_pending = true;
+            }
         }
     }
 }
@@ -310,8 +290,9 @@ InfiniteScrollTable::Render()
         m_last_total_row_count = total_row_count;
     }
 
-    // Emptying the table forgets manual sizes so the next content re-fits fresh.
-    if(total_row_count == 0)
+    // Only a fully cleared table (all tracks deselected -> no columns) forgets
+    // manual widths. A filter that matches no rows keeps them.
+    if(column_names.empty())
     {
         m_columns_emptied = true;
     }
@@ -445,8 +426,14 @@ InfiniteScrollTable::Render()
 
                 if(m_refit_pending)
                 {
-                    FitColumnsToContent();
+                    FitColumnsToContent(false);  // fresh fit (may shrink)
                     m_refit_pending = false;
+                    m_grow_pending  = false;
+                }
+                else if(m_grow_pending)
+                {
+                    FitColumnsToContent(true);  // scroll page-in: grow only
+                    m_grow_pending = false;
                 }
 
                 if(m_display_filter_row)
@@ -459,11 +446,15 @@ InfiniteScrollTable::Render()
                         ImGui::TableNextColumn();
                         ImGui::PushID(static_cast<int>(i));
                         std::pair<bool, bool> filter_input = InputTextWithClear(
-                            "", m_displayed_filter_row_inputs[i]->tooltip,
+                            "", FILTER_INPUT_PLACEHOLDER,
                             m_displayed_filter_row_inputs[i]->input,
                             m_settings.GetFontManager().GetFont(FontType::kIcon),
                             m_settings.GetColor(Colors::kBgMain), style,
                             ImGui::GetContentRegionAvail().x);
+                        if(ImGui::IsItemHovered())
+                        {
+                            RenderFilterHelpTooltip(*m_displayed_filter_row_inputs[i]);
+                        }
                         if(filter_input.second)
                         {
                             m_displayed_filter_row_inputs[i]->input.clear();
@@ -735,7 +726,7 @@ InfiniteScrollTable::FetchData()
 }
 
 void
-InfiniteScrollTable::FitColumnsToContent()
+InfiniteScrollTable::FitColumnsToContent(bool grow_only)
 {
     ImGuiTable* table = ImGui::GetCurrentTable();
     if(!table)
@@ -756,32 +747,35 @@ InfiniteScrollTable::FitColumnsToContent()
         return;
     }
 
-    // Forget manual sizes when the column set changes or the table was emptied.
-    const int cols = table->ColumnsCount;
-    if(m_columns_emptied || static_cast<int>(m_user_sized_columns.size()) != cols)
+    // Only a full table clear (all tracks deselected) forgets manual widths;
+    // adding or removing columns keeps every surviving column's sizing by name.
+    if(m_columns_emptied)
     {
-        m_user_sized_columns.assign(cols, false);
-        m_column_fit_widths.assign(cols, -1.0f);
+        m_user_sized_columns.clear();
+        m_column_fit_widths.clear();
         m_columns_emptied = false;
     }
 
+    const float min_width = ImGui::GetFontSize() * MIN_COLUMN_WIDTH_EM;
     const float max_width = ImGui::GetFontSize() * MAX_COLUMN_FIT_WIDTH_EM;
     const float padding   = ImGui::GetStyle().ItemSpacing.x;
-    const int   column_count = std::min(static_cast<int>(column_names.size()), cols);
+    const int   column_count =
+        std::min(static_cast<int>(column_names.size()), table->ColumnsCount);
 
     for(int c = 0; c < column_count; c++)
     {
-        if(column_names[c].empty() || column_names[c][0] == '_')
+        const std::string& name = column_names[c];
+        if(name.empty() || name[0] == '_')
         {
             continue;  // Internal / hidden column.
         }
-        if(m_user_sized_columns[c])
+        if(m_user_sized_columns.count(name))
         {
             continue;  // Respect the user's manual width.
         }
 
-        // Header label plus room for the sort arrow, then the widest cached cell.
-        float width = ImGui::CalcTextSize(column_names[c].c_str()).x + ImGui::GetFontSize();
+        // Header label plus room for the sort arrow, then the widest loaded cell.
+        float content = ImGui::CalcTextSize(name.c_str()).x + ImGui::GetFontSize();
 
         const FormattedColumnInfo* formatting =
             (c < static_cast<int>(formatted.size())) ? &formatted[c] : nullptr;
@@ -797,13 +791,21 @@ InfiniteScrollTable::FitColumnsToContent()
             {
                 value = &formatting->formatted_row_value[row];
             }
-            width = std::max(width, ImGui::CalcTextSize(value->c_str()).x);
+            content = std::max(content, ImGui::CalcTextSize(value->c_str()).x);
         }
 
-        width                          = std::min(width, max_width) + padding;
+        const float width = std::min(std::max(content + padding, min_width), max_width);
+
+        // grow_only: keep the wider width so columns never shrink mid-scroll.
+        const auto it = m_column_fit_widths.find(name);
+        if(grow_only && it != m_column_fit_widths.end() && width <= it->second)
+        {
+            continue;
+        }
+
         table->Columns[c].WidthRequest = width;
         table->Columns[c].AutoFitQueue = 0;
-        m_column_fit_widths[c]         = width;
+        m_column_fit_widths[name]      = width;
     }
 }
 
@@ -816,19 +818,27 @@ InfiniteScrollTable::DetectUserColumnResizes()
         return;
     }
 
+    const std::vector<std::string>& column_names =
+        m_table_model().GetTableHeader(m_table_type);
     const int count =
-        std::min(table->ColumnsCount, static_cast<int>(m_column_fit_widths.size()));
+        std::min(table->ColumnsCount, static_cast<int>(column_names.size()));
     for(int c = 0; c < count; c++)
     {
-        if(m_user_sized_columns[c] || m_column_fit_widths[c] < 0.0f)
+        const std::string& name = column_names[c];
+        if(name.empty() || m_user_sized_columns.count(name))
         {
             continue;
         }
+        const auto it = m_column_fit_widths.find(name);
+        if(it == m_column_fit_widths.end())
+        {
+            continue;  // No auto-fit applied yet; nothing to compare against.
+        }
         // WidthRequest only diverges from our applied value on a user drag.
-        const float delta = table->Columns[c].WidthRequest - m_column_fit_widths[c];
+        const float delta = table->Columns[c].WidthRequest - it->second;
         if(delta > 0.5f || delta < -0.5f)
         {
-            m_user_sized_columns[c] = true;
+            m_user_sized_columns.insert(name);
         }
     }
 }
@@ -869,6 +879,29 @@ InfiniteScrollTable::RenderCell(const std::string* cell_text, int row, int colum
                             ImGuiHoveredFlags_AllowWhenOverlappedByItem))
     {
         m_hovered_row = row;
+    }
+}
+
+void
+InfiniteScrollTable::RenderFilterHelpTooltip(const FilterInput& input) const
+{
+    if(input.is_time)
+    {
+        SetTooltipStyled("Compare against a time in nanoseconds.\n"
+                         "Operators: %s\nExample: > 1000000",
+                         FILTER_OPERATORS);
+    }
+    else if(input.column_type == kRPVControllerPrimitiveTypeUInt64 ||
+            input.column_type == kRPVControllerPrimitiveTypeDouble)
+    {
+        SetTooltipStyled("Compare against a numeric value.\n"
+                         "Operators: %s\nExample: >= 30",
+                         FILTER_OPERATORS);
+    }
+    else
+    {
+        SetTooltipStyled("Match rows that contain this text (case-insensitive).\n"
+                         "Example: hipLaunchKernel");
     }
 }
 

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -11,6 +11,8 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace RocProfVis
@@ -135,7 +137,7 @@ private:
         std::string                            column_name;
         rocprofvis_controller_primitive_type_t column_type;
         std::string                            input;
-        const char*                            tooltip;
+        bool                                   is_time;  // Value is a timestamp (ns).
     };
 
     void FetchData();
@@ -143,9 +145,13 @@ private:
     void RenderContextMenu();
     void ProcessSortOrFilterRequest(uint64_t frame_count);
 
-    // Sizes non-user-resized columns to their widest cached value (capped). Call
-    // while the table is active.
-    void FitColumnsToContent();
+    // Hover tooltip explaining how to filter a column, with an example.
+    void RenderFilterHelpTooltip(const FilterInput& input) const;
+
+    // Sizes non-user-resized columns to their widest loaded value, clamped to
+    // [MIN_COLUMN_WIDTH_EM, MAX_COLUMN_FIT_WIDTH_EM]. With grow_only, columns only
+    // grow (scroll page-in); otherwise they fit fresh. Call while the table is active.
+    void FitColumnsToContent(bool grow_only);
 
     // Flags columns the user manually resized so FitColumnsToContent skips them.
     void DetectUserColumnResizes();
@@ -163,9 +169,11 @@ private:
     bool     m_skip_data_fetch;
     bool     m_refit_pending;    // Fresh content-change data is loaded; re-fit columns.
     bool     m_refit_requested;  // A content change (filter/selection) is in flight.
+    bool     m_grow_pending;     // A scroll page loaded; grow columns to fit it.
     bool     m_columns_emptied;  // Table went empty; the next fit forgets manual sizes.
-    std::vector<bool>  m_user_sized_columns;  // Columns the user manually resized.
-    std::vector<float> m_column_fit_widths;   // Width last auto-fit per column (-1 = none).
+    // Keyed by column name so adding/removing columns never disturbs existing sizing.
+    std::unordered_set<std::string>        m_user_sized_columns;  // User-resized columns.
+    std::unordered_map<std::string, float> m_column_fit_widths;   // Last auto-fit width.
     uint64_t m_last_total_row_count;
     ImVec2   m_last_table_size;
 

--- a/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
+++ b/src/view/src/widgets/rocprofvis_infinite_scroll_table.h
@@ -143,6 +143,13 @@ private:
     void RenderContextMenu();
     void ProcessSortOrFilterRequest(uint64_t frame_count);
 
+    // Sizes non-user-resized columns to their widest cached value (capped). Call
+    // while the table is active.
+    void FitColumnsToContent();
+
+    // Flags columns the user manually resized so FitColumnsToContent skips them.
+    void DetectUserColumnResizes();
+
     int      m_fetch_pad_items;
     int      m_fetch_threshold_items;
     uint64_t m_fetch_start_row;
@@ -154,6 +161,11 @@ private:
     // Internal state flags below
     bool     m_open_context_menu;
     bool     m_skip_data_fetch;
+    bool     m_refit_pending;    // Fresh content-change data is loaded; re-fit columns.
+    bool     m_refit_requested;  // A content change (filter/selection) is in flight.
+    bool     m_columns_emptied;  // Table went empty; the next fit forgets manual sizes.
+    std::vector<bool>  m_user_sized_columns;  // Columns the user manually resized.
+    std::vector<float> m_column_fit_widths;   // Width last auto-fit per column (-1 = none).
     uint64_t m_last_total_row_count;
     ImVec2   m_last_table_size;
 


### PR DESCRIPTION
## Motivation

Closes #1023.

Table columns sized themselves to their raw content, so a single very long
value (e.g. a demangled kernel name, which can be multiple KB) would stretch a
column to thousands of pixels and force endless horizontal scrolling, making
tables hard to read. The goal is to keep columns to a sensible width, elide
overflowing text while keeping the full value accessible, and auto-fit columns
to what's on screen without fighting the user's manual resizes.

## Technical Details

- **Clamped auto-fit:** columns are fitted to the widest loaded value, clamped
  to `[MIN_COLUMN_WIDTH_EM, MAX_COLUMN_FIT_WIDTH_EM]` (font-size multiples, so it
  scales with DPI). The min keeps the filter row usable; the max stops runaway
  columns.
- **Fit timing:** a full fit runs on content changes (track selection / filter);
  scroll page-ins only ever grow columns (never shrink mid-browse); sorting and
  plain scrolling don't refit.
- **Respects manual resizing:** manual column drags are detected and skipped by
  the auto-fit. Sizing state is keyed by column name, so adding or removing
  tracks (and their columns) no longer resets widths you set yourself; only a
  full clear (all tracks deselected) restores default sizing.
- **Text elision:** cell values that exceed the column width are elided with an
  ellipsis; the full value remains available in the hover tooltip and in copy
  actions. Elision is centralized in a shared `gui_helpers` helper.
- **Filter hints:** replaced the verbose per-column placeholder strings with a
  simple "Filter" placeholder plus a hover tooltip that shows the supported
  operators (`> < = >= <= !=`) and an example, styled to match existing tooltips.