### PR TITLE
Polish profiler launch & remote file browser UI

### DIFF
--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.cpp
@@ -44,14 +44,18 @@ constexpr float kToggleKnobInset    = 2.0f;   // knob padding inside the track
 // form instead of a column of tall panels.
 constexpr float kCardPadY = 5.0f;
 
-// A dimmed "(?)" that shows a wrapped tooltip on hover.
+// Minimum height for the run-output console child.
+constexpr float kMinOutputConsoleHeight = 60.0f;
+
+// A dimmed "(?)" tooltip marker, frame-aligned to sit level with its field.
 void HelpTip(const char* tooltip)
 {
     ImGui::SameLine();
+    ImGui::AlignTextToFramePadding();
     ImGui::TextDisabled("(?)");
     if (ImGui::BeginItemTooltip())
     {
-        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 25.0f);
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * kLaunchTooltipWrapEm);
         ImGui::TextUnformatted(tooltip);
         ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
@@ -123,7 +127,24 @@ void LaunchCardHeader(const char* icon, const char* title, const char* help)
 
     if (help && help[0])
     {
-        HelpTip(help);
+        // Center the "(?)" on the larger title font (frame-padding alignment
+        // would leave it sitting low against the bigger header text).
+        const float title_cy =
+            (ImGui::GetItemRectMin().y + ImGui::GetItemRectMax().y) * 0.5f;
+        ImGui::SameLine();
+        const ImVec2 q_sz = ImGui::CalcTextSize("(?)");
+        const ImVec2 q_at(ImGui::GetCursorScreenPos().x, title_cy - q_sz.y * 0.5f);
+        ImGui::GetWindowDrawList()->AddText(q_at, settings.GetColor(Colors::kTextDim),
+                                            "(?)");
+        ImGui::Dummy(q_sz);
+        if (ImGui::IsMouseHoveringRect(q_at, ImVec2(q_at.x + q_sz.x, q_at.y + q_sz.y)))
+        {
+            ImGui::BeginTooltip();
+            ImGui::PushTextWrapPos(ImGui::GetFontSize() * kLaunchTooltipWrapEm);
+            ImGui::TextUnformatted(help);
+            ImGui::PopTextWrapPos();
+            ImGui::EndTooltip();
+        }
     }
     ImGui::Unindent(kAccentBarWidth + kAccentBarGap);
 }
@@ -242,6 +263,11 @@ void LaunchSubHeader(const char* text, const char* help)
 {
     SettingsManager& settings = SettingsManager::Get();
     ImGui::Spacing();
+    // Frame-align the label so its trailing "(?)" lines up with it.
+    if (help && help[0])
+    {
+        ImGui::AlignTextToFramePadding();
+    }
     ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kAccent));
     ImGui::TextUnformatted(text);
     ImGui::PopStyleColor();
@@ -310,6 +336,11 @@ bool ToggleSwitch(const char* label, bool* value)
     return changed;
 }
 
+float ToggleSwitchWidth()
+{
+    return ImGui::GetFrameHeight() * kToggleHeightScale * kToggleWidthScale;
+}
+
 bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindow* app_window,
                          const std::function<void()>& on_remote_browse_program,
                          const std::function<void()>& on_remote_browse_output)
@@ -327,8 +358,10 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
     SettingsManager&  settings      = SettingsManager::Get();
     ProfilerSettings& prof_settings = settings.GetProfilerSettings();
 
-    const float label_w  = 105.0f;
-    const float browse_w = 84.0f;
+    // Size the label column to the widest label so nothing clips at high DPI.
+    const float label_w  = std::max(kLaunchLabelColumnMinWidth,
+        ImGui::CalcTextSize("Output folder").x + ImGui::GetStyle().ItemSpacing.x * 2.0f);
+    const float browse_w = kLaunchActionButtonWidth;
     const float spacing  = ImGui::GetStyle().ItemSpacing.x;
     const float arrow_w  = ImGui::GetFrameHeight();
 
@@ -349,32 +382,8 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
         modified = true;
     }
 
-    ImGui::SameLine();
-    // Disabled only in remote mode without a remote-browse handler; local mode
-    // and remote-with-handler both keep the button live.
-    const bool exe_disabled = is_remote && !remote_browse_exe;
-    if (exe_disabled)
-    {
-        ImGui::BeginDisabled();
-    }
-    if (ImGui::Button("Browse##TargetExe", ImVec2(browse_w, 0)))
-    {
-        if (remote_browse_exe)
-        {
-            on_remote_browse_program();
-        }
-        else if (!is_remote && app_window)
-        {
-            app_window->ShowOpenFileDialog(
-                "Choose Program", {}, "",
-                [&target](std::string const& path) { target.executable = path; });
-        }
-    }
-    if (exe_disabled)
-    {
-        ImGui::EndDisabled();
-    }
-
+    // Recent-targets dropdown sits before Browse so Browse stays right-anchored
+    // and lines up with the Output folder row's Browse.
     if (has_recent)
     {
         ImGui::SameLine();
@@ -409,11 +418,38 @@ bool RenderTargetSection(TargetSpec& target, ConnectionType connection, AppWindo
         }
     }
 
+    ImGui::SameLine();
+    // Disabled only in remote mode without a remote-browse handler; local mode
+    // and remote-with-handler both keep the button live.
+    const bool exe_disabled = is_remote && !remote_browse_exe;
+    if (exe_disabled)
+    {
+        ImGui::BeginDisabled();
+    }
+    if (ImGui::Button("Browse##TargetExe", ImVec2(browse_w, 0)))
+    {
+        if (remote_browse_exe)
+        {
+            on_remote_browse_program();
+        }
+        else if (!is_remote && app_window)
+        {
+            app_window->ShowOpenFileDialog(
+                "Choose Program", {}, "",
+                [&target](std::string const& path) { target.executable = path; });
+        }
+    }
+    if (exe_disabled)
+    {
+        ImGui::EndDisabled();
+    }
+
     // --- Arguments (free-form, passed verbatim to the program) ----------------
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Arguments");
     ImGui::SameLine(label_w);
-    ImGui::SetNextItemWidth(-FLT_MIN);
+    // Reserve the Browse-row trailing width so this box's right edge lines up.
+    ImGui::SetNextItemWidth(-(browse_w + spacing));
     if (InputTextStringWithHint(
             "##TargetArgs", "e.g.  --iterations 100 --input data.bin", target.arguments))
     {
@@ -475,8 +511,10 @@ bool RenderToolLocationSection(std::string& tool_directory, ConnectionType conne
     const bool is_remote     = (connection == ConnectionType::kSsh);
     const bool remote_browse = is_remote && static_cast<bool>(on_remote_browse_directory);
 
-    const float label_w  = 105.0f;
-    const float browse_w = 84.0f;
+    // Size the label column to fit its label (matches RenderTargetSection).
+    const float label_w  = std::max(kLaunchLabelColumnMinWidth,
+        ImGui::CalcTextSize("Tools folder").x + ImGui::GetStyle().ItemSpacing.x * 2.0f);
+    const float browse_w = kLaunchActionButtonWidth;
     const float spacing  = ImGui::GetStyle().ItemSpacing.x;
 
     ImGui::AlignTextToFramePadding();
@@ -649,7 +687,9 @@ bool RenderOutputConsole(
 
     FontManager&     fonts       = settings.GetFontManager();
     ImGuiWindowFlags output_flags = ImGuiWindowFlags_HorizontalScrollbar;
-    float output_height = std::max(ImGui::GetContentRegionAvail().y - 30.0f, 60.0f);
+    // Fill the remaining height (no uneven bottom gap below the console).
+    float output_height =
+        std::max(ImGui::GetContentRegionAvail().y, kMinOutputConsoleHeight);
 
     // Terminal-style panel: darker background, soft corners, monospaced text.
     ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, settings.GetDefaultStyle().ChildRounding);

--- a/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
+++ b/src/view/src/profiler/rocprofvis_launch_shared_tabs.h
@@ -19,6 +19,12 @@ namespace View
 
 class AppWindow;
 
+// Shared launcher layout metrics (kept here so the Browse / Add action buttons
+// and form label columns line up across the Target and Arguments sections).
+inline constexpr float kLaunchActionButtonWidth   = 84.0f;
+inline constexpr float kLaunchLabelColumnMinWidth = 105.0f;
+inline constexpr float kLaunchTooltipWrapEm       = 25.0f;
+
 // =============================================================================
 // Modern launcher UI primitives
 //
@@ -44,6 +50,9 @@ void LaunchSubHeader(const char* text, const char* help = nullptr);
 // iOS-style animated on/off switch. Returns true on the frame it is toggled.
 // Draws the label (and keeps it clickable) to the right of the switch.
 bool ToggleSwitch(const char* label, bool* value);
+
+// Advance width of a ToggleSwitch, for laying out controls beside it.
+float ToggleSwitchWidth();
 
 // A small rounded "tag": tinted background + accent border + accent text.
 // Advances the cursor by the chip size (use SameLine to place several).

--- a/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
+++ b/src/view/src/profiler/rocprofvis_profiler_launcher_dialog.cpp
@@ -37,6 +37,37 @@ constexpr float kSplitterWidth       = 6.0f;
 constexpr float kMinPreviewWidth     = 300.0f;
 constexpr float kMinFormWidth        = 320.0f;
 constexpr float kInitialPreviewRatio = 2.0f / 5.0f;
+
+// Inner padding for the advanced-window tab panels (matches the main cards).
+constexpr float kAdvancedTabPadX     = 14.0f;
+constexpr float kAdvancedTabPadY     = 10.0f;
+
+// In-body header (icon + title, trailing close "x", separator) that replaces the
+// native title bar on the frameless profiler windows. Returns true when closed.
+bool RenderDialogHeader(const char* icon, const char* title)
+{
+    SettingsManager&  settings = SettingsManager::Get();
+    FontManager&      fonts    = settings.GetFontManager();
+    const ImGuiStyle& style    = ImGui::GetStyle();
+
+    ImGui::PushFont(fonts.GetFont(FontType::kIcon), ImGui::GetFontSize());
+    ImGui::PushStyleColor(ImGuiCol_Text, settings.GetColor(Colors::kAccent));
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(icon);
+    ImGui::PopStyleColor();
+    ImGui::PopFont();
+
+    ImGui::SameLine(0.0f, style.ItemInnerSpacing.x);
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(title);
+
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(ImGui::GetWindowContentRegionMax().x - ImGui::GetFrameHeight());
+    bool close_clicked = XButton("##dialog_close", "Close", &settings);
+
+    ImGui::Separator();
+    return close_clicked;
+}
 }  // namespace
 
 ProfilerLauncherDialog::ProfilerLauncherDialog(AppWindow* app_window)
@@ -139,10 +170,16 @@ void ProfilerLauncherDialog::Render()
 
     bool window_open = true;
     bool visible     = ImGui::Begin("Launch Profiler", &window_open,
-                                    ImGuiWindowFlags_NoScrollbar);
+                                    ImGuiWindowFlags_NoScrollbar |
+                                        ImGuiWindowFlags_NoTitleBar);
     if (visible)
     {
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, def.ItemSpacing);
+
+        if (RenderDialogHeader(ICON_CHART_BAR, "Launch Profiler"))
+        {
+            window_open = false;
+        }
 
         // The dialog is a small two-step wizard: author the run (configure), then
         // watch it (run). Splitting them keeps the configuration uncluttered and
@@ -582,6 +619,10 @@ void ProfilerLauncherDialog::RenderMainContent()
 
     if (!advanced_tabs.empty())
     {
+        ImGui::Spacing();
+        // Indent to line up with the cards' inner content (inset by card padding).
+        const float adv_indent = SettingsManager::Get().GetDefaultStyle().WindowPadding.x;
+        ImGui::Indent(adv_indent);
         if (ImGui::Button("Advanced Options...", ImVec2(180, 0)))
         {
             m_show_advanced_window = true;
@@ -590,6 +631,8 @@ void ProfilerLauncherDialog::RenderMainContent()
         {
             ImGui::SetTooltip("Sampling, ROCm domains, Perfetto, parallelism, logging");
         }
+        ImGui::Unindent(adv_indent);
+        ImGui::Spacing();
     }
     ImGui::EndChild();
 
@@ -674,10 +717,16 @@ void ProfilerLauncherDialog::RenderAdvancedWindow()
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, def.WindowRounding);
 
     bool open    = true;
-    bool visible = ImGui::Begin("Advanced Profiling Options", &open);
+    bool visible = ImGui::Begin("Advanced Profiling Options", &open,
+                                ImGuiWindowFlags_NoTitleBar);
     if (visible)
     {
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, def.ItemSpacing);
+
+        if (RenderDialogHeader(ICON_GEAR, "Advanced Profiling Options"))
+        {
+            open = false;
+        }
 
         ImGui::TextDisabled("Fine-grained settings, applied on top of the selected preset.");
         ImGui::Spacing();
@@ -724,9 +773,22 @@ void ProfilerLauncherDialog::RenderAdvancedWindow()
                 if (ImGui::BeginTabItem(tab.display_name.c_str()))
                 {
                     ImGui::Spacing();
-                    ImGui::BeginChild("adv_scroll", ImVec2(0.0f, 0.0f), ImGuiChildFlags_None);
+                    // Wrap the tab body in a padded card, matching the main dialog.
+                    SettingsManager& card_settings = SettingsManager::Get();
+                    ImGui::PushStyleColor(ImGuiCol_ChildBg,
+                                          card_settings.GetColor(Colors::kBgPanel));
+                    ImGui::PushStyleColor(ImGuiCol_Border,
+                                          card_settings.GetColor(Colors::kPanelBorderSubtle));
+                    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, PANEL_CARD_ROUNDING);
+                    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                                        ImVec2(kAdvancedTabPadX, kAdvancedTabPadY));
+                    ImGui::BeginChild("adv_scroll", ImVec2(0.0f, 0.0f),
+                                      ImGuiChildFlags_Borders |
+                                          ImGuiChildFlags_AlwaysUseWindowPadding);
                     m_execution_cache_dirty |= tab.render_fn();
                     ImGui::EndChild();
+                    ImGui::PopStyleVar(2);
+                    ImGui::PopStyleColor(2);
                     ImGui::EndTabItem();
                 }
             }
@@ -770,14 +832,14 @@ void ProfilerLauncherDialog::RenderArgsEnvPanel()
                     "Passed to the profiler, one entry at a time (a flag, or a flag + value).");
 
     bool add_arg = false;
-    ImGui::SetNextItemWidth(-90.0f);
+    ImGui::SetNextItemWidth(-(kLaunchActionButtonWidth + style.ItemSpacing.x));
     if (InputTextStringWithHint("##ArgInput", "e.g.  --sampling-freq 500",
                                 m_arg_input, ImGuiInputTextFlags_EnterReturnsTrue))
     {
         add_arg = true;
     }
     ImGui::SameLine();
-    if (ImGui::Button("Add##Arg", ImVec2(80.0f, 0.0f)))
+    if (ImGui::Button("Add##Arg", ImVec2(kLaunchActionButtonWidth, 0.0f)))
     {
         add_arg = true;
     }
@@ -843,14 +905,14 @@ void ProfilerLauncherDialog::RenderArgsEnvPanel()
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("=");
     ImGui::SameLine();
-    ImGui::SetNextItemWidth(-90.0f);
+    ImGui::SetNextItemWidth(-(kLaunchActionButtonWidth + style.ItemSpacing.x));
     if (InputTextStringWithHint("##EnvValue", "value", m_env_value_input,
                                 ImGuiInputTextFlags_EnterReturnsTrue))
     {
         add_env = true;
     }
     ImGui::SameLine();
-    if (ImGui::Button("Add##Env", ImVec2(80.0f, 0.0f)))
+    if (ImGui::Button("Add##Env", ImVec2(kLaunchActionButtonWidth, 0.0f)))
     {
         add_env = true;
     }
@@ -1079,7 +1141,7 @@ void ProfilerLauncherDialog::RenderButtonRow()
     {
         ImGui::BeginDisabled();
     }
-    if (AccentButton("Launch Profiler", ImVec2(160, 0)))
+    if (AccentButton("Launch Profiler", ImVec2(0, 0)))
     {
         OnLaunchClicked();
     }
@@ -1098,7 +1160,7 @@ void ProfilerLauncherDialog::RenderButtonRow()
     if (has_run_view && !m_output_text.empty())
     {
         ImGui::SameLine();
-        if (ImGui::Button(is_running ? "View Run" : "View Last Run", ImVec2(130, 0)))
+        if (ImGui::Button(is_running ? "View Run" : "View Last Run", ImVec2(0, 0)))
         {
             m_show_run_view = true;
         }
@@ -1154,7 +1216,8 @@ void ProfilerLauncherDialog::RenderRunButtonRow()
         }
 
         ImGui::SameLine();
-        if (ImGui::Button("Back to Configuration", ImVec2(190, 0)))
+        // Auto-size so the label is never clipped at high DPI.
+        if (ImGui::Button("Back to Configuration", ImVec2(0, 0)))
         {
             m_show_run_view = false;
         }

--- a/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
+++ b/src/view/src/profiler/rocprofvis_rocprof_sys_backend.cpp
@@ -130,11 +130,13 @@ namespace
 
 void HelpMarker(char const* env_var, char const* desc)
 {
+    // Frame-align so the "(?)" sits level with the field/toggle/label it follows.
     ImGui::SameLine();
+    ImGui::AlignTextToFramePadding();
     ImGui::TextDisabled("(?)");
     if (ImGui::BeginItemTooltip())
     {
-        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 25.0f);
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * kLaunchTooltipWrapEm);
         ImGui::TextUnformatted(env_var);
         ImGui::Separator();
         ImGui::TextUnformatted(desc);
@@ -160,10 +162,8 @@ constexpr int   kCheckboxMaxCols  = 4;
 // Duration on one line).
 constexpr float kPresetLabelW    = 110.0f;
 constexpr float kPresetComboW    = 240.0f;
-constexpr float kOutputColW      = 160.0f;
-constexpr float kTraceInlineNumW = 85.0f;   // Delay / Duration inputs (share a row)
-constexpr float kTraceFieldGapX  = 16.0f;   // gap between Delay and Duration
-constexpr float kTraceRegionTrail = 26.0f;  // width reserved for the Region (?)
+constexpr float kOutputColW      = 160.0f;  // OUTPUT FORMAT column minimum width
+constexpr float kTraceInlineNumW = 85.0f;   // Delay / Duration numeric inputs
 
 // Renders a label in a fixed-width column and sizes the next item so a whole
 // column of controls lines up regardless of label length.
@@ -1133,26 +1133,31 @@ bool RocprofSysBackend::RenderGeneralTraceOptions()
 {
     bool changed = false;
 
-    // Delay + Duration share a row; Region takes the next.
+    // Stack Delay / Duration / Region in their own rows sharing a fixed label
+    // column, so their input boxes align and survive a compressed pane.
+    const ImGuiStyle& gs      = ImGui::GetStyle();
+    const float       label_w = ImGui::CalcTextSize("Duration (s)").x + gs.ItemSpacing.x * 2.0f;
+
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Delay (s)");
-    ImGui::SameLine();
+    ImGui::SameLine(label_w);
     ImGui::SetNextItemWidth(kTraceInlineNumW);
     changed |=
         ImGui::InputDouble("##TraceDelay", &m_settings.trace_delay, 0.0, 0.0, "%.2f");
 
-    ImGui::SameLine(0.0f, kTraceFieldGapX);
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Duration (s)");
-    ImGui::SameLine();
+    ImGui::SameLine(label_w);
     ImGui::SetNextItemWidth(kTraceInlineNumW);
     changed |= ImGui::InputDouble("##TraceDuration", &m_settings.trace_duration, 0.0,
                                   0.0, "%.2f");
 
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted("Region");
-    ImGui::SameLine();
-    ImGui::SetNextItemWidth(-kTraceRegionTrail);
+    ImGui::SameLine(label_w);
+    // Reserve room for the trailing "(?)" so it neither overlaps nor clips.
+    const float region_trail = gs.ItemSpacing.x * 2.0f + ImGui::CalcTextSize("(?)").x;
+    ImGui::SetNextItemWidth(-region_trail);
     changed |= InputTextStringWithHint("##TraceRegion",
                                        "ROCTX regions (comma-separated)",
                                        m_settings.trace_region);
@@ -1222,26 +1227,53 @@ bool RocprofSysBackend::RenderBackendsTab()
         }
     }
 
-    // Output format and the trace window sit side by side.
-    if (ImGui::BeginTable("general_split", 2, ImGuiTableFlags_None))
-    {
-        ImGui::TableSetupColumn("##out", ImGuiTableColumnFlags_WidthFixed, kOutputColW);
-        ImGui::TableSetupColumn("##trace", ImGuiTableColumnFlags_WidthStretch);
+    // Output format and the trace window sit side by side, stacking vertically
+    // when the pane is too narrow to keep both columns usable. The OUTPUT FORMAT
+    // column is sized to fit its widest row (the "ROCpd database" toggle + "(?)").
+    const ImGuiStyle& gs       = ImGui::GetStyle();
+    const float       toggle_w = ToggleSwitchWidth();
+    const float output_col_w =
+        std::max(kOutputColW, toggle_w + gs.ItemSpacing.x +
+                                  ImGui::CalcTextSize("ROCpd database").x +
+                                  gs.ItemSpacing.x + ImGui::CalcTextSize("(?)").x +
+                                  gs.ItemSpacing.x);
 
-        ImGui::TableNextColumn();
+    auto render_output_format = [&]() {
         LaunchSubHeader("OUTPUT FORMAT");
         changed |= ToggleSwitch("Perfetto trace", &m_settings.trace_backend);
         HelpMarker("ROCPROFSYS_TRACE", "Enable the Perfetto trace backend");
         changed |= ToggleSwitch("ROCpd database", &m_settings.use_rocpd);
         HelpMarker("ROCPROFSYS_USE_ROCPD", "Enable ROCpd SQLite output");
-
-        ImGui::TableNextColumn();
+    };
+    auto render_trace_window = [&]() {
         ImGui::BeginDisabled(has_preset);
         LaunchSubHeader("TRACE WINDOW");
         changed |= RenderGeneralTraceOptions();
         ImGui::EndDisabled();
+    };
+
+    // A usable trace column needs its label column plus a numeric input.
+    const float trace_min = ImGui::CalcTextSize("Duration (s)").x +
+                            gs.ItemSpacing.x * 3.0f + kTraceInlineNumW;
+    if (ImGui::GetContentRegionAvail().x >= output_col_w + trace_min &&
+        ImGui::BeginTable("general_split", 2, ImGuiTableFlags_None))
+    {
+        ImGui::TableSetupColumn("##out", ImGuiTableColumnFlags_WidthFixed, output_col_w);
+        ImGui::TableSetupColumn("##trace", ImGuiTableColumnFlags_WidthStretch);
+
+        ImGui::TableNextColumn();
+        render_output_format();
+
+        ImGui::TableNextColumn();
+        render_trace_window();
 
         ImGui::EndTable();
+    }
+    else
+    {
+        render_output_format();
+        ImGui::Spacing();
+        render_trace_window();
     }
 
     if (has_preset)
@@ -1338,6 +1370,7 @@ bool RocprofSysBackend::RenderRocmTab()
 
     BeginPresetLockedSection(m_settings.rocprof_preset);
 
+    ImGui::AlignTextToFramePadding();
     ImGui::Text("ROCm Domains:");
     HelpMarker("ROCPROFSYS_ROCM_DOMAINS",
                "ROCm SDK domains to trace (checked = enabled)");
@@ -1436,6 +1469,7 @@ bool RocprofSysBackend::RenderPerfettoTab()
     bool has_enable  = AnyEnabled(m_settings.enable_categories);
     bool has_disable = AnyEnabled(m_settings.disable_categories);
 
+    ImGui::AlignTextToFramePadding();
     ImGui::Text("Enable Categories (allowlist):");
     HelpMarker("ROCPROFSYS_ENABLE_CATEGORIES",
                "Perfetto categories to enable (mutually exclusive with disable list)");
@@ -1452,6 +1486,7 @@ bool RocprofSysBackend::RenderPerfettoTab()
 
     ImGui::Spacing();
 
+    ImGui::AlignTextToFramePadding();
     ImGui::Text("Disable Categories (denylist):");
     HelpMarker("ROCPROFSYS_DISABLE_CATEGORIES",
                "Perfetto categories to disable (mutually exclusive with enable list)");
@@ -1497,6 +1532,7 @@ bool RocprofSysBackend::RenderProcessSamplingTab()
 
     ImGui::Separator();
 
+    ImGui::AlignTextToFramePadding();
     ImGui::Text("AMD SMI Metrics:");
     HelpMarker("ROCPROFSYS_AMD_SMI_METRICS",
                "GPU metrics to collect (checked = enabled)");

--- a/src/view/src/remote/rocprofvis_remote_file_browser.cpp
+++ b/src/view/src/remote/rocprofvis_remote_file_browser.cpp
@@ -29,6 +29,10 @@ namespace View
 
 namespace
 {
+    // Interior padding for the file-listing card.
+    constexpr float kFileTableCardPadX = 10.0f;
+    constexpr float kFileTableCardPadY = 6.0f;
+
     // Formats a byte count as a compact human-readable size (e.g. "4.0 KiB").
     std::string format_file_size(uint64_t bytes)
     {
@@ -364,6 +368,9 @@ void RemoteFileBrowser::Render()
     PopUpStyle popup_style;
     popup_style.PushPopupStyles();
 
+    // Round to 12 px to match the app's other frameless pop-ups.
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 12.0f);
+
     ImGui::SetNextWindowSize(ImVec2(900, 600), ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSizeConstraints(ImVec2(640, 440), ImVec2(FLT_MAX, FLT_MAX));
 
@@ -510,12 +517,18 @@ void RemoteFileBrowser::Render()
                         accum += "/";
                         accum += segment;
 
+                        // Draw the separator centered in the crumb-button frame
+                        // height (icon-font metrics leave it high otherwise).
                         ImGui::SameLine(0, 2.0f);
                         ImGui::PushFont(icon_font, ImGui::GetFontSize());
-                        ImGui::PushStyleColor(ImGuiCol_Text, text_dim);
-                        ImGui::AlignTextToFramePadding();
-                        ImGui::TextUnformatted(ICON_CHEVRON_RIGHT);
-                        ImGui::PopStyleColor();
+                        const ImVec2 chevron_size = ImGui::CalcTextSize(ICON_CHEVRON_RIGHT);
+                        const float  chevron_frame = ImGui::GetFrameHeight();
+                        const ImVec2 chevron_pos   = ImGui::GetCursorScreenPos();
+                        ImGui::GetWindowDrawList()->AddText(
+                            ImVec2(chevron_pos.x,
+                                   chevron_pos.y + (chevron_frame - chevron_size.y) * 0.5f),
+                            text_dim, ICON_CHEVRON_RIGHT);
+                        ImGui::Dummy(ImVec2(chevron_size.x, chevron_frame));
                         ImGui::PopFont();
                         ImGui::SameLine(0, 2.0f);
 
@@ -640,9 +653,21 @@ void RemoteFileBrowser::Render()
             ImGuiTableFlags_BordersInnerH | ImGuiTableFlags_Resizable |
             ImGuiTableFlags_Sortable;
 
+        // Wrap the listing in a rounded, bordered card matching the header/footer
+        // cards; interior padding insets the rows from the border.
+        ImGui::PushStyleColor(ImGuiCol_ChildBg, settings.GetColor(Colors::kBgPanel));
+        ImGui::PushStyleColor(ImGuiCol_Border,
+                              settings.GetColor(Colors::kPanelBorderSubtle));
+        ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, PANEL_CARD_ROUNDING);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                            ImVec2(kFileTableCardPadX, kFileTableCardPadY));
+        ImGui::BeginChild("RemoteFilesCard", ImVec2(0.0f, -footer_reserve),
+                          ImGuiChildFlags_Borders | ImGuiChildFlags_AlwaysUseWindowPadding,
+                          ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse);
+
         ImGui::PushStyleVar(ImGuiStyleVar_CellPadding,
                             ImVec2(style.CellPadding.x, style.CellPadding.y + 3.0f));
-        if (ImGui::BeginTable("RemoteFiles", 4, table_flags, ImVec2(0, -footer_reserve)))
+        if (ImGui::BeginTable("RemoteFiles", 4, table_flags, ImVec2(0, 0)))
         {
             ImGui::TableSetupScrollFreeze(0, 1);
             ImGui::TableSetupColumn("Name",
@@ -652,10 +677,14 @@ void RemoteFileBrowser::Render()
             ImGui::TableSetupColumn("Modified", ImGuiTableColumnFlags_WidthFixed, 150.0f);
             ImGui::TableHeadersRow();
 
-            // Selected and hovered rows use the accent color.
-            ImGui::PushStyleColor(ImGuiCol_Header, accent);
-            ImGui::PushStyleColor(ImGuiCol_HeaderHovered, accent_hover);
-            ImGui::PushStyleColor(ImGuiCol_HeaderActive, accent_active);
+            // Use the shared translucent selection tint (as every other table)
+            // so row text stays readable rather than washing out on opaque accent.
+            ImGui::PushStyleColor(ImGuiCol_Header,
+                                  settings.GetColor(Colors::kSelection));
+            ImGui::PushStyleColor(ImGuiCol_HeaderHovered,
+                                  settings.GetColor(Colors::kHighlightChart));
+            ImGui::PushStyleColor(ImGuiCol_HeaderActive,
+                                  settings.GetColor(Colors::kHighlightChart));
 
             // Sort the visible list; directories always sort before files.
             if (ImGuiTableSortSpecs* specs = ImGui::TableGetSortSpecs())
@@ -734,7 +763,7 @@ void RemoteFileBrowser::Render()
                         NavigateBrowserTo(posix_parent_path(m_browser_dir), true);
                     }
                 }
-                const ImU32 c = parent_selected ? text_on_accent : accent;
+                const ImU32 c = accent;
                 ImGui::SameLine(0, 0);
                 row_icon(ICON_FOLDER, c);
                 ImGui::PushStyleColor(ImGuiCol_Text, c);
@@ -810,12 +839,9 @@ void RemoteFileBrowser::Render()
                     ImGui::SetScrollHereY();
                 }
 
-                // Selected rows draw on the accent color; otherwise folders are
-                // accented and files use the default text with a dimmed icon.
-                const ImU32 icon_color =
-                    row_selected ? text_on_accent : (f.is_dir ? accent : text_dim);
-                const ImU32 name_color =
-                    row_selected ? text_on_accent : (f.is_dir ? accent : text_main);
+                // Folders accented; files use default text with a dimmed icon.
+                const ImU32 icon_color = f.is_dir ? accent : text_dim;
+                const ImU32 name_color = f.is_dir ? accent : text_main;
                 ImGui::SameLine(0, 0);
                 row_icon(f.is_dir ? ICON_FOLDER : ICON_DOCUMENT, icon_color);
                 // Directory rows show the name (folders with a trailing slash).
@@ -852,7 +878,10 @@ void RemoteFileBrowser::Render()
             ImGui::PopStyleColor(3);
             ImGui::EndTable();
         }
-        ImGui::PopStyleVar();
+        ImGui::PopStyleVar();  // CellPadding
+        ImGui::EndChild();     // RemoteFilesCard
+        ImGui::PopStyleVar(2);   // ChildRounding, WindowPadding
+        ImGui::PopStyleColor(2); // ChildBg, Border
         m_scroll_to_selected = false;
 
         // Footer: item count, selection summary, Cancel and Open.
@@ -1080,6 +1109,7 @@ void RemoteFileBrowser::Render()
         ImGui::EndPopup();
     }
 
+    ImGui::PopStyleVar();  // WindowRounding
     popup_style.PopStyles();
 }
 

--- a/src/view/src/widgets/rocprofvis_gui_helpers.cpp
+++ b/src/view/src/widgets/rocprofvis_gui_helpers.cpp
@@ -51,19 +51,20 @@ InputTextStringWithHint(const char* id, const char* hint, std::string& str,
                         ImGuiInputTextFlags flags)
 {
     bool input_changed = InputTextString(id, str, flags);
-    if(str.empty())
+    if(str.empty() && hint && hint[0])
     {
-        const float& padding = ImGui::GetStyle().FramePadding.x;
-        ImGui::BeginDisabled();
-        ImGui::SetCursorScreenPos(
-            ImVec2(ImGui::GetItemRectMin().x + padding, ImGui::GetItemRectMin().y));
-        if(ElidedText(hint, ImGui::GetItemRectSize().x - 2.0f * padding, 0.0f,
-                   Alignment_Left, true) && BeginItemTooltipStyled())
-        {
-            ImGui::TextUnformatted(hint);
-            EndTooltipStyled();
-        }
-        ImGui::EndDisabled();
+        // Draw the placeholder as a decorative draw-list overlay (clipped,
+        // vertically centered). It must not add a layout item, or it would shift
+        // the caller's following SameLine() widget.
+        const ImVec2 mn  = ImGui::GetItemRectMin();
+        const ImVec2 mx  = ImGui::GetItemRectMax();
+        const float  pad = ImGui::GetStyle().FramePadding.x;
+        const float  th  = ImGui::GetTextLineHeight();
+        ImDrawList*  dl  = ImGui::GetWindowDrawList();
+        dl->PushClipRect(ImVec2(mn.x + pad, mn.y), ImVec2(mx.x - pad, mx.y), true);
+        dl->AddText(ImVec2(mn.x + pad, mn.y + ((mx.y - mn.y) - th) * 0.5f),
+                    ImGui::GetColorU32(ImGuiCol_TextDisabled), hint);
+        dl->PopClipRect();
     }
     return input_changed;
 }


### PR DESCRIPTION
## Motivation

The profiler launch and remote file browser UI had several inconsistencies with the rest of the app: the Launch Profiler and Advanced Options windows used native ImGui title bars (every other dialog is frameless), the remote file browser's row selection was hard to read, help `(?)` markers and the Browse/Add buttons were misaligned, and the layout broke on high-DPI displays and when the pane was compressed.

## Technical Details

- Make the Launch Profiler and Advanced Options windows frameless with an in-body header (icon + title + close), matching the app's other pop-up dialogs.
- Remote file browser: use the shared translucent selection tint so row text stays readable, wrap the listing in a rounded/padded card, center the breadcrumb chevrons, and round the window to 12 px.
- Center the `(?)` help markers consistently, and align the Browse/Add buttons by drawing input placeholder hints as a non-layout draw-list overlay (a hidden child window previously added a stray grey box and shifted the following button).
- Handle high-DPI / narrow panes: derive label and column widths from font metrics, auto-size wide action buttons, and stack OUTPUT FORMAT / TRACE WINDOW vertically when the pane is too narrow.
- Indent the Advanced Options button to line up with the cards, and pull shared layout magic-numbers into named constants.