### PR TITLE
Bind metric definitions to their real entry id (fixes >100% memory chart values)

### DIFF
--- a/src/controller/inc/rocprofvis_controller_enums.h
+++ b/src/controller/inc/rocprofvis_controller_enums.h
@@ -999,6 +999,7 @@ typedef enum rocprofvis_controller_workload_properties_t : uint32_t
     kRPVControllerWorkloadNumAvailableMetrics,
     kRPVControllerWorkloadAvailableMetricCategoryIdIndexed,
     kRPVControllerWorkloadAvailableMetricTableIdIndexed,
+    kRPVControllerWorkloadAvailableMetricEntryIdIndexed,
     kRPVControllerWorkloadAvailableMetricCategoryNameIndexed,
     kRPVControllerWorkloadAvailableMetricTableNameIndexed,
     kRPVControllerWorkloadAvailableMetricNameIndexed,

--- a/src/controller/src/compute/rocprofvis_controller_trace_compute.cpp
+++ b/src/controller/src/compute/rocprofvis_controller_trace_compute.cpp
@@ -923,6 +923,7 @@ rocprofvis_result_t ComputeTrace::LoadRocpd(Future* future)
                                             { kRPVComputeColumnMetricDescription, std::nullopt },
                                             { kRPVComputeColumnTableId, std::nullopt },
                                             { kRPVComputeColumnSubTableId, std::nullopt },
+                                            { kRPVComputeColumnEntryId, std::nullopt },
                                             { kRPVComputeColumnMetricTableName, std::nullopt },
                                             { kRPVComputeColumnMetricSubTableName, std::nullopt },
                                             { kRPVComputeColumnMetricUnit, std::nullopt },

--- a/src/controller/src/compute/rocprofvis_controller_workload.cpp
+++ b/src/controller/src/compute/rocprofvis_controller_workload.cpp
@@ -114,6 +114,19 @@ rocprofvis_result_t Workload::GetUInt64(rocprofvis_property_t property, uint64_t
                 }
                 break;
             }
+            case kRPVControllerWorkloadAvailableMetricEntryIdIndexed:
+            {
+                if(index < m_available_metrics.size())
+                {
+                    *value = m_available_metrics[index].entry_id;
+                    result = kRocProfVisResultSuccess;
+                }
+                else
+                {
+                    result = kRocProfVisResultOutOfRange;
+                }
+                break;
+            }
             case kRPVControllerWorkloadNumMetricValueNames:
             {
                 *value = m_metric_value_names.size();
@@ -381,6 +394,19 @@ rocprofvis_result_t Workload::SetUInt64(rocprofvis_property_t property, uint64_t
             if(index < m_available_metrics.size())
             {
                 m_available_metrics[index].table_id = (uint32_t)value;
+                result = kRocProfVisResultSuccess;
+            }
+            else
+            {
+                result = kRocProfVisResultOutOfRange;
+            }
+            break;
+        }
+        case kRPVControllerWorkloadAvailableMetricEntryIdIndexed:
+        {
+            if(index < m_available_metrics.size())
+            {
+                m_available_metrics[index].entry_id = (uint32_t)value;
                 result = kRocProfVisResultSuccess;
             }
             else
@@ -658,6 +684,12 @@ bool Workload::QueryToPropertyEnum(rocprofvis_db_compute_column_enum_t in, rocpr
         case kRPVComputeColumnSubTableId:
         {
             property = kRPVControllerWorkloadAvailableMetricTableIdIndexed;
+            type = kRPVControllerPrimitiveTypeUInt64;
+            break;
+        }
+        case kRPVComputeColumnEntryId:
+        {
+            property = kRPVControllerWorkloadAvailableMetricEntryIdIndexed;
             type = kRPVControllerPrimitiveTypeUInt64;
             break;
         }

--- a/src/controller/src/compute/rocprofvis_controller_workload.h
+++ b/src/controller/src/compute/rocprofvis_controller_workload.h
@@ -42,13 +42,19 @@ private:
         std::vector<std::string> values;
     };
     struct MetricDefinition {
-        uint32_t category_id;
-        uint32_t table_id;
-        size_t category_name_idx;
-        size_t table_name_idx;
-        size_t name_idx;
-        size_t description_idx;
-        size_t unit_idx;
+        static constexpr uint32_t kUnknownEntryId = UINT32_MAX;
+
+        uint32_t category_id = 0;
+        uint32_t table_id = 0;
+        // Trailing component of the "category.table.entry" metric id. Left as
+        // kUnknownEntryId when the database predates the column, so consumers can
+        // fall back to positional numbering.
+        uint32_t entry_id = kUnknownEntryId;
+        size_t category_name_idx = 0;
+        size_t table_name_idx = 0;
+        size_t name_idx = 0;
+        size_t description_idx = 0;
+        size_t unit_idx = 0;
     };
     struct MetricValueName {
         uint32_t category_id;

--- a/src/controller/src/compute/rocprofvis_controller_workload.h
+++ b/src/controller/src/compute/rocprofvis_controller_workload.h
@@ -42,14 +42,9 @@ private:
         std::vector<std::string> values;
     };
     struct MetricDefinition {
-        static constexpr uint32_t kUnknownEntryId = UINT32_MAX;
-
         uint32_t category_id = 0;
         uint32_t table_id = 0;
-        // Trailing component of the "category.table.entry" metric id. Left as
-        // kUnknownEntryId when the database predates the column, so consumers can
-        // fall back to positional numbering.
-        uint32_t entry_id = kUnknownEntryId;
+        uint32_t entry_id = 0;
         size_t category_name_idx = 0;
         size_t table_name_idx = 0;
         size_t name_idx = 0;

--- a/src/controller/tests/rocprofvis_controller_compute_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_compute_tests.cpp
@@ -7,7 +7,9 @@
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cfloat>
+#include <cstdint>
 #include <filesystem>
+#include <string>
 #include <unordered_map>
 
 std::string g_input_file =
@@ -46,9 +48,10 @@ struct RocProfVisControllerFixture
     {
         struct Entry
         {
-            uint64_t category_id = 0;
-            uint64_t table_id    = 0;
-            uint64_t id          = 0;
+            uint64_t    category_id = 0;
+            uint64_t    table_id    = 0;
+            uint64_t    id          = 0;
+            std::string name;
         };
         struct Table
         {
@@ -366,17 +369,38 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture,
                 category.id       = category_id;
                 auto& table       = category.tables[table_id];
                 table.id          = table_id;
-                uint64_t entry_id = static_cast<uint64_t>(table.entry_count++);
+                uint64_t entry_id = 0;
+                result            = rocprofvis_controller_get_uint64(
+                    workload.handle, kRPVControllerWorkloadAvailableMetricEntryIdIndexed,
+                    j, &entry_id);
+                REQUIRE(result == kRocProfVisResultSuccess);
+                REQUIRE(entry_id != static_cast<uint64_t>(UINT32_MAX));
+                table.entry_count++;
 
-                workload.available_metrics.list.push_back(
-                    AvailableMetrics::Entry{ category_id, table_id, entry_id });
+                workload.available_metrics.list.push_back(AvailableMetrics::Entry{
+                    category_id, table_id, entry_id, metric_name });
 
                 spdlog::info("  Metric {0}: cat={1}({2}) tbl={3}({4}) name={5}", entry_id,
                              category_id, category_name, table_id, table_name,
                              metric_name);
+
+                if(metric_name == "SALU" && category_id == 3 && table_id == 1)
+                {
+                    REQUIRE(entry_id == 2);
+                }
             }
 
             REQUIRE(!workload.available_metrics.list.empty());
+            bool saw_salu = false;
+            for(const auto& e : workload.available_metrics.list)
+            {
+                if(e.name == "SALU" && e.category_id == 3 && e.table_id == 1)
+                {
+                    saw_salu = true;
+                    REQUIRE(e.id == 2);
+                }
+            }
+            REQUIRE(saw_salu);
         }
     }
 
@@ -827,6 +851,20 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture,
                 REQUIRE(result == kRocProfVisResultSuccess);
                 REQUIRE(!metric_id.empty());
 
+                len    = 0;
+                result = rocprofvis_controller_get_string(
+                    output, kRPVControllerMetricsContainerMetricNameIndexed, i, nullptr,
+                    &len);
+                REQUIRE(result == kRocProfVisResultSuccess);
+
+                std::string metric_name;
+                metric_name.resize(len);
+                result = rocprofvis_controller_get_string(
+                    output, kRPVControllerMetricsContainerMetricNameIndexed, i,
+                    const_cast<char*>(metric_name.c_str()), &len);
+                REQUIRE(result == kRocProfVisResultSuccess);
+                REQUIRE(!metric_name.empty());
+
                 auto     cat_end = metric_id.find('.');
                 auto     tbl_end = metric_id.find('.', cat_end + 1);
                 uint64_t parsed_cat_id =
@@ -852,6 +890,7 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture,
                     if(e.category_id == parsed_cat_id && e.table_id == parsed_tbl_id &&
                        e.id == parsed_entry_id)
                     {
+                        REQUIRE(e.name == metric_name);
                         entry_found = true;
                         break;
                     }
@@ -992,6 +1031,20 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture,
                     REQUIRE(result == kRocProfVisResultSuccess);
                     REQUIRE(!metric_id.empty());
 
+                    len    = 0;
+                    result = rocprofvis_controller_get_string(
+                        output, kRPVControllerMetricsContainerMetricNameIndexed, i, nullptr,
+                        &len);
+                    REQUIRE(result == kRocProfVisResultSuccess);
+
+                    std::string metric_name;
+                    metric_name.resize(len);
+                    result = rocprofvis_controller_get_string(
+                        output, kRPVControllerMetricsContainerMetricNameIndexed, i,
+                        const_cast<char*>(metric_name.c_str()), &len);
+                    REQUIRE(result == kRocProfVisResultSuccess);
+                    REQUIRE(!metric_name.empty());
+
                     auto     cat_end = metric_id.find('.');
                     auto     tbl_end = metric_id.find('.', cat_end + 1);
                     uint64_t parsed_cat_id =
@@ -1017,6 +1070,7 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture,
                         if(e.category_id == parsed_cat_id &&
                            e.table_id == parsed_tbl_id && e.id == parsed_entry_id)
                         {
+                            REQUIRE(e.name == metric_name);
                             entry_found = true;
                             break;
                         }

--- a/src/controller/tests/rocprofvis_controller_compute_tests.cpp
+++ b/src/controller/tests/rocprofvis_controller_compute_tests.cpp
@@ -7,7 +7,6 @@
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cfloat>
-#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <unordered_map>
@@ -374,7 +373,6 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisControllerFixture,
                     workload.handle, kRPVControllerWorkloadAvailableMetricEntryIdIndexed,
                     j, &entry_id);
                 REQUIRE(result == kRocProfVisResultSuccess);
-                REQUIRE(entry_id != static_cast<uint64_t>(UINT32_MAX));
                 table.entry_count++;
 
                 workload.available_metrics.list.push_back(AvailableMetrics::Entry{

--- a/src/model/inc/rocprofvis_interface_types.h
+++ b/src/model/inc/rocprofvis_interface_types.h
@@ -513,6 +513,7 @@ typedef enum rocprofvis_db_compute_column_enum_t
     kRPVComputeColumnMetricId,
     kRPVComputeColumnTableId,
     kRPVComputeColumnSubTableId,
+    kRPVComputeColumnEntryId,
     kRPVComputeColumnMetricTableName,
     kRPVComputeColumnMetricSubTableName,
 

--- a/src/model/src/database/rocprofvis_db_compute.cpp
+++ b/src/model/src/database/rocprofvis_db_compute.cpp
@@ -58,6 +58,7 @@ namespace DataModel
 		{"lds_cache_data", kRPVComputeColumnRooflineLDSCacheData},
 		{"table_id", kRPVComputeColumnTableId},
 		{"sub_table_id", kRPVComputeColumnSubTableId},
+		{"entry_id", kRPVComputeColumnEntryId},
 		{"table_name", kRPVComputeColumnMetricTableName},
 		{"sub_table_name", kRPVComputeColumnMetricSubTableName},
 		{"metric_id", kRPVComputeColumnMetricId},
@@ -234,6 +235,7 @@ namespace DataModel
 				query_out += "description as metric_description, ";
 				query_out += "substr(metric_id, 0, instr(metric_id, '.')) as table_id, ";
 				query_out += "metric_id as sub_table_id, "; //parsed in callback method
+				query_out += "metric_id as entry_id, "; //parsed in callback method
 				query_out += "table_name, ";
 				query_out += "sub_table_name, ";
 				query_out += "unit ";
@@ -1429,6 +1431,12 @@ void ComputeQueryFactory::ParseMetricParam(std::string metric_str, uint32_t work
 					auto first = column_text.find('.');
 					auto second = column_text.find('.', first + 1);
 					column_text = column_text.substr(first + 1, second - first - 1);
+				}
+				else if (strcmp(azColName[i], "entry_id") == 0)
+				{
+					auto first = column_text.find('.');
+					auto second = column_text.find('.', first + 1);
+					column_text = (second == std::string::npos) ? "" : column_text.substr(second + 1);
 				}
 				if (kRocProfVisDmResultSuccess != db->BindObject()->FuncAddTableRowCell(row, column_text.c_str())) return 1;
 			}

--- a/src/model/src/tests/rocprofvis_dm_compute_tests.cpp
+++ b/src/model/src/tests/rocprofvis_dm_compute_tests.cpp
@@ -293,7 +293,10 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisDMFixture, "Compute Trace Data-Model Test
     }
 
     // Fetches the metric catalog for each workload. Builds unique metric prefixes
-    // (tableId.subTableId) and reconstructs full metric IDs (tableId.subTableId.entryId).
+    // (tableId.subTableId) and full metric IDs from the parsed category, table, and
+    // entry components. Asserts that entry_id is the trailing metric_id component
+    // rather than the row index — SQLite serves this query from UNIQUE(workload_id,
+    // metric_id), which orders "3.1.10" before "3.1.2".
     // Fixture Reads:  m_db, m_trace, m_workloads[].id
     // Fixture Writes: m_workloads[].metric_prefixes, m_workloads[].full_metric_ids
     SECTION("Fetch Workload Metrics Definition")
@@ -316,30 +319,44 @@ TEST_CASE_PERSISTENT_FIXTURE(RocProfVisDMFixture, "Compute Trace Data-Model Test
             REQUIRE(metrics.columns.count(kRPVComputeColumnMetricName) > 0);
             REQUIRE(metrics.columns.count(kRPVComputeColumnTableId) > 0);
             REQUIRE(metrics.columns.count(kRPVComputeColumnSubTableId) > 0);
+            REQUIRE(metrics.columns.count(kRPVComputeColumnEntryId) > 0);
 
             int table_id_col     = metrics.columns.at(kRPVComputeColumnTableId);
             int sub_table_id_col = metrics.columns.at(kRPVComputeColumnSubTableId);
+            int entry_id_col     = metrics.columns.at(kRPVComputeColumnEntryId);
 
-            std::map<std::string, int> prefix_entry_count;
+            std::map<std::string, std::set<std::string>> prefix_entry_ids;
+            bool saw_salu = false;
             for(size_t i = 0; i < metrics.rows.size(); i++)
             {
                 const std::string& name =
                     metrics.rows[i][metrics.columns.at(kRPVComputeColumnMetricName)];
-                const std::string& tid  = metrics.rows[i][table_id_col];
-                const std::string& stid = metrics.rows[i][sub_table_id_col];
+                const std::string& tid      = metrics.rows[i][table_id_col];
+                const std::string& stid     = metrics.rows[i][sub_table_id_col];
+                const std::string& entry_id = metrics.rows[i][entry_id_col];
                 REQUIRE(!name.empty());
-                spdlog::info("  Metric {}: name={}, tableId={}, subTableId={}", i, name,
-                             tid, stid);
+                spdlog::info("  Metric {}: name={}, tableId={}, subTableId={}, entryId={}",
+                             i, name, tid, stid, entry_id);
 
                 if(!tid.empty() && !stid.empty())
                 {
+                    REQUIRE(!entry_id.empty());
+                    REQUIRE(entry_id.find_first_not_of("0123456789") ==
+                            std::string::npos);
+
                     std::string prefix = tid + "." + stid;
+                    REQUIRE(prefix_entry_ids[prefix].insert(entry_id).second);
                     workload.metric_prefixes.insert(prefix);
-                    int entry_id = prefix_entry_count[prefix]++;
-                    workload.full_metric_ids.push_back(prefix + "." +
-                                                       std::to_string(entry_id));
+                    workload.full_metric_ids.push_back(prefix + "." + entry_id);
+
+                    if(name == "SALU" && prefix == "3.1")
+                    {
+                        saw_salu = true;
+                        REQUIRE(entry_id == "2");
+                    }
                 }
             }
+            REQUIRE(saw_salu);
         }
     }
 

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -4712,20 +4712,11 @@ DataProvider::LoadMetricList(WorkloadInfo& workload, rocprofvis_handle_t* worklo
         table.id   = workload.available_metrics.list[j].table_id;
         table.name = GetString(workload_handle,
                                kRPVControllerWorkloadAvailableMetricTableNameIndexed, j);
-        // Metric values are keyed by the trailing component of their
-        // "category.table.entry" id, so the definitions have to use that same id.
-        // Row position is not a valid substitute: the definition query is served
-        // from the UNIQUE(workload_id, metric_id) index, which orders rows by
-        // metric_id as a string ("3.1.10" before "3.1.2"). Databases that predate
-        // the column report no entry id, so fall back to positional numbering.
-        uint32_t entry_id = static_cast<uint32_t>(table.entries.size());
-        if(rocprofvis_controller_get_uint64(
-               workload_handle, kRPVControllerWorkloadAvailableMetricEntryIdIndexed, j,
-               &uint64_data) == kRocProfVisResultSuccess &&
-           uint64_data != UINT32_MAX)
-        {
-            entry_id = static_cast<uint32_t>(uint64_data);
-        }
+        result = rocprofvis_controller_get_uint64(
+            workload_handle, kRPVControllerWorkloadAvailableMetricEntryIdIndexed, j,
+            &uint64_data);
+        ROCPROFVIS_ASSERT(result == kRocProfVisResultSuccess);
+        uint32_t entry_id = static_cast<uint32_t>(uint64_data);
         workload.available_metrics.list[j].id = entry_id;
         table.entries.insert({ entry_id, workload.available_metrics.list[j] });
     }

--- a/src/view/src/rocprofvis_data_provider.cpp
+++ b/src/view/src/rocprofvis_data_provider.cpp
@@ -4712,11 +4712,22 @@ DataProvider::LoadMetricList(WorkloadInfo& workload, rocprofvis_handle_t* worklo
         table.id   = workload.available_metrics.list[j].table_id;
         table.name = GetString(workload_handle,
                                kRPVControllerWorkloadAvailableMetricTableNameIndexed, j);
-        // Last position of id is not returned, for now assume index...
-        workload.available_metrics.list[j].id =
-            static_cast<uint32_t>(table.entries.size());
-        table.entries.insert({ static_cast<uint32_t>(table.entries.size()),
-                               workload.available_metrics.list[j] });
+        // Metric values are keyed by the trailing component of their
+        // "category.table.entry" id, so the definitions have to use that same id.
+        // Row position is not a valid substitute: the definition query is served
+        // from the UNIQUE(workload_id, metric_id) index, which orders rows by
+        // metric_id as a string ("3.1.10" before "3.1.2"). Databases that predate
+        // the column report no entry id, so fall back to positional numbering.
+        uint32_t entry_id = static_cast<uint32_t>(table.entries.size());
+        if(rocprofvis_controller_get_uint64(
+               workload_handle, kRPVControllerWorkloadAvailableMetricEntryIdIndexed, j,
+               &uint64_data) == kRocProfVisResultSuccess &&
+           uint64_data != UINT32_MAX)
+        {
+            entry_id = static_cast<uint32_t>(uint64_data);
+        }
+        workload.available_metrics.list[j].id = entry_id;
+        table.entries.insert({ entry_id, workload.available_metrics.list[j] });
     }
 }
 


### PR DESCRIPTION
## Problem

The memory chart shows cache hit rates well above 100% and disagrees with the `rocprof-compute` CLI for the same kernel. Reported as AIPROFCOMP-842.

For `__amd_rocclr_fillBufferUnAligned` in an MI300A profile (analysis schema 2.2.0), the chart rendered:

| Row | Chart (before) | Database / CLI |
| --- | --- | --- |
| `VL1 Hit` | 0.00 % | 0 % |
| `sL1D Hit` | **4.19M %** | 0 % |
| `IL1 Hit` | **360 %** | 100 % |
| `L2 Hit` | **2.05B %** | 50 % |
| `VL1 Coalescing` | 0.00 % | 25 % |
| `L2 Rd` / `L2 Wr` / `L2 Atomic` | 530K / 765 / 2.28K | 2798 / 4194300 / 0 |
| `LDS Latency` | 262K cycles | NULL (should be N/A) |

The generated database is correct: all 67 memory-chart metrics for that kernel are in range. The corruption is entirely on the read path.

## Root cause

Metric values are keyed by the trailing component of their `category.table.entry` metric id, parsed from the `metric_id` string in `DataProvider::OnMetricsFetched`. The definitions that supply the *names* were keyed by row position instead:

```cpp
// Last position of id is not returned, for now assume index...
workload.available_metrics.list[j].id = static_cast<uint32_t>(table.entries.size());
table.entries.insert({ static_cast<uint32_t>(table.entries.size()), ... });
```

That assumption does not hold. `compute_metric_definition` declares `UNIQUE (workload_id, metric_id)`, so `WHERE workload_id = ?` is served from that autoindex and SQLite returns rows ordered by `metric_id` **as a string** — `3.1.10` before `3.1.2`. Any table with eleven or more metrics therefore binds each name to whichever value sits at its *lexicographic* position.

Instrumenting `LoadMetricList` confirms it directly: definition `j=2` is `VGPR` (`3.1.10`) while value `entry=2` is `SALU` (`3.1.2`).

The shift explains every wrong cell. `L2 Hit` is `3.1.52`, lexicographic position 48, and the 2.05B it displayed is exactly the value of `3.1.48 IL1_L2 Read BW` — a bandwidth counter rendered with a `%` suffix.

This is also why #901 (switching the memory chart from positional to name-based lookup) did not fix the symptom: the name-based lookup was correct, but the names themselves were attached to the wrong values one layer down. The bug is present in `v1.0.0-optiq` and on current `main`, and it affects the repo's own `sample/rocprof_compute_23ed6f36.db` (55 memory-chart metrics) too.

## Fix

Expose the trailing component of `metric_id` as an `entry_id` column on the metrics-definition query, parsed in the same callback that already splits out the category and table components, and carry it through `kRPVComputeColumnEntryId` and `kRPVControllerWorkloadAvailableMetricEntryIdIndexed` into `LoadMetricList`. Definitions and values then agree on the key.

The metric definition contract requires a complete `category.table.entry` id; `LoadMetricList` now requires the controller entry-id lookup to succeed and uses that id directly.

## Verification

Built from `main` and opened the reproduction database. Every memory-chart cell now matches the database exactly, including the four hit rates above, `VL1 Stall` 67 cycles, `sL1D Latency` 58.3K cycles, `IL1 Latency` 765 cycles, `Fabric Rd Lat` 1.11K cycles, and `HBM Wr` 4.19M. `LDS Latency` and `Fabric Atomic Lat` correctly report `N/A` where the database stores NULL, instead of borrowing a neighbour's value.

Also verified against `sample/rocprof_compute_23ed6f36.db`, which was affected too: its first kernel now shows `IL1 Hit` 100 %, `L2 Hit` 84 %, `sL1D Hit` 88 %, `VL1 Coalesce` 25 %, `IL1 Lat` 725 — matching the stored values.

Tests:

- `datamodel-compute-tests` — all passed (472,842 assertions)
- `roc-optiq-controller-compute-tests` — all passed (1,015,245 assertions)

The two system-test suites fail both with and without this change, because `sample/trace_70b_1024_32.rpd` is a Git LFS pointer rather than a real trace in a plain clone.

## Note on ordering

`Table::ordered_entries` sorts by entry id, so metric tables now list metrics in their config-defined numeric order rather than the string order (`3.1.10` before `3.1.2`) they used previously.
