### PR TITLE
[Defect] Cancelling table fetch then fetching again results in incorrect row count.

### DIFF
--- a/src/model/src/database/rocprofvis_db_table_processor.cpp
+++ b/src/model/src/database/rocprofvis_db_table_processor.cpp
@@ -136,7 +136,7 @@ namespace DataModel
             }
 
 
-            if (kRocProfVisDmResultSuccess == result && m_merged_table.RowCount() > 0)
+            if (kRocProfVisDmResultSuccess == result && m_merged_table.RowCount() > 0 && !future->Interrupted())
             {
                 result = ProcessCompoundQuery(handle, commands, !same_queries);
                 m_tracks = tracks;


### PR DESCRIPTION
-Invalidate `TableProcessor` cache on cancel, otherwise subsequent identical query will skip processing and return whatever partial results produced by prior cancelled attempt.
